### PR TITLE
Dev/autoload dataobjects

### DIFF
--- a/pkg/model/events/end.go
+++ b/pkg/model/events/end.go
@@ -103,15 +103,6 @@ func (ee *EndEvent) Exec(
 	ctx context.Context,
 	re exec.RuntimeEnvironment,
 ) ([]*flow.SequenceFlow, error) {
-	if err := ee.fillInputs(); err != nil {
-		return nil,
-			errs.New(
-				errs.M("EndEvent %q[%s] execution failed",
-					ee.Name(), ee.Id()),
-				errs.C(errorClass, errs.OperationFailed),
-				errs.E(err))
-	}
-
 	ers := []error{}
 
 	for _, ed := range ee.definitions {

--- a/pkg/model/events/start.go
+++ b/pkg/model/events/start.go
@@ -7,7 +7,6 @@ import (
 	"reflect"
 
 	"github.com/dr-dobermann/gobpm/internal/exec"
-	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
@@ -113,13 +112,6 @@ func (se *StartEvent) Exec(
 	ctx context.Context,
 	re exec.RuntimeEnvironment,
 ) ([]*flow.SequenceFlow, error) {
-	if err := se.fillOutput(); err != nil {
-		return nil,
-			errs.New(
-				errs.M("couldn't fill StartEvent %q[%s] output data",
-					se.Name(), se.Id()),
-				errs.E(err))
-	}
 
 	return append([]*flow.SequenceFlow{}, se.Outgoing()...), nil
 }

--- a/pkg/model/flow/node.go
+++ b/pkg/model/flow/node.go
@@ -1,6 +1,7 @@
 package flow
 
 import (
+	"context"
 	"errors"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
@@ -72,6 +73,26 @@ type Node interface {
 
 	// Node returns underlying node object.
 	Node() Node
+}
+
+// NodeDataProducer implemented by Nodes which needs to load data from
+// flow.DataObject over its incoming data.Associations.
+// This interface is used before Node execution.
+type NodeDataProducer interface {
+	Node
+
+	// UploadData uploads Node's data onto its outgoing data.Association.
+	UploadData(context.Context) error
+}
+
+// NodeDataConsumer implemented by Nodes which upload data to flow.DataObjects
+// over its outgoing data.Associations.
+// This interface is used after Node execution.
+type NodeDataConsumer interface {
+	Node
+
+	// LoadData loads Node's data from its incoming data.Associations.
+	LoadData(context.Context) error
 }
 
 // *****************************************************************************


### PR DESCRIPTION
- Add exec.DataNode Producer/Consumer interfaces for automatic load data from incoming data.Associations into the Node and automatic upload data into outgoing data.Associations of the Node.
- Use these interfaces on node execution
- Implement these interfaces for throw and catch events.

