### PR TITLE
fix(SRD-001): tidy-check-all needs mocks generated first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ lint-all-modules:
 	done
 .PHONY: lint-all-modules
 
-tidy-check-all:
+tidy-check-all: gen_mock_files
 	@set -e; for dir in $(MODULES); do \
 		echo "::group::tidy $$dir"; \
 		(cd $$dir && $(GO) mod tidy) || exit 1; \


### PR DESCRIPTION
make tidy-check-all was failing because go mod tidy couldn't resolve the generated/mock* import paths referenced by test files. The mocks are produced by mockery and live in a gitignored generated/ tree, so on a fresh checkout (or after rm -rf generated/) the import paths look unresolvable.

Fix: add gen_mock_files as a prerequisite of tidy-check-all so mocks exist before tidy runs. test-all already had this dependency; tidy- check-all was missing it.

The ci umbrella target inherits this through tidy-check-all's deps: gen_mock_files runs once at the start, then tidy-check-all and test-all reuse the generated mocks without regenerating (though make's phony target semantics mean mockery may run more than once locally - harmless, just wasteful by a few seconds).