### PR TITLE
Add BPMN 2.0 spec knowledge base for Process Execution Conformance

### DIFF
--- a/docs/bpmn-spec/conformance.md
+++ b/docs/bpmn-spec/conformance.md
@@ -1,0 +1,177 @@
+# Process Execution Conformance — Scope
+
+Per BPMN 2.0 §2.1.2, **Process Execution Conformance** requires an engine to implement the operational semantics defined in §13 for the set of elements declared as its conformant subset. The minimum conformant subset is the **Common Executable Subclass** (§2.1.3).
+
+`gobpm` targets exactly this: Common Executable Subclass + §13 execution semantics, **plus ComplexGateway as an explicit extension**. Anything else is out of scope.
+
+**Scope note on ComplexGateway:** §13.4.5 defines ComplexGateway with a complete operational semantics, but it is NOT in the minimum Common Executable Subclass per §2.1.3. We include it because it enables workflow patterns (Structured Discriminator WCP-9, Blocking Discriminator WCP-28, Structured Partial Join WCP-30, Blocking Partial Join WCP-31) not otherwise expressible. Process Execution Conformance permits supersets of the Common Executable Subclass — including ComplexGateway makes the engine *more* conformant, not less.
+
+## In scope
+
+### Process container
+| Element | bpmn-moddle type | Notes |
+|---|---|---|
+| Process | `Process` | Top-level executable process (`isExecutable=true`) |
+| SubProcess | `SubProcess` | Embedded sub-process; also Event Sub-Process when `triggeredByEvent=true` |
+| Transaction | `Transaction` | Sub-process with ACID-like semantics, cancel/compensation triggers |
+| AdHocSubProcess | `AdHocSubProcess` | Unordered activity set with completion condition |
+| CallActivity | `CallActivity` | Invokes a reusable `CallableElement` |
+| Lane / LaneSet | `Lane`, `LaneSet` | Organizational grouping only — no execution semantics attached |
+
+### Activities
+| Element | bpmn-moddle type | Notes |
+|---|---|---|
+| Task (abstract) | `Task` | Base for typed tasks |
+| ServiceTask | `ServiceTask` | Operation invocation |
+| UserTask | `UserTask` | Human task with form |
+| ManualTask | `ManualTask` | Out-of-system task, no engine action |
+| ScriptTask | `ScriptTask` | Inline script execution |
+| BusinessRuleTask | `BusinessRuleTask` | DMN / rule engine call |
+| SendTask | `SendTask` | Message throw |
+| ReceiveTask | `ReceiveTask` | Message catch |
+
+### Markers (on activities)
+| Element | bpmn-moddle type | Notes |
+|---|---|---|
+| StandardLoopCharacteristics | `StandardLoopCharacteristics` | Sequential loop with test condition |
+| MultiInstanceLoopCharacteristics | `MultiInstanceLoopCharacteristics` | Sequential or parallel MI with cardinality / collection |
+| ComplexBehaviorDefinition | `ComplexBehaviorDefinition` | Custom MI completion / event handling |
+
+### Events
+| Element | bpmn-moddle type | Position |
+|---|---|---|
+| StartEvent | `StartEvent` | Process start, top-level or event-sub-process |
+| IntermediateCatchEvent | `IntermediateCatchEvent` | Inline wait |
+| IntermediateThrowEvent | `IntermediateThrowEvent` | Inline emit |
+| EndEvent | `EndEvent` | Process / sub-process termination |
+| BoundaryEvent | `BoundaryEvent` | Attached to activity (interrupting + non-interrupting via `cancelActivity`) |
+| ImplicitThrowEvent | `ImplicitThrowEvent` | Implicit throw at process end (rarely used directly) |
+
+### Event definitions (subtypes)
+| Element | bpmn-moddle type | Applies to |
+|---|---|---|
+| MessageEventDefinition | `MessageEventDefinition` | Start, IntermediateCatch, IntermediateThrow, End, Boundary |
+| TimerEventDefinition | `TimerEventDefinition` | Start, IntermediateCatch, Boundary |
+| SignalEventDefinition | `SignalEventDefinition` | Start, IntermediateCatch, IntermediateThrow, End, Boundary |
+| ErrorEventDefinition | `ErrorEventDefinition` | Start (event sub-process only), End, Boundary |
+| EscalationEventDefinition | `EscalationEventDefinition` | Start (event sub-process), IntermediateThrow, End, Boundary |
+| CompensateEventDefinition | `CompensateEventDefinition` | Start (event sub-process), IntermediateThrow, End, Boundary |
+| CancelEventDefinition | `CancelEventDefinition` | End, Boundary — Transaction sub-process only |
+| ConditionalEventDefinition | `ConditionalEventDefinition` | Start, IntermediateCatch, Boundary |
+| LinkEventDefinition | `LinkEventDefinition` | IntermediateCatch (target), IntermediateThrow (source) |
+| TerminateEventDefinition | `TerminateEventDefinition` | End — terminates entire process instance |
+| Message, Signal, Error, Escalation | (referenced item definitions) | Resolved by event definitions |
+
+### Gateways
+| Element | bpmn-moddle type | Notes |
+|---|---|---|
+| ExclusiveGateway | `ExclusiveGateway` | XOR — first true condition wins |
+| ParallelGateway | `ParallelGateway` | AND — all paths split / all paths sync |
+| InclusiveGateway | `InclusiveGateway` | OR — all true conditions; merge waits for all expected tokens |
+| EventBasedGateway | `EventBasedGateway` | Race between catching events |
+| ComplexGateway | `ComplexGateway` | Activation expression over per-gate token counts, 2-phase activation/reset. **Extension above Common Executable** (see scope note). |
+
+### Flows
+| Element | bpmn-moddle type | Notes |
+|---|---|---|
+| SequenceFlow | `SequenceFlow` | Conditional (`conditionExpression`), default (referenced by `default` on source) |
+| Association | `Association` | Compensation associations (sources to compensation handlers) |
+
+### Data
+| Element | bpmn-moddle type | Notes |
+|---|---|---|
+| ItemDefinition | `ItemDefinition` | Type descriptor for data items |
+| DataObject | `DataObject` | Process-scoped data |
+| DataObjectReference | `DataObjectReference` | Reference to a DataObject within flow scope |
+| DataStore | `DataStore` | External persistent data |
+| DataStoreReference | `DataStoreReference` | Reference to a DataStore |
+| Property | `Property` | Process / activity local variable |
+| DataInput / DataOutput | `DataInput`, `DataOutput` | Activity I/O variables |
+| DataInputAssociation | `DataInputAssociation` | Data flow into activity |
+| DataOutputAssociation | `DataOutputAssociation` | Data flow out of activity |
+| InputSet / OutputSet | `InputSet`, `OutputSet` | I/O grouping with optional / while-executing semantics |
+| InputOutputSpecification | `InputOutputSpecification` | Activity I/O contract |
+| InputOutputBinding | `InputOutputBinding` | Maps Operation I/O to CallableElement I/O |
+| Assignment | `Assignment` | Single from/to expression pair within a DataAssociation |
+| DataState | `DataState` | Optional state qualifier on data |
+| DataAssociation | `DataAssociation` | Abstract base for In/Out associations |
+| ItemAwareElement | `ItemAwareElement` | Base for all data-carrying elements |
+
+### Human interaction (UserTask support)
+| Element | bpmn-moddle type | Notes |
+|---|---|---|
+| HumanPerformer | `HumanPerformer` | Specialized Performer |
+| PotentialOwner | `PotentialOwner` | Candidate owner expression |
+| Performer | `Performer` | Generic performer |
+| Rendering | `Rendering` | UI hint |
+| Resource | `Resource` | Resource definition |
+| ResourceRole | `ResourceRole` | Role assignment |
+| ResourceParameter | `ResourceParameter` | Resource query parameter |
+| ResourceParameterBinding | `ResourceParameterBinding` | Binds value to ResourceParameter |
+| ResourceAssignmentExpression | `ResourceAssignmentExpression` | Expression resolving to resource(s) |
+
+### Correlation (Message events)
+| Element | bpmn-moddle type | Notes |
+|---|---|---|
+| CorrelationKey | `CorrelationKey` | Named set of correlation properties |
+| CorrelationProperty | `CorrelationProperty` | Property used to match messages to process instance |
+| CorrelationPropertyRetrievalExpression | `CorrelationPropertyRetrievalExpression` | Extracts property value from a message |
+| CorrelationPropertyBinding | `CorrelationPropertyBinding` | Binds property to subscription |
+| CorrelationSubscription | `CorrelationSubscription` | Process-level subscription to a correlation key |
+
+### Operations / Interfaces (Service/Send/Receive tasks)
+| Element | bpmn-moddle type | Notes |
+|---|---|---|
+| Interface | `Interface` | Operation grouping |
+| Operation | `Operation` | Service operation with in/out message |
+| EndPoint | `EndPoint` | Operation endpoint reference |
+| GlobalTask / GlobalManualTask / GlobalUserTask / GlobalScriptTask / GlobalBusinessRuleTask | `GlobalTask`, ... | Reusable task definitions invocable via CallActivity |
+
+### Foundation / base types
+| Element | bpmn-moddle type | Notes |
+|---|---|---|
+| Definitions | `Definitions` | Top-level container of all root elements |
+| BaseElement | `BaseElement` | Root of all BPMN elements (id, documentation, extensions) |
+| RootElement | `RootElement` | Marker for top-level-only elements |
+| FlowElement | `FlowElement` | Anything that appears in a process flow |
+| FlowNode | `FlowNode` | Connectable element (activities, events, gateways) |
+| FlowElementsContainer | `FlowElementsContainer` | Holds flowElements + laneSets (Process, SubProcess) |
+| CallableElement | `CallableElement` | Invocable thing (Process, GlobalTask) — has I/O specification |
+| Expression / FormalExpression | `Expression`, `FormalExpression` | Conditions, assignments, completion criteria |
+| Documentation | `Documentation` | Human-readable annotation |
+| Extension / ExtensionDefinition / ExtensionAttributeDefinition / ExtensionElements | (as named) | Vendor extension mechanism |
+| Import | `Import` | External type/schema reference |
+| Auditing / Monitoring | `Auditing`, `Monitoring` | Process-level audit/monitor placeholders |
+
+## Out of scope
+
+| Element / family | bpmn-moddle types | Reason |
+|---|---|---|
+| Choreography family | `Choreography`, `SubChoreography`, `CallChoreography`, `ChoreographyTask`, `ChoreographyActivity`, `GlobalChoreographyTask` | Separate Choreography Modeling Conformance subclass |
+| Conversation family | `Conversation`, `SubConversation`, `CallConversation`, `GlobalConversation`, `ConversationNode`, `ConversationLink`, `ConversationAssociation` | Modeling-only, not execution |
+| Collaboration family | `Collaboration`, `Participant`, `ParticipantAssociation`, `ParticipantMultiplicity`, `PartnerEntity`, `PartnerRole`, `InteractionNode`, `MessageFlow`, `MessageFlowAssociation` | Cross-process modeling layer; inter-process messaging covered by Message events |
+| Visual artifacts | `TextAnnotation`, `Group`, `Category`, `CategoryValue`, `Artifact` | Pure visual — Association is kept because it carries compensation semantics |
+| Cross-namespace | `Relationship` | Not execution-related |
+| DI / DC | `BPMNShape`, `BPMNEdge`, `Bounds`, `Point`, all `bpmndi:*` and `dc:*`, `di:*` | Visual layout metamodel; not part of execution conformance |
+| BPEL mapping | (no bpmn-moddle types) | Separate conformance subclass |
+
+## Boundary cases noted
+
+- **Lane / LaneSet** — kept in scope as organizational grouping only. The spec defines lanes as having no token-flow semantics; activities in lanes execute exactly as if no lanes existed. Engine MUST parse and preserve, MUST NOT attach behavior.
+- **Boundary events on CallActivity** — explicitly allowed by §10.5.4. In scope.
+- **Event Sub-Process** — modeled as `SubProcess` with `triggeredByEvent=true`. In scope.
+- **Compensation Association** — `Association` between an activity and its compensation handler. The element is visual elsewhere; here it carries normative semantics.
+
+## Spec section index (for cross-reference)
+
+| Topic | Spec section |
+|---|---|
+| Conformance subclasses | §2 |
+| Common Executable Subclass element list | §2.1.3 |
+| Process model | §10 |
+| Activities | §10.5 |
+| Events | §10.4 |
+| Gateways | §10.6 |
+| Data | §10.3 |
+| Execution semantics (state machines, token flow) | §13 |
+| Correlation | §8.4.2 |

--- a/docs/bpmn-spec/elements/activities.md
+++ b/docs/bpmn-spec/elements/activities.md
@@ -1,0 +1,767 @@
+# Activities
+
+_Structural metamodel for **Activities** elements, extracted from bpmn-moddle. In-scope per [../conformance.md](../conformance.md)._
+
+_Kind legend: `attr` = XML attribute, `child elem` = XML child element, `(ref)` = ID reference to another element rather than embedded._
+
+---
+
+### Activity
+
+_Abstract type._
+
+**Type hierarchy:** `Activity → FlowNode → FlowElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `isForCompensation` | `Boolean` | attr | 0..1 | default `False` |
+| `default` | `SequenceFlow` | attr (ref) | 0..1 |  |
+| `ioSpecification` | `InputOutputSpecification` | child elem | 0..1 |  |
+| `boundaryEventRefs` | `BoundaryEvent` | child elem (ref) | 0..* |  |
+| `properties` | `Property` | child elem | 0..* |  |
+| `dataInputAssociations` | `DataInputAssociation` | child elem | 0..* |  |
+| `dataOutputAssociations` | `DataOutputAssociation` | child elem | 0..* |  |
+| `startQuantity` | `Integer` | attr | 0..1 | default `1` |
+| `resources` | `ResourceRole` | child elem | 0..* |  |
+| `completionQuantity` | `Integer` | attr | 0..1 | default `1` |
+| `loopCharacteristics` | `LoopCharacteristics` | child elem | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Task
+
+**Type hierarchy:** `Task → Activity → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### ServiceTask
+
+**Type hierarchy:** `ServiceTask → Task → Activity → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `implementation` | `String` | attr | 0..1 |  |
+| `operationRef` | `Operation` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### UserTask
+
+**Type hierarchy:** `UserTask → Task → Activity → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `renderings` | `Rendering` | child elem | 0..* |  |
+| `implementation` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### ManualTask
+
+**Type hierarchy:** `ManualTask → Task → Activity → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### ScriptTask
+
+**Type hierarchy:** `ScriptTask → Task → Activity → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `scriptFormat` | `String` | attr | 0..1 |  |
+| `script` | `String` | child elem | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### BusinessRuleTask
+
+**Type hierarchy:** `BusinessRuleTask → Task → Activity → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `implementation` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### SendTask
+
+**Type hierarchy:** `SendTask → Task → Activity → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `implementation` | `String` | attr | 0..1 |  |
+| `operationRef` | `Operation` | attr (ref) | 0..1 |  |
+| `messageRef` | `Message` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### ReceiveTask
+
+**Type hierarchy:** `ReceiveTask → Task → Activity → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `implementation` | `String` | attr | 0..1 |  |
+| `instantiate` | `Boolean` | attr | 0..1 | default `False` |
+| `operationRef` | `Operation` | attr (ref) | 0..1 |  |
+| `messageRef` | `Message` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### SubProcess
+
+**Type hierarchy:** `SubProcess → Activity → FlowNode → FlowElement → BaseElement → FlowElementsContainer → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `triggeredByEvent` | `Boolean` | attr | 0..1 | default `False` |
+| `artifacts` | `Artifact` | child elem | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `laneSets` | `FlowElementsContainer` | `LaneSet` | child elem | 0..* |
+| `flowElements` | `FlowElementsContainer` | `FlowElement` | child elem | 0..* |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### Transaction
+
+**Type hierarchy:** `Transaction → SubProcess → Activity → FlowNode → FlowElement → BaseElement → FlowElementsContainer → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `protocol` | `String` | attr | 0..1 |  |
+| `method` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `triggeredByEvent` | `SubProcess` | `Boolean` | attr | 0..1 |
+| `artifacts` | `SubProcess` | `Artifact` | child elem | 0..* |
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `laneSets` | `FlowElementsContainer` | `LaneSet` | child elem | 0..* |
+| `flowElements` | `FlowElementsContainer` | `FlowElement` | child elem | 0..* |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### AdHocSubProcess
+
+**Type hierarchy:** `AdHocSubProcess → SubProcess → Activity → FlowNode → FlowElement → BaseElement → FlowElementsContainer → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `completionCondition` | `Expression` | child elem | 0..1 |  |
+| `ordering` | `AdHocOrdering` | attr | 0..1 |  |
+| `cancelRemainingInstances` | `Boolean` | attr | 0..1 | default `True` |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `triggeredByEvent` | `SubProcess` | `Boolean` | attr | 0..1 |
+| `artifacts` | `SubProcess` | `Artifact` | child elem | 0..* |
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `laneSets` | `FlowElementsContainer` | `LaneSet` | child elem | 0..* |
+| `flowElements` | `FlowElementsContainer` | `FlowElement` | child elem | 0..* |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### CallActivity
+
+**Type hierarchy:** `CallActivity → Activity → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `calledElement` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `isForCompensation` | `Activity` | `Boolean` | attr | 0..1 |
+| `default` | `Activity` | `SequenceFlow` | attr (ref) | 0..1 |
+| `ioSpecification` | `Activity` | `InputOutputSpecification` | child elem | 0..1 |
+| `boundaryEventRefs` | `Activity` | `BoundaryEvent` | child elem (ref) | 0..* |
+| `properties` | `Activity` | `Property` | child elem | 0..* |
+| `dataInputAssociations` | `Activity` | `DataInputAssociation` | child elem | 0..* |
+| `dataOutputAssociations` | `Activity` | `DataOutputAssociation` | child elem | 0..* |
+| `startQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `resources` | `Activity` | `ResourceRole` | child elem | 0..* |
+| `completionQuantity` | `Activity` | `Integer` | attr | 0..1 |
+| `loopCharacteristics` | `Activity` | `LoopCharacteristics` | child elem | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### LoopCharacteristics
+
+_Abstract type._
+
+**Type hierarchy:** `LoopCharacteristics → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### StandardLoopCharacteristics
+
+**Type hierarchy:** `StandardLoopCharacteristics → LoopCharacteristics → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `testBefore` | `Boolean` | attr | 0..1 | default `False` |
+| `loopCondition` | `Expression` | child elem | 0..1 |  |
+| `loopMaximum` | `Integer` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### MultiInstanceLoopCharacteristics
+
+**Type hierarchy:** `MultiInstanceLoopCharacteristics → LoopCharacteristics → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `isSequential` | `Boolean` | attr | 0..1 | default `False` |
+| `behavior` | `MultiInstanceBehavior` | attr | 0..1 | default `All` |
+| `loopCardinality` | `Expression` | child elem | 0..1 |  |
+| `loopDataInputRef` | `ItemAwareElement` | child elem (ref) | 0..1 |  |
+| `loopDataOutputRef` | `ItemAwareElement` | child elem (ref) | 0..1 |  |
+| `inputDataItem` | `DataInput` | child elem | 0..1 |  |
+| `outputDataItem` | `DataOutput` | child elem | 0..1 |  |
+| `complexBehaviorDefinition` | `ComplexBehaviorDefinition` | child elem | 0..* |  |
+| `completionCondition` | `Expression` | child elem | 0..1 |  |
+| `oneBehaviorEventRef` | `EventDefinition` | attr (ref) | 0..1 |  |
+| `noneBehaviorEventRef` | `EventDefinition` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ComplexBehaviorDefinition
+
+**Type hierarchy:** `ComplexBehaviorDefinition → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `condition` | `FormalExpression` | child elem | 0..1 |  |
+| `event` | `ImplicitThrowEvent` | child elem | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### GlobalTask
+
+**Type hierarchy:** `GlobalTask → CallableElement → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `resources` | `ResourceRole` | child elem | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `name` | `CallableElement` | `String` | attr | 0..1 |
+| `ioSpecification` | `CallableElement` | `InputOutputSpecification` | child elem | 0..1 |
+| `supportedInterfaceRef` | `CallableElement` | `Interface` | child elem (ref) | 0..* |
+| `ioBinding` | `CallableElement` | `InputOutputBinding` | child elem | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### GlobalManualTask
+
+**Type hierarchy:** `GlobalManualTask → GlobalTask → CallableElement → RootElement → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `resources` | `GlobalTask` | `ResourceRole` | child elem | 0..* |
+| `name` | `CallableElement` | `String` | attr | 0..1 |
+| `ioSpecification` | `CallableElement` | `InputOutputSpecification` | child elem | 0..1 |
+| `supportedInterfaceRef` | `CallableElement` | `Interface` | child elem (ref) | 0..* |
+| `ioBinding` | `CallableElement` | `InputOutputBinding` | child elem | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### GlobalUserTask
+
+**Type hierarchy:** `GlobalUserTask → GlobalTask → CallableElement → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `implementation` | `String` | attr | 0..1 |  |
+| `renderings` | `Rendering` | child elem | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `resources` | `GlobalTask` | `ResourceRole` | child elem | 0..* |
+| `name` | `CallableElement` | `String` | attr | 0..1 |
+| `ioSpecification` | `CallableElement` | `InputOutputSpecification` | child elem | 0..1 |
+| `supportedInterfaceRef` | `CallableElement` | `Interface` | child elem (ref) | 0..* |
+| `ioBinding` | `CallableElement` | `InputOutputBinding` | child elem | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### GlobalScriptTask
+
+**Type hierarchy:** `GlobalScriptTask → GlobalTask → CallableElement → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `scriptLanguage` | `String` | attr | 0..1 |  |
+| `script` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `resources` | `GlobalTask` | `ResourceRole` | child elem | 0..* |
+| `name` | `CallableElement` | `String` | attr | 0..1 |
+| `ioSpecification` | `CallableElement` | `InputOutputSpecification` | child elem | 0..1 |
+| `supportedInterfaceRef` | `CallableElement` | `Interface` | child elem (ref) | 0..* |
+| `ioBinding` | `CallableElement` | `InputOutputBinding` | child elem | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### GlobalBusinessRuleTask
+
+**Type hierarchy:** `GlobalBusinessRuleTask → GlobalTask → CallableElement → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `implementation` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `resources` | `GlobalTask` | `ResourceRole` | child elem | 0..* |
+| `name` | `CallableElement` | `String` | attr | 0..1 |
+| `ioSpecification` | `CallableElement` | `InputOutputSpecification` | child elem | 0..1 |
+| `supportedInterfaceRef` | `CallableElement` | `Interface` | child elem (ref) | 0..* |
+| `ioBinding` | `CallableElement` | `InputOutputBinding` | child elem | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---

--- a/docs/bpmn-spec/elements/correlation.md
+++ b/docs/bpmn-spec/elements/correlation.md
@@ -1,0 +1,118 @@
+# Message Correlation
+
+_Structural metamodel for **Message Correlation** elements, extracted from bpmn-moddle. In-scope per [../conformance.md](../conformance.md)._
+
+_Kind legend: `attr` = XML attribute, `child elem` = XML child element, `(ref)` = ID reference to another element rather than embedded._
+
+---
+
+### CorrelationKey
+
+**Type hierarchy:** `CorrelationKey → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `correlationPropertyRef` | `CorrelationProperty` | child elem (ref) | 0..* |  |
+| `name` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### CorrelationProperty
+
+**Type hierarchy:** `CorrelationProperty → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `correlationPropertyRetrievalExpression` | `CorrelationPropertyRetrievalExpression` | child elem | 0..* |  |
+| `name` | `String` | attr | 0..1 |  |
+| `type` | `ItemDefinition` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### CorrelationPropertyRetrievalExpression
+
+**Type hierarchy:** `CorrelationPropertyRetrievalExpression → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `messagePath` | `FormalExpression` | child elem | 0..1 |  |
+| `messageRef` | `Message` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### CorrelationPropertyBinding
+
+**Type hierarchy:** `CorrelationPropertyBinding → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `dataPath` | `FormalExpression` | child elem | 0..1 |  |
+| `correlationPropertyRef` | `CorrelationProperty` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### CorrelationSubscription
+
+**Type hierarchy:** `CorrelationSubscription → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `correlationKeyRef` | `CorrelationKey` | attr (ref) | 0..1 |  |
+| `correlationPropertyBinding` | `CorrelationPropertyBinding` | child elem | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---

--- a/docs/bpmn-spec/elements/data.md
+++ b/docs/bpmn-spec/elements/data.md
@@ -1,0 +1,405 @@
+# Data
+
+_Structural metamodel for **Data** elements, extracted from bpmn-moddle. In-scope per [../conformance.md](../conformance.md)._
+
+_Kind legend: `attr` = XML attribute, `child elem` = XML child element, `(ref)` = ID reference to another element rather than embedded._
+
+---
+
+### ItemAwareElement
+
+**Type hierarchy:** `ItemAwareElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `itemSubjectRef` | `ItemDefinition` | attr (ref) | 0..1 |  |
+| `dataState` | `DataState` | child elem | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### DataObject
+
+**Type hierarchy:** `DataObject → FlowElement → BaseElement → ItemAwareElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `isCollection` | `Boolean` | attr | 0..1 | default `False` |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `itemSubjectRef` | `ItemAwareElement` | `ItemDefinition` | attr (ref) | 0..1 |
+| `dataState` | `ItemAwareElement` | `DataState` | child elem | 0..1 |
+
+---
+
+### DataObjectReference
+
+**Type hierarchy:** `DataObjectReference → ItemAwareElement → BaseElement → FlowElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `dataObjectRef` | `DataObject` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `itemSubjectRef` | `ItemAwareElement` | `ItemDefinition` | attr (ref) | 0..1 |
+| `dataState` | `ItemAwareElement` | `DataState` | child elem | 0..1 |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+
+---
+
+### DataStore
+
+**Type hierarchy:** `DataStore → RootElement → BaseElement → ItemAwareElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `capacity` | `Integer` | attr | 0..1 |  |
+| `isUnlimited` | `Boolean` | attr | 0..1 | default `True` |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `itemSubjectRef` | `ItemAwareElement` | `ItemDefinition` | attr (ref) | 0..1 |
+| `dataState` | `ItemAwareElement` | `DataState` | child elem | 0..1 |
+
+---
+
+### DataStoreReference
+
+**Type hierarchy:** `DataStoreReference → ItemAwareElement → BaseElement → FlowElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `dataStoreRef` | `DataStore` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `itemSubjectRef` | `ItemAwareElement` | `ItemDefinition` | attr (ref) | 0..1 |
+| `dataState` | `ItemAwareElement` | `DataState` | child elem | 0..1 |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+
+---
+
+### Property
+
+**Type hierarchy:** `Property → ItemAwareElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `itemSubjectRef` | `ItemAwareElement` | `ItemDefinition` | attr (ref) | 0..1 |
+| `dataState` | `ItemAwareElement` | `DataState` | child elem | 0..1 |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### DataInput
+
+**Type hierarchy:** `DataInput → ItemAwareElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `isCollection` | `Boolean` | attr | 0..1 | default `False` |
+| `inputSetRef` | `InputSet` | child elem (ref) | 0..* |  |
+| `inputSetWithOptional` | `InputSet` | child elem (ref) | 0..* |  |
+| `inputSetWithWhileExecuting` | `InputSet` | child elem (ref) | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `itemSubjectRef` | `ItemAwareElement` | `ItemDefinition` | attr (ref) | 0..1 |
+| `dataState` | `ItemAwareElement` | `DataState` | child elem | 0..1 |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### DataOutput
+
+**Type hierarchy:** `DataOutput → ItemAwareElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `isCollection` | `Boolean` | attr | 0..1 | default `False` |
+| `outputSetRef` | `OutputSet` | child elem (ref) | 0..* |  |
+| `outputSetWithOptional` | `OutputSet` | child elem (ref) | 0..* |  |
+| `outputSetWithWhileExecuting` | `OutputSet` | child elem (ref) | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `itemSubjectRef` | `ItemAwareElement` | `ItemDefinition` | attr (ref) | 0..1 |
+| `dataState` | `ItemAwareElement` | `DataState` | child elem | 0..1 |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### DataInputAssociation
+
+**Type hierarchy:** `DataInputAssociation → DataAssociation → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `sourceRef` | `DataAssociation` | `ItemAwareElement` | child elem (ref) | 0..* |
+| `targetRef` | `DataAssociation` | `ItemAwareElement` | child elem (ref) | 0..1 |
+| `transformation` | `DataAssociation` | `FormalExpression` | child elem | 0..1 |
+| `assignment` | `DataAssociation` | `Assignment` | child elem | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### DataOutputAssociation
+
+**Type hierarchy:** `DataOutputAssociation → DataAssociation → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `sourceRef` | `DataAssociation` | `ItemAwareElement` | child elem (ref) | 0..* |
+| `targetRef` | `DataAssociation` | `ItemAwareElement` | child elem (ref) | 0..1 |
+| `transformation` | `DataAssociation` | `FormalExpression` | child elem | 0..1 |
+| `assignment` | `DataAssociation` | `Assignment` | child elem | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### DataAssociation
+
+**Type hierarchy:** `DataAssociation → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `sourceRef` | `ItemAwareElement` | child elem (ref) | 0..* |  |
+| `targetRef` | `ItemAwareElement` | child elem (ref) | 0..1 |  |
+| `transformation` | `FormalExpression` | child elem | 0..1 |  |
+| `assignment` | `Assignment` | child elem | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### InputSet
+
+**Type hierarchy:** `InputSet → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `dataInputRefs` | `DataInput` | child elem (ref) | 0..* |  |
+| `optionalInputRefs` | `DataInput` | child elem (ref) | 0..* |  |
+| `whileExecutingInputRefs` | `DataInput` | child elem (ref) | 0..* |  |
+| `outputSetRefs` | `OutputSet` | child elem (ref) | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### OutputSet
+
+**Type hierarchy:** `OutputSet → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `dataOutputRefs` | `DataOutput` | child elem (ref) | 0..* |  |
+| `name` | `String` | attr | 0..1 |  |
+| `inputSetRefs` | `InputSet` | child elem (ref) | 0..* |  |
+| `optionalOutputRefs` | `DataOutput` | child elem (ref) | 0..* |  |
+| `whileExecutingOutputRefs` | `DataOutput` | child elem (ref) | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### InputOutputSpecification
+
+**Type hierarchy:** `InputOutputSpecification → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `dataInputs` | `DataInput` | child elem | 0..* |  |
+| `dataOutputs` | `DataOutput` | child elem | 0..* |  |
+| `inputSets` | `InputSet` | child elem | 0..* |  |
+| `outputSets` | `OutputSet` | child elem | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### InputOutputBinding
+
+**Type hierarchy:** `InputOutputBinding`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `inputDataRef` | `InputSet` | attr (ref) | 0..1 |  |
+| `outputDataRef` | `OutputSet` | attr (ref) | 0..1 |  |
+| `operationRef` | `Operation` | attr (ref) | 0..1 |  |
+
+---
+
+### Assignment
+
+**Type hierarchy:** `Assignment → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `from` | `Expression` | child elem | 0..1 |  |
+| `to` | `Expression` | child elem | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### DataState
+
+**Type hierarchy:** `DataState → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---

--- a/docs/bpmn-spec/elements/event-definitions.md
+++ b/docs/bpmn-spec/elements/event-definitions.md
@@ -1,0 +1,318 @@
+# Event Definitions
+
+_Structural metamodel for **Event Definitions** elements, extracted from bpmn-moddle. In-scope per [../conformance.md](../conformance.md)._
+
+_Kind legend: `attr` = XML attribute, `child elem` = XML child element, `(ref)` = ID reference to another element rather than embedded._
+
+---
+
+### EventDefinition
+
+_Abstract type._
+
+**Type hierarchy:** `EventDefinition → RootElement → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### MessageEventDefinition
+
+**Type hierarchy:** `MessageEventDefinition → EventDefinition → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `messageRef` | `Message` | attr (ref) | 0..1 |  |
+| `operationRef` | `Operation` | child elem (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### TimerEventDefinition
+
+**Type hierarchy:** `TimerEventDefinition → EventDefinition → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `timeDate` | `Expression` | child elem | 0..1 |  |
+| `timeCycle` | `Expression` | child elem | 0..1 |  |
+| `timeDuration` | `Expression` | child elem | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### SignalEventDefinition
+
+**Type hierarchy:** `SignalEventDefinition → EventDefinition → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `signalRef` | `Signal` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ErrorEventDefinition
+
+**Type hierarchy:** `ErrorEventDefinition → EventDefinition → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `errorRef` | `Error` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### EscalationEventDefinition
+
+**Type hierarchy:** `EscalationEventDefinition → EventDefinition → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `escalationRef` | `Escalation` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### CompensateEventDefinition
+
+**Type hierarchy:** `CompensateEventDefinition → EventDefinition → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `waitForCompletion` | `Boolean` | attr | 0..1 | default `True` |
+| `activityRef` | `Activity` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### CancelEventDefinition
+
+**Type hierarchy:** `CancelEventDefinition → EventDefinition → RootElement → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ConditionalEventDefinition
+
+**Type hierarchy:** `ConditionalEventDefinition → EventDefinition → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `condition` | `Expression` | child elem | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### LinkEventDefinition
+
+**Type hierarchy:** `LinkEventDefinition → EventDefinition → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `target` | `LinkEventDefinition` | child elem (ref) | 0..1 |  |
+| `source` | `LinkEventDefinition` | child elem (ref) | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### TerminateEventDefinition
+
+**Type hierarchy:** `TerminateEventDefinition → EventDefinition → RootElement → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Message
+
+**Type hierarchy:** `Message → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `itemRef` | `ItemDefinition` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Signal
+
+**Type hierarchy:** `Signal → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `structureRef` | `ItemDefinition` | attr (ref) | 0..1 |  |
+| `name` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Error
+
+**Type hierarchy:** `Error → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `structureRef` | `ItemDefinition` | attr (ref) | 0..1 |  |
+| `name` | `String` | attr | 0..1 |  |
+| `errorCode` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Escalation
+
+**Type hierarchy:** `Escalation → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `structureRef` | `ItemDefinition` | attr (ref) | 0..1 |  |
+| `name` | `String` | attr | 0..1 |  |
+| `escalationCode` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---

--- a/docs/bpmn-spec/elements/events.md
+++ b/docs/bpmn-spec/elements/events.md
@@ -1,0 +1,310 @@
+# Events
+
+_Structural metamodel for **Events** elements, extracted from bpmn-moddle. In-scope per [../conformance.md](../conformance.md)._
+
+_Kind legend: `attr` = XML attribute, `child elem` = XML child element, `(ref)` = ID reference to another element rather than embedded._
+
+---
+
+### Event
+
+_Abstract type._
+
+**Type hierarchy:** `Event → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `properties` | `Property` | child elem | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### CatchEvent
+
+_Abstract type._
+
+**Type hierarchy:** `CatchEvent → Event → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `parallelMultiple` | `Boolean` | attr | 0..1 | default `False` |
+| `dataOutputs` | `DataOutput` | child elem | 0..* |  |
+| `dataOutputAssociations` | `DataOutputAssociation` | child elem | 0..* |  |
+| `outputSet` | `OutputSet` | child elem | 0..1 |  |
+| `eventDefinitions` | `EventDefinition` | child elem | 0..* |  |
+| `eventDefinitionRef` | `EventDefinition` | child elem (ref) | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `properties` | `Event` | `Property` | child elem | 0..* |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### ThrowEvent
+
+_Abstract type._
+
+**Type hierarchy:** `ThrowEvent → Event → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `dataInputs` | `DataInput` | child elem | 0..* |  |
+| `dataInputAssociations` | `DataInputAssociation` | child elem | 0..* |  |
+| `inputSet` | `InputSet` | child elem | 0..1 |  |
+| `eventDefinitions` | `EventDefinition` | child elem | 0..* |  |
+| `eventDefinitionRef` | `EventDefinition` | child elem (ref) | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `properties` | `Event` | `Property` | child elem | 0..* |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### StartEvent
+
+**Type hierarchy:** `StartEvent → CatchEvent → Event → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `isInterrupting` | `Boolean` | attr | 0..1 | default `True` |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `parallelMultiple` | `CatchEvent` | `Boolean` | attr | 0..1 |
+| `dataOutputs` | `CatchEvent` | `DataOutput` | child elem | 0..* |
+| `dataOutputAssociations` | `CatchEvent` | `DataOutputAssociation` | child elem | 0..* |
+| `outputSet` | `CatchEvent` | `OutputSet` | child elem | 0..1 |
+| `eventDefinitions` | `CatchEvent` | `EventDefinition` | child elem | 0..* |
+| `eventDefinitionRef` | `CatchEvent` | `EventDefinition` | child elem (ref) | 0..* |
+| `properties` | `Event` | `Property` | child elem | 0..* |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### IntermediateCatchEvent
+
+**Type hierarchy:** `IntermediateCatchEvent → CatchEvent → Event → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `parallelMultiple` | `CatchEvent` | `Boolean` | attr | 0..1 |
+| `dataOutputs` | `CatchEvent` | `DataOutput` | child elem | 0..* |
+| `dataOutputAssociations` | `CatchEvent` | `DataOutputAssociation` | child elem | 0..* |
+| `outputSet` | `CatchEvent` | `OutputSet` | child elem | 0..1 |
+| `eventDefinitions` | `CatchEvent` | `EventDefinition` | child elem | 0..* |
+| `eventDefinitionRef` | `CatchEvent` | `EventDefinition` | child elem (ref) | 0..* |
+| `properties` | `Event` | `Property` | child elem | 0..* |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### IntermediateThrowEvent
+
+**Type hierarchy:** `IntermediateThrowEvent → ThrowEvent → Event → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `dataInputs` | `ThrowEvent` | `DataInput` | child elem | 0..* |
+| `dataInputAssociations` | `ThrowEvent` | `DataInputAssociation` | child elem | 0..* |
+| `inputSet` | `ThrowEvent` | `InputSet` | child elem | 0..1 |
+| `eventDefinitions` | `ThrowEvent` | `EventDefinition` | child elem | 0..* |
+| `eventDefinitionRef` | `ThrowEvent` | `EventDefinition` | child elem (ref) | 0..* |
+| `properties` | `Event` | `Property` | child elem | 0..* |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### EndEvent
+
+**Type hierarchy:** `EndEvent → ThrowEvent → Event → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `dataInputs` | `ThrowEvent` | `DataInput` | child elem | 0..* |
+| `dataInputAssociations` | `ThrowEvent` | `DataInputAssociation` | child elem | 0..* |
+| `inputSet` | `ThrowEvent` | `InputSet` | child elem | 0..1 |
+| `eventDefinitions` | `ThrowEvent` | `EventDefinition` | child elem | 0..* |
+| `eventDefinitionRef` | `ThrowEvent` | `EventDefinition` | child elem (ref) | 0..* |
+| `properties` | `Event` | `Property` | child elem | 0..* |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### BoundaryEvent
+
+**Type hierarchy:** `BoundaryEvent → CatchEvent → Event → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `cancelActivity` | `Boolean` | attr | 0..1 | default `True` |
+| `attachedToRef` | `Activity` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `parallelMultiple` | `CatchEvent` | `Boolean` | attr | 0..1 |
+| `dataOutputs` | `CatchEvent` | `DataOutput` | child elem | 0..* |
+| `dataOutputAssociations` | `CatchEvent` | `DataOutputAssociation` | child elem | 0..* |
+| `outputSet` | `CatchEvent` | `OutputSet` | child elem | 0..1 |
+| `eventDefinitions` | `CatchEvent` | `EventDefinition` | child elem | 0..* |
+| `eventDefinitionRef` | `CatchEvent` | `EventDefinition` | child elem (ref) | 0..* |
+| `properties` | `Event` | `Property` | child elem | 0..* |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---
+
+### ImplicitThrowEvent
+
+**Type hierarchy:** `ImplicitThrowEvent → ThrowEvent → Event → FlowNode → FlowElement → BaseElement → InteractionNode`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `dataInputs` | `ThrowEvent` | `DataInput` | child elem | 0..* |
+| `dataInputAssociations` | `ThrowEvent` | `DataInputAssociation` | child elem | 0..* |
+| `inputSet` | `ThrowEvent` | `InputSet` | child elem | 0..1 |
+| `eventDefinitions` | `ThrowEvent` | `EventDefinition` | child elem | 0..* |
+| `eventDefinitionRef` | `ThrowEvent` | `EventDefinition` | child elem (ref) | 0..* |
+| `properties` | `Event` | `Property` | child elem | 0..* |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `incomingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+| `outgoingConversationLinks` | `InteractionNode` | `ConversationLink` | child elem (ref) | 0..* |
+
+---

--- a/docs/bpmn-spec/elements/flows.md
+++ b/docs/bpmn-spec/elements/flows.md
@@ -1,0 +1,58 @@
+# Flows
+
+_Structural metamodel for **Flows** elements, extracted from bpmn-moddle. In-scope per [../conformance.md](../conformance.md)._
+
+_Kind legend: `attr` = XML attribute, `child elem` = XML child element, `(ref)` = ID reference to another element rather than embedded._
+
+---
+
+### SequenceFlow
+
+**Type hierarchy:** `SequenceFlow → FlowElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `isImmediate` | `Boolean` | attr | 0..1 |  |
+| `conditionExpression` | `Expression` | child elem | 0..1 |  |
+| `sourceRef` | `FlowNode` | attr (ref) | 0..1 |  |
+| `targetRef` | `FlowNode` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Association
+
+**Type hierarchy:** `Association → Artifact → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `associationDirection` | `AssociationDirection` | attr | 0..1 |  |
+| `sourceRef` | `BaseElement` | attr (ref) | 0..1 |  |
+| `targetRef` | `BaseElement` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---

--- a/docs/bpmn-spec/elements/foundation.md
+++ b/docs/bpmn-spec/elements/foundation.md
@@ -1,0 +1,388 @@
+# Foundation
+
+_Structural metamodel for **Foundation** elements, extracted from bpmn-moddle. In-scope per [../conformance.md](../conformance.md)._
+
+_Kind legend: `attr` = XML attribute, `child elem` = XML child element, `(ref)` = ID reference to another element rather than embedded._
+
+---
+
+### Definitions
+
+**Type hierarchy:** `Definitions → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `targetNamespace` | `String` | attr | 0..1 |  |
+| `expressionLanguage` | `String` | attr | 0..1 | default `http://www.w3.org/1999/XPath` |
+| `typeLanguage` | `String` | attr | 0..1 | default `http://www.w3.org/2001/XMLSchema` |
+| `imports` | `Import` | child elem | 0..* |  |
+| `extensions` | `Extension` | child elem | 0..* |  |
+| `rootElements` | `RootElement` | child elem | 0..* |  |
+| `diagrams` | `bpmndi:BPMNDiagram` | child elem | 0..* |  |
+| `exporter` | `String` | attr | 0..1 |  |
+| `relationships` | `Relationship` | child elem | 0..* |  |
+| `exporterVersion` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### BaseElement
+
+_Abstract type._
+
+**Type hierarchy:** `BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `id` | `String` | attr | 0..1 | id |
+| `documentation` | `Documentation` | child elem | 0..* |  |
+| `extensionDefinitions` | `ExtensionDefinition` | child elem (ref) | 0..* |  |
+| `extensionElements` | `ExtensionElements` | child elem | 0..1 |  |
+
+---
+
+### RootElement
+
+_Abstract type._
+
+**Type hierarchy:** `RootElement → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### FlowElement
+
+_Abstract type._
+
+**Type hierarchy:** `FlowElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `auditing` | `Auditing` | child elem | 0..1 |  |
+| `monitoring` | `Monitoring` | child elem | 0..1 |  |
+| `categoryValueRef` | `CategoryValue` | child elem (ref) | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### FlowNode
+
+_Abstract type._
+
+**Type hierarchy:** `FlowNode → FlowElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `incoming` | `SequenceFlow` | child elem (ref) | 0..* |  |
+| `outgoing` | `SequenceFlow` | child elem (ref) | 0..* |  |
+| `lanes` | `Lane` | child elem (ref) | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### FlowElementsContainer
+
+_Abstract type._
+
+**Type hierarchy:** `FlowElementsContainer → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `laneSets` | `LaneSet` | child elem | 0..* |  |
+| `flowElements` | `FlowElement` | child elem | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### CallableElement
+
+_Abstract type._
+
+**Type hierarchy:** `CallableElement → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `ioSpecification` | `InputOutputSpecification` | child elem | 0..1 |  |
+| `supportedInterfaceRef` | `Interface` | child elem (ref) | 0..* |  |
+| `ioBinding` | `InputOutputBinding` | child elem | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ItemAwareElement
+
+**Type hierarchy:** `ItemAwareElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `itemSubjectRef` | `ItemDefinition` | attr (ref) | 0..1 |  |
+| `dataState` | `DataState` | child elem | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ItemDefinition
+
+**Type hierarchy:** `ItemDefinition → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `itemKind` | `ItemKind` | attr | 0..1 |  |
+| `structureRef` | `String` | attr | 0..1 |  |
+| `isCollection` | `Boolean` | attr | 0..1 | default `False` |
+| `import` | `Import` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Expression
+
+**Type hierarchy:** `Expression → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `body` | `String` | child elem | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### FormalExpression
+
+**Type hierarchy:** `FormalExpression → Expression → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `language` | `String` | attr | 0..1 |  |
+| `evaluatesToTypeRef` | `ItemDefinition` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `body` | `Expression` | `String` | child elem | 0..1 |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Documentation
+
+**Type hierarchy:** `Documentation → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `text` | `String` | child elem | 0..1 |  |
+| `textFormat` | `String` | attr | 0..1 | default `text/plain` |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Extension
+
+**Type hierarchy:** `Extension`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `mustUnderstand` | `Boolean` | attr | 0..1 | default `False` |
+| `definition` | `ExtensionDefinition` | attr (ref) | 0..1 |  |
+
+---
+
+### ExtensionDefinition
+
+**Type hierarchy:** `ExtensionDefinition`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `extensionAttributeDefinitions` | `ExtensionAttributeDefinition` | child elem | 0..* |  |
+
+---
+
+### ExtensionAttributeDefinition
+
+**Type hierarchy:** `ExtensionAttributeDefinition`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `type` | `String` | attr | 0..1 |  |
+| `isReference` | `Boolean` | attr | 0..1 | default `False` |
+| `extensionDefinition` | `ExtensionDefinition` | attr (ref) | 0..1 |  |
+
+---
+
+### ExtensionElements
+
+**Type hierarchy:** `ExtensionElements`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `valueRef` | `Element` | attr (ref) | 0..1 |  |
+| `values` | `Element` | child elem | 0..* |  |
+| `extensionAttributeDefinition` | `ExtensionAttributeDefinition` | attr (ref) | 0..1 |  |
+
+---
+
+### Import
+
+**Type hierarchy:** `Import`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `importType` | `String` | attr | 0..1 |  |
+| `location` | `String` | attr | 0..1 |  |
+| `namespace` | `String` | attr | 0..1 |  |
+
+---
+
+### Auditing
+
+**Type hierarchy:** `Auditing → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Monitoring
+
+**Type hierarchy:** `Monitoring → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---

--- a/docs/bpmn-spec/elements/gateways.md
+++ b/docs/bpmn-spec/elements/gateways.md
@@ -1,0 +1,178 @@
+# Gateways
+
+_Structural metamodel for **Gateways** elements, extracted from bpmn-moddle. In-scope per [../conformance.md](../conformance.md)._
+
+_Kind legend: `attr` = XML attribute, `child elem` = XML child element, `(ref)` = ID reference to another element rather than embedded._
+
+---
+
+### Gateway
+
+_Abstract type._
+
+**Type hierarchy:** `Gateway → FlowNode → FlowElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `gatewayDirection` | `GatewayDirection` | attr | 0..1 | default `Unspecified` |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ExclusiveGateway
+
+**Type hierarchy:** `ExclusiveGateway → Gateway → FlowNode → FlowElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `default` | `SequenceFlow` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `gatewayDirection` | `Gateway` | `GatewayDirection` | attr | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ParallelGateway
+
+**Type hierarchy:** `ParallelGateway → Gateway → FlowNode → FlowElement → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `gatewayDirection` | `Gateway` | `GatewayDirection` | attr | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### InclusiveGateway
+
+**Type hierarchy:** `InclusiveGateway → Gateway → FlowNode → FlowElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `default` | `SequenceFlow` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `gatewayDirection` | `Gateway` | `GatewayDirection` | attr | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### EventBasedGateway
+
+**Type hierarchy:** `EventBasedGateway → Gateway → FlowNode → FlowElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `instantiate` | `Boolean` | attr | 0..1 | default `False` |
+| `eventGatewayType` | `EventBasedGatewayType` | attr | 0..1 | default `Exclusive` |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `gatewayDirection` | `Gateway` | `GatewayDirection` | attr | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ComplexGateway
+
+**Type hierarchy:** `ComplexGateway → Gateway → FlowNode → FlowElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `activationCondition` | `Expression` | child elem | 0..1 |  |
+| `default` | `SequenceFlow` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `gatewayDirection` | `Gateway` | `GatewayDirection` | attr | 0..1 |
+| `incoming` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `outgoing` | `FlowNode` | `SequenceFlow` | child elem (ref) | 0..* |
+| `lanes` | `FlowNode` | `Lane` | child elem (ref) | 0..* |
+| `name` | `FlowElement` | `String` | attr | 0..1 |
+| `auditing` | `FlowElement` | `Auditing` | child elem | 0..1 |
+| `monitoring` | `FlowElement` | `Monitoring` | child elem | 0..1 |
+| `categoryValueRef` | `FlowElement` | `CategoryValue` | child elem (ref) | 0..* |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---

--- a/docs/bpmn-spec/elements/human-interaction.md
+++ b/docs/bpmn-spec/elements/human-interaction.md
@@ -1,0 +1,191 @@
+# Human Interaction
+
+_Structural metamodel for **Human Interaction** elements, extracted from bpmn-moddle. In-scope per [../conformance.md](../conformance.md)._
+
+_Kind legend: `attr` = XML attribute, `child elem` = XML child element, `(ref)` = ID reference to another element rather than embedded._
+
+---
+
+### HumanPerformer
+
+**Type hierarchy:** `HumanPerformer → Performer → ResourceRole → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `resourceRef` | `ResourceRole` | `Resource` | child elem (ref) | 0..1 |
+| `resourceParameterBindings` | `ResourceRole` | `ResourceParameterBinding` | child elem | 0..* |
+| `resourceAssignmentExpression` | `ResourceRole` | `ResourceAssignmentExpression` | child elem | 0..1 |
+| `name` | `ResourceRole` | `String` | attr | 0..1 |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### PotentialOwner
+
+**Type hierarchy:** `PotentialOwner → HumanPerformer → Performer → ResourceRole → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `resourceRef` | `ResourceRole` | `Resource` | child elem (ref) | 0..1 |
+| `resourceParameterBindings` | `ResourceRole` | `ResourceParameterBinding` | child elem | 0..* |
+| `resourceAssignmentExpression` | `ResourceRole` | `ResourceAssignmentExpression` | child elem | 0..1 |
+| `name` | `ResourceRole` | `String` | attr | 0..1 |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Performer
+
+**Type hierarchy:** `Performer → ResourceRole → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `resourceRef` | `ResourceRole` | `Resource` | child elem (ref) | 0..1 |
+| `resourceParameterBindings` | `ResourceRole` | `ResourceParameterBinding` | child elem | 0..* |
+| `resourceAssignmentExpression` | `ResourceRole` | `ResourceAssignmentExpression` | child elem | 0..1 |
+| `name` | `ResourceRole` | `String` | attr | 0..1 |
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Rendering
+
+**Type hierarchy:** `Rendering → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Resource
+
+**Type hierarchy:** `Resource → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `resourceParameters` | `ResourceParameter` | child elem | 0..* |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ResourceRole
+
+**Type hierarchy:** `ResourceRole → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `resourceRef` | `Resource` | child elem (ref) | 0..1 |  |
+| `resourceParameterBindings` | `ResourceParameterBinding` | child elem | 0..* |  |
+| `resourceAssignmentExpression` | `ResourceAssignmentExpression` | child elem | 0..1 |  |
+| `name` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ResourceParameter
+
+**Type hierarchy:** `ResourceParameter → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `isRequired` | `Boolean` | attr | 0..1 |  |
+| `type` | `ItemDefinition` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ResourceParameterBinding
+
+**Type hierarchy:** `ResourceParameterBinding → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `expression` | `Expression` | child elem | 0..1 |  |
+| `parameterRef` | `ResourceParameter` | attr (ref) | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### ResourceAssignmentExpression
+
+**Type hierarchy:** `ResourceAssignmentExpression → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `expression` | `Expression` | child elem | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---

--- a/docs/bpmn-spec/elements/process.md
+++ b/docs/bpmn-spec/elements/process.md
@@ -1,0 +1,91 @@
+# Process / Container
+
+_Structural metamodel for **Process / Container** elements, extracted from bpmn-moddle. In-scope per [../conformance.md](../conformance.md)._
+
+_Kind legend: `attr` = XML attribute, `child elem` = XML child element, `(ref)` = ID reference to another element rather than embedded._
+
+---
+
+### Process
+
+**Type hierarchy:** `Process → FlowElementsContainer → BaseElement → CallableElement → RootElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `processType` | `ProcessType` | attr | 0..1 |  |
+| `isClosed` | `Boolean` | attr | 0..1 |  |
+| `auditing` | `Auditing` | child elem | 0..1 |  |
+| `monitoring` | `Monitoring` | child elem | 0..1 |  |
+| `properties` | `Property` | child elem | 0..* |  |
+| `laneSets` | `LaneSet` | child elem | 0..* | replaces `FlowElementsContainer#laneSets` |
+| `flowElements` | `FlowElement` | child elem | 0..* | replaces `FlowElementsContainer#flowElements` |
+| `artifacts` | `Artifact` | child elem | 0..* |  |
+| `resources` | `ResourceRole` | child elem | 0..* |  |
+| `correlationSubscriptions` | `CorrelationSubscription` | child elem | 0..* |  |
+| `supports` | `Process` | child elem (ref) | 0..* |  |
+| `definitionalCollaborationRef` | `Collaboration` | attr (ref) | 0..1 |  |
+| `isExecutable` | `Boolean` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+| `name` | `CallableElement` | `String` | attr | 0..1 |
+| `ioSpecification` | `CallableElement` | `InputOutputSpecification` | child elem | 0..1 |
+| `supportedInterfaceRef` | `CallableElement` | `Interface` | child elem (ref) | 0..* |
+| `ioBinding` | `CallableElement` | `InputOutputBinding` | child elem | 0..* |
+
+---
+
+### Lane
+
+**Type hierarchy:** `Lane → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `partitionElementRef` | `BaseElement` | attr (ref) | 0..1 |  |
+| `partitionElement` | `BaseElement` | child elem | 0..1 |  |
+| `flowNodeRef` | `FlowNode` | child elem (ref) | 0..* |  |
+| `childLaneSet` | `LaneSet` | child elem | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### LaneSet
+
+**Type hierarchy:** `LaneSet → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `lanes` | `Lane` | child elem | 0..* |  |
+| `name` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---

--- a/docs/bpmn-spec/elements/service-interfaces.md
+++ b/docs/bpmn-spec/elements/service-interfaces.md
@@ -1,0 +1,70 @@
+# Service Interfaces
+
+_Structural metamodel for **Service Interfaces** elements, extracted from bpmn-moddle. In-scope per [../conformance.md](../conformance.md)._
+
+_Kind legend: `attr` = XML attribute, `child elem` = XML child element, `(ref)` = ID reference to another element rather than embedded._
+
+---
+
+### Interface
+
+**Type hierarchy:** `Interface → RootElement → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `operations` | `Operation` | child elem | 0..* |  |
+| `implementationRef` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### Operation
+
+**Type hierarchy:** `Operation → BaseElement`
+
+**Own properties:**
+
+| Name | Type | Kind | Card | Notes |
+|---|---|---|---|---|
+| `name` | `String` | attr | 0..1 |  |
+| `inMessageRef` | `Message` | child elem (ref) | 0..1 |  |
+| `outMessageRef` | `Message` | child elem (ref) | 0..1 |  |
+| `errorRef` | `Error` | child elem (ref) | 0..* |  |
+| `implementationRef` | `String` | attr | 0..1 |  |
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---
+
+### EndPoint
+
+**Type hierarchy:** `EndPoint → RootElement → BaseElement`
+
+**Inherited properties** (see ancestor pages for details):
+
+| Name | From | Type | Kind | Card |
+|---|---|---|---|---|
+| `id` | `BaseElement` | `String` | attr | 0..1 |
+| `documentation` | `BaseElement` | `Documentation` | child elem | 0..* |
+| `extensionDefinitions` | `BaseElement` | `ExtensionDefinition` | child elem (ref) | 0..* |
+| `extensionElements` | `BaseElement` | `ExtensionElements` | child elem | 0..1 |
+
+---

--- a/docs/bpmn-spec/index.md
+++ b/docs/bpmn-spec/index.md
@@ -1,0 +1,24 @@
+# BPMN 2.0 KB
+
+Reference extracted from OMG BPMN 2.0 spec, scoped to **Process Execution Conformance** (the subclass `gobpm` targets).
+
+**Sources:**
+- Spec PDF: `../../docs/BPMN formal-13-12-09.pdf` (OMG formal/2013-12-09, v2.0.2 with errata) — semantics, normative claims
+- bpmn-moddle: `github.com/bpmn-io/bpmn-moddle` `resources/bpmn/json/bpmn.json` — structural metamodel
+- OMG XSD: tiebreaker for compliance edge cases
+
+**Layout:**
+
+| Path | Content |
+|---|---|
+| [conformance.md](conformance.md) | In/out element list per §2.1.2 |
+| [elements/](elements/) | Structural metamodel — attributes, associations, type hierarchy. 11 files by category |
+| [state-machines/](state-machines/) | Activity + Process lifecycles from §13 |
+| [semantics/](semantics/) | Token-flow, per-task behavior, sub-process variants, MI/Loop, compensation, events, end-events, data, correlation, event-handling |
+| [scripts/](scripts/) | `gen.py` regenerates `elements/*.md` from cached `bpmn-moddle.json` |
+
+Snapshot, not continuously updated. Regenerate `elements/` via `python3 scripts/gen.py` after updating `scripts/bpmn-moddle.json`. State-machines and semantics are authored from the spec PDF — manual update only.
+
+## Gaps
+
+_None currently. The §10.5–§13 execution-semantics core is covered. Further detail would come from §10.3.4 Human Interactions (UserTask form mapping), §10.4.3 XPath bindings (only relevant if engine targets XPath as `expressionLanguage`), and §10.6 Gateways (notation-level; structural and execution coverage already done)._

--- a/docs/bpmn-spec/scripts/bpmn-moddle.json
+++ b/docs/bpmn-spec/scripts/bpmn-moddle.json
@@ -1,0 +1,2957 @@
+{
+  "name": "BPMN20",
+  "uri": "http://www.omg.org/spec/BPMN/20100524/MODEL",
+  "prefix": "bpmn",
+  "associations": [],
+  "types": [
+    {
+      "name": "Interface",
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "operations",
+          "type": "Operation",
+          "isMany": true
+        },
+        {
+          "name": "implementationRef",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Operation",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "inMessageRef",
+          "type": "Message",
+          "isReference": true
+        },
+        {
+          "name": "outMessageRef",
+          "type": "Message",
+          "isReference": true
+        },
+        {
+          "name": "errorRef",
+          "type": "Error",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "implementationRef",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "EndPoint",
+      "superClass": [
+        "RootElement"
+      ]
+    },
+    {
+      "name": "Auditing",
+      "superClass": [
+        "BaseElement"
+      ]
+    },
+    {
+      "name": "GlobalTask",
+      "superClass": [
+        "CallableElement"
+      ],
+      "properties": [
+        {
+          "name": "resources",
+          "type": "ResourceRole",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "Monitoring",
+      "superClass": [
+        "BaseElement"
+      ]
+    },
+    {
+      "name": "Performer",
+      "superClass": [
+        "ResourceRole"
+      ]
+    },
+    {
+      "name": "Process",
+      "superClass": [
+        "FlowElementsContainer",
+        "CallableElement"
+      ],
+      "properties": [
+        {
+          "name": "processType",
+          "type": "ProcessType",
+          "isAttr": true
+        },
+        {
+          "name": "isClosed",
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "auditing",
+          "type": "Auditing"
+        },
+        {
+          "name": "monitoring",
+          "type": "Monitoring"
+        },
+        {
+          "name": "properties",
+          "type": "Property",
+          "isMany": true
+        },
+        {
+          "name": "laneSets",
+          "isMany": true,
+          "replaces": "FlowElementsContainer#laneSets",
+          "type": "LaneSet"
+        },
+        {
+          "name": "flowElements",
+          "isMany": true,
+          "replaces": "FlowElementsContainer#flowElements",
+          "type": "FlowElement"
+        },
+        {
+          "name": "artifacts",
+          "type": "Artifact",
+          "isMany": true
+        },
+        {
+          "name": "resources",
+          "type": "ResourceRole",
+          "isMany": true
+        },
+        {
+          "name": "correlationSubscriptions",
+          "type": "CorrelationSubscription",
+          "isMany": true
+        },
+        {
+          "name": "supports",
+          "type": "Process",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "definitionalCollaborationRef",
+          "type": "Collaboration",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "isExecutable",
+          "isAttr": true,
+          "type": "Boolean"
+        }
+      ]
+    },
+    {
+      "name": "LaneSet",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "lanes",
+          "type": "Lane",
+          "isMany": true
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Lane",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "partitionElementRef",
+          "type": "BaseElement",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "partitionElement",
+          "type": "BaseElement"
+        },
+        {
+          "name": "flowNodeRef",
+          "type": "FlowNode",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "childLaneSet",
+          "type": "LaneSet",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        }
+      ]
+    },
+    {
+      "name": "GlobalManualTask",
+      "superClass": [
+        "GlobalTask"
+      ]
+    },
+    {
+      "name": "ManualTask",
+      "superClass": [
+        "Task"
+      ]
+    },
+    {
+      "name": "UserTask",
+      "superClass": [
+        "Task"
+      ],
+      "properties": [
+        {
+          "name": "renderings",
+          "type": "Rendering",
+          "isMany": true
+        },
+        {
+          "name": "implementation",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Rendering",
+      "superClass": [
+        "BaseElement"
+      ]
+    },
+    {
+      "name": "HumanPerformer",
+      "superClass": [
+        "Performer"
+      ]
+    },
+    {
+      "name": "PotentialOwner",
+      "superClass": [
+        "HumanPerformer"
+      ]
+    },
+    {
+      "name": "GlobalUserTask",
+      "superClass": [
+        "GlobalTask"
+      ],
+      "properties": [
+        {
+          "name": "implementation",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "renderings",
+          "type": "Rendering",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "Gateway",
+      "isAbstract": true,
+      "superClass": [
+        "FlowNode"
+      ],
+      "properties": [
+        {
+          "name": "gatewayDirection",
+          "type": "GatewayDirection",
+          "default": "Unspecified",
+          "isAttr": true
+        }
+      ]
+    },
+    {
+      "name": "EventBasedGateway",
+      "superClass": [
+        "Gateway"
+      ],
+      "properties": [
+        {
+          "name": "instantiate",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "eventGatewayType",
+          "type": "EventBasedGatewayType",
+          "isAttr": true,
+          "default": "Exclusive"
+        }
+      ]
+    },
+    {
+      "name": "ComplexGateway",
+      "superClass": [
+        "Gateway"
+      ],
+      "properties": [
+        {
+          "name": "activationCondition",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        },
+        {
+          "name": "default",
+          "type": "SequenceFlow",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "ExclusiveGateway",
+      "superClass": [
+        "Gateway"
+      ],
+      "properties": [
+        {
+          "name": "default",
+          "type": "SequenceFlow",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "InclusiveGateway",
+      "superClass": [
+        "Gateway"
+      ],
+      "properties": [
+        {
+          "name": "default",
+          "type": "SequenceFlow",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "ParallelGateway",
+      "superClass": [
+        "Gateway"
+      ]
+    },
+    {
+      "name": "RootElement",
+      "isAbstract": true,
+      "superClass": [
+        "BaseElement"
+      ]
+    },
+    {
+      "name": "Relationship",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "type",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "direction",
+          "type": "RelationshipDirection",
+          "isAttr": true
+        },
+        {
+          "name": "source",
+          "isMany": true,
+          "isReference": true,
+          "type": "Element"
+        },
+        {
+          "name": "target",
+          "isMany": true,
+          "isReference": true,
+          "type": "Element"
+        }
+      ]
+    },
+    {
+      "name": "BaseElement",
+      "isAbstract": true,
+      "properties": [
+        {
+          "name": "id",
+          "isAttr": true,
+          "type": "String",
+          "isId": true
+        },
+        {
+          "name": "documentation",
+          "type": "Documentation",
+          "isMany": true
+        },
+        {
+          "name": "extensionDefinitions",
+          "type": "ExtensionDefinition",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "extensionElements",
+          "type": "ExtensionElements"
+        }
+      ]
+    },
+    {
+      "name": "Extension",
+      "properties": [
+        {
+          "name": "mustUnderstand",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "definition",
+          "type": "ExtensionDefinition",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "ExtensionDefinition",
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "extensionAttributeDefinitions",
+          "type": "ExtensionAttributeDefinition",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "ExtensionAttributeDefinition",
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "isReference",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "extensionDefinition",
+          "type": "ExtensionDefinition",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "ExtensionElements",
+      "properties": [
+        {
+          "name": "valueRef",
+          "isAttr": true,
+          "isReference": true,
+          "type": "Element"
+        },
+        {
+          "name": "values",
+          "type": "Element",
+          "isMany": true
+        },
+        {
+          "name": "extensionAttributeDefinition",
+          "type": "ExtensionAttributeDefinition",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Documentation",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "text",
+          "type": "String",
+          "isBody": true
+        },
+        {
+          "name": "textFormat",
+          "default": "text/plain",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Event",
+      "isAbstract": true,
+      "superClass": [
+        "FlowNode",
+        "InteractionNode"
+      ],
+      "properties": [
+        {
+          "name": "properties",
+          "type": "Property",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "IntermediateCatchEvent",
+      "superClass": [
+        "CatchEvent"
+      ]
+    },
+    {
+      "name": "IntermediateThrowEvent",
+      "superClass": [
+        "ThrowEvent"
+      ]
+    },
+    {
+      "name": "EndEvent",
+      "superClass": [
+        "ThrowEvent"
+      ]
+    },
+    {
+      "name": "StartEvent",
+      "superClass": [
+        "CatchEvent"
+      ],
+      "properties": [
+        {
+          "name": "isInterrupting",
+          "default": true,
+          "isAttr": true,
+          "type": "Boolean"
+        }
+      ]
+    },
+    {
+      "name": "ThrowEvent",
+      "isAbstract": true,
+      "superClass": [
+        "Event"
+      ],
+      "properties": [
+        {
+          "name": "dataInputs",
+          "type": "DataInput",
+          "isMany": true
+        },
+        {
+          "name": "dataInputAssociations",
+          "type": "DataInputAssociation",
+          "isMany": true
+        },
+        {
+          "name": "inputSet",
+          "type": "InputSet"
+        },
+        {
+          "name": "eventDefinitions",
+          "type": "EventDefinition",
+          "isMany": true
+        },
+        {
+          "name": "eventDefinitionRef",
+          "type": "EventDefinition",
+          "isMany": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "CatchEvent",
+      "isAbstract": true,
+      "superClass": [
+        "Event"
+      ],
+      "properties": [
+        {
+          "name": "parallelMultiple",
+          "isAttr": true,
+          "type": "Boolean",
+          "default": false
+        },
+        {
+          "name": "dataOutputs",
+          "type": "DataOutput",
+          "isMany": true
+        },
+        {
+          "name": "dataOutputAssociations",
+          "type": "DataOutputAssociation",
+          "isMany": true
+        },
+        {
+          "name": "outputSet",
+          "type": "OutputSet"
+        },
+        {
+          "name": "eventDefinitions",
+          "type": "EventDefinition",
+          "isMany": true
+        },
+        {
+          "name": "eventDefinitionRef",
+          "type": "EventDefinition",
+          "isMany": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "BoundaryEvent",
+      "superClass": [
+        "CatchEvent"
+      ],
+      "properties": [
+        {
+          "name": "cancelActivity",
+          "default": true,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "attachedToRef",
+          "type": "Activity",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "EventDefinition",
+      "isAbstract": true,
+      "superClass": [
+        "RootElement"
+      ]
+    },
+    {
+      "name": "CancelEventDefinition",
+      "superClass": [
+        "EventDefinition"
+      ]
+    },
+    {
+      "name": "ErrorEventDefinition",
+      "superClass": [
+        "EventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "errorRef",
+          "type": "Error",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "TerminateEventDefinition",
+      "superClass": [
+        "EventDefinition"
+      ]
+    },
+    {
+      "name": "EscalationEventDefinition",
+      "superClass": [
+        "EventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "escalationRef",
+          "type": "Escalation",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Escalation",
+      "properties": [
+        {
+          "name": "structureRef",
+          "type": "ItemDefinition",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "escalationCode",
+          "isAttr": true,
+          "type": "String"
+        }
+      ],
+      "superClass": [
+        "RootElement"
+      ]
+    },
+    {
+      "name": "CompensateEventDefinition",
+      "superClass": [
+        "EventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "waitForCompletion",
+          "isAttr": true,
+          "type": "Boolean",
+          "default": true
+        },
+        {
+          "name": "activityRef",
+          "type": "Activity",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "TimerEventDefinition",
+      "superClass": [
+        "EventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "timeDate",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        },
+        {
+          "name": "timeCycle",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        },
+        {
+          "name": "timeDuration",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        }
+      ]
+    },
+    {
+      "name": "LinkEventDefinition",
+      "superClass": [
+        "EventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "target",
+          "type": "LinkEventDefinition",
+          "isReference": true
+        },
+        {
+          "name": "source",
+          "type": "LinkEventDefinition",
+          "isMany": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "MessageEventDefinition",
+      "superClass": [
+        "EventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "messageRef",
+          "type": "Message",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "operationRef",
+          "type": "Operation",
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "ConditionalEventDefinition",
+      "superClass": [
+        "EventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "condition",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        }
+      ]
+    },
+    {
+      "name": "SignalEventDefinition",
+      "superClass": [
+        "EventDefinition"
+      ],
+      "properties": [
+        {
+          "name": "signalRef",
+          "type": "Signal",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Signal",
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "structureRef",
+          "type": "ItemDefinition",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "ImplicitThrowEvent",
+      "superClass": [
+        "ThrowEvent"
+      ]
+    },
+    {
+      "name": "DataState",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "ItemAwareElement",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "itemSubjectRef",
+          "type": "ItemDefinition",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "dataState",
+          "type": "DataState"
+        }
+      ]
+    },
+    {
+      "name": "DataAssociation",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "sourceRef",
+          "type": "ItemAwareElement",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "targetRef",
+          "type": "ItemAwareElement",
+          "isReference": true
+        },
+        {
+          "name": "transformation",
+          "type": "FormalExpression",
+          "xml": {
+            "serialize": "property"
+          }
+        },
+        {
+          "name": "assignment",
+          "type": "Assignment",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "DataInput",
+      "superClass": [
+        "ItemAwareElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "isCollection",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "inputSetRef",
+          "type": "InputSet",
+          "isMany": true,
+          "isVirtual": true,
+          "isReference": true
+        },
+        {
+          "name": "inputSetWithOptional",
+          "type": "InputSet",
+          "isMany": true,
+          "isVirtual": true,
+          "isReference": true
+        },
+        {
+          "name": "inputSetWithWhileExecuting",
+          "type": "InputSet",
+          "isMany": true,
+          "isVirtual": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "DataOutput",
+      "superClass": [
+        "ItemAwareElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "isCollection",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "outputSetRef",
+          "type": "OutputSet",
+          "isMany": true,
+          "isVirtual": true,
+          "isReference": true
+        },
+        {
+          "name": "outputSetWithOptional",
+          "type": "OutputSet",
+          "isMany": true,
+          "isVirtual": true,
+          "isReference": true
+        },
+        {
+          "name": "outputSetWithWhileExecuting",
+          "type": "OutputSet",
+          "isMany": true,
+          "isVirtual": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "InputSet",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "dataInputRefs",
+          "type": "DataInput",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "optionalInputRefs",
+          "type": "DataInput",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "whileExecutingInputRefs",
+          "type": "DataInput",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "outputSetRefs",
+          "type": "OutputSet",
+          "isMany": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "OutputSet",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "dataOutputRefs",
+          "type": "DataOutput",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "inputSetRefs",
+          "type": "InputSet",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "optionalOutputRefs",
+          "type": "DataOutput",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "whileExecutingOutputRefs",
+          "type": "DataOutput",
+          "isMany": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Property",
+      "superClass": [
+        "ItemAwareElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "DataInputAssociation",
+      "superClass": [
+        "DataAssociation"
+      ]
+    },
+    {
+      "name": "DataOutputAssociation",
+      "superClass": [
+        "DataAssociation"
+      ]
+    },
+    {
+      "name": "InputOutputSpecification",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "dataInputs",
+          "type": "DataInput",
+          "isMany": true
+        },
+        {
+          "name": "dataOutputs",
+          "type": "DataOutput",
+          "isMany": true
+        },
+        {
+          "name": "inputSets",
+          "type": "InputSet",
+          "isMany": true
+        },
+        {
+          "name": "outputSets",
+          "type": "OutputSet",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "DataObject",
+      "superClass": [
+        "FlowElement",
+        "ItemAwareElement"
+      ],
+      "properties": [
+        {
+          "name": "isCollection",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        }
+      ]
+    },
+    {
+      "name": "InputOutputBinding",
+      "properties": [
+        {
+          "name": "inputDataRef",
+          "type": "InputSet",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "outputDataRef",
+          "type": "OutputSet",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "operationRef",
+          "type": "Operation",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Assignment",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "from",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        },
+        {
+          "name": "to",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        }
+      ]
+    },
+    {
+      "name": "DataStore",
+      "superClass": [
+        "RootElement",
+        "ItemAwareElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "capacity",
+          "isAttr": true,
+          "type": "Integer"
+        },
+        {
+          "name": "isUnlimited",
+          "default": true,
+          "isAttr": true,
+          "type": "Boolean"
+        }
+      ]
+    },
+    {
+      "name": "DataStoreReference",
+      "superClass": [
+        "ItemAwareElement",
+        "FlowElement"
+      ],
+      "properties": [
+        {
+          "name": "dataStoreRef",
+          "type": "DataStore",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "DataObjectReference",
+      "superClass": [
+        "ItemAwareElement",
+        "FlowElement"
+      ],
+      "properties": [
+        {
+          "name": "dataObjectRef",
+          "type": "DataObject",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "ConversationLink",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "sourceRef",
+          "type": "InteractionNode",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "targetRef",
+          "type": "InteractionNode",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "ConversationAssociation",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "innerConversationNodeRef",
+          "type": "ConversationNode",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "outerConversationNodeRef",
+          "type": "ConversationNode",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "CallConversation",
+      "superClass": [
+        "ConversationNode"
+      ],
+      "properties": [
+        {
+          "name": "calledCollaborationRef",
+          "type": "Collaboration",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "participantAssociations",
+          "type": "ParticipantAssociation",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "Conversation",
+      "superClass": [
+        "ConversationNode"
+      ]
+    },
+    {
+      "name": "SubConversation",
+      "superClass": [
+        "ConversationNode"
+      ],
+      "properties": [
+        {
+          "name": "conversationNodes",
+          "type": "ConversationNode",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "ConversationNode",
+      "isAbstract": true,
+      "superClass": [
+        "InteractionNode",
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "participantRef",
+          "type": "Participant",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "messageFlowRefs",
+          "type": "MessageFlow",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "correlationKeys",
+          "type": "CorrelationKey",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "GlobalConversation",
+      "superClass": [
+        "Collaboration"
+      ]
+    },
+    {
+      "name": "PartnerEntity",
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "participantRef",
+          "type": "Participant",
+          "isMany": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "PartnerRole",
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "participantRef",
+          "type": "Participant",
+          "isMany": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "CorrelationProperty",
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "correlationPropertyRetrievalExpression",
+          "type": "CorrelationPropertyRetrievalExpression",
+          "isMany": true
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "type": "ItemDefinition",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Error",
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "structureRef",
+          "type": "ItemDefinition",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "errorCode",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "CorrelationKey",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "correlationPropertyRef",
+          "type": "CorrelationProperty",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Expression",
+      "superClass": [
+        "BaseElement"
+      ],
+      "isAbstract": false,
+      "properties": [
+        {
+          "name": "body",
+          "isBody": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "FormalExpression",
+      "superClass": [
+        "Expression"
+      ],
+      "properties": [
+        {
+          "name": "language",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "evaluatesToTypeRef",
+          "type": "ItemDefinition",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Message",
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "itemRef",
+          "type": "ItemDefinition",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "ItemDefinition",
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "itemKind",
+          "type": "ItemKind",
+          "isAttr": true
+        },
+        {
+          "name": "structureRef",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "isCollection",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "import",
+          "type": "Import",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "FlowElement",
+      "isAbstract": true,
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "auditing",
+          "type": "Auditing"
+        },
+        {
+          "name": "monitoring",
+          "type": "Monitoring"
+        },
+        {
+          "name": "categoryValueRef",
+          "type": "CategoryValue",
+          "isMany": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "SequenceFlow",
+      "superClass": [
+        "FlowElement"
+      ],
+      "properties": [
+        {
+          "name": "isImmediate",
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "conditionExpression",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        },
+        {
+          "name": "sourceRef",
+          "type": "FlowNode",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "targetRef",
+          "type": "FlowNode",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "FlowElementsContainer",
+      "isAbstract": true,
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "laneSets",
+          "type": "LaneSet",
+          "isMany": true
+        },
+        {
+          "name": "flowElements",
+          "type": "FlowElement",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "CallableElement",
+      "isAbstract": true,
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "ioSpecification",
+          "type": "InputOutputSpecification",
+          "xml": {
+            "serialize": "property"
+          }
+        },
+        {
+          "name": "supportedInterfaceRef",
+          "type": "Interface",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "ioBinding",
+          "type": "InputOutputBinding",
+          "isMany": true,
+          "xml": {
+            "serialize": "property"
+          }
+        }
+      ]
+    },
+    {
+      "name": "FlowNode",
+      "isAbstract": true,
+      "superClass": [
+        "FlowElement"
+      ],
+      "properties": [
+        {
+          "name": "incoming",
+          "type": "SequenceFlow",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "outgoing",
+          "type": "SequenceFlow",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "lanes",
+          "type": "Lane",
+          "isMany": true,
+          "isVirtual": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "CorrelationPropertyRetrievalExpression",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "messagePath",
+          "type": "FormalExpression"
+        },
+        {
+          "name": "messageRef",
+          "type": "Message",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "CorrelationPropertyBinding",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "dataPath",
+          "type": "FormalExpression"
+        },
+        {
+          "name": "correlationPropertyRef",
+          "type": "CorrelationProperty",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Resource",
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "resourceParameters",
+          "type": "ResourceParameter",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "ResourceParameter",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "isRequired",
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "type",
+          "type": "ItemDefinition",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "CorrelationSubscription",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "correlationKeyRef",
+          "type": "CorrelationKey",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "correlationPropertyBinding",
+          "type": "CorrelationPropertyBinding",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "MessageFlow",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "sourceRef",
+          "type": "InteractionNode",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "targetRef",
+          "type": "InteractionNode",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "messageRef",
+          "type": "Message",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "MessageFlowAssociation",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "innerMessageFlowRef",
+          "type": "MessageFlow",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "outerMessageFlowRef",
+          "type": "MessageFlow",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "InteractionNode",
+      "isAbstract": true,
+      "properties": [
+        {
+          "name": "incomingConversationLinks",
+          "type": "ConversationLink",
+          "isMany": true,
+          "isVirtual": true,
+          "isReference": true
+        },
+        {
+          "name": "outgoingConversationLinks",
+          "type": "ConversationLink",
+          "isMany": true,
+          "isVirtual": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Participant",
+      "superClass": [
+        "InteractionNode",
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "interfaceRef",
+          "type": "Interface",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "participantMultiplicity",
+          "type": "ParticipantMultiplicity"
+        },
+        {
+          "name": "endPointRefs",
+          "type": "EndPoint",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "processRef",
+          "type": "Process",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "ParticipantAssociation",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "innerParticipantRef",
+          "type": "Participant",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "outerParticipantRef",
+          "type": "Participant",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "ParticipantMultiplicity",
+      "properties": [
+        {
+          "name": "minimum",
+          "default": 0,
+          "isAttr": true,
+          "type": "Integer"
+        },
+        {
+          "name": "maximum",
+          "default": 1,
+          "isAttr": true,
+          "type": "Integer"
+        }
+      ],
+      "superClass": [
+        "BaseElement"
+      ]
+    },
+    {
+      "name": "Collaboration",
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "isClosed",
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "participants",
+          "type": "Participant",
+          "isMany": true
+        },
+        {
+          "name": "messageFlows",
+          "type": "MessageFlow",
+          "isMany": true
+        },
+        {
+          "name": "artifacts",
+          "type": "Artifact",
+          "isMany": true
+        },
+        {
+          "name": "conversations",
+          "type": "ConversationNode",
+          "isMany": true
+        },
+        {
+          "name": "conversationAssociations",
+          "type": "ConversationAssociation"
+        },
+        {
+          "name": "participantAssociations",
+          "type": "ParticipantAssociation",
+          "isMany": true
+        },
+        {
+          "name": "messageFlowAssociations",
+          "type": "MessageFlowAssociation",
+          "isMany": true
+        },
+        {
+          "name": "correlationKeys",
+          "type": "CorrelationKey",
+          "isMany": true
+        },
+        {
+          "name": "choreographyRef",
+          "type": "Choreography",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "conversationLinks",
+          "type": "ConversationLink",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "ChoreographyActivity",
+      "isAbstract": true,
+      "superClass": [
+        "FlowNode"
+      ],
+      "properties": [
+        {
+          "name": "participantRef",
+          "type": "Participant",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "initiatingParticipantRef",
+          "type": "Participant",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "correlationKeys",
+          "type": "CorrelationKey",
+          "isMany": true
+        },
+        {
+          "name": "loopType",
+          "type": "ChoreographyLoopType",
+          "default": "None",
+          "isAttr": true
+        }
+      ]
+    },
+    {
+      "name": "CallChoreography",
+      "superClass": [
+        "ChoreographyActivity"
+      ],
+      "properties": [
+        {
+          "name": "calledChoreographyRef",
+          "type": "Choreography",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "participantAssociations",
+          "type": "ParticipantAssociation",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "SubChoreography",
+      "superClass": [
+        "ChoreographyActivity",
+        "FlowElementsContainer"
+      ],
+      "properties": [
+        {
+          "name": "artifacts",
+          "type": "Artifact",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "ChoreographyTask",
+      "superClass": [
+        "ChoreographyActivity"
+      ],
+      "properties": [
+        {
+          "name": "messageFlowRef",
+          "type": "MessageFlow",
+          "isMany": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Choreography",
+      "superClass": [
+        "Collaboration",
+        "FlowElementsContainer"
+      ]
+    },
+    {
+      "name": "GlobalChoreographyTask",
+      "superClass": [
+        "Choreography"
+      ],
+      "properties": [
+        {
+          "name": "initiatingParticipantRef",
+          "type": "Participant",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "TextAnnotation",
+      "superClass": [
+        "Artifact"
+      ],
+      "properties": [
+        {
+          "name": "text",
+          "type": "String"
+        },
+        {
+          "name": "textFormat",
+          "default": "text/plain",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Group",
+      "superClass": [
+        "Artifact"
+      ],
+      "properties": [
+        {
+          "name": "categoryValueRef",
+          "type": "CategoryValue",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Association",
+      "superClass": [
+        "Artifact"
+      ],
+      "properties": [
+        {
+          "name": "associationDirection",
+          "type": "AssociationDirection",
+          "isAttr": true
+        },
+        {
+          "name": "sourceRef",
+          "type": "BaseElement",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "targetRef",
+          "type": "BaseElement",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "Category",
+      "superClass": [
+        "RootElement"
+      ],
+      "properties": [
+        {
+          "name": "categoryValue",
+          "type": "CategoryValue",
+          "isMany": true
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Artifact",
+      "isAbstract": true,
+      "superClass": [
+        "BaseElement"
+      ]
+    },
+    {
+      "name": "CategoryValue",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "categorizedFlowElements",
+          "type": "FlowElement",
+          "isMany": true,
+          "isVirtual": true,
+          "isReference": true
+        },
+        {
+          "name": "value",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Activity",
+      "isAbstract": true,
+      "superClass": [
+        "FlowNode"
+      ],
+      "properties": [
+        {
+          "name": "isForCompensation",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "default",
+          "type": "SequenceFlow",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "ioSpecification",
+          "type": "InputOutputSpecification",
+          "xml": {
+            "serialize": "property"
+          }
+        },
+        {
+          "name": "boundaryEventRefs",
+          "type": "BoundaryEvent",
+          "isMany": true,
+          "isReference": true
+        },
+        {
+          "name": "properties",
+          "type": "Property",
+          "isMany": true
+        },
+        {
+          "name": "dataInputAssociations",
+          "type": "DataInputAssociation",
+          "isMany": true
+        },
+        {
+          "name": "dataOutputAssociations",
+          "type": "DataOutputAssociation",
+          "isMany": true
+        },
+        {
+          "name": "startQuantity",
+          "default": 1,
+          "isAttr": true,
+          "type": "Integer"
+        },
+        {
+          "name": "resources",
+          "type": "ResourceRole",
+          "isMany": true
+        },
+        {
+          "name": "completionQuantity",
+          "default": 1,
+          "isAttr": true,
+          "type": "Integer"
+        },
+        {
+          "name": "loopCharacteristics",
+          "type": "LoopCharacteristics"
+        }
+      ]
+    },
+    {
+      "name": "ServiceTask",
+      "superClass": [
+        "Task"
+      ],
+      "properties": [
+        {
+          "name": "implementation",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "operationRef",
+          "type": "Operation",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "SubProcess",
+      "superClass": [
+        "Activity",
+        "FlowElementsContainer",
+        "InteractionNode"
+      ],
+      "properties": [
+        {
+          "name": "triggeredByEvent",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "artifacts",
+          "type": "Artifact",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "LoopCharacteristics",
+      "isAbstract": true,
+      "superClass": [
+        "BaseElement"
+      ]
+    },
+    {
+      "name": "MultiInstanceLoopCharacteristics",
+      "superClass": [
+        "LoopCharacteristics"
+      ],
+      "properties": [
+        {
+          "name": "isSequential",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "behavior",
+          "type": "MultiInstanceBehavior",
+          "default": "All",
+          "isAttr": true
+        },
+        {
+          "name": "loopCardinality",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        },
+        {
+          "name": "loopDataInputRef",
+          "type": "ItemAwareElement",
+          "isReference": true
+        },
+        {
+          "name": "loopDataOutputRef",
+          "type": "ItemAwareElement",
+          "isReference": true
+        },
+        {
+          "name": "inputDataItem",
+          "type": "DataInput",
+          "xml": {
+            "serialize": "property"
+          }
+        },
+        {
+          "name": "outputDataItem",
+          "type": "DataOutput",
+          "xml": {
+            "serialize": "property"
+          }
+        },
+        {
+          "name": "complexBehaviorDefinition",
+          "type": "ComplexBehaviorDefinition",
+          "isMany": true
+        },
+        {
+          "name": "completionCondition",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        },
+        {
+          "name": "oneBehaviorEventRef",
+          "type": "EventDefinition",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "noneBehaviorEventRef",
+          "type": "EventDefinition",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "StandardLoopCharacteristics",
+      "superClass": [
+        "LoopCharacteristics"
+      ],
+      "properties": [
+        {
+          "name": "testBefore",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "loopCondition",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        },
+        {
+          "name": "loopMaximum",
+          "type": "Integer",
+          "isAttr": true
+        }
+      ]
+    },
+    {
+      "name": "CallActivity",
+      "superClass": [
+        "Activity",
+        "InteractionNode"
+      ],
+      "properties": [
+        {
+          "name": "calledElement",
+          "type": "String",
+          "isAttr": true
+        }
+      ]
+    },
+    {
+      "name": "Task",
+      "superClass": [
+        "Activity",
+        "InteractionNode"
+      ]
+    },
+    {
+      "name": "SendTask",
+      "superClass": [
+        "Task"
+      ],
+      "properties": [
+        {
+          "name": "implementation",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "operationRef",
+          "type": "Operation",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "messageRef",
+          "type": "Message",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "ReceiveTask",
+      "superClass": [
+        "Task"
+      ],
+      "properties": [
+        {
+          "name": "implementation",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "instantiate",
+          "default": false,
+          "isAttr": true,
+          "type": "Boolean"
+        },
+        {
+          "name": "operationRef",
+          "type": "Operation",
+          "isAttr": true,
+          "isReference": true
+        },
+        {
+          "name": "messageRef",
+          "type": "Message",
+          "isAttr": true,
+          "isReference": true
+        }
+      ]
+    },
+    {
+      "name": "ScriptTask",
+      "superClass": [
+        "Task"
+      ],
+      "properties": [
+        {
+          "name": "scriptFormat",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "script",
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "BusinessRuleTask",
+      "superClass": [
+        "Task"
+      ],
+      "properties": [
+        {
+          "name": "implementation",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "AdHocSubProcess",
+      "superClass": [
+        "SubProcess"
+      ],
+      "properties": [
+        {
+          "name": "completionCondition",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        },
+        {
+          "name": "ordering",
+          "type": "AdHocOrdering",
+          "isAttr": true
+        },
+        {
+          "name": "cancelRemainingInstances",
+          "default": true,
+          "isAttr": true,
+          "type": "Boolean"
+        }
+      ]
+    },
+    {
+      "name": "Transaction",
+      "superClass": [
+        "SubProcess"
+      ],
+      "properties": [
+        {
+          "name": "protocol",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "method",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "GlobalScriptTask",
+      "superClass": [
+        "GlobalTask"
+      ],
+      "properties": [
+        {
+          "name": "scriptLanguage",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "script",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "GlobalBusinessRuleTask",
+      "superClass": [
+        "GlobalTask"
+      ],
+      "properties": [
+        {
+          "name": "implementation",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "ComplexBehaviorDefinition",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "condition",
+          "type": "FormalExpression"
+        },
+        {
+          "name": "event",
+          "type": "ImplicitThrowEvent"
+        }
+      ]
+    },
+    {
+      "name": "ResourceRole",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "resourceRef",
+          "type": "Resource",
+          "isReference": true
+        },
+        {
+          "name": "resourceParameterBindings",
+          "type": "ResourceParameterBinding",
+          "isMany": true
+        },
+        {
+          "name": "resourceAssignmentExpression",
+          "type": "ResourceAssignmentExpression"
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "ResourceParameterBinding",
+      "properties": [
+        {
+          "name": "expression",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        },
+        {
+          "name": "parameterRef",
+          "type": "ResourceParameter",
+          "isAttr": true,
+          "isReference": true
+        }
+      ],
+      "superClass": [
+        "BaseElement"
+      ]
+    },
+    {
+      "name": "ResourceAssignmentExpression",
+      "properties": [
+        {
+          "name": "expression",
+          "type": "Expression",
+          "xml": {
+            "serialize": "xsi:type"
+          }
+        }
+      ],
+      "superClass": [
+        "BaseElement"
+      ]
+    },
+    {
+      "name": "Import",
+      "properties": [
+        {
+          "name": "importType",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "location",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "namespace",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Definitions",
+      "superClass": [
+        "BaseElement"
+      ],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "targetNamespace",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "expressionLanguage",
+          "default": "http://www.w3.org/1999/XPath",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "typeLanguage",
+          "default": "http://www.w3.org/2001/XMLSchema",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "imports",
+          "type": "Import",
+          "isMany": true
+        },
+        {
+          "name": "extensions",
+          "type": "Extension",
+          "isMany": true
+        },
+        {
+          "name": "rootElements",
+          "type": "RootElement",
+          "isMany": true
+        },
+        {
+          "name": "diagrams",
+          "isMany": true,
+          "type": "bpmndi:BPMNDiagram"
+        },
+        {
+          "name": "exporter",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "relationships",
+          "type": "Relationship",
+          "isMany": true
+        },
+        {
+          "name": "exporterVersion",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    }
+  ],
+  "enumerations": [
+    {
+      "name": "ProcessType",
+      "literalValues": [
+        {
+          "name": "None"
+        },
+        {
+          "name": "Public"
+        },
+        {
+          "name": "Private"
+        }
+      ]
+    },
+    {
+      "name": "GatewayDirection",
+      "literalValues": [
+        {
+          "name": "Unspecified"
+        },
+        {
+          "name": "Converging"
+        },
+        {
+          "name": "Diverging"
+        },
+        {
+          "name": "Mixed"
+        }
+      ]
+    },
+    {
+      "name": "EventBasedGatewayType",
+      "literalValues": [
+        {
+          "name": "Parallel"
+        },
+        {
+          "name": "Exclusive"
+        }
+      ]
+    },
+    {
+      "name": "RelationshipDirection",
+      "literalValues": [
+        {
+          "name": "None"
+        },
+        {
+          "name": "Forward"
+        },
+        {
+          "name": "Backward"
+        },
+        {
+          "name": "Both"
+        }
+      ]
+    },
+    {
+      "name": "ItemKind",
+      "literalValues": [
+        {
+          "name": "Physical"
+        },
+        {
+          "name": "Information"
+        }
+      ]
+    },
+    {
+      "name": "ChoreographyLoopType",
+      "literalValues": [
+        {
+          "name": "None"
+        },
+        {
+          "name": "Standard"
+        },
+        {
+          "name": "MultiInstanceSequential"
+        },
+        {
+          "name": "MultiInstanceParallel"
+        }
+      ]
+    },
+    {
+      "name": "AssociationDirection",
+      "literalValues": [
+        {
+          "name": "None"
+        },
+        {
+          "name": "One"
+        },
+        {
+          "name": "Both"
+        }
+      ]
+    },
+    {
+      "name": "MultiInstanceBehavior",
+      "literalValues": [
+        {
+          "name": "None"
+        },
+        {
+          "name": "One"
+        },
+        {
+          "name": "All"
+        },
+        {
+          "name": "Complex"
+        }
+      ]
+    },
+    {
+      "name": "AdHocOrdering",
+      "literalValues": [
+        {
+          "name": "Parallel"
+        },
+        {
+          "name": "Sequential"
+        }
+      ]
+    }
+  ],
+  "xml": {
+    "tagAlias": "lowerCase",
+    "typePrefix": "t"
+  }
+}

--- a/docs/bpmn-spec/scripts/gen.py
+++ b/docs/bpmn-spec/scripts/gen.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""
+Generate per-element markdown KB files under docs/bpmn-spec/elements/
+from the bpmn-moddle JSON descriptor (bpmn-moddle.json in this dir).
+
+Scope is restricted to BPMN 2.0 Process Execution Conformance (Common
+Executable Subclass per spec §2.1.3) — see ../conformance.md.
+
+Re-run after updating bpmn-moddle.json. Output files are overwritten.
+"""
+
+import json
+import sys
+from pathlib import Path
+from collections import OrderedDict
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent
+ELEMENTS_DIR = ROOT / "elements"
+
+# In-scope types grouped by output file. Order within each group is the
+# emission order in the markdown. See ../conformance.md for rationale.
+GROUPS = OrderedDict([
+    ("foundation", [
+        "Definitions", "BaseElement", "RootElement",
+        "FlowElement", "FlowNode", "FlowElementsContainer", "CallableElement",
+        "ItemAwareElement", "ItemDefinition",
+        "Expression", "FormalExpression",
+        "Documentation",
+        "Extension", "ExtensionDefinition", "ExtensionAttributeDefinition", "ExtensionElements",
+        "Import", "Auditing", "Monitoring",
+    ]),
+    ("process", [
+        "Process", "Lane", "LaneSet",
+    ]),
+    ("activities", [
+        "Activity",
+        "Task", "ServiceTask", "UserTask", "ManualTask",
+        "ScriptTask", "BusinessRuleTask", "SendTask", "ReceiveTask",
+        "SubProcess", "Transaction", "AdHocSubProcess", "CallActivity",
+        "LoopCharacteristics", "StandardLoopCharacteristics",
+        "MultiInstanceLoopCharacteristics", "ComplexBehaviorDefinition",
+        "GlobalTask", "GlobalManualTask", "GlobalUserTask",
+        "GlobalScriptTask", "GlobalBusinessRuleTask",
+    ]),
+    ("events", [
+        "Event", "CatchEvent", "ThrowEvent",
+        "StartEvent", "IntermediateCatchEvent", "IntermediateThrowEvent",
+        "EndEvent", "BoundaryEvent", "ImplicitThrowEvent",
+    ]),
+    ("event-definitions", [
+        "EventDefinition",
+        "MessageEventDefinition", "TimerEventDefinition", "SignalEventDefinition",
+        "ErrorEventDefinition", "EscalationEventDefinition",
+        "CompensateEventDefinition", "CancelEventDefinition",
+        "ConditionalEventDefinition", "LinkEventDefinition",
+        "TerminateEventDefinition",
+        "Message", "Signal", "Error", "Escalation",
+    ]),
+    ("gateways", [
+        "Gateway",
+        "ExclusiveGateway", "ParallelGateway",
+        "InclusiveGateway", "EventBasedGateway",
+        "ComplexGateway",
+    ]),
+    ("flows", [
+        "SequenceFlow", "Association",
+    ]),
+    ("data", [
+        "ItemAwareElement",
+        "DataObject", "DataObjectReference",
+        "DataStore", "DataStoreReference",
+        "Property",
+        "DataInput", "DataOutput",
+        "DataInputAssociation", "DataOutputAssociation", "DataAssociation",
+        "InputSet", "OutputSet",
+        "InputOutputSpecification", "InputOutputBinding",
+        "Assignment", "DataState",
+    ]),
+    ("service-interfaces", [
+        "Interface", "Operation", "EndPoint",
+    ]),
+    ("human-interaction", [
+        "HumanPerformer", "PotentialOwner", "Performer", "Rendering",
+        "Resource", "ResourceRole", "ResourceParameter",
+        "ResourceParameterBinding", "ResourceAssignmentExpression",
+    ]),
+    ("correlation", [
+        "CorrelationKey", "CorrelationProperty",
+        "CorrelationPropertyRetrievalExpression",
+        "CorrelationPropertyBinding", "CorrelationSubscription",
+    ]),
+])
+
+# Group titles for the markdown file headings.
+GROUP_TITLES = {
+    "foundation": "Foundation",
+    "process": "Process / Container",
+    "activities": "Activities",
+    "events": "Events",
+    "event-definitions": "Event Definitions",
+    "gateways": "Gateways",
+    "flows": "Flows",
+    "data": "Data",
+    "service-interfaces": "Service Interfaces",
+    "human-interaction": "Human Interaction",
+    "correlation": "Message Correlation",
+}
+
+
+def load_descriptor() -> dict:
+    with (HERE / "bpmn-moddle.json").open() as f:
+        return json.load(f)
+
+
+def index_types(descriptor: dict) -> dict:
+    """Map type name -> type descriptor."""
+    return {t["name"]: t for t in descriptor["types"]}
+
+
+def walk_supers(types: dict, name: str, seen=None) -> list:
+    """Return ancestor chain (excluding self) in MRO-ish order: direct supers first, then their supers."""
+    if seen is None:
+        seen = set()
+    if name not in types:
+        return []
+    chain = []
+    for s in types[name].get("superClass", []):
+        if s in seen:
+            continue
+        seen.add(s)
+        chain.append(s)
+        chain.extend(walk_supers(types, s, seen))
+    return chain
+
+
+def aggregate_properties(types: dict, name: str) -> list:
+    """Collect (origin, property) pairs, with `replaces` honored.
+
+    Walks self + all ancestors. A property with `replaces: <Origin>#<name>`
+    on a descendant suppresses the matching ancestor property.
+    """
+    if name not in types:
+        return []
+    own = [("self", p) for p in types[name].get("properties", [])]
+    inherited = []
+    for ancestor in walk_supers(types, name):
+        for p in types[ancestor].get("properties", []):
+            inherited.append((ancestor, p))
+
+    # Honor `replaces`: if any descendant property has replaces="X#prop", drop X's prop.
+    replaced_keys = set()
+    for _, p in own:
+        if "replaces" in p:
+            replaced_keys.add(p["replaces"])
+    inherited = [
+        (o, p) for (o, p) in inherited
+        if f"{o}#{p['name']}" not in replaced_keys
+    ]
+    return own + inherited
+
+
+def kind(prop: dict) -> str:
+    """Classify property as attribute / element / reference."""
+    if prop.get("isAttr"):
+        return "attr (ref)" if prop.get("isReference") else "attr"
+    return "child elem (ref)" if prop.get("isReference") else "child elem"
+
+
+def card(prop: dict) -> str:
+    """0..1 or 0..*."""
+    return "0..*" if prop.get("isMany") else "0..1"
+
+
+def fmt_type(prop: dict) -> str:
+    return prop.get("type", "?")
+
+
+def render_element(name: str, types: dict) -> str:
+    """Render one element as a markdown section."""
+    if name not in types:
+        return f"### {name}\n\n_Not found in bpmn-moddle descriptor._\n\n"
+
+    t = types[name]
+    supers = walk_supers(types, name)
+    super_chain = " → ".join([name] + supers) if supers else name
+
+    lines = [f"### {name}", ""]
+
+    if t.get("isAbstract"):
+        lines.append("_Abstract type._")
+        lines.append("")
+
+    lines.append(f"**Type hierarchy:** `{super_chain}`")
+    lines.append("")
+
+    own = [p for p in t.get("properties", [])]
+    if own:
+        lines.append("**Own properties:**")
+        lines.append("")
+        lines.append("| Name | Type | Kind | Card | Notes |")
+        lines.append("|---|---|---|---|---|")
+        for p in own:
+            notes = []
+            if "default" in p:
+                notes.append(f"default `{p['default']}`")
+            if "replaces" in p:
+                notes.append(f"replaces `{p['replaces']}`")
+            if p.get("isId"):
+                notes.append("id")
+            lines.append(
+                f"| `{p['name']}` | `{fmt_type(p)}` | {kind(p)} | {card(p)} | "
+                f"{'; '.join(notes)} |"
+            )
+        lines.append("")
+
+    # Inherited properties: list briefly, since they're available on the ancestor's page.
+    inherited = aggregate_properties(types, name)
+    inherited_only = [(o, p) for (o, p) in inherited if o != "self"]
+    if inherited_only:
+        lines.append("**Inherited properties** (see ancestor pages for details):")
+        lines.append("")
+        lines.append("| Name | From | Type | Kind | Card |")
+        lines.append("|---|---|---|---|---|")
+        for origin, p in inherited_only:
+            lines.append(
+                f"| `{p['name']}` | `{origin}` | `{fmt_type(p)}` | {kind(p)} | {card(p)} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def render_group(group: str, names: list, types: dict) -> str:
+    title = GROUP_TITLES[group]
+    out = [
+        f"# {title}",
+        "",
+        f"_Structural metamodel for **{title}** elements, extracted from bpmn-moddle. "
+        f"In-scope per [../conformance.md](../conformance.md)._",
+        "",
+        "_Kind legend: `attr` = XML attribute, `child elem` = XML child element, "
+        "`(ref)` = ID reference to another element rather than embedded._",
+        "",
+        "---",
+        "",
+    ]
+    for name in names:
+        out.append(render_element(name, types))
+        out.append("---")
+        out.append("")
+    return "\n".join(out)
+
+
+def main() -> int:
+    descriptor = load_descriptor()
+    types = index_types(descriptor)
+    ELEMENTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    # Validate all listed names exist.
+    missing = []
+    for names in GROUPS.values():
+        for n in names:
+            if n not in types:
+                missing.append(n)
+    if missing:
+        print(f"ERROR: types not found in descriptor: {missing}", file=sys.stderr)
+        return 1
+
+    for group, names in GROUPS.items():
+        path = ELEMENTS_DIR / f"{group}.md"
+        path.write_text(render_group(group, names, types))
+        print(f"wrote {path.relative_to(ROOT)}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/bpmn-spec/semantics/compensation.md
+++ b/docs/bpmn-spec/semantics/compensation.md
@@ -1,0 +1,118 @@
+# Compensation
+
+_Source: BPMN 2.0 §13.5.5 + §10.7 (spec p441–443, p301)._
+
+Compensation undoes the effects of activities that **already successfully completed**. Used when the side-effects of a completed action need to be reversed because the larger transaction failed or is being aborted.
+
+## Core distinction: compensation vs cancellation
+
+| Term | Applies to | Purpose |
+|---|---|---|
+| **Cancellation** | _Active_ activities | Halt in-progress work |
+| **Compensation** | _Completed_ activities | Reverse the side-effects of already-finished work |
+
+An active activity cannot be compensated — it must be cancelled first. Cancellation of a Sub-Process can in turn trigger compensation of the successfully completed activities inside.
+
+## Compensation handler — three forms
+
+A compensation handler is a set of `Activities` not connected to the rest of the model. Three forms:
+
+| Form | Where defined | Catch element |
+|---|---|---|
+| **Boundary compensation handler** | Boundary event on a specific Activity | `boundaryEvent` with `CompensateEventDefinition` |
+| **Compensation Event Sub-Process** | Inside a Sub-Process or Process | Event Sub-Process whose Start Event has `CompensateEventDefinition` |
+| **Compensation Activity** (associated) | Anywhere in the model | Linked via `Association` from a `compensationActivity` reference |
+
+A handler connected via boundary event can only perform **"black-box" compensation** of the original Activity — modeled with a specialized **Compensation Activity** (a Task with `isForCompensation=true`).
+
+## Implicit / default compensation
+
+A Sub-Process has a `compensable` attribute. When set, **default compensation** is implicitly defined:
+
+- Recursively compensates all successfully completed Activities within that Sub-Process.
+- In **reverse order** of forward execution.
+
+No explicit handler needed.
+
+## Compensation triggering
+
+Compensation is triggered by a **throw Compensation Event**, either:
+- `Intermediate Throw Event` with `CompensateEventDefinition`, OR
+- `End Event` with `CompensateEventDefinition`.
+
+The Activity to compensate is referenced via the `CompensateEventDefinition`'s `activityRef`. If unspecified, defaults to the **current Activity** (i.e., the context in which the throw event resides).
+
+### Scoping rules
+
+| Scope of throw | Effect |
+|---|---|
+| Inline `error handler` of a Sub-Process | Triggers compensation for that Sub-Process |
+| Global context (no `activityRef`) | All completed Activities in the Process are compensated |
+
+### Sync vs async
+
+| `waitForCompletion` | Behavior |
+|---|---|
+| `true` (default) | The throw Compensation Event waits for the compensation handler to complete |
+| `false` | Fire-and-forget — compensation triggered, throw proceeds |
+
+### Multi-Instance / Loop
+
+- Each instance of a Loop or MI Sub-Process has its own **Compensation Event Sub-Process** with its own **snapshot data** captured at the time of that instance's completion.
+- Triggering compensation for the MI Sub-Process **individually triggers** compensation for all instances within the current scope.
+- If compensation is specified via a **boundary handler**, that boundary handler is invoked **once per instance** of the MI Sub-Process.
+
+## Relationship between error handling and compensation
+
+The spec calls out a **"presumed abort" principle**:
+
+1. **Only completed activities are compensated.** Compensation of a failed Activity results in an empty operation. When an Activity fails (state: `Failing` / `Failed`), the responsibility of the error handler is to ensure no further compensation is triggered for it.
+2. **Default error-driven compensation:** if no error Event Sub-Process is specified for a Sub-Process and an `error` occurs, the default behavior is to automatically call compensation for all contained Activities of that Sub-Process. This ensures the "presumed abort" invariant.
+
+## Operational semantics
+
+### Compensation handler enablement
+
+- A `Compensation Event Sub-Process` becomes _enabled_ when its parent Activity transitions into state `Completed`.
+- At that moment, a **snapshot** of the data associated with the parent Activity is taken and kept for later use.
+- For MI / Loop: a separate snapshot is taken per instance.
+
+### Compensation triggering
+
+- When compensation is triggered for the parent Activity:
+  - The `Compensation Event Sub-Process` is **activated** and runs.
+  - The parent Activity's original data context is **restored** from the snapshot.
+  - For MI / Loop: the dedicated snapshot for the affected instance is restored, and a dedicated `Compensation Event Sub-Process` is activated.
+- An **associated Compensation Activity** becomes enabled when the Activity it is associated with transitions to `Completed`. When triggered, it is activated.
+  - For MI / Loop parent: the Compensation Activity is triggered ONCE but compensates the effects of all instances (the activity is required to handle this internally).
+
+### Ordering of default compensation
+
+Default compensation runs Compensation Activities in **reverse order of forward execution**. Concurrency is allowed when there was no dependency between original activities.
+
+**Dependencies MUST be respected:**
+
+| Dependency | Rule |
+|---|---|
+| `Sequence Flow` from A → B | Compensate B before A |
+| Data dependency (`IORules` specifying B references data produced by A) | Compensate B before A |
+| Ad-Hoc Sub-Process: A and B were active; A completed before B started | Compensate B before A |
+| Loop / sequential MI | Reverse order of forward execution |
+| Parallel MI | Compensate in parallel |
+| Sub-Process A has boundary event triggering B; event occurred | Compensate B before A. Applies also to multi-instances and loops. |
+
+## Compensating state transitions
+
+From the activity lifecycle ([../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)):
+
+- `Completed` → `Compensating` when a throw Compensation Event references this Activity.
+- `Compensating` → `Compensated` when compensation completes successfully.
+- `Compensating` → `Failed` when the compensation handler raises an exception.
+- `Compensating` → `Terminated` when compensation is interrupted by controlled or uncontrolled termination.
+
+## Cross-references
+
+- Activity lifecycle (Compensating / Compensated states): [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)
+- Multi-instance per-instance snapshots: [multi-instance.md](multi-instance.md)
+- CompensateEventDefinition structural attributes: [../elements/event-definitions.md](../elements/event-definitions.md)
+- Sub-Process `compensable` attribute: [../elements/activities.md](../elements/activities.md)

--- a/docs/bpmn-spec/semantics/correlation.md
+++ b/docs/bpmn-spec/semantics/correlation.md
@@ -1,0 +1,233 @@
+# Message Correlation
+
+_Source: BPMN 2.0 **§8.4.2** (Correlation, pp.72–78). Cross-cuts with §13.3.3 (Receive Task), §13.5.1 (Start Event), §13.5.2–§13.5.4 (Intermediate / Event Sub-Process), §10.6.6 (Event-Based Gateway)._
+
+> **Section label note:** earlier KB indexes referred to "§8.3.2 Correlation" — the actual spec section number is **§8.4.2**. Earlier references corrected.
+
+## Purpose
+
+Business Processes run for days or months and many instances of the same Process run in parallel (many order processes, each for a different order). When an asynchronous `Message` arrives, the engine MUST decide:
+
+- Does this Message create a **new** Process instance, or route to an **existing** one?
+- If an existing instance — *which* one?
+
+Correlation is the mechanism that answers this. It uses values **extracted from the Message payload itself** (e.g. an `orderID` or `customerID`) — no need to introduce technical correlation tokens like sticky IDs.
+
+**Footnote 1 of §8.4.2:** _"All references to Send or Receive Tasks in this sub-clause also include message catch or throw Events; they behave identically with respect to correlation."_ — i.e., everything below applies to `ReceiveTask` + `SendTask` AND to `IntermediateCatchEvent` / `IntermediateThrowEvent` / `BoundaryEvent` / `StartEvent` / `EndEvent` carrying a `MessageEventDefinition`.
+
+## Structural model
+
+Five elements, all RootElement / BaseElement subclasses:
+
+```
+                            Conversation (out of scope; logical grouping only)
+                                 |
+                                 | correlationKeys  (0..*)
+                                 v
+                        CorrelationKey
+                        - name: string [0..1]
+                        - correlationPropertyRef: CorrelationProperty [0..*]
+                                 |
+                                 | (partial keys)
+                                 v
+        +----------------> CorrelationProperty
+        |                  - name: string [0..1]
+        |                  - type: string [0..1]
+        |                  - correlationPropertyRetrievalExpression: [1..*]
+        |                          |
+        |                          v
+        |             CorrelationPropertyRetrievalExpression
+        |             - messagePath: FormalExpression
+        |             - messageRef: Message
+        |             (one per Message-type in the Conversation)
+        |
+        |  CorrelationSubscription (Process-specific; for context-based correlation)
+        |  - correlationKeyRef: CorrelationKey
+        |  - correlationPropertyBinding: CorrelationPropertyBinding [0..*]
+        |             |
+        |             v
+        |  CorrelationPropertyBinding
+        |  - correlationPropertyRef: CorrelationProperty -----+
+        +-----------------------------------------------------+
+           - dataPath: FormalExpression  (extracts from Process context)
+```
+
+### Attribute tables
+
+**CorrelationKey** (Table 8.31, p75):
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `name` | `string [0..1]` | Name of the key. |
+| `correlationPropertyRef` | `CorrelationProperty [0..*]` | Partial keys composing this composite key. |
+
+**CorrelationProperty** (Table 8.32, p75) — inherits `RootElement`:
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `name` | `string [0..1]` | Property name. |
+| `type` | `string [0..1]` (QName) | Type identifier. |
+| `correlationPropertyRetrievalExpression` | `CorrelationPropertyRetrievalExpression [1..*]` | One extraction Expression **per Message type** in the Conversation. |
+
+**CorrelationPropertyRetrievalExpression** (Table 8.33, p76):
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `messagePath` | `FormalExpression [1]` | Extracts the CorrelationProperty value from the referenced Message's payload. |
+| `messageRef` | `Message [1]` | The specific Message this extraction applies to. |
+
+**CorrelationSubscription** (Table 8.34, p76) — Process-specific:
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `correlationKeyRef` | `CorrelationKey [1]` | The CorrelationKey this subscription supplements. |
+| `correlationPropertyBinding` | `CorrelationPropertyBinding [0..*]` | Bindings to specific CorrelationProperties via FormalExpressions against Process context. |
+
+**CorrelationPropertyBinding** (Table 8.35, p77):
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `correlationPropertyRef` | `CorrelationProperty [1]` (`required`) | Which CorrelationProperty this binding fills. |
+| `dataPath` | `FormalExpression [1]` | Extraction rule atop the Process context (Data Objects / Properties). |
+
+## Two correlation mechanisms (non-exclusive)
+
+Per §8.4.2 they are explicitly described as "non-exclusive" — a Process MAY use both simultaneously.
+
+### Key-based correlation (§8.4.2 p72, p74–75)
+
+Simple and efficient. Identifies a Conversation by one or more `CorrelationKey`s.
+
+**Initialization:**
+1. The first `Send Task` or `Receive Task` in a Conversation MUST populate at least one of the CorrelationKey instances.
+2. Population works by extracting `CorrelationProperty` values from the initially sent / received Message via the corresponding `CorrelationPropertyRetrievalExpression`s (whose `messageRef` matches the message in flight).
+3. A CorrelationKey is **only valid** for use once **all** its CorrelationProperty fields have been populated.
+
+**Matching incoming Messages:**
+1. Extract `CorrelationProperty` values from the incoming Message via its matching `CorrelationPropertyRetrievalExpression` (the one whose `messageRef` matches).
+2. Form a composite key from those values.
+3. Compare to the initialized `CorrelationKey` instance for the candidate Conversation.
+4. If they match → Message routed to that Conversation (and the Process instance behind it).
+
+**Subsequent-Message rules:**
+- If a follow-up Message derives a CorrelationKey instance that **had already been initialized** → the Message's value MUST equal the Conversation's value. (Mismatch = no match — Message does not route to this Conversation.)
+- If a follow-up Message derives a CorrelationKey associated with the Conversation but **not yet initialized** → the derived value becomes associated with the Conversation (lazy initialization of secondary keys).
+
+Conceptual model from the spec: a "joint Conversation token" passed back and forth between participants in every outgoing and incoming Message.
+
+### Context-based correlation (§8.4.2 p76)
+
+Also called **predicate-based correlation** in execution-semantics text (e.g. §13.3.3 Receive Task). A more expressive form built on top of key-based correlation.
+
+A Process MAY provide a `CorrelationSubscription` that acts as the Process-specific counterpart to a specific `CorrelationKey`. The subscription evaluates `FormalExpression`s **against the Process context** (Data Objects / Properties) — rather than against the Message payload.
+
+**Initialization:**
+- When a Process instance is created, the `CorrelationKey` instances of all its Conversations are initialized with values that specify "correlate any incoming Message for these Conversations" (effectively a wildcard match initially).
+
+**Dynamic update:**
+- A "SubscriptionProperty" is updated **whenever any Data Object or Property referenced by the associated `FormalExpression` changes**.
+- Incoming Messages are then matched against the now-populated `CorrelationKey` instance.
+
+**Mid-process change:**
+- The SubscriptionProperties can change again during the Process run, which **implicitly changes the correlation criterion**. A Process can effectively re-target what Messages it is willing to accept.
+
+**Coexistence with key-based:**
+- The first Send Task / Receive Task can still populate the CorrelationKey via the key-based mechanism, in parallel with context-based dynamic updates.
+
+## Message-to-instance resolution algorithm
+
+End-to-end, when a Message arrives at the engine:
+
+1. Identify candidate Conversations the Message might belong to (typically determined by the `Message` reference / endpoint binding).
+2. For each candidate Conversation:
+   - For each `CorrelationKey` associated with the Conversation:
+     - Find the `CorrelationPropertyRetrievalExpression` whose `messageRef` equals the incoming Message's type.
+     - Evaluate each `CorrelationProperty`'s `messagePath` against the Message payload to extract the composite key value.
+     - Compare against the Conversation's initialized CorrelationKey instance.
+   - If all required keys match → Message routes to this Conversation.
+3. Resolve the **Process instance** from the matched Conversation:
+   - For a `ReceiveTask` / `IntermediateCatchEvent` / boundary Message event: the unique Process instance owning the waiting receiver.
+   - For an instantiating `Message Start Event` or instantiating `ReceiveTask`: create a new Process instance UNLESS an instance already exists for this Conversation (then route to existing).
+4. If no candidate Conversation matches:
+   - If the Message can instantiate a new Process (`MessageStartEvent` with `instantiate=true`, or Event-Based Gateway at start with `instantiate=true`) → create new instance.
+   - Otherwise → no routing target; engine drops or holds the Message per implementation policy (the spec is silent on the unrouteable-message case).
+
+Per §13.3.3 (Receive Task):
+- **Key-based:** only a single Receive Task for a given `CorrelationKey` can be active → Message matches **at most one** Process instance.
+- **Predicate-based (= context-based):** Message MAY be passed to **multiple** Receive Tasks simultaneously.
+
+## Interaction with executable elements
+
+### Instantiating Message Start Event (§13.2 / §13.5.1)
+
+- A Process is instantiated when a Start Event occurs.
+- If the Start Event participates in a **Conversation that includes other Start Events**:
+  - A new instance is created **only if** no instance already exists for the specific Conversation (identified through correlation info of the Event occurrence).
+  - Subsequent Start Events that share the same correlation info as a Start Event that created an instance → routed to that instance.
+
+### Receive Task (§13.3.3)
+
+- Upon activation, waits for the associated Message.
+- When the Message arrives matching correlation: Data Output filled from Message data, Receive Task completes.
+- Constraints (see "resolution algorithm" above):
+  - Key-based: single active receiver per `CorrelationKey`.
+  - Predicate-based: multiple receivers possible.
+- `instantiate=true`: an unbounded (no incoming sequence flows) ReceiveTask can start a new Process instance — same instance-routing rules as Message Start Event apply.
+
+### Event-Based Gateway (§13.4.4 / §13.5.1 / §10.6.6)
+
+- A Process can be started by an Event-Based Gateway with `instantiate=true`.
+- **Exclusive** Event-Based Gateway: first matching Event creates new instance; other branches stop waiting.
+- **Parallel** Event-Based Gateway used at start:
+  - Only **message-based triggers** allowed.
+  - All Message triggers in the gateway configuration MUST be part of a Conversation **with the same correlation information**.
+  - After the first trigger instantiates the Process, remaining Message triggers join the **existing** instance (do not create new ones).
+- Multiple groups of Event-Based Gateways at start, all in the same Conversation sharing correlation info:
+  - One Event from each group needs to arrive.
+  - First arriving creates the instance; subsequent ones (from the other groups) route to the existing instance.
+
+### Intermediate Message Events (§13.5.2) and Boundary Message Events (§13.5.3)
+
+- Same correlation semantics as Receive Tasks.
+
+### Send Task / Intermediate Throw Message Event / Message End Event
+
+- Send-side counterpart. When a `SendTask` (or throw Message event) fires:
+  - If the Send is the **first Message in the Conversation**: it populates the relevant `CorrelationKey` instance(s) from the outgoing Message via `CorrelationPropertyRetrievalExpression`.
+  - If a follow-up: it MUST carry compatible correlation values (the Conversation token).
+
+## Conversation: how it fits despite being out of scope
+
+The full Conversation / Collaboration metamodel (Pool, Participant, ConversationNode, etc.) is **out of scope** for Process Execution Conformance — see [../conformance.md](../conformance.md). But the **logical concept of a Conversation as a grouping mechanism for correlation** is referenced by §13.2 / §13.5.1 (instance-routing rules above) and cannot be cleanly excised.
+
+**Minimum engine understanding required:**
+
+- A `Conversation` (in this minimal sense) = a logical grouping of related Messages that share a `CorrelationKey`.
+- It is the **identity scope** of an in-flight message exchange.
+- It does NOT need to be modeled with a Pool / Participant / ConversationNode (those are visual Collaboration constructs); it only needs to be modeled to the degree that the engine can associate Messages with the right Conversation instance.
+- For a single-Process executable model that exchanges Messages with the outside world: the Conversation is implicitly the binding between the Process's Message events and the external world's send/receive endpoints. CorrelationKeys are attached to the Process via `CorrelationSubscription`.
+
+Spec quote (§9.5.1, referenced for context only — Conversation metamodel is otherwise out of scope):
+> A Conversation is a logical grouping of Message exchanges (Message Flows) that can share a Correlation. … A Conversation is associated with a set of name-value pairs, or a Correlation Key … which is recorded in the Messages that are exchanged. In this way, a Message can be routed to the specific Process instance responsible for receiving and processing the Message.
+
+**Multi-level scoping** (out of scope detail, noted): CorrelationKeys can be attached at Collaboration / Choreography / ConversationNode / ChoreographyActivity level; multiple layers may apply to the same Message Flow. For Process Execution Conformance, only the Process-level binding matters.
+
+## Engine implementation notes
+
+- **CorrelationKey instance identity is per-Conversation, not per-Process instance.** Multiple Process instances can participate in the same Conversation; the Conversation's CorrelationKey instance is the routing target.
+- **A CorrelationKey is invalid until all its CorrelationProperty fields are populated.** Engines MUST track per-CorrelationProperty population state to know when a key becomes usable.
+- **Initial population is order-sensitive.** The "first Send Task or Receive Task in a Conversation" initializes the CorrelationKey. After that, subsequent participants compare against the initialized value (mismatch = no match).
+- **Lazy secondary-key initialization:** if a Conversation has multiple CorrelationKeys (typical for layered routing), follow-up Messages that derive previously-uninitialized keys associate those values with the Conversation. This is lazy — keys initialize as Messages arrive that carry them.
+- **Context-based correlation requires reactive evaluation.** When a `Data Object` or `Property` referenced by a `CorrelationPropertyBinding`'s `dataPath` changes, the engine MUST re-evaluate the subscription. Implementing this efficiently typically means dependency-tracking from FormalExpressions to underlying data items.
+- **Single-receiver invariant under key-based correlation** (§13.3.3): the engine MUST NOT have two active `ReceiveTask`s (or catch Message events) for the same `CorrelationKey` simultaneously. This is a modeling-time check ideally, but runtime enforcement is also required when MI Activities can spawn receivers dynamically.
+- **Predicate-based correlation allows fan-out:** a single Message MAY be delivered to multiple `ReceiveTask`s if all of their subscriptions match. Engine MUST not "consume" the Message after first delivery.
+- **Conversation modeling minimum:** for a single-process executable model, the engine needs (a) the set of `Conversation`s the Process participates in, (b) for each, the `CorrelationKey`s, (c) per Message type, the `CorrelationPropertyRetrievalExpression`s for extracting correlation values from payloads. Visual Conversation/Collaboration metamodel elements (`Pool`, `Participant`, etc.) are NOT required.
+
+## Cross-references
+
+- Activity lifecycle (Receive Task in Active state waiting for Message): [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)
+- Receive Task / Send Task semantics: [tasks.md](tasks.md)
+- Start Event Conversation-bound instantiation: [events.md](events.md), [../state-machines/process-lifecycle.md](../state-machines/process-lifecycle.md)
+- Event-Based Gateway as instantiator (Parallel mode correlation constraint): [gateways.md](gateways.md)
+- Structural attribute catalogue: [../elements/correlation.md](../elements/correlation.md)
+- Data semantics (CorrelationPropertyBinding evaluates FormalExpressions against Process context — same data plane as DataAssociation): [data.md](data.md)

--- a/docs/bpmn-spec/semantics/data.md
+++ b/docs/bpmn-spec/semantics/data.md
@@ -1,0 +1,301 @@
+# Data Semantics
+
+_Source: BPMN 2.0 §8.4.10 (ItemDefinition), §10.4 (Items and Data), §10.4.2 (Execution Semantics for Data), §13.3.2 (data binding in Activity Lifecycle)._
+
+This file covers the data-flow model for executable BPMN: what data elements exist, where they live, how they're typed, and exactly when DataAssociations fire during activity execution.
+
+## 1. The item-aware hierarchy
+
+All BPMN data-carrying elements inherit from `ItemAwareElement`. The element holds (or conveys) **items** whose type is described by an `ItemDefinition`.
+
+```
+                BaseElement
+                    ^
+                    |
+              ItemAwareElement
+                    ^
+        +-----------+-----------+-----------+--------+--------+
+        |           |           |           |        |        |
+     DataObject  DataStore   Property   DataInput  DataOutput …Reference variants
+```
+
+### ItemAwareElement attributes (§10.4.1, Table 10.51)
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `itemSubjectRef` | `ItemDefinition [0..1]` | Type of the item stored / conveyed. MAY be omitted ("under-specified") if modeler doesn't want to specify structure. |
+| `dataState` | `DataState [0..1]` | Optional state qualifier on the data (e.g. `Draft`, `Approved`). State value semantics are **out of scope** of the standard — engines / domains define their own. |
+
+### ItemDefinition (§8.4.10, Table 8.47)
+
+Lives in `Definitions` (global scope, reusable across the model).
+
+| Attribute | Type / Card | Default | Purpose |
+|---|---|---|---|
+| `itemKind` | `ItemKind { Information \| Physical }` | `Information` | Nature of the item. Physical items are non-operational per §13.1 — engines MAY ignore. |
+| `structureRef` | `Element [0..1]` | — | The concrete data structure (typically an XSD complex type or element). |
+| `import` | `Import [0..1]` | — | External schema location for the structure. |
+| `isCollection` | `boolean` | `false` | True if the type represents a collection. If `true` but `structureRef` is not a collection type, the model is invalid. |
+
+Default `typeLanguage` for the structure is set on `Definitions` and defaults to XML Schema (`http://www.w3.org/2001/XMLSchema`).
+
+## 2. Data element catalog
+
+### DataObject (§10.4.1)
+
+The primary visual data variable inside a process flow.
+
+- **MUST** be contained in `Process` or `SubProcess`.
+- Lifecycle is tied to the parent: instantiated when parent is, disposed when parent is.
+- Accessibility: parent + siblings + their children (including DataObjectReferences referencing it).
+- **Cannot specify a `DataState`.** If you need to show the same data in different states, use multiple `DataObjectReference`s — each can carry its own `DataState`.
+- `isCollection` (on DataObject): if `itemSubjectRef` is set, MUST match the referenced ItemDefinition's `isCollection`.
+
+### DataObjectReference (§10.4.1, Table 10.53)
+
+Visual pointer to a DataObject. Used to:
+- Avoid spaghetti wiring (multiple appearances of one DataObject in a diagram).
+- Show the same DataObject in different `DataState`s at different points in the process.
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `dataObjectRef` | `DataObject [1]` | The underlying DataObject. |
+
+DataObjectReferences cannot specify `itemSubjectRef` themselves (they inherit it from the referenced DataObject).
+
+### DataStore (§10.4.1, Table 10.55) + DataStoreReference
+
+Persistent storage that **outlives the Process instance**.
+
+| Attribute | Type / Card | Default | Purpose |
+|---|---|---|---|
+| `name` | `string` | — | Descriptive name. |
+| `capacity` | `integer [0..1]` | — | Capacity. Ignored if `isUnlimited=true`. |
+| `isUnlimited` | `boolean` | `false` | True → capacity unbounded (overrides `capacity`). |
+
+- `DataStore` lives in `Definitions` (RootElement). Globally reusable.
+- `DataStoreReference` is the visual ItemAwareElement appearing in flow scope; it carries `dataStoreRef → DataStore`.
+- Data flowing into/out of a `DataStoreReference` effectively flows into/out of the global `DataStore`.
+
+### Property (§10.4.1, Table 10.57)
+
+Hidden, non-visual container for data attached to a `FlowElement` — specifically a `Process`, `Activity`, or `Event`.
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `name` | `string` | Property name. |
+
+- **MUST** be contained in a `FlowElement`.
+- Lifecycle tied to parent FlowElement instance.
+- Accessibility: parent + (if parent is Process/SubProcess) immediate children including their nested children. Used for engine-internal state (loop counters, temporary context).
+- Property of a `Process A` is accessible by Process A + all nested Activities + Sub-Processes + their nested Activities. Property of a `Sub-Process A` is accessible by Sub-Process A + its immediate children only.
+
+### DataInput / DataOutput (§10.4.1, Tables 10.59, 10.60)
+
+Declared interface I/O for an Activity or CallableElement. Visible on the diagram (small unfilled arrow = input, filled = output).
+
+**Containment rules (§10.4.1, p210):**
+- Only `Tasks` and `CallableElements` (Processes, GlobalTasks) MAY define DataInputs/DataOutputs (via their `InputOutputSpecification`).
+- Embedded `SubProcess`es MUST NOT define DataInputs/DataOutputs directly — but MAY do so indirectly via `MultiInstanceLoopCharacteristics`.
+
+**DataInput attributes (Table 10.59):**
+
+| Attribute | Type / Card | Default | Purpose |
+|---|---|---|---|
+| `name` | `string [0..1]` | — | Descriptive name. |
+| `inputSetRefs` | `InputSet [1..*]` | — | Derived. The InputSets this DataInput is part of. |
+| `inputSetwithOptional` | `InputSet [0..*]` | — | InputSets in which this DataInput MAY be "unavailable" at Activity start. |
+| `inputSetWithWhileExecuting` | `InputSet [0..*]` | — | InputSets in which this DataInput MAY be evaluated WHILE the Activity is executing. |
+| `isCollection` | `boolean` | `false` | If `itemDefinition` referenced, MUST equal that ItemDefinition's `isCollection`. |
+
+**DataOutput attributes (Table 10.60):** mirror DataInput with `outputSetRefs`, `outputSetwithOptional`, `outputSetWithWhileExecuting`, `isCollection`.
+
+**Additional `optional` attribute** (text, p213): defines if a DataInput is valid even if its state is "unavailable". Default `false`. If `true`, Activity execution will not begin until a value is assigned via DataAssociations.
+
+## 3. InputOutputSpecification (§10.4.1)
+
+Aggregates I/O contract for a Task or CallableElement. Activity has 0..1 `ioSpecification`.
+
+**Attributes (Table 10.58):**
+
+| Attribute | Type / Card | Notes |
+|---|---|---|
+| `inputSets` | `InputSet [1..*]` | MUST define at least one InputSet. |
+| `outputSets` | `OutputSet [1..*]` | MUST define at least one OutputSet. |
+| `dataInputs` | `DataInput [0..*]` | Optional. Ordered set. If empty → no data required to start the Activity. |
+| `dataOutputs` | `DataOutput [0..*]` | Optional. Ordered set. If empty → no data required to finish the Activity. |
+
+## 4. InputSet and OutputSet (§10.4.1, p217–220)
+
+### InputSet (Table 10.61)
+
+A named collection of DataInputs that together constitutes one valid input mode for an Activity.
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `name` | `string [0..1]` | — |
+| `dataInputRefs` | `DataInput [0..*]` | DataInputs that collectively make up this requirement. |
+| `optionalInputRefs` | `DataInput [0..*]` | Subset of `dataInputRefs` that MAY be "unavailable" when Activity starts. MUST NOT reference DataInputs not listed in `dataInputRefs`. |
+| `whileExecutingInputRefs` | `DataInput [0..*]` | Subset of `dataInputRefs` that MAY be evaluated WHILE the Activity is executing. MUST NOT reference DataInputs not listed in `dataInputRefs`. |
+| `outputSetRefs` | `OutputSet [0..*]` | **IORule pairing.** Specifies which `OutputSet` is expected to be produced when this InputSet became valid. Paired with `inputSetRefs` on OutputSet. Replaces `IORules` from BPMN 1.2. |
+
+Notes:
+- An InputOutputSpecification MUST have at least one InputSet.
+- A single DataInput MAY belong to multiple InputSets but MUST always be referenced by at least one.
+- An **"empty" InputSet** (no `dataInputRefs`) signifies the Activity requires no data to start.
+- **InputSet order is significant** — the order of inclusion in `InputOutputSpecification` is the evaluation order.
+
+### OutputSet (Table 10.62)
+
+Mirror of InputSet for produced data.
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `name` | `string [0..1]` | — |
+| `dataOutputRefs` | `DataOutput [0..*]` | DataOutputs that MAY collectively be output. |
+| `optionalOutputRefs` | `DataOutput [0..*]` | Subset of `dataOutputRefs` that need NOT be produced when Activity completes. |
+| `whileExecutingOutputRefs` | `DataOutput [0..*]` | Subset of `dataOutputRefs` that MAY be produced while the Activity is executing. |
+| `inputSetRefs` | `InputSet [0..*]` | **IORule pairing.** Specifies which InputSet has to become valid to expect this OutputSet. Paired with `outputSetRefs` on InputSet. |
+
+- An OutputSet MUST be defined; an "empty" OutputSet means the Activity produces no data.
+- Which OutputSet is actually produced is determined by the Activity implementation (Service execution, User decision, etc.).
+
+## 5. DataAssociation (§10.4.1, p220–223)
+
+Moves data between item-aware elements. `BaseElement` contained by an `Activity` or `Event`. **Tokens do NOT flow along DataAssociations** — they have no direct effect on control flow.
+
+**Two concrete subtypes:**
+- `DataInputAssociation` — target is a DataInput contained in an Activity; sources are item-aware elements accessible in current scope (DataObject, Property, Expression).
+- `DataOutputAssociation` — source is a DataOutput contained in an Activity; target is any item-aware element accessible in current scope.
+
+**Attributes (Table 10.63):**
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `sourceRef` | `ItemAwareElement [0..*]` | Source(s) — MUST be ItemAwareElement(s). |
+| `targetRef` | `ItemAwareElement [1]` | Target — MUST be ItemAwareElement. |
+| `transformation` | `Expression [0..1]` | Optional transformation Expression. |
+| `assignment` | `Assignment [0..*]` | Zero or more single-element assignments. |
+
+**Constraint on types:**
+- `ItemDefinition` of `sourceRef` and `targetRef` MUST match, **OR** the DataAssociation MUST have a `transformation` Expression that transforms source ItemDefinition into target ItemDefinition.
+
+### Execution semantics of a single DataAssociation (§10.4.2, p225)
+
+The execution of ANY DataAssociation MUST follow these rules:
+
+1. **If `transformation` specified:** evaluate the Expression, copy result to `targetRef`. This **completely replaces** the previous value of the target. (Sources are used as scope-availability gate but need not be referenced inside the Expression.)
+2. **For each `assignment`:**
+   - Evaluate `from` Expression → obtain *source value*.
+   - Evaluate `to` Expression → obtain *target element* (any element in context or sub-element of it, e.g. a DataObject or a field of one).
+   - Copy *source value* to *target element*.
+3. **If neither `transformation` nor `assignment` specified:** simple copy of `sourceRef` value into `targetRef`. **Only ONE `sourceRef` is allowed in this case.**
+
+### Availability gating
+
+- "Sources are used to define if the data association can be _executed_."
+- If ANY source is in state `unavailable`, the DataAssociation CANNOT execute.
+- The Activity or Event where the DataAssociation is defined MUST wait until the unavailable condition is resolved.
+
+### Assignment (Table 10.64)
+
+Used for mapping a single sub-element of a structure instead of a whole-payload copy.
+
+| Attribute | Type / Card | Purpose |
+|---|---|---|
+| `from` | `Expression [1]` | Evaluates the source. |
+| `to` | `Expression [1]` | Defines the actual Assignment operation and locates the target element. |
+
+Default `Expression` language is from `Definitions.expressionLanguage`; can be overridden on each `Assignment`.
+
+## 6. Activity execution semantics for data (§10.4.2)
+
+This is the precise wiring of DataAssociations into the activity lifecycle ([../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)).
+
+### InputSet selection (Ready → Active)
+
+When an element with an `InputOutputSpecification` is ready to begin execution (triggered by Sequence Flow OR an Event being caught):
+
+1. The defined InputSets are evaluated **in declaration order** within the `InputOutputSpecification`.
+2. For each InputSet, the data inputs it references are evaluated:
+   - ALL DataAssociations whose target is one of those DataInputs are evaluated.
+   - If ANY source of those DataAssociations is `unavailable` → the InputSet is `unavailable` → move to next InputSet.
+3. The **first** InputSet where all required DataInputs are `available` is selected.
+4. ALL DataAssociations targeting DataInputs of the selected InputSet execute — filling the Activity's DataInputs from process-scope DataObjects / Properties.
+5. The Activity transitions Ready → Active.
+
+If NO InputSet is "available" → execution **waits** until the condition is met. (Timing/frequency of re-evaluation is OUT OF SCOPE of the spec — implementations choose.)
+
+### OutputSet execution (Completing → Completed)
+
+When the Activity finishes execution:
+
+1. The defined OutputSets are checked in declaration order.
+2. The first available OutputSet is selected.
+3. ALL DataAssociations whose sources are any DataOutputs of that OutputSet execute — copying values from Activity DataOutputs back into the container's context (DataObjects, Properties, etc.).
+
+**Runtime exception** (§13.3.2): if no OutputSet becomes available, the engine throws a runtime exception.
+
+### IORule check (§13.3.2)
+
+If `outputSetRefs` is set on the InputSet that started the Activity, the chosen OutputSet at completion is checked: it MUST be one of the OutputSets the originating InputSet's `outputSetRefs` allows. **Runtime exception** if the pairing is violated.
+
+## 7. Event DataAssociations (§10.4.2, p224)
+
+Events have ONE set of DataAssociations (vs Activities' two). Usage depends on direction:
+
+### Throw Events
+
+- When activated, ALL `DataInputAssociation`s of the Event execute, filling the Event's DataInputs from context.
+- DataInputs are then copied to elements thrown by the Event (Message, Signal, etc.).
+- **Events have no InputSets** — execution NEVER waits.
+
+### Catch Events
+
+- When activated, the Event's DataOutputs are filled with the element that triggered the Event (the incoming Message / Signal / etc.).
+- ALL `DataOutputAssociation`s of the Event execute, pushing values into context (DataObjects, Properties).
+- **Events have no OutputSets.**
+
+### Process-level Start / End Events (special case for Call Activity + Message Flow)
+
+To allow invoking a Process from both a Call Activity and via Message Flow:
+
+- **Start Event:** the DataInputs of the **enclosing Process** are available as TARGETS to the Event's `DataOutputAssociation`s. Process DataInputs can be filled using the elements that triggered the Start Event.
+- **End Event:** the DataOutputs of the **enclosing Process** are available as SOURCES to the Event's `DataInputAssociation`s. End Event resulting elements can use Process DataOutputs as sources.
+
+## 8. Task-type-specific data mapping (§10.4.1, p216)
+
+Cross-cuts with [tasks.md](tasks.md). Key constraints:
+
+| Task type | I/O constraint |
+|---|---|
+| **ServiceTask** with `operationRef` | MUST have one `Message Data Input` with `itemDefinition` matching the Operation's `inMessageRef` Message. If Operation defines output Messages, MUST have one `DataOutput` matching `outMessageRef`. |
+| **SendTask** | MUST have at most one `InputSet` and at most one `DataInput`. If `DataInput` present, its `itemDefinition` MUST equal the associated Message's. If absent, Message is sent without payload data. |
+| **ReceiveTask** | MUST have at most one `OutputSet` and at most one `DataOutput`. If `DataOutput` present, its `itemDefinition` MUST equal the associated Message's. If absent, Message payload does not flow into the Process. |
+| **UserTask / ScriptTask** | Access to its DataInput, DataOutput, and data-aware elements in scope. |
+| **CallActivity** | DataInputs / DataOutputs are mapped to corresponding elements in the CallableElement **without any explicit DataAssociation** — direct positional mapping. |
+
+### Event data binding (p217)
+
+If any `EventDefinition` is associated with an item-bearing element (Message, Escalation, Error, Signal):
+
+- For multiple `EventDefinition`s on one Event: MUST have one DataInput (throw) or one DataOutput (catch) **per** EventDefinition. The **order** of `EventDefinition`s and the order of DataInputs/DataOutputs determines the correspondence.
+- For each `EventDefinition` ↔ DataInput/DataOutput pair: the DataInput/DataOutput's `itemDefinition` MUST equal the one defined by the Message/Escalation/Error/Signal on the EventDefinition. If absent, payload does not flow.
+
+## 9. Engine implementation notes
+
+- DataAssociation evaluation is **synchronous to lifecycle transitions** — there's no parallel data plane. The activity blocks on Ready→Active until its chosen InputSet's DataAssociations all complete, and the outgoing tokens are not emitted (Completed→outgoing flows) until Completing→Completed's OutputSet DataAssociations all complete.
+- **"Unavailable" is a first-class state**, not just an empty value. Engines need to track availability separately from value content for DataObjects and Properties — at minimum to gate DataInputAssociation execution.
+- **Snapshot vs reference:** the spec uses "copy" language consistently. A DataAssociation `source → target` copies the source's current value to the target; later changes to the source do NOT propagate. This is true both for the simple-copy case and the transformation case ("This operation replaces completely the previous value of the targetRef element").
+- **DataObject collections** require the `MultiInstanceLoopCharacteristics` mediator pattern for per-instance extraction — see [multi-instance.md](multi-instance.md). The data-extraction mechanism is "left under-specified" by the spec.
+- **DataState semantics are out of scope.** Engines/domains define their own state values and what they mean. The spec only mandates the structural attachment.
+- **XPath bindings (§10.4.3)** for accessing DataObjects, DataInputs, DataOutputs, Properties, and instance attributes via XPath extension functions — only relevant if the engine supports XPath as an `expressionLanguage`. Functions: `getDataObject`, `getDataInput`, `getDataOutput`, `getProcessProperty`, `getActivityProperty`, `getEventProperty`, `getProcessInstanceAttribute`, `getActivityInstanceAttribute`.
+
+## Cross-references
+
+- Activity lifecycle (when InputSet/OutputSet evaluation happens): [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)
+- Task-type-specific behavior: [tasks.md](tasks.md)
+- Multi-instance data flow (loopDataInput / loopDataOutput / inputDataItem / outputDataItem): [multi-instance.md](multi-instance.md)
+- Event handling (catch/throw Events with data): [events.md](events.md)
+- Structural attributes catalogue: [../elements/data.md](../elements/data.md)
+- Service interface (Interface / Operation / Message data binding for Service/Send/Receive Tasks): [../elements/service-interfaces.md](../elements/service-interfaces.md)

--- a/docs/bpmn-spec/semantics/end-events.md
+++ b/docs/bpmn-spec/semantics/end-events.md
@@ -1,0 +1,78 @@
+# End Event Termination Conditions
+
+_Source: BPMN 2.0 §13.5.6 (spec p443)._
+
+End Events terminate token-flow on a branch. Their behavior depends on (a) where they occur — Process-level vs Sub-Process-level — and (b) their `EventDefinition` type.
+
+## Process-level End Events
+
+### Terminate End Event
+
+- The **Process is abnormally terminated**.
+- No other ongoing **Process instances** are affected (terminates only this one instance).
+- Remaining tokens are discarded.
+- Other End Events behavior is NOT performed.
+
+### Other End Event types (Message / Signal / Error / Escalation / Compensation / None)
+
+- The behavior associated with the Event type is performed:
+  - Message End Event → the associated `Message` is sent.
+  - Signal End Event → the associated `Signal` is sent.
+  - Error End Event → the associated `Error` is thrown.
+  - Escalation End Event → the associated `Escalation` is thrown.
+  - Compensation End Event → a throw Compensation Event is triggered (see [compensation.md](compensation.md)).
+  - None End Event → no specific behavior, just consumes the token.
+- The Process instance is then **completed** if and only if both:
+  1. All start nodes of the Process have been visited (i.e., all Start Events have been triggered, and for every starting Event-Based Gateway, one of the associated Events has been triggered).
+  2. No `token` remains within the Process instance.
+
+## Sub-Process-level End Events
+
+### Terminate End Event
+
+- The **Sub-Process is abnormally terminated**.
+- For a multi-instance Sub-Process: ONLY the affected instance is terminated. Other Sub-Process instances and higher-level Sub-Processes / Process instances are NOT affected.
+- Remaining tokens within the affected Sub-Process instance are discarded.
+
+### Cancel End Event
+
+- The **Sub-Process is abnormally terminated** AND the associated **Transaction is aborted**.
+- Control leaves the Sub-Process through a **Cancel intermediate boundary event** attached to the Sub-Process.
+- Use case: only valid within a `Transaction` Sub-Process.
+
+### Other End Event types
+
+- Same as Process-level: the type-specific behavior is performed.
+- The Sub-Process instance is then **completed** iff:
+  1. All start nodes of the Sub-Process have been visited.
+  2. No `token` remains within the Sub-Process instance.
+
+## Comparison table
+
+| End Event Type | Process-level effect | Sub-Process-level effect |
+|---|---|---|
+| `None` | Token consumed; instance completes if conditions met | Token consumed; instance completes if conditions met |
+| `Terminate` | Abnormal Process termination | Abnormal Sub-Process termination (only affected MI instance for MI) |
+| `Cancel` | (Not valid at Process level) | Abnormal Sub-Process termination + Transaction abort; control leaves via Cancel boundary event |
+| `Message` | Send Message; instance completes if conditions met | Send Message; instance completes if conditions met |
+| `Signal` | Throw Signal; instance completes if conditions met | Throw Signal; instance completes if conditions met |
+| `Error` | Throw Error; instance fails (propagation per error-handling) | Throw Error; propagates up to enclosing scope |
+| `Escalation` | Throw Escalation; instance completes if conditions met | Throw Escalation; propagates up to enclosing scope |
+| `Compensation` | Trigger compensation per `CompensateEventDefinition` | Trigger compensation per `CompensateEventDefinition` |
+
+## Completion conditions recap
+
+Normal Process / Sub-Process completion requires:
+
+1. **All start nodes visited** — every Start Event triggered, and for every starting Event-Based Gateway one of its associated Events triggered.
+2. **No tokens remaining** — every token has reached an End Event.
+
+When a Process is created via an instantiating **Parallel Event-Based Gateway**, condition (1) extends: all subsequent Events of that gateway MUST have occurred (§13.2). See [../state-machines/process-lifecycle.md](../state-machines/process-lifecycle.md).
+
+## Cross-references
+
+- Process lifecycle: [../state-machines/process-lifecycle.md](../state-machines/process-lifecycle.md)
+- Compensation triggering by Compensation End Event: [compensation.md](compensation.md)
+- Cancel boundary event on Transaction Sub-Process: [sub-processes.md](sub-processes.md)
+- Error propagation (out of scope of this file): handled by error event handlers / boundary error events / event sub-processes — see [events.md](events.md)
+- Event definition structural attributes: [../elements/event-definitions.md](../elements/event-definitions.md)

--- a/docs/bpmn-spec/semantics/event-handling.md
+++ b/docs/bpmn-spec/semantics/event-handling.md
@@ -1,0 +1,237 @@
+# Event Handling — Resolution, Propagation, Scopes
+
+_Source: BPMN 2.0 §10.5.1 (Concepts, p233) + §10.5.6 (Handling Events, p274–279) + §10.5.7 (Scopes, p280)._
+
+This file covers the **modeling-level architecture** of events: how triggers are forwarded to catching handlers, multiplicity constraints on handlers, precedence between inline (Event Sub-Process) and boundary handlers, and the scope hierarchy that defines event resolution boundaries.
+
+Companion to [events.md](events.md), which covers per-position handling (Start / Intermediate / Boundary / Event Sub-Process), and [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md), which covers state transitions triggered by events.
+
+## 1. Event resolution strategies (§10.5.1)
+
+The mechanism by which a thrown trigger reaches its catching handler depends on the trigger type:
+
+| Strategy | Triggers | Forwarding rule |
+|---|---|---|
+| **Publication** | Message, Signal | Trigger MAY be received by any catching Event in any scope where the trigger is published. Messages = typically B2B / cross-Pool. Signals = broadcast within and across Pools, Processes, and diagrams. |
+| **Direct resolution** | Cancellation, Compensation, Termination | Trigger directed at a **specific Process or Activity instance**. Cancellation/Compensation reference an activityRef; Termination targets the enclosing scope. |
+| **Propagation** | Error, Escalation | Trigger forwarded from the throw location **upward to the innermost enclosing scope instance** that has an attached catching Event for it. Errors are **critical** — suspend execution at throw location. Escalations are **non-critical** — execution continues at throw location. |
+| **Implicit throw** | Timer, Conditional | Triggers thrown automatically when their condition (time / Boolean state) is satisfied. |
+
+**Unresolved trigger:** if no catching Event is found anywhere in the scope chain for an Error or Escalation, the trigger is **unresolved**. The spec does not mandate a specific engine reaction — implementations typically log + abort the Process instance for an unresolved Error, and ignore an unresolved Escalation.
+
+**Conversation grouping for Publication:** Events whose strategy is publication (Messages, Signals) are grouped into **Conversations**. A published Event MAY participate in several Conversations. For Messages, **correlation** (see [correlation.md](correlation.md)) identifies which Process instance the Message reaches.
+
+## 2. Three categories of Event handlers (§10.5.6)
+
+Per §10.5.6 intro, BPMN has three types of Event handlers:
+
+| Category | Where attached | Effect of trigger |
+|---|---|---|
+| **Process-starting** | `StartEvent` (top-level or in an event sub-process) | Instantiate a new Process (or new Event Sub-Process) |
+| **Inline in Sequence Flow** | `IntermediateCatchEvent` in normal flow | Wait → consume → follow outgoing flows |
+| **Attached to Activity** | `BoundaryEvent` OR `Event Sub-Process` inside the Activity | Interrupt or augment the Activity's execution |
+
+## 3. Start Event handling patterns
+
+**Single Start Event:** each occurrence creates a new Process instance, sequence flows are followed as usual.
+
+**Exclusive start** (multiple alternative Start Events): the most common multi-trigger pattern. Each Start Event is an alternative entry; each occurrence creates an independent new Process instance. A single `MultipleStartEvent` with multiple Message Event Definitions behaves the same way.
+
+**Event-Based Gateway start** (`instantiate=true`): first matching Event creates the instance; siblings stop waiting (Event-Based Exclusive Gateway semantics). This is the **only scenario** where a Gateway can exist without incoming Sequence Flows.
+
+**Multiple Event-Based Gateway groups at start:** several groups, all in the same Conversation sharing correlation info. One Event per group needs to arrive. First one creates the Process instance; subsequent (from other groups) route to the existing instance.
+
+**Event synchronization (Parallel Start Event):** when a modeler requires several disjoint Start Events to be **merged into a single Process instance**, the Parallel Start Event MAY group them. Each grouped Start Event MUST occur exactly once for the Process instance to be created.
+
+For lifecycle / token semantics see [../state-machines/process-lifecycle.md](../state-machines/process-lifecycle.md).
+
+## 4. Boundary Event attachment rules
+
+A `BoundaryEvent` attaches to an Activity's boundary to change normal flow into exception or augmenting flow.
+
+### Allowed triggers on boundary (§10.5.4 + §10.5.6, Table 10.90 / 10.92)
+
+| Trigger | Allowed on boundary | `cancelActivity` allowed values |
+|---|---|---|
+| Message | yes | `true` (interrupting) or `false` (non-interrupting) |
+| Timer | yes | `true` or `false` |
+| Signal | yes | `true` or `false` |
+| Conditional | yes | `true` or `false` |
+| Escalation | yes | `true` or `false` |
+| Multiple | yes | `true` or `false` |
+| Parallel Multiple | yes | `true` or `false` |
+| **Error** | yes | **always `true`** (no non-interrupting Error event exists) |
+| **Cancel** | yes — **only on Transaction Sub-Process** | **always `true`** |
+| **Compensation** | yes | `cancelActivity` does not apply (compensation is special — triggered by throw Compensation Event, not by activity execution) |
+| None | NO (only in normal flow) | — |
+| Link | NO (only in normal flow) | — |
+
+### Visual notation rule
+
+- Interrupting (`cancelActivity=true`): **solid** boundary marker.
+- Non-interrupting (`cancelActivity=false`): **dashed** boundary marker.
+
+The visual notation **implicitly sets** `cancelActivity` — a modeling tool MUST infer the value from notation.
+
+### Effect rules
+
+**Interrupting** (`cancelActivity=true`):
+- Event occurrence consumed.
+- Associated Activity is **terminated**.
+- A downstream token is generated which activates the next element via the boundary's outgoing **exception flow**.
+
+**Non-interrupting** (`cancelActivity=false`):
+- Event occurrence consumed.
+- Activity **continues** to execute.
+- A token is generated for the boundary's outgoing Sequence Flow **in parallel** with the continuing Activity.
+- "Care MUST be taken" when this parallel flow merges back into the main flow — typically it should be ended with its own End Event to avoid merge-time ambiguities.
+
+## 5. Handler multiplicity rules (§10.5.6, p278)
+
+For a given parent Activity (Sub-Process), the spec constrains how many handlers (Event Sub-Processes + boundary Events combined) may target the same Event Declaration:
+
+### Interrupting handlers
+
+- For each Event Declaration: **only ONE interrupting handler** (Event Sub-Process OR boundary Event) MAY be modeled.
+- Reason: interrupting handlers terminate the parent immediately after handler completion → only one can execute at a time per Event Declaration.
+- This restriction is **per Event Declaration**, not per Event type. A modeler MAY specify multiple interrupting handlers if each refers to a **different Event Declaration** (e.g., different `errorRef`, different `messageRef`).
+- Once an interrupting handler is started, no further handlers (interrupting OR non-interrupting) may be initiated for the parent.
+
+### Non-interrupting handlers
+
+- For each Event Declaration: an **unlimited** number of non-interrupting Event Sub-Processes can be modeled and execute in parallel.
+- At runtime, they are invoked in **non-deterministic order**.
+- During execution of a non-interrupting Event Sub-Process, the parent Activity **continues executing** normally.
+- Same restrictions apply to non-interrupting boundary Events.
+
+### Interrupting Event Declarations
+
+The following triggers can be interrupting: Error, Escalation, Message, Signal, Timer, Conditional, Multiple, Parallel Multiple.
+
+### Non-interrupting Event Declarations
+
+The following triggers can be non-interrupting: Escalation, Message, Signal, Timer, Conditional, Multiple, Parallel Multiple. (**Error is excluded** — errors always interrupt.)
+
+## 6. Inline (Event Sub-Process) vs boundary handler precedence
+
+When a Sub-Process has **both** an inline Event Sub-Process AND a boundary Event handler for the **same `EventDefinition`** (§10.5.6, p278):
+
+| Case | Outcome |
+|---|---|
+| Inline Event Sub-Process **"re-throws"** the Event after completion | The boundary Event is triggered. Inline handler runs first, then re-emits the Event, then boundary handler runs. |
+| Inline Event Sub-Process completes **without re-throwing** | The parent Activity is considered to have completed. Normal Sequence Flow resumes. The Event Sub-Process **"absorbs"** the Event — the boundary handler is NOT triggered. |
+
+This gives the modeler explicit control over whether an inline handler is a **terminal** handler ("absorbs") or a **decorator** ("re-throws").
+
+## 7. Interrupting Event Handler runtime flow
+
+When an interrupting Event (Error / Escalation / Message / Signal / Timer / Conditional / Multiple / Parallel Multiple) occurs on a parent Activity:
+
+1. Whenever the Event occurs — regardless of inline-handler vs boundary-handler delivery — the associated parent Activity is **interrupted**.
+2. If an **inline error handler** is specified (Sub-Process case): the handler runs **within the context** of that Sub-Process — has access to Sub-Process's data context.
+3. If a **boundary Error Event** is present: Sequence Flows from that boundary Event are then followed.
+4. The parent Activity is **cancelled** AFTER either:
+   - The error handler completes, OR
+   - The Sequence Flow from the boundary Event is followed.
+
+## 8. Non-interrupting Event Handler runtime flow
+
+For Event Sub-Processes:
+- Whenever the Event occurs, it is consumed and the associated Event Sub-Process is performed.
+- If several Events happen in parallel: handled concurrently — several Event Sub-Process **instances** are created.
+- A non-interrupting Start Event indicates the Event Sub-Process instance runs **concurrently** to the parent Sub-Process proper.
+
+For boundary Events:
+- Whenever the Event occurs, the handler runs **concurrently** to the Activity.
+- If an Event Sub-Process is also specified for that Event (Sub-Process case): it runs within the Sub-Process's context.
+- Sequence Flows from the boundary Event are followed.
+- A token is generated for the boundary's outgoing Sequence Flow in parallel with the continuing Activity.
+- Merge-back caution as noted in §4 above.
+
+## 9. End Event handling recap (§10.5.6, p279)
+
+| End Event type | Effect |
+|---|---|
+| **Terminate** | All remaining active Activities within the Process (or Sub-Process) are terminated. |
+| **Cancel** | Only allowed in a **Transaction Sub-Process**. Cancels the Sub-Process and aborts the associated Transaction. |
+| All others (None / Message / Signal / Error / Escalation / Compensation) | EventDefinition behavior performed. When no further active Activities remain → Sub-Process / Process instance is completed. |
+
+Full conditions in [end-events.md](end-events.md).
+
+## 10. Scopes (§10.5.7)
+
+A **scope** describes the context in which an Activity executes. Conceptually:
+
+> _"A scope describes the context in which execution of an Activity happens. This consists of the set of: Data Objects available (including DataInput and DataOutput); Events available for catching or throwing triggers; Conversations going on in that scope."_ — §10.5.7
+
+### Scope structure
+
+- A scope contains **exactly one main flow** of Activities. The flow is started when the scope gets activated.
+- All Activities are enclosed by a scope.
+- Scopes are **hierarchically nested**.
+
+### Scope instances
+
+- A scope can have **several scope instances** at runtime (e.g., for multi-instance Sub-Processes).
+- Scope instances are hierarchically nested according to their generation.
+- A single scope instance can have **multiple tokens** active in it concurrently.
+
+### Scope instance lifecycle
+
+A scope instance has its own lifecycle states (separate from the Activity lifecycle):
+
+- `Activated`
+- `In execution`
+- `Completed`
+- `In Compensation`
+- `Compensation`
+- `In Error`
+- `In Cancellation`
+- `Cancelled`
+
+### Elements with scope characteristics
+
+| Element | Scope role |
+|---|---|
+| `Choreography` | Out of scope for execution conformance (see [../conformance.md](../conformance.md)) |
+| `Pool` | Out of scope for execution conformance |
+| `SubProcess` | Primary in-scope scope container |
+| `Task` | Implicit micro-scope (data inputs / outputs + ability to attach boundary Events) |
+| `Activity` | Generic |
+| `Multi-instances body` | The per-iteration body of an MI Activity is a scope |
+
+### What scopes define the semantics of
+
+Per §10.5.7, scopes are used to define the semantics of three things:
+
+1. **Visibility of Data Objects** (including DataInput and DataOutput) — see [data.md](data.md).
+2. **Event resolution** — propagated triggers (Error / Escalation) climb the scope chain looking for a catching handler; published triggers (Message / Signal) are matched against scope-attached Conversations.
+3. **Starting / stopping of token execution** — token-flow gates at scope boundaries.
+
+### Implicit vs explicit modeling
+
+The Data Objects, Events, and `correlationKeys` described by a scope can be:
+- **Explicitly modeled** (e.g., a Sub-Process with declared DataObjects and attached boundary Events), OR
+- **Implicitly defined** (e.g., the implicit scope of a Task with no declared data — it still has a scope, just empty).
+
+## 11. Engine implementation notes
+
+- **Scope chain walk for Error / Escalation propagation:** when a throw Error / Escalation occurs, the engine MUST walk from the throwing scope outward to enclosing scopes, checking each for a catching Event with matching `errorRef` / `escalationRef`. First match consumes the trigger. No match → unresolved (Error → critical, typically aborts; Escalation → silent).
+- **Conversation-bound Message publication:** Messages MUST be matched not only by Message ref but also by correlation (see [correlation.md](correlation.md)). A subscriber in a scope doesn't see a published Message unless the Message's correlation matches the subscriber's Conversation correlation.
+- **Signal publication is unscoped within reach:** Signals do NOT use correlation. Every catching Signal handler in reach (within the Process, within the same Pool depending on engine architecture) receives the Signal. Engines need a Signal-name → set-of-subscribers index.
+- **Interrupting handler exclusion is per Event Declaration:** an interrupting handler for ErrorEventDefinition with `errorRef=X` does NOT exclude an interrupting handler for `errorRef=Y` on the same parent. Engines need to track multiplicity per (parent Activity, EventDefinition reference) pair.
+- **Inline vs boundary handler delivery order:** when a Sub-Process has both inline and boundary handler for the same EventDefinition, the engine MUST deliver to the inline first. After inline completes, check whether it "re-threw" (modeled via an Intermediate or End Throw Event with the same EventDefinition in the Event Sub-Process) — if so, deliver to boundary. Otherwise absorb.
+- **Multi-instance Activity termination:** a Terminate End Event in an MI Sub-Process terminates **only the affected instance** (§13.5.6), not the whole MI Activity. Cross-checked with scope: each MI iteration body is a separate scope instance.
+- **Scope instance state machine** ≠ Activity state machine. Scope instances have their own lifecycle (Activated → In execution → Completed → optionally In Compensation / In Error / Cancelled). Engines that model scope instances explicitly (Camunda-style "concurrent execution tree") gain cleaner semantics for compensation and error handling.
+
+## Cross-references
+
+- Per-position event handling (Start / Intermediate / Boundary / Event Sub-Process): [events.md](events.md)
+- Lifecycle transitions triggered by events: [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)
+- Process-instance instantiation: [../state-machines/process-lifecycle.md](../state-machines/process-lifecycle.md)
+- End Event termination conditions: [end-events.md](end-events.md)
+- Compensation triggering and handler invocation: [compensation.md](compensation.md)
+- Message correlation: [correlation.md](correlation.md)
+- Data visibility within scopes: [data.md](data.md)
+- Event Sub-Process structural rules: [sub-processes.md](sub-processes.md)
+- Structural attributes per event type: [../elements/events.md](../elements/events.md), [../elements/event-definitions.md](../elements/event-definitions.md)

--- a/docs/bpmn-spec/semantics/events.md
+++ b/docs/bpmn-spec/semantics/events.md
@@ -1,0 +1,126 @@
+# Event Handling
+
+_Source: BPMN 2.0 §13.5.1–§13.5.4 (spec p439–441)._
+
+Event behavior is defined per position (Start / Intermediate / End / Boundary) and per type (Message, Timer, Signal, Error, etc.). This file covers the position-level semantics. Per-type catalogue is in [../elements/event-definitions.md](../elements/event-definitions.md).
+
+## Start Events (§13.5.1)
+
+Handling = **starting a new Process instance** each time the Event occurs. Sequence flows leaving the Event are then followed as usual.
+
+### Conversation-bound start
+
+If the Start Event participates in a **Conversation** that includes other Start Events:
+
+- A new Process instance is created ONLY IF no instance already exists for the specific Conversation (identified by correlation information of the Event occurrence).
+- Otherwise the Event is routed to the existing instance.
+
+### Start via Event-Based Gateway
+
+Already covered in [gateways.md](gateways.md) (Event-Based Gateway) and [../state-machines/process-lifecycle.md](../state-machines/process-lifecycle.md). Recap:
+
+- First matching Event creates a new Process instance.
+- For Parallel Event-Based Gateway at start: subsequent matching Events route to the already-created instance (do not create new ones), as long as their correlation matches.
+- Multiple groups of Event-Based Gateways may exist (each a "starting group"). One Event from each group needs to arrive. First creates the instance; subsequent ones join the existing instance.
+
+## Intermediate Events (§13.5.2)
+
+For Intermediate Catching Events:
+
+- Handling = **waiting** for the Event to occur.
+- Waiting starts when the Intermediate Event is **reached** by a token.
+- Once the Event occurs: it is **consumed**.
+- Outgoing sequence flows are followed as usual.
+
+For Intermediate Throwing Events:
+
+- Handling = **producing** the Event (Message sent, Signal sent, Escalation thrown, etc.).
+- Then immediately followed by outgoing sequence flows.
+
+### Correlation for catching Message Intermediate Events
+
+Same as `ReceiveTask` correlation (see [tasks.md](tasks.md)):
+
+- **Key-based:** Message matches at most one Process instance per `CorrelationKey`.
+- **Predicate-based:** Message MAY be passed to multiple receivers.
+
+## Boundary Events (§13.5.3)
+
+Boundary events are attached to an Activity. Their handling depends on `cancelActivity`:
+
+### Interrupting (`cancelActivity=true`)
+
+- Consume the Event occurrence.
+- **Cancel** the Activity to which the boundary event is attached.
+  - For a multi-instance Activity: ALL its instances are cancelled.
+- Execution follows the sequence flow connected to the boundary event.
+
+### Non-interrupting (`cancelActivity=false`)
+
+- Consume the Event occurrence.
+- The Activity **continues execution** in parallel.
+- Execution follows the sequence flow connected to the boundary event (a parallel branch).
+- Only possible for **Message, Signal, Timer, Conditional** events.
+- **NOT allowed** for Error events (error always interrupts).
+
+### Message correlation on boundary
+
+For boundary Message Intermediate Events: same correlation as Receive Tasks (key-based / predicate-based).
+
+## Event Sub-Processes (§13.5.4)
+
+An `Event Sub-Process` is a `SubProcess` with `triggeredByEvent=true`. See [sub-processes.md](sub-processes.md) for structural and lifecycle details.
+
+### Trigger / scope
+
+- Allow handling an Event **within the context of** a Sub-Process or Process.
+- Begins with a Start Event of a specific type. The Start Event's `isInterrupting` flag determines interrupting vs non-interrupting handling.
+- Created when its associated Start Event triggers — NOT by normal control flow.
+- Self-contained: NOT connected to the parent's sequence flows. No boundary events on it.
+- Runs in the **context** of the parent (has access to parent's data).
+- MAY optionally re-trigger the Event outside the parent's boundary (continuation upward). In that case the Event Sub-Process performs its work; the Event is then re-thrown to the parent's boundary, which may itself trigger handlers (and may cancel the parent including running handlers).
+
+### Initiation rules
+
+- An Event Sub-Process becomes _initiated / Enabled / Running_ through the Activity to which it is attached.
+- The Event Handler MAY only be initiated AFTER the parent Activity is `Running` (Active or Completing).
+
+### Concurrency rules
+
+- More than one **non-interrupting** Event Handler MAY be initiated concurrently. Multiple instances of the same handler are possible.
+- Only ONE **interrupting** Event Handler MAY be initiated for a given `EventDefinition` within a parent Activity at any time.
+- Once an interrupting Event Handler started: the parent is interrupted; no new Event Handlers can be initiated.
+
+### Effect on parent
+
+| Trigger | Parent Activity state transition |
+|---|---|
+| Interrupting Event Sub-Process triggered by Error (e.g. Escalation classified as error) | Parent → `Failing` |
+| Interrupting Event Sub-Process triggered by non-error | Parent → `Terminating` |
+| Non-interrupting Event Sub-Process triggered | No state change on parent |
+
+The parent stays in Failing / Terminating until the interrupting Event Handler reaches a final state. During this time the handler can access the parent's data context; new Event Handlers MUST NOT be started.
+
+### Completion conditions
+
+- An Event Sub-Process completes when all tokens have reached an End Event (same shape as Sub-Process completion).
+- If the parent is in `Completing`: the parent remains there until all contained active Event Sub-Processes have completed. No new Event Sub-Processes can be initiated while parent is in Completing.
+
+## Message correlation (general)
+
+Used by: Message Start Event, catching Message Intermediate Event, boundary Message Event, Receive Task, Message Event Sub-Process Start, message-instance routing.
+
+Two modes:
+
+- **Key-based (`CorrelationKey`):** a named set of `CorrelationProperty`s. At most one receiver per key active at a time. Message matches at most one Process instance.
+- **Predicate-based:** the Message may be passed to multiple receivers simultaneously.
+
+Detailed mechanism: see [correlation.md](correlation.md) (spec §8.4.2). Structural elements: [../elements/correlation.md](../elements/correlation.md).
+
+## Cross-references
+
+- Position-by-type matrix (which event definitions are allowed at which positions): [../conformance.md](../conformance.md) "Event definitions"
+- Structural attributes per event type: [../elements/events.md](../elements/events.md), [../elements/event-definitions.md](../elements/event-definitions.md)
+- End-event termination conditions: [end-events.md](end-events.md)
+- Event-Based Gateway interaction: [gateways.md](gateways.md)
+- Sub-Process and Event Sub-Process structure: [sub-processes.md](sub-processes.md)

--- a/docs/bpmn-spec/semantics/gateways.md
+++ b/docs/bpmn-spec/semantics/gateways.md
@@ -1,0 +1,194 @@
+# Gateway Execution Semantics
+
+_Source: BPMN 2.0 §13.4 (spec p434–438)._
+
+All in-scope gateways consume tokens on incoming sequence flows and produce tokens on outgoing flows according to type-specific rules below.
+
+**Scope note:** Common Executable Subclass (§2.1.3) includes Exclusive, Parallel, Inclusive, and Event-Based gateways. **ComplexGateway is an explicit extension** above Common Executable, added because it enables workflow patterns (Structured Discriminator, Partial Joins) not otherwise expressible. See [../conformance.md](../conformance.md).
+
+## Parallel Gateway (§13.4.1)
+
+**Symbol:** `+`
+
+**Operational semantics (Table 13.1):**
+
+- **Activation:** at least one token on _each_ incoming sequence flow.
+- **Consumption:** exactly one token from each incoming sequence flow.
+- **Production:** exactly one token on each outgoing sequence flow.
+- **Excess tokens:** if multiple tokens are present on a single incoming flow, only one is consumed; the rest remain on that flow after gateway execution.
+- **Exceptions:** Parallel Gateway cannot throw an exception.
+
+**Workflow patterns:** WCP-2 Parallel Split, WCP-3 Synchronization.
+
+**Engine notes:**
+
+- Acts as both fork (when multiple outgoing) and join (when multiple incoming) — same element, configuration determined by direction.
+- Synchronization is _exact_: needs one token per incoming flow before it fires. Does not consume extras.
+
+## Exclusive Gateway (§13.4.2)
+
+**Symbol:** `×` (with optional X marker) or no marker
+
+**Pass-through semantics for incoming (merging behavior). Each activation routes to exactly one outgoing branch (branching behavior).**
+
+**Operational semantics (Table 13.2):**
+
+- Each `token` arriving at _any_ incoming flow activates the gateway and is routed to exactly one outgoing flow.
+- Conditions on outgoing flows are evaluated **in order**.
+- The **first** condition that evaluates to `true` determines the chosen outgoing flow. No more conditions are evaluated.
+- If and only if no condition evaluates to `true`, the token is passed on the **default** sequence flow (referenced by the `default` attribute on the Gateway).
+- If all conditions evaluate to `false` AND no default flow is specified → engine throws an exception.
+
+**Workflow patterns:** WCP-4 Exclusive Choice, WCP-5 Simple Merge, WCP-8 Multi-Merge.
+
+**Engine notes:**
+
+- Evaluation **order** is significant — model authors MUST express priority via flow ordering.
+- A token on any incoming flow fires the gateway independently (uncontrolled merge — different from Inclusive merge which synchronizes).
+- The `default` attribute on `ExclusiveGateway` references the `SequenceFlow` taken when no condition matches.
+
+## Inclusive Gateway (§13.4.3)
+
+**Symbol:** `O`
+
+**Operational semantics (Table 13.3) — most complex of the four:**
+
+### Activation condition
+
+The Inclusive Gateway is activated iff:
+
+- **(A)** at least one incoming sequence flow has at least one token, AND
+- **(B)** For every directed path formed by sequence flow that:
+  - starts with a sequence flow `f` of the diagram that has a token,
+  - ends with an incoming sequence flow of the inclusive gateway that has _no_ token, and
+  - does not visit the inclusive gateway
+  
+  there is _also_ a directed path formed by sequence flow that:
+  - starts with `f`,
+  - ends with an incoming sequence flow of the inclusive gateway that _has_ a token, and
+  - does not visit the inclusive gateway.
+
+Informally: the gateway waits until all expected tokens have arrived; expectation is computed by tracing upstream tokens.
+
+### Execution
+
+- Upon execution, **one token is consumed from each incoming flow that has one** (tokens on non-token incoming flows obviously stay zero).
+- **Production:** evaluate all conditions on outgoing flows (in any order). Each condition that evaluates to `true` produces a token on its respective outgoing flow.
+- If and only if no condition evaluates to `true`, the token is passed on the default flow.
+- If all conditions evaluate to `false` AND no default → exception thrown.
+
+**Exception:** thrown when all conditions are false and no default flow specified.
+
+**Workflow patterns:** WCP-6 Multi-Choice, WCP-7 Structured Synchronizing Merge, WCP-37 Acyclic Synchronizing Merge, WCP-38 General Synchronizing Merge.
+
+**Engine notes:**
+
+- The activation condition requires reasoning about the **graph reachability** of upstream tokens — non-trivial. Engines typically maintain expected-token counts per inclusive gateway.
+- Used both as inclusive split (multi-choice fork) and inclusive merge (synchronizing merge).
+
+## Event-Based Gateway (§13.4.4)
+
+**Symbol:** pentagon inside double-circle
+
+**Pass-through for incoming. Exactly one outgoing branch is activated based on which subsequent Event/Task fires first.**
+
+**Operational semantics (Table 13.4):**
+
+- Choice of outgoing branch is **deferred** until one of the subsequent Tasks or Events completes.
+- The first subsequent element to complete causes all other branches to be **withdrawn** (sibling activities transition to `Withdrawn` state — see [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)).
+- **Exception:** cannot throw an exception.
+
+**Workflow patterns:** WCP-16 Deferred Choice.
+
+**Engine notes:**
+
+- The "Tasks following an Event Gateway" are limited to **Receive Tasks** — see §10.6.6.
+- The "Events following" are intermediate catching events: Message, Timer, Signal, Conditional.
+- When used at Process start (`instantiate=true`), only **message-based** triggers are allowed.
+- If used at Process start with `eventGatewayType=Parallel`: first trigger instantiates the Process; remaining triggers join the existing instance (do not create new instances).
+- Distinct configurations via `eventGatewayType`: `Exclusive` (default) vs `Parallel`.
+
+### Race-withdrawal interaction with Activity Lifecycle
+
+When an Event-Based Gateway has multiple subsequent receive activities, all of them simultaneously transition `Inactive → Ready` when the gateway fires. The first one whose triggering Event arrives transitions `Ready → Active → Completing → Completed`; all siblings transition `Ready → Withdrawn` via the "Activity Interrupted + Alternative Path Selected" transition.
+
+## Complex Gateway (§13.4.5)
+
+**Symbol:** `*` (asterisk inside diamond)
+
+Facilitates complex synchronization, particularly **race situations** where the diverging behavior is similar to Inclusive Gateway but the activation rule is an explicit Boolean expression over per-incoming-flow token counts.
+
+### Runtime attributes
+
+Each **incoming** gate has an `activationCount` runtime attribute — an integer representing the number of tokens currently on that incoming sequence flow.
+
+The gateway has an `activationExpression` — a Boolean `Expression` that:
+- References the `activationCount` of incoming gates (e.g., `x1 + x2 + ... + xm >= 3` — "at least 3 of m incoming gates have a token").
+- MAY also reference Process data.
+- **Should use only addition and constants** in subexpressions over `activationCount` — i.e., `expr >= const` form — to prevent **undesirable oscillation** of gateway activation.
+
+Each **outgoing** sequence flow has a Boolean condition evaluated during gateway execution to determine if it receives a token. These conditions MAY refer to the gateway's internal state via the runtime attribute `waitingForStart` (Boolean).
+
+### Two-phase state machine
+
+The gateway is in one of two runtime states:
+- `waitingForStart = true` — initial state, waiting for `activationExpression` to fire
+- `waitingForStart = false` — `waitingForReset`, waiting for trailing tokens
+
+**Phase 1 — Waiting for start (Table 13.5):**
+
+- Wait for `activationExpression` to become `true`. The expression is **not evaluated** until at least one token exists on some incoming sequence flow.
+- When `activationExpression` becomes `true`:
+  - Consume one token from each incoming sequence flow that has a token.
+  - Determine outgoing flows: evaluate all outgoing conditions (in any order). Those evaluating `true` receive a token.
+  - If no outgoing condition evaluates `true`: token passed on the **default** sequence flow.
+  - If all conditions `false` AND no default → **runtime exception**.
+- Gateway changes state to `waitingForReset`.
+- Gateway **remembers** which incoming sequence flows it consumed tokens from in phase 1.
+
+**Phase 2 — Waiting for reset:**
+
+- Gateway waits for a token on each of the incoming flows from which it has **not yet** received a token in phase 1, UNLESS such a token is not expected per **Inclusive Gateway join semantics** (graph-based reachability — see Inclusive Gateway above).
+- Formally: resets when, for every directed path formed by sequence flow that
+  - starts with a sequence flow `f` having a token,
+  - ends with an incoming flow of the ComplexGateway that has no token AND has not consumed a token in phase 1,
+  - does not visit the ComplexGateway,
+  
+  there is also a path that
+  - starts with `f`,
+  - ends with an incoming flow of the ComplexGateway that has a token OR consumed a token in phase 1,
+  - does not visit the ComplexGateway.
+- If contained in a Sub-Process: paths crossing the Sub-Process boundary are NOT considered.
+- When the gateway resets:
+  - Consume one token from each incoming flow that has a token AND did NOT consume a token in phase 1.
+  - Evaluate outgoing conditions. Those true receive a token. If none → default. (Note: outgoing conditions MAY evaluate differently in the two phases — e.g., by referring to `waitingForStart`.)
+- Gateway state returns to `waitingForStart`.
+
+**Notes:**
+- The gateway MAY produce no tokens at all in phase 2 — no exception is thrown in that case (the phase-1 outputs already covered the activation).
+- If `activationExpression` never becomes `true`, tokens are blocked indefinitely → MAY cause **deadlock** of the entire Process. Engine SHOULD provide deadlock detection or timeouts.
+
+**Exceptions:** the ComplexGateway throws an exception when it is activated in state `waitingForStart`, no condition on any outgoing sequence flow evaluates `true`, AND no default sequence flow is specified.
+
+**Workflow patterns:** WCP-9 Structured Discriminator, WCP-28 Blocking Discriminator, WCP-30 Structured Partial Join, WCP-31 Blocking Partial Join.
+
+**Engine notes:**
+- The activation Expression typically references `activationCount` variables that are NOT process data — they are runtime counters maintained by the engine per incoming gate. Engines need a per-instance map `{incomingFlowId → activationCount}` and re-evaluate the activation Expression whenever the count changes.
+- The `waitingForStart` runtime attribute is a Boolean exposed to the engine's Expression evaluator so outgoing condition Expressions can branch on the phase.
+- Reset-phase reachability test is the same graph-based join logic used by Inclusive Gateway — share the implementation if possible.
+
+## Decision matrix
+
+| Gateway | Merge behavior | Split behavior | Synchronizes? | Can throw exception? |
+|---|---|---|---|---|
+| Parallel | Wait for all incoming | Fork all outgoing | yes (exact) | no |
+| Exclusive | Pass-through any | Pick first true | no | yes (no default + all false) |
+| Inclusive | Wait for expected subset | Fork all true | yes (graph-based) | yes (no default + all false) |
+| Event-Based | Pass-through any | First event/task wins | no | no |
+| Complex | Activation expression over per-gate counts | Evaluate all outgoing conditions | yes (custom, 2-phase) | yes (no default + all false in phase 1) |
+
+## Cross-references
+
+- Token-flow basics: [token-flow.md](token-flow.md)
+- Withdraw transition on race-loss: [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)
+- Structural attributes (`default`, `gatewayDirection`, etc.): [../elements/gateways.md](../elements/gateways.md)

--- a/docs/bpmn-spec/semantics/multi-instance.md
+++ b/docs/bpmn-spec/semantics/multi-instance.md
@@ -1,0 +1,133 @@
+# Loop and Multi-Instance
+
+_Source: BPMN 2.0 §13.3.6 + §13.3.7 (spec p432–433)._
+
+`StandardLoopCharacteristics` and `MultiInstanceLoopCharacteristics` are markers attached to an activity (`Task`, `SubProcess`, `CallActivity`) to make it execute multiple times. Reference structural definitions in [../elements/activities.md](../elements/activities.md).
+
+## Standard Loop (§13.3.6)
+
+Wraps an inner Activity executed **sequentially** multiple times.
+
+| Attribute | Meaning |
+|---|---|
+| `loopCondition` | Boolean `Expression`. Loop continues while `true`. |
+| `testBefore` | `true` = pre-tested loop (check before each iteration). `false` (default) = post-tested loop. |
+| `loopMaximum` | Optional integer. Maximum iteration count. If unset → unbounded. |
+
+**Workflow pattern:** WCP-21 Structured Loop.
+
+## Multi-Instance Activity (§13.3.7)
+
+Wraps an Activity to execute multiple times — sequentially OR in parallel.
+
+### Cardinality
+
+The number of instances is determined ONCE at activation, by one of:
+
+| Source | Mechanism |
+|---|---|
+| `loopCardinality` | Integer-valued `Expression`. Evaluated once. |
+| Collection-based | Cardinality = size of the collection-valued data item referenced by `loopDataInputRef`. |
+
+### Sequencing
+
+| `isSequential` | Behavior |
+|---|---|
+| `true` | New instance generated only after the previous instance has completed. |
+| `false` (default) | All instances generated and execute in parallel. |
+
+### Completion
+
+- `completionCondition`: boolean `Expression` evaluated every time an instance completes.
+  - When `true`: the **remaining instances are canceled** and the MI Activity itself completes.
+  - When `false`: instance is counted, remaining continue.
+- Without a `completionCondition`, MI Activity completes when all instances have completed.
+
+### Event throwing on completion — `behavior` attribute
+
+Determines if and when an Event is thrown from an MI Activity about to complete:
+
+| Value | Behavior |
+|---|---|
+| `none` | An `EventDefinition` is thrown for ALL instances completing. |
+| `one` | An `EventDefinition` is thrown upon FIRST instance completing. |
+| `all` | No Event is ever thrown. |
+| `complex` | `ComplexBehaviorDefinition`s are consulted — see below. |
+
+For `none` and `one`: the `EventDefinition` is referenced from `MultiInstanceLoopCharacteristics` via `noneEvent` / `oneEvent` associations. It implicitly carries the current runtime attributes of the MI Activity (the `ItemDefinition` of these `SignalEventDefinition`s is implicitly the MI Activity's runtime attributes).
+
+### ComplexBehaviorDefinition (for `behavior=complex`)
+
+- Holds multiple `ComplexBehaviorDefinition` entries, each consisting of:
+  - A boolean condition (a `FormalExpression`).
+  - An `Event` which is an `ImplicitThrowEvent`.
+- Whenever an Activity instance completes, ALL `ComplexBehaviorDefinition` conditions are evaluated.
+- Each one whose condition evaluates `true` causes its associated Event to be thrown.
+- A single instance completion can therefore lead to multiple different Events being thrown.
+- The `Event`s can be caught on the **boundary of the MI Activity** — allowing different flows depending on progress state.
+
+**Available variables** inside `completionCondition`, `condition` in `ComplexBehaviorDefinition`, and `DataInputAssociation` of an `Event` in `ComplexBehaviorDefinition`:
+- MI Activity instance runtime attributes
+- `loopDataInput`, `loopDataOutput`, `inputDataItem`, `outputDataItem` (from `MultiInstanceLoopCharacteristics`)
+
+## Data semantics for Multi-Instance
+
+Multi-Instance Activities process data **collections**:
+
+```
+                                  Process scope
+                                  
+                         DataObject (collection)
+                              |  (DataInputAssociation)
+                              v
+                    MI Activity's loopDataInput
+                              |  (split per instance)
+                              v
+                    inputDataItem (per instance)
+                              |  (DataInputAssociation)
+                              v
+                     Inner Activity DataInput
+                              |
+                              .... (executes)
+                              |
+                     Inner Activity DataOutput
+                              |  (DataOutputAssociation)
+                              v
+                    outputDataItem (per instance)
+                              |  (assembled)
+                              v
+                    MI Activity's loopDataOutput
+                              |  (DataOutputAssociation)
+                              v
+                         DataObject (collection)
+                                  Process scope
+```
+
+### Constraints
+
+- The MI Activity's `loopDataInput` MUST be linked to a process-scope `DataObject` via `DataInputAssociation`.
+- The source `DataObject` MUST be a collection (visual: marked with the MI indicator — three-bar).
+- The items of the `loopDataInput` collection determine the number of instances (whether sequential or parallel).
+- Inner instances are created; data values are extracted and assigned to each instance via `inputDataItem` → `DataInputAssociation` → inner `DataInput`.
+- The extraction mechanism is **under-specified** by the spec — typically requires a special-purpose mediator that handles both extraction and any necessary data transformation.
+- Output: each instance produces a value in its `DataOutput`. This is passed to a corresponding `outputDataItem`. The mechanism for updating `loopDataOutput` collection is also under-specified — typically the same kind of mediator.
+- The `loopDataOutput` collection in Process scope **should not be accessible** until all items have been written to it (could otherwise be accessed by a concurrent Activity, and control flow through token passing cannot guarantee the collection is fully written before access).
+
+## Compensation of Multi-Instance
+
+The MI Activity is compensated only if ALL its instances completed successfully — see [compensation.md](compensation.md).
+
+For Loop / sequential MI: instances compensated in **reverse order** of forward execution.
+For parallel MI: instances can be compensated in parallel.
+
+## Workflow patterns supported
+
+- Standard Loop: WCP-21 Structured Loop.
+- Multi-Instance: WCP-21 Structured Loop, plus Multiple Instance Patterns WCP-13, WCP-14, WCP-34, WCP-36.
+
+## Cross-references
+
+- Activity lifecycle (MI does not replace the lifecycle; each instance follows it): [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)
+- Compensation per-instance snapshot: [compensation.md](compensation.md)
+- Structural attributes of MultiInstanceLoopCharacteristics / ComplexBehaviorDefinition: [../elements/activities.md](../elements/activities.md)
+- Data flow basics: see §10.4 in the spec PDF (not yet in this KB)

--- a/docs/bpmn-spec/semantics/sub-processes.md
+++ b/docs/bpmn-spec/semantics/sub-processes.md
@@ -1,0 +1,128 @@
+# Sub-Process Variants
+
+_Source: BPMN 2.0 §13.3.4 + §13.3.5 (spec p430–431)._
+
+`SubProcess` is an activity that encapsulates an inner Process — modeled by Activities, Gateways, Events, and Sequence Flows. Once instantiated, contents execute as if in a normal Process. Sub-process completion follows the activity lifecycle ([../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)).
+
+## Plain Sub-Process
+
+### Instantiation
+
+A Sub-Process is instantiated when reached by a Sequence Flow `token`. Two structural variants:
+
+| Configuration | Token-routing behavior |
+|---|---|
+| Single empty Start Event + flows from it | Start Event receives the token on instantiation; sequence flows from it carry it onward. |
+| No Start Event, with Activities/Gateways without incoming sequence flows | All such elements receive a token on instantiation. |
+
+**Constraint:** A Sub-Process MUST NOT have non-empty Start Events (Message, Timer, Signal, etc.). Those belong to **Event Sub-Processes** (see below).
+
+### Event-triggered Sub-Process (no incoming flow)
+
+If the Sub-Process has no incoming sequence flows but contains `Start Event`s targeted by sequence flows _from outside_ — those external Start Events instantiate the Sub-Process when reached by a token. Multiple such Start Events are alternatives — each one creates its own instance.
+
+### Completion
+
+A Sub-Process instance completes when:
+- No tokens remain inside, AND
+- No nested Activity is still active.
+
+### Abnormal termination
+
+- **Terminate End Event** reached inside: Sub-Process abnormally terminated.
+- **Cancel End Event** reached inside: Sub-Process abnormally terminated AND the enclosing transaction is aborted; control leaves via a Cancel intermediate boundary event attached to the Sub-Process.
+- For all other End Event types: the End Event behavior is performed (Message sent, Signal sent, etc.).
+
+## Call Activity
+
+Invokes a reusable `CallableElement` — typically a global Process or `GlobalTask` variant.
+
+- **If the callable is a Process:** the Call Activity has the same instantiation and termination semantics as a Sub-Process.
+- The called Process MAY have non-empty Start Events (unlike a Sub-Process). When invoked via Call Activity, those non-empty Start Events are **ignored** — the empty Start Event is used. (Non-empty Start Events are alternatives for direct/independent invocation, not for the call-activity path.)
+
+**Engine notes:** Call Activity is a reuse mechanism. The boundary between caller and callee is identical to a Sub-Process boundary from the perspective of token flow, error propagation, and compensation scoping.
+
+## Event Sub-Process (§13.5.4)
+
+A `SubProcess` with `triggeredByEvent=true`. Specialized handling — instantiated by an event, not by control flow.
+
+- Always begins with a Start Event of a specific type (Message, Timer, Error, Escalation, Compensation, Signal, Conditional).
+- **NOT instantiated by normal control flow.** Instantiated only when its Start Event triggers.
+- **Self-contained:** MUST NOT be connected to the rest of the parent Sub-Process's sequence flows.
+- Cannot have boundary events attached.
+- Runs in the **context** of the parent Sub-Process (has access to its data).
+- Can re-throw the triggering Event outside the parent's boundary (continuation).
+
+### Interrupting vs non-interrupting
+
+Determined by `isInterrupting` on the **Start Event** of the Event Sub-Process.
+
+| `isInterrupting` | Effect on parent activity |
+|---|---|
+| `true` (interrupting) | Parent activity is interrupted. For MI parent, only the affected instance is cancelled. No new Event Handlers can be initiated in the parent after this. |
+| `false` (non-interrupting) | Parent continues in parallel with the Event Sub-Process. Multiple non-interrupting handlers MAY be initiated, at different times. |
+
+### Trigger constraints
+
+- Only **one** interrupting Event Handler MAY be initiated for a given `EventDefinition` within a parent Activity at any time.
+- Once the interrupting handler started, parent is interrupted; no new handlers (interrupting OR non-interrupting) may be initiated.
+- Multiple **non-interrupting** handlers MAY be initiated concurrently.
+
+### Effect on parent's lifecycle
+
+- Triggered by an `Error` (interrupting): parent activity enters `Failing` state.
+- Triggered by a non-error (interrupting, e.g. Escalation): parent activity enters `Terminating` state.
+- During Failing/Terminating: running Event Handler can access parent's data context; NO new Event Handlers may start.
+
+### Event Sub-Process completion
+
+- Completes when all tokens reach an `End Event`.
+- If the parent is in `Completing` state: it remains there until ALL active Event Sub-Processes complete. No new Event Sub-Processes can be initiated during Completing.
+
+## Ad-Hoc Sub-Process (§13.3.5)
+
+Loose-ordered activity container. Contents execute multiple times in an order constrained only by explicitly specified sequence flows.
+
+**Containment constraints:**
+- Contains: Activities, Sequence Flows, Gateways, Intermediate Events.
+- MAY contain: Data Objects, Data Associations.
+- Activities within an Ad-Hoc Sub-Process are NOT required to have incoming/outgoing sequence flows.
+- Intermediate Events MUST have outgoing sequence flows (they can be triggered multiple times while Ad-Hoc Sub-Process is active).
+
+**Operational semantics:**
+
+- At any point, a **subset** of embedded inner Activities is `enabled`. Initially: all Activities without incoming sequence flows.
+- One enabled Activity is selected for execution — typically by a Human Performer (not necessarily by the implementation).
+- `ordering` attribute:
+  - `sequential`: another enabled Activity can be selected only after the previous terminates.
+  - `parallel`: another enabled Activity can be selected at any time. Allows multiple parallel instances of the same inner Activity.
+- After each completion of an inner Activity, the `completionCondition` is evaluated.
+  - `false`: enabled set is updated; new selections can occur.
+  - `true`: Ad-Hoc Sub-Process completes.
+    - If `cancelRemainingInstances=true` (default): running inner Activity instances are **canceled**.
+    - If `cancelRemainingInstances=false`: Ad-Hoc Sub-Process waits for remaining instances to complete or terminate.
+
+**Token-flow within:**
+
+- When an inner Activity with outgoing sequence flows completes, tokens are produced on outgoing flows per `completionQuantity`.
+- Resulting state may also have tokens on incoming flows of converging Parallel/Complex Gateways or Intermediate Events.
+- Tokens propagated as far as possible — converging gateways execute until quiescence.
+- An inner Activity is re-enabled when its incoming sequence flows have sufficient tokens (per `startQuantity`).
+
+**Workflow pattern:** WCP-17 Interleaved Parallel Routing.
+
+## Transaction Sub-Process
+
+A Sub-Process variant (`Transaction`) with ACID-like semantics. Distinguished by:
+- Reaching a **Cancel End Event** inside triggers transaction abort.
+- A Cancel intermediate boundary event MAY be attached to the Transaction Sub-Process — control leaves through it on cancellation.
+
+The execution semantics of the Transaction Sub-Process itself follow the plain Sub-Process semantics; the Cancel behavior is the distinguishing feature.
+
+## Cross-references
+
+- Activity lifecycle: [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)
+- Event Sub-Process structural attributes: [../elements/activities.md](../elements/activities.md) (SubProcess with triggeredByEvent)
+- Compensation in Sub-Processes: [compensation.md](compensation.md)
+- Multi-instance / Loop wrappers on Sub-Processes: [multi-instance.md](multi-instance.md)
+- Cancel End Event: [end-events.md](end-events.md)

--- a/docs/bpmn-spec/semantics/tasks.md
+++ b/docs/bpmn-spec/semantics/tasks.md
@@ -1,0 +1,94 @@
+# Task Execution Semantics
+
+_Source: BPMN 2.0 §13.3.3 (spec p430)._
+
+Per-task-type execution rules. All tasks share the activity lifecycle ([../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)); this file documents what each task DOES during its Active state.
+
+## ServiceTask
+
+- Upon activation: data in the `inMessage` of the referenced `Operation` is assigned from data in the Service Task's `DataInput`.
+- The `Operation` is invoked.
+- On completion of the service: data in the Service Task's `DataOutput` is assigned from data in the `outMessage` of the `Operation`, and the Service Task **completes**.
+- If the invoked service returns a **fault**, that fault is treated as an **interrupting error** and the activity **fails** (state: `Failing` → `Failed`).
+
+**Engine notes:** the `operationRef` attribute on `ServiceTask` resolves the `Operation`. The `implementation` attribute is a string hint (e.g. `##WebService`, `##Unspecified`) for the invocation mechanism.
+
+## SendTask
+
+- Upon activation: data in the associated `Message` is assigned from data in the Send Task's `DataInput`.
+- The `Message` is sent.
+- The Send Task **completes**.
+
+**Engine notes:** the destination of the message is determined by the messaging mechanism (operation reference, message flow at Collaboration level — though Collaboration is out of scope here, see [../conformance.md](../conformance.md)).
+
+## ReceiveTask
+
+- Upon activation: the Receive Task **begins waiting** for the associated `Message`.
+- When the Message arrives: data in the Receive Task's `DataOutput` is assigned from data in the Message, AND the Receive Task **completes**.
+
+### Correlation
+
+- **Key-based correlation:** for a given `CorrelationKey`, only a single Receive Task instance can be active at a time. A Message matches at most one Process instance.
+- **Predicate-based correlation:** the Message MAY be passed to multiple Receive Tasks simultaneously.
+
+### Instantiating Receive Task
+
+- If `instantiate=true` and the Receive Task has no incoming sequence flows, the Receive Task itself can start a new Process instance (acts like a Message Start Event).
+
+## UserTask
+
+- Upon activation: the User Task is **distributed** to the assigned person or group of people (per `HumanPerformer` / `PotentialOwner` / `Performer` / `Rendering` — see [../elements/human-interaction.md](../elements/human-interaction.md)).
+- When the work has been done: the User Task **completes**.
+
+**Engine notes:** distribution mechanism is implementation-defined. The spec does not mandate a specific task list / inbox structure.
+
+## ManualTask
+
+- Upon activation: the manual task is **distributed** to the assigned person or group.
+- When the work has been done: the Manual Task **completes**.
+- **Conceptual only** — a Manual Task is _never actually executed by an IT system_.
+
+**Conformance note:** Manual Task is listed in §13.1 as a **non-operational** element. An engine conforming to Process Execution Conformance MAY ignore Manual Tasks (treat as no-op pass-through). Implementations MAY extend it to become operational — that is an optional extension to BPMN.
+
+## BusinessRuleTask
+
+- Upon activation: the associated business rule is **called**.
+- On completion of the business rule: the Business Rule Task **completes**.
+
+**Engine notes:** the spec does not mandate a rule engine binding. Typical wiring is to DMN.
+
+## ScriptTask
+
+- Upon activation: the associated **script** is invoked.
+- On completion of the script: the Script Task **completes**.
+
+**Engine notes:** the spec does not mandate a script language. The `scriptFormat` attribute on `ScriptTask` (MIME type) and `script` element carry the language and source.
+
+## AbstractTask (Task base)
+
+- Upon activation: the Abstract Task **completes** (immediately).
+- **Conceptual only** — never actually executed by an IT system.
+
+**Conformance note:** Abstract Task (the un-typed `Task` base) is listed in §13.1 as **non-operational**. An engine MAY treat it as a no-op pass-through. This is the bare `<bpmn:task>` with no type specialization.
+
+## Common patterns
+
+### Data flow on activation (Ready → Active)
+
+For all task types: `InputSet` evaluation populates `DataInput`s via `DataInputAssociation`s before the task begins its specific behavior. See [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md) "Ready → Active (data binding)".
+
+### Completion → outgoing tokens
+
+On completion, the task transitions through `Completing → Completed`, then emits `completionQuantity` tokens on each outgoing sequence flow (acts as implicit Parallel Gateway for multiple outgoing). See [token-flow.md](token-flow.md).
+
+### Faults during execution
+
+Any task that raises an error (Service Task on service fault; Script Task on script exception; etc.) transitions `Active → Failing`. Recovery follows the standard error-handling chain — boundary error events, error event sub-processes, or unhandled propagation up the parent chain. See [events.md](events.md).
+
+## Cross-references
+
+- Activity lifecycle: [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)
+- Structural attributes per task type: [../elements/activities.md](../elements/activities.md)
+- Operation / Message: [../elements/service-interfaces.md](../elements/service-interfaces.md)
+- Message correlation: [events.md](events.md), [../elements/correlation.md](../elements/correlation.md)
+- User Task distribution: [../elements/human-interaction.md](../elements/human-interaction.md)

--- a/docs/bpmn-spec/semantics/token-flow.md
+++ b/docs/bpmn-spec/semantics/token-flow.md
@@ -1,0 +1,69 @@
+# Token Flow
+
+_Source: BPMN 2.0 §13.3.1 (spec p427) + §13.2._
+
+`token` is a theoretical concept used to describe sequence flow behavior. Implementations are NOT required to materialize tokens; they MAY use any internal representation as long as observable behavior matches.
+
+## Sequence flow basics
+
+A `SequenceFlow` connects two `FlowNode`s. A `token` traverses the flow from source to target. Token movement has no timing constraints — it MAY take arbitrary time.
+
+### `isImmediate` attribute
+
+| Value | Effect |
+|---|---|
+| `true` (or unset, treated as `true` for non-Process Modeling Conformance) | Activities not in the model MAY NOT execute while the token is moving. |
+| `false` | Other (out-of-model) activities MAY execute while the token is in transit. |
+
+For Process Execution Conformance, `isImmediate` is a **non-operational** attribute (§13.1) — engines MAY ignore it.
+
+## Multiple incoming sequence flows on an activity
+
+An activity with multiple incoming sequence flows participates in **uncontrolled flow**:
+
+- For each token arriving on _any_ incoming sequence flow, the activity is enabled independently. Multiple tokens on different incoming flows behave as an implicit **Exclusive Gateway**.
+- If the modeler needs synchronization, an explicit Gateway (Parallel / Inclusive) MUST precede the activity.
+
+## Multiple outgoing sequence flows on an activity
+
+When an activity transitions to **Completed**, all of its outgoing sequence flows receive a token. Behavior depends on the conditions:
+
+| Configuration | Behavior |
+|---|---|
+| All outgoing unconditional | Parallel split — all branches activated. |
+| All outgoing have `conditionExpression` | Inclusive split — each true condition produces a token. |
+| Mix of unconditional + conditional | Combination — unconditional always fire, conditional fire when their condition is true. |
+
+This is illustrated by Figure 13.1: a Task with 3 outgoing flows behaves like a Task followed by an implicit Parallel Gateway (or Inclusive, per above rules).
+
+The number of tokens placed on each outgoing flow is `completionQuantity` (default 1).
+
+## No outgoing sequence flows
+
+An activity with no outgoing sequence flows terminates without producing tokens. Termination semantics of the containing Process / Sub-Process then apply (see [../state-machines/process-lifecycle.md](../state-machines/process-lifecycle.md)).
+
+## No incoming sequence flows
+
+An activity / gateway with no incoming sequence flows is instantiated when the containing `Process` / `SubProcess` is instantiated. It receives a token at that point. Exception: Compensation Activities (which are triggered by compensation events, not by control flow).
+
+## Token semantics at gateways
+
+Gateways consume and produce tokens per their type-specific rules — see [gateways.md](gateways.md).
+
+## Token flow at Process instantiation
+
+- Each `Start Event` that occurs creates a token on its outgoing sequence flow(s).
+- Activities / Gateways with no incoming sequence flows receive a token at Process instantiation (with the exceptions above).
+
+## Token flow at termination
+
+- All tokens MUST reach an end node (no outgoing sequence flows) for normal completion.
+- A token reaching an `End Event` triggers the behavior of that End Event type — Message sent, Signal sent, etc. — and is consumed.
+- A token reaching a **Terminate End Event** abnormally terminates the entire Process instance (or Sub-Process if scoped).
+
+## Cross-references
+
+- Gateway-specific token consumption / production rules: [gateways.md](gateways.md)
+- Activity lifecycle (when tokens cause Inactive → Ready): [../state-machines/activity-lifecycle.md](../state-machines/activity-lifecycle.md)
+- Process termination conditions: [../state-machines/process-lifecycle.md](../state-machines/process-lifecycle.md)
+- End Event behavior: [end-events.md](end-events.md)

--- a/docs/bpmn-spec/state-machines/activity-lifecycle.md
+++ b/docs/bpmn-spec/state-machines/activity-lifecycle.md
@@ -1,0 +1,148 @@
+# Activity Lifecycle
+
+_Source: BPMN 2.0 §13.3.2 (spec p428–429). Normative state machine in Figure 13.2._
+
+Every BPMN activity — Task variants, SubProcess, Transaction, Ad-Hoc Sub-Process, Call Activity — follows this lifecycle. State transitions are observable points where engine MUST persist state, emit events, and apply data assignments.
+
+## State diagram
+
+```
+                Inactive
+                   |
+                A Token Arrives
+                   v
+                 Ready ─────────[Activity Interrupted, Alt Path for Event GW]──> Withdrawn
+                   |                                                                  |
+              Data InputSet Available                                       [The Process Ends]
+                   v                                                                  |
+                 Active ─────────[Activity Interrupted, Alt Path for Event GW]─> Withdrawn
+                   |                                                                  v
+              Activity's work completed                                            Closed
+                   v
+                Completing ─────[Activity Interrupted, Alt Path for Event GW]─> Withdrawn
+                   |
+              Completing Requirements Done + Assignments Completed
+                   v
+                Completed
+                   |
+              Compensation Occurs ─────────────> Compensating
+                   |                                  |
+              The Process Ends                  Compensation Completes ─> Compensated ─[Process Ends]─> Closed
+                   v                            Compensation Failed   ─> Failed       ─[Process Ends]─> Closed
+                 Closed                         Compensation Interrupted (decision)
+
+  From Ready/Active/Completing on Interrupting Event:
+                   |
+              Error?
+                Yes ─> Failing  ────[handler reaches final state]──> Failed     ─[Process Ends]─> Closed
+                No  ─> Terminating ─[Terminating Requirements Done]─> Terminated ─[Process Ends]─> Closed
+```
+
+## States
+
+| State | Terminal? | Meaning |
+|---|---|---|
+| **Inactive** | no | Activity not yet enabled. No tokens have arrived. |
+| **Ready** | no | Required tokens have arrived (per `startQuantity`). Waiting for data InputSet to become available. |
+| **Active** | no | InputSet bound; activity performing its work. New non-interrupting Event Sub-Processes MAY be created. |
+| **Withdrawn** | yes | Lost a race at an Event-Based Exclusive Gateway. Reached via interrupt + alternative-path-selected. |
+| **Completing** | no | Work done; waiting for non-interrupting Event Handlers attached during Active to finish. No new processing steps allowed. New non-interrupting Event Sub-Processes MAY NOT be created. |
+| **Completed** | no | All completion dependencies satisfied. Outgoing sequence flows will be activated with `completionQuantity` tokens each (implicit Parallel Gateway). Data OutputSet selected and pushed. |
+| **Compensating** | no | A throw Compensation Event has targeted this activity (which had been Completed). |
+| **Compensated** | yes | Compensation handler completed successfully. |
+| **Failing** | no | Interrupting Event Sub-Process triggered by an error has started. Activity remains here while running Event Handler is still active. |
+| **Terminating** | no | Interrupting non-error event triggered. Activity remains here while running Event Handler is still active. |
+| **Failed** | yes | Compensation failed, OR Failing handler reached final state. |
+| **Terminated** | yes | Terminating handler reached final state. |
+| **Closed** | yes (sink) | The Process ends. Terminal pseudo-state for all final-state activities. |
+
+## Transitions
+
+| From | To | Trigger / Condition |
+|---|---|---|
+| Inactive | Ready | A token arrives (count = `startQuantity`) |
+| Ready | Active | A data InputSet becomes available |
+| Ready | Withdrawn | Activity Interrupted + Event Gateway alternative-path selected |
+| Ready | Failing | Activity Interrupted + Interrupting Event + Error |
+| Ready | Terminating | Activity Interrupted + Interrupting Event + Non-Error |
+| Active | Completing | Activity's work completed without anomalies |
+| Active | Withdrawn | Activity Interrupted + Event Gateway alternative-path selected |
+| Active | Failing | Activity Interrupted + Interrupting Event + Error |
+| Active | Terminating | Activity Interrupted + Interrupting Event + Non-Error |
+| Completing | Completed | All completion dependencies satisfied (Event Handlers done, Assignments complete) |
+| Completing | Withdrawn | Activity Interrupted + Event Gateway alternative-path selected |
+| Completing | Failing | Activity Interrupted + Interrupting Event + Error |
+| Completing | Terminating | Activity Interrupted + Interrupting Event + Non-Error |
+| Completed | Compensating | A throw Compensation Event references this activity |
+| Completed | Closed | The Process ends |
+| Compensating | Compensated | Compensation handler completed successfully |
+| Compensating | Failed | Compensation handler raised an exception |
+| Compensating | Terminated | Compensation interrupted by controlled / uncontrolled termination |
+| Failing | Failed | Interrupting Event Handler reached final state |
+| Terminating | Terminated | Terminating requirements done |
+| Withdrawn / Compensated / Failed / Terminated | Closed | The Process ends |
+
+## State-specific normative behavior
+
+### Ready
+
+- Required number of tokens is determined by `startQuantity` (default 1).
+- An activity with multiple incoming sequence flows behaves as if preceded by an implied **Exclusive Gateway** (uncontrolled flow) — see [../semantics/token-flow.md](../semantics/token-flow.md).
+- Activity with no incoming sequence flows is instantiated when the containing Process / SubProcess is instantiated (exception: Compensation Activities).
+
+### Ready → Active (data binding)
+
+- Each `InputSet` is evaluated in declaration order until one becomes _available_.
+- An `InputSet` is _available_ iff each of its REQUIRED `DataInput`s is bound. A `DataInput` is REQUIRED iff it is NOT optional within that `InputSet`.
+- Data binding executes the input `DataInputAssociation`s — values flow from process-scope `DataObject`s / `Property`s into the activity.
+- If no `InputSet` is available, the activity waits until one becomes available. Does NOT proceed to Active.
+
+### Active
+
+- New non-interrupting Event Sub-Processes MAY be created and attached while in Active.
+- Interrupt sources: thrown error, or any interrupting Event Sub-Process triggering.
+- Race-condition withdrawal: when this activity is attached after an Event-Based Exclusive Gateway, the first sibling to complete causes all others to enter Withdrawn (from Ready or Active).
+
+### Completing
+
+- Exists to give non-interrupting Event Handlers attached during Active time to finish.
+- Running handlers MAY complete; new non-interrupting handlers MAY NOT be created.
+- No further processing steps of the activity itself are performed in this state.
+
+### Active / Completing → Failing / Terminating
+
+- All nested activities not in a final state (Completed, Compensated, Failed, etc.) are terminated.
+- Non-interrupting Event Sub-Processes are terminated.
+- Data context of the activity is preserved while an interrupting Event Sub-Process runs (so the handler can access it).
+- Data context is released after the Event Sub-Process reaches a final state.
+
+### Completed (outflow)
+
+- Outgoing sequence flows activated; `completionQuantity` tokens (default 1) emitted on each (acts as implicit Parallel Gateway for multiple outgoing).
+- `OutputSet` selection mirrors `InputSet` selection — evaluated in order until one is available. If none → runtime exception.
+- If `IORule` defined: the chosen `OutputSet` is checked for compliance with the `InputSet` that started the instance. Non-compliance → runtime exception.
+
+### Completed → Compensating
+
+- Only Completed activities can be compensated.
+- A `Compensation Event Sub-Process` (if defined) operates against a data snapshot taken at the moment the parent reached Completed.
+- For Loop / MI Sub-Processes, each instance has its own snapshot and its own Compensation Event Sub-Process.
+
+## Sub-Process-specific notes
+
+A Sub-Process completes (Active → Completing → Completed) only when:
+1. No tokens remain inside the Sub-Process.
+2. No nested Activity is still active.
+
+If a Terminate End Event fires inside, the Sub-Process is abnormally terminated (→ Terminating → Terminated).
+If a Cancel End Event fires inside a Transaction, the Sub-Process is abnormally terminated AND the transaction aborted; control leaves through a cancel intermediate boundary event.
+
+## Cross-references
+
+- Process-level instantiation and termination: [process-lifecycle.md](process-lifecycle.md)
+- Per-task-type behavior (Service / User / Send / Receive / etc.): [../semantics/tasks.md](../semantics/tasks.md)
+- Sub-Process variants: [../semantics/sub-processes.md](../semantics/sub-processes.md)
+- Multi-instance / Loop: [../semantics/multi-instance.md](../semantics/multi-instance.md)
+- Compensation: [../semantics/compensation.md](../semantics/compensation.md)
+- Token-flow at activity boundaries: [../semantics/token-flow.md](../semantics/token-flow.md)
+- Event Sub-Process triggering: [../semantics/events.md](../semantics/events.md)

--- a/docs/bpmn-spec/state-machines/process-lifecycle.md
+++ b/docs/bpmn-spec/state-machines/process-lifecycle.md
@@ -1,0 +1,67 @@
+# Process Lifecycle
+
+_Source: BPMN 2.0 §13.2 (spec p426) + §13.5.6 (spec p443)._
+
+The spec does not define a UML state machine for Process — it defines instantiation triggers and termination conditions. The Process instance is implicitly _running_ between the two.
+
+## Instantiation
+
+A Process is instantiated when one of its **Start Events** occurs. Each occurrence creates a new Process instance — UNLESS the Start Event participates in a `Conversation` that includes other Start Events sharing the same correlation information. In that case:
+
+- If no instance exists yet for that Conversation → create new instance.
+- If an instance already exists → route the event to the existing instance.
+
+### Other instantiation triggers
+
+| Trigger | Condition |
+|---|---|
+| Receive Task with no incoming sequence flows AND `instantiate=true` | Acts like an implicit Message Start Event |
+| Event-Based Gateway with no incoming sequence flows AND `instantiate=true` | See below |
+
+### Event-Based Gateway as instantiator
+
+- **Exclusive** Event-Based Gateway (`eventGatewayType=Exclusive`): the first matching Event creates a new Process instance. The Process does NOT wait for other Events originating from that gateway.
+- **Parallel** Event-Based Gateway (`eventGatewayType=Parallel`): the first matching Event creates a new instance, BUT the Process then waits for all other Events to arrive (they MUST share correlation info with the first). Process instance completes only if all Events that succeed a Parallel Event-Based Gateway have occurred.
+- A `MultipleParallel` Start Event achieves the same multi-trigger waiting at top-level.
+- Multiple Parallel Event-Based Gateways may exist — allowing "either all Events after the first OR all Events after the second" instantiation.
+
+### Constraints on instantiation
+
+- A **global Process** MUST NOT have any empty Start Events.
+- A **global Process** MUST NOT have any Gateway or Activity without incoming sequence flows. **Exception:** Event-Based Gateway acting as instantiator (`instantiate=true`).
+- An ordinary (non-global) Process MAY have activities without incoming sequence flows — they receive a token upon Process instantiation.
+
+## Normal termination
+
+A Process instance _completes_ iff and only if all three conditions hold:
+
+1. If the instance was created through an instantiating **Parallel Event-Based Gateway**, all subsequent Events of that gateway MUST have occurred.
+2. No `token` remains within the Process instance.
+3. No Activity of the Process is still active.
+
+For (2): all tokens MUST reach an _end node_ (a node with no outgoing sequence flows). When a token reaches an End Event, the behavior associated with the End Event type is performed (Message sent, Signal sent, etc.). See [../semantics/end-events.md](../semantics/end-events.md).
+
+## Abnormal termination
+
+A token reaching a **Terminate End Event** abnormally terminates the entire Process instance. No other End Event behaviors are performed; remaining tokens are discarded; nested Sub-Processes are interrupted.
+
+Sub-Process-level termination is scoped:
+
+- **Terminate End Event** inside a Sub-Process: terminates that Sub-Process only. For an MI Sub-Process, terminates only the affected instance.
+- **Cancel End Event** inside a Transaction Sub-Process: abnormally terminates the Sub-Process AND aborts the transaction. Control leaves the Sub-Process through a Cancel intermediate boundary event attached to it.
+
+## Sub-Process completion (recap)
+
+A Sub-Process instance completes iff:
+
+1. All start nodes have been visited (all Start Events triggered, and for every starting Event-Based Gateway one of the associated Events has been triggered).
+2. No `token` remains within the Sub-Process instance.
+
+Same shape as the Process completion conditions, scoped one level deeper.
+
+## Cross-references
+
+- Per-activity lifecycle: [activity-lifecycle.md](activity-lifecycle.md)
+- Start Event semantics: [../semantics/events.md](../semantics/events.md)
+- End Event semantics: [../semantics/end-events.md](../semantics/end-events.md)
+- Conversation-based correlation: [../semantics/events.md](../semantics/events.md) (correlation section)


### PR DESCRIPTION
Adds docs/bpmn-spec/ as a curated normative reference, scoped to the BPMN 2.0 Process Execution Conformance subclass (§2.1.2 / Common Executable Subclass §2.1.3) plus ComplexGateway as an explicit extension above Common Executable.

Why: the OMG BPMN 2.0 PDF (formal/2013-12-09, v2.0.2) is 538 pages with element semantics scattered across §8 (Core Structure), §10 (Process / Items and Data), §13 (Execution Semantics) and others. Looking up "what attributes does X have" or "when do data associations fire relative to activity lifecycle" requires multi-page jumps. The KB reorganizes the spec along axes implementers actually need: structural metamodel, lifecycle state machines, per-area execution semantics. Hand-authored snapshot, not a continuously updated reference.

Layout:
  conformance.md     in/out element list per §2.1.2
  elements/          structural metamodel (attributes, associations,
                     type hierarchy) -- 11 files generated from
                     bpmn-moddle JSON
  state-machines/    activity-lifecycle + process-lifecycle from
                     §13.2-§13.3
  semantics/         token-flow, gateways, tasks, sub-processes,
                     multi-instance, compensation, events,
                     event-handling, end-events, data, correlation
                     -- synthesized from §10.4, §10.5, §13, §8.4.2
  scripts/           gen.py + cached bpmn-moddle.json for
                     deterministic regeneration of elements/

Sources:
- Structural: bpmn-moddle (bpmn-io/bpmn-moddle, MIT-licensed), cached as scripts/bpmn-moddle.json for reproducible regeneration.
- Semantic: BPMN 2.0 spec PDF (referenced by path, not committed).

Out of scope (explicitly excluded): Choreography, Collaboration metamodel, DI/DC diagram interchange, BPEL mapping, visual artifacts beyond Association.

Regenerate elements/ via 'python3 scripts/gen.py' after updating scripts/bpmn-moddle.json. State-machines and semantics are hand-authored; manual update only.