### PR TITLE
Two-layer instance/track runtime refactor (SRD-001)

### DIFF
--- a/docs/srd/SRD-001-instance-track-token-refactor.md
+++ b/docs/srd/SRD-001-instance-track-token-refactor.md
@@ -1,0 +1,233 @@
+# SRD-001 — Instance / Track / Token Runtime Refactor
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-06-06 |
+| Owner | Ruslan Gabitov |
+| Implements | [ADR-001 v.3 Execution Model](../design/ADR-001-execution-model.md) |
+| Refines | [SAD-001 v.1 §10 Execution Model](../design/SAD-001-vision-and-architecture.md) |
+
+This SRD specifies the **Group-A** landing that brings `internal/instance/` to the two-layer runtime defined in [ADR-001 v.3](../design/ADR-001-execution-model.md): a `track` is the operational thread of execution; `token` becomes a **logical projection** of a track's current step rather than a stored type; instance state is mutated only inside a single event-loop goroutine. Completing this landing closes ADR-001 v.3's §7 acceptance gate.
+
+## 1. Background & motivation
+
+### 1.1 Current state (verified against the code)
+
+The current `internal/instance/` implements the three-layer model ADR-001 v.3 supersedes:
+
+- **`token` is a stored, cross-linked object** — `type token struct { inst *Instance; trk *track; …; prevs []*token; nexts []*token; state TokenState }` (`token.go:36`). It back-references both the Instance and its track.
+- **Instance owns a token registry** — `tokens []*token` (`instance.go:101`) under a `sync.RWMutex` (`instance.go:103`); `newToken` self-registers via `inst.addToken` (`token.go:67`, `instance.go:440`).
+- **Lower layer drives instance lifecycle** — `token.updateState` calls up into `t.inst.tokenConsumed(t)` when a token is consumed (`token.go:81`, `instance.go:452`); `tokenConsumed` scans the token registry for any `TokenAlive` and stops the instance when none remain.
+- **Fork keeps tokens on one track, then reassigns** — `token.split(n)` creates N tokens all bound to the same track (`newToken(t.inst, t.trk)`, `token.go:89–95`); `checkFlows` then reassigns N−1 of them to freshly-created tracks (`track.go:454–512`, split called at `track.go:470`).
+- **A track has no single token** — the current token lives in `stepInfo.tk` (`track.go:140–142`); the track is `type track struct { …; steps []*stepInfo; m sync.RWMutex; state trackState }` (`track.go:148`).
+- **State mutation is lock-based and reactive** — tracks call Instance methods directly (`addTrack`, `track.go` callers) guarded by `RWMutex`.
+- **Lineage is duplicated** — on the track (`track.prev`) and on the token (`token.prevs/nexts`).
+- **Token state enum** — `TokenInvalid / TokenAlive / TokenWaitForEvent / TokenConsumed` (`token.go:15–22`); no `Withdrawn`.
+
+### 1.2 Why change
+
+[ADR-001 v.3 §3.1/§6](../design/ADR-001-execution-model.md) records the decision: at 1:1 with no migration, the stored token only duplicates the track (forced back-references, a second registry, a duplicate lineage chain) and the lock-based reactive model is the race-prone class the project is moving away from (cf. FIX-001). The refactor removes the token type, makes the token a projection, and serializes all instance-state mutation through a single event-loop goroutine.
+
+## 2. Goals & scope
+
+### 2.1 Goals (in scope)
+
+G1. `token` is no longer a stored entity — it is a value **projected** from a track's current step.
+G2. A `track` owns exactly one position+state; exposes it via `track.Token()`.
+G3. The Instance holds a **track registry only** — no token registry, no `token→Instance`/`token→track` back-references.
+G4. Instance state is mutated **only** inside a single event-loop goroutine; tracks report progress as events on a channel; no locks on instance state.
+G5. **Fork** constructs a new track per additional active flow (parent continues on the first flow); lineage on `track.prev`.
+G6. **Instance completion** is decided from the track registry (all tracks ended), not by scanning token states.
+G7. Token **state** is a projection of track/step state (+ a track end-reason).
+G8. **No external behavior change** for currently-implemented elements: None Start/End events, Service/User tasks, Exclusive gateway, sequence flows (incl. conditions/default), and timer events continue to execute as today (existing tests + `examples/*` pass unchanged).
+G9. The Instance can report the **token-flow path history** — the ordered node sequence each token traversed — reconstructed from tracks (live and ended) and their steps.
+G10. Steps carry **timestamps**, so the path history (G9) is a timeline (per-node entered/left, duration). Time comes from an injectable seam, forward-compatible with the ADR-002 `Clock` extension (not built here).
+
+### 2.2 Non-goals (explicitly deferred)
+
+N1. **Persistence / rehydration** — Scope/timer/compensation/error/activity state, the per-node state contract, checkpoints, restart recovery → dedicated Persistence & State ADR (see ADR-001 v.3 §4.7).
+N2. **Real synchronizing-join policies** (Parallel / Inclusive / Complex) and **OR-join semantics** → the gateway SRD. *In scope here:* the full join **mechanism** + the `JoinController` policy interface + per-join accounting, with the pass-through default (matching today's Exclusive / uncontrolled merges) and a fake `JoinController` proving the wait/fire path (FR-12). *Out of scope:* the concrete gateway policies, which will just implement `JoinController` with no change to the loop.
+N3. **Event-Based Gateway** and a `Withdrawn` **producer** → gateway SRD. The token-state projection (G7) defines `Withdrawn`, but nothing produces it in this landing.
+N4. **New BPMN elements** (Parallel/Inclusive/Complex gateways, sub-processes, message correlation, etc.).
+N5. **Public API promotion** — `Token` / `GetTokens` stay in `internal/instance/`; moving execution types to `pkg/` is ADR-003 module-layout work.
+
+## 3. Functional requirements
+
+| # | Requirement | Acceptance |
+|---|---|---|
+| FR-1 | The stored `token` type is removed; no struct holds `inst`/`trk` back-references or a token `state` field. | `grep` shows no `token` struct with Instance/track back-refs; build passes. |
+| FR-2 | `track` owns its single position+state and exposes `track.Token() Token`, where `Token` is a computed read-model (node position, projected state, lineage). | `track.Token()` returns the current step's projection; the value is computed, not stored as a cross-linked object. |
+| FR-3 | `Instance` holds only a track registry and exposes `Instance.GetTokens() []Token` projected from active tracks. No `tokens []*token`, `addToken`, or `tokenConsumed`. | Those identifiers are gone; `GetTokens()` returns one projection per active track. |
+| FR-4 | Instance state (track registry, lifecycle) is mutated only inside `Instance.loop()`; tracks communicate via a channel; no `sync.RWMutex` guards instance state. | Code review + `-race`: instance-state fields written only in `loop()`. |
+| FR-5 | A fork at a node with N>1 active outgoing flows: the executing track continues on the first flow; one new track is constructed per remaining flow with `track.prev` lineage; `token.split` is removed. | Fork test (FR mapped to §5): N independent tracks, each its own position; parent did not end at the fork. |
+| FR-6 | The instance completes (`InstanceCompleted`) exactly when **no active track remains** — decided in the event loop from the track registry. Ended tracks are retained as history (FR-10), so completion keys off *active* tracks, not record deletion. | Completion test passes; no token-alive scan exists. |
+| FR-7 | Token state is a pure projection: `Alive` ← track ready/executing; `WaitForEvent` ← `TrackWaitForEvent`; `Consumed` ← `TrackEnded`/`TrackMerged`; `Withdrawn` ← `TrackCanceled` + end-reason=withdrawn. | Projection unit test over each track/step state. |
+| FR-8 | Non-synchronizing merge preserved: a node with N>1 incoming flows lets each arriving track continue independently (no wait, no consumption at the node). | Merge test: 3 tokens through an Exclusive/uncontrolled merge → 3 continuations. |
+| FR-9 | No regression for implemented elements (G8). | Full existing test suite + `examples/*` build and pass; `make ci` green. |
+| FR-10 | Each track records its step-state transitions in an **append-only list** (record, don't overwrite). `Instance` exposes a **token-flow path history** (e.g. `TokenHistory()`) **derived** from those lists across all tracks (live and ended), stitched by `track.prev` lineage — path, current position, and terminal state are all read from the entries. | For a forked process, the history shows the shared pre-fork path and one path per branch, each with correct parentage and terminal state. |
+| FR-11 | Each step-state-update entry carries a **timestamp**, so timing (per-node entered/duration) is derived from the same list. The time source is an **injectable seam** (deterministic in tests), forward-compatible with the ADR-002 `Clock` extension (not built here). | History timestamps are monotonic non-decreasing; under an injected fixed/fake clock the values are deterministic. |
+| FR-12 | The join **seam** exists: a pure `JoinController` interface (`arrivals + context → wait \| fire(consumed)`); `loop()` consults it on each join-arrival, defaulting to fire-immediately when the node doesn't implement it. Per-join accounting lives in the loop, keyed by node ID. (Real gateway policies deferred — N2.) | Pass-through merge fires immediately; a **fake** synchronizing `JoinController` correctly waits until its set arrives, then fires once and merges the rest. |
+
+**Non-functional**
+
+| # | Requirement | Acceptance |
+|---|---|---|
+| NFR-1 | Race-free under the detector. | `make ci` (race-gated) green; `go test -race -count=N` stress on fork/instance tests clean. |
+| NFR-2 | Goroutine-leak-free. | Helper asserts `runtime.NumGoroutine()` returns to baseline after instance completion. |
+| NFR-3 | Coverage not reduced for `internal/instance`. | Post-refactor coverage ≥ pre-refactor for the package. |
+
+## 4. Design & implementation plan
+
+### 4.1 Target shapes (illustrative)
+
+```go
+// Token — a computed read-model, never stored as a live cross-linked object.
+type Token struct {
+    Node  flow.Node    // current flow position (node pointer, from the snapshot)
+    State TokenState   // projected from track/step state
+    // lineage exposed via track.prev projection
+}
+
+// The track records each step-state transition as an entry in an ordered,
+// append-only list (record, don't overwrite). Token projection, path history,
+// and timing are ALL derived from these lists — there are no separately
+// maintained projection structures to keep in sync.
+type stepUpdate struct {
+    Node  flow.Node  // the node executed at this step (pointer; the snapshot holds all nodes)
+    State stepState  // step/track state at this transition
+    At    time.Time  // from the injectable time seam (→ ADR-002 Clock later)
+}
+// each track holds: updates []stepUpdate  +  track.prev (fork lineage). Track owns this
+// list (Option B); live current-position reads are served by a lock-free atomic snapshot.
+
+// track→loop events (the loop's contract) carry the track + node POINTER, not a string ID:
+//   Fork(track, active []*flow.SequenceFlow)
+//   JoinArrival(track, joinNode flow.Node, via *flow.SequenceFlow)
+//   Ended(track, endReason)
+//   Wait(track, node flow.Node, subscription)
+// the loop keys per-join accounting by joinNode.ID() internally.
+
+func (t *track) Token() Token          // derived: latest update (position + projected token state)
+func (i *Instance) GetTokens() []Token // derived: latest update of each ACTIVE track
+func (i *Instance) TokenHistory() ...  // derived: the update lists of all tracks (live + ended),
+                                       // stitched by track.prev — caller reads path, timing,
+                                       // and terminal state straight from the entries
+
+// Join policy seam (§4.2). The loop owns the mechanism (accounting + action);
+// a join node supplies the policy as a PURE method. The Instance implements
+// JoinerContext, handing the policy FACTS (not decisions); the policy computes
+// the verdict — so the deferred Inclusive reachability lives in the policy, not
+// the loop. Group A ships the interface + consult-or-default mechanism + a fake
+// policy test; real gateway policies come later.
+type JoinerContext interface {        // implemented by the Instance; grows as policies need
+    JoinNode() flow.Node              // the join being evaluated
+    Arrived() []*flow.SequenceFlow    // incoming flows currently holding a token
+    // (future: live-track positions / history, for the Inclusive reachability rule)
+}
+type JoinVerdict struct {
+    Fire     bool                  // false => keep waiting
+    Consumed []*flow.SequenceFlow  // incoming flows consumed when firing
+}
+type JoinController interface {        // optional; synchronizing nodes implement it
+    EvaluateJoin(ctx JoinerContext) JoinVerdict
+}
+// loop: node implements JoinController -> consult; else -> fire immediately (pass-through)
+
+type Instance struct {
+    ctx    context.Context
+    cancel context.CancelFunc
+    trackEvents chan trackEvent   // tracks -> loop()
+    external    chan ExternalSignal
+    tracks map[string]*track      // mutated ONLY in loop()
+    state  InstanceState
+    // no tokens[]; no RWMutex on instance state
+}
+```
+
+### 4.2 Fork & join mechanics (event-driven)
+
+Both fork and join are reactions of `Instance.loop()` to events emitted by tracks — a track never mutates the instance registry itself.
+
+**Fork** — a node with N>1 active outgoing flows (Parallel/Inclusive split, or an activity with multiple outgoing flows = uncontrolled split):
+
+1. The executing track determines its active outgoing flows F1…FN (selecting *which* flows are active is the gateway/node's job; the mechanics below act on the already-selected set) and emits one **fork event** carrying them plus its own ID (for lineage).
+2. The track advances its own position onto F1's target and continues — it does **not** end at the fork.
+3. `loop()` receives the event and, for each remaining flow F2…FN, constructs a new track at that flow's target with `track.prev` = the forking track, registers it, and spawns its goroutine.
+4. Result: N tracks run independently (original on F1 + N−1 new), each with its own position and goroutine.
+
+**Join** — a node with N>1 incoming flows:
+
+1. A track arriving at a join emits a **join-arrival event**. For a non-synchronizing merge it then simply continues; for a synchronizing join it ends its goroutine pending the loop's decision.
+2. `loop()` coordinates by merge type:
+   - **Non-synchronizing** (Exclusive merge, uncontrolled merge) — the only kind in Group-A scope: no wait, no consumption; each arriving track continues on the outgoing flow independently (several tracks may legitimately cross the same node).
+   - **Synchronizing** (Parallel/Inclusive) — out of Group-A scope (gateway SRD): the loop holds arrivals until the expected set is complete, then one track continues and the others end (`TrackMerged`).
+3. No new track is created at a join — continuation always rides an arriving track.
+
+**Join coordination ownership.** Flow synchronization at a join is the **Instance's** responsibility, not the node's. Per-join runtime state (which incoming flows have arrived) — needed only by synchronizing joins — lives in `loop()`, keyed by node ID, mutated only there (single-writer, lock-free). The node definition stays **immutable and shared** across instances and tracks, so it never holds arrival state — putting it on the node would reintroduce the cross-track shared-mutable-state race this design removes. The join-arrival event is the attachment point where synchronizing-join logic (gateway SRD) will plug in.
+
+**Policy vs mechanism — who decides the join.** The Instance owns the *mechanism*: it holds the cross-track arrival accounting and performs the action (continue one track, merge/end the others). The *policy* — "is the awaited set complete, and which arrivals are consumed?" — belongs to the join **node** (its gateway type/config), because only the node knows the join semantics and only the process graph defines the expected incoming set. The arriving track cannot decide (it knows only itself; it just reports). So on each join-arrival, `loop()` **consults the node through a pure, read-only `JoinController.EvaluateJoin`**, handing it a `JoinerContext` the Instance implements — **facts only**: the arrived incoming flows now, plus live-track positions / history for the Inclusive rule later. The policy computes a verdict — *wait*, or *fire* with the consumed flows — and the loop acts on it. Facts, not decisions: the ambiguous Inclusive reachability is computed inside the policy from those facts, never by the loop. The node stores nothing; it is a pure policy evaluated against state the Instance supplies (node immutability preserved). Consequently the expected count is **not** hardcoded in the Instance: for a Parallel join it is the node's static incoming flows; for an Inclusive join the node's policy derives it from the live execution.
+
+Group A builds this **whole seam**, not just a hole for it: the `JoinController` policy interface, the loop's consult-or-default mechanism, and the per-join accounting. The default — a node that does **not** implement `JoinController` ⇒ fire immediately — covers today's non-synchronizing merges; a **fake `JoinController`** in tests exercises the wait/fire path so the seam is proven, not dead code. Only the real gateway policies (Parallel/Inclusive/Complex) are deferred; they implement `JoinController` with no change to the loop. The interface is generic (`arrivals + context → wait | fire(consumed)`), so building it now does **not** pull in the deferred OR-join semantics — those live inside a future policy implementation.
+
+### 4.3 Per-area changes
+
+- **`token.go`** — remove the stored `token` struct (back-refs, `state`, `prevs/nexts`), `newToken`'s `addToken` call, `updateState`'s `tokenConsumed` call, and `split`. Keep `TokenState` as the projected enum (add a `Withdrawn` value, no producer yet). Add the `Token` projection value.
+- **`track.go`** — the track owns its position+state directly; add `Token()` projecting the current step; add a track **end-reason** (to distinguish withdrawn vs canceled, FR-7); rework `checkFlows` to **emit a fork event** instead of `split`-then-reassign — the loop constructs the new tracks (§4.2, FR-5); lineage stays on `track.prev`; record each step-state transition as a timestamped entry in an append-only list (record, don't overwrite — FR-10/11), stamped from an injectable time seam (→ ADR-002 `Clock`) — `Token()` / `GetTokens()` / `TokenHistory()` and all timing derive from these lists; remove the instance-state `RWMutex` usage in favor of emitting events.
+- **`instance.go`** — remove `tokens[]`, `addToken`, `tokenConsumed`; add the `loop()` goroutine + channel topology (FR-4) as the sole state mutator and the **fork/join coordinator** (§4.2); convert `addTrack`/track-spawn/fork/join-arrival/completion into events applied in `loop()`; decide completion from the track registry (FR-6); add `GetTokens()` and `TokenHistory()` (FR-10). **Retain ended tracks** (their step-update lists + lineage + end-reason) for the instance's lifetime so history can be reconstructed; the registry distinguishes active vs ended, and completion (FR-6) keys off active tracks, not record deletion. (Unbounded retention under loops / multi-instance is a later concern — those elements are out of scope here; durable/bounded history belongs to the Persistence & State ADR.)
+- **Mocks** — regenerate via `make gen_mock_files` if any mocked interface signature changes.
+
+### 4.4 Milestones (each independently buildable and CI-green)
+
+1. **M1 — infra: time seam + test helpers.** Injectable internal time seam (→ ADR-002 `Clock` later); fake clock + goroutine-leak assert helper. (FR-11 source.)
+2. **M2 — Instance event loop + serialized mutation.** `Instance.loop()` + channel topology becomes the sole mutator of instance state and the fork/join coordinator (§4.2); existing fork path rerouted through an event (still `split`-based here); the `JoinController` seam + consult-or-default join-arrival handling + per-join accounting (pass-through default, fake-policy test — FR-12); drop `RWMutex` on instance state. (FR-4, FR-12)
+3. **M3 — step-state list + projections.** Append-only step-state-update list with timestamps; `track.Token()` / `Instance.GetTokens()` / `TokenHistory()` derivations + token-state projection, coexisting with the current token type. (FR-2, 7, 10, 11)
+4. **M4 — fork rework.** The fork-event handler in `loop()` constructs one new track per extra active flow (parent continues on F1, `track.prev` lineage); remove `token.split`; new tracks self-create their token on execution (token type still present). (FR-5)
+5. **M5 — token-type removal.** Remove the stored `token` type + `Instance.tokens` / `addToken` / `tokenConsumed` / `token.inst` / `trk`; token state purely via the M3 projection; completion decided from active tracks. (FR-1, 3, 6)
+6. **M6 — acceptance verification.** Full ADR-001 v.3 §7 suite + non-synchronizing merge pass-through (FR-8) + race-stress (`-count=N`) + examples + coverage; `make ci` green. (FR-9, NFR-1..3)
+
+Sequencing rationale: stand up the event loop first (M1/M2) so the ownership changes (M4/M5) land on the serialized-mutation foundation rather than racing the old lock-based paths; projections (M3) precede token-type removal (M5) so the projection is the source of token state before the type is deleted.
+
+## 5. Verification (Definition of Done)
+
+Maps to [ADR-001 v.3 §7](../design/ADR-001-execution-model.md):
+
+| Test | Asserts |
+|---|---|
+| Race-freedom | `-race` CI-gated; instance state mutated only in `loop()`; `-race -count=N` stress on fork/instance clean. |
+| Goroutine-leak-free | `runtime.NumGoroutine()` returns to baseline after completion. |
+| 1:1 fork | 3-way split → 3 independent tracks, each own position; parent continued on the first flow. |
+| No token registry | Instance exposes tokens only via `GetTokens()`; no `tokens` field; `track.Token()` reflects the current step. |
+| Instance completion | `InstanceCompleted` iff all tracks ended (no token-alive scan). |
+| Non-synchronizing merge | 3 tokens through Exclusive/uncontrolled merge → 3 continuations; none consumed/merged at the node. |
+| Join seam | a node implementing a fake synchronizing `JoinController` waits until its set arrives, then fires once and merges the rest; a node without one fires immediately (pass-through). |
+| Token-state projection | each track/step state maps to the expected `Token.State`. |
+| Termination cascade | Terminate End Event → all track goroutines exit via `ctx.Done()`. |
+| Token path history | After a forked run completes, `TokenHistory()` returns the shared pre-fork path and one path per branch, each with correct lineage and terminal state. |
+| Step timing | History timestamps are monotonic non-decreasing; under an injected fake clock the per-node entered/left values are deterministic. |
+| No regression | existing `internal/instance` + engine tests and `examples/*` pass unchanged. |
+
+**DoD:** all FR/NFR satisfied; the table above green; `make ci` green; coverage ≥ baseline. Completing this DoD closes ADR-001 v.3's §7 acceptance gate — flipping ADR-001 Draft → Accepted is a **separate** follow-up (not part of this SRD).
+
+## 6. Risks & regressions
+
+- **Event-loop rewrite is invasive.** Risk of deadlock or leaked goroutines. Mitigation: `defer` cleanup emitting a terminal track event; NFR-2 leak test; staged milestones (M1/M2 before M3/M4).
+- **Completion-semantics change** (track-registry vs token-alive scan). Risk: instances that never complete or complete early. Mitigation: FR-6 test + existing `TestMonitoring` (`instance_test.go`) must still pass.
+- **Event handling during waits.** Current waiting tracks use `ProcessEvent`; the event-loop respawn model (ADR-001 §4.7) must preserve EventHub signal delivery for timer/message waits. Mitigation: timer-event tests + `examples/simple-timer`, `examples/timer-event` pass.
+- **Time source.** Using `time.Now()` directly is untestable and bypasses the future `Clock` extension. Mitigation: a single injectable internal time seam now (deterministic tests), to be swapped for the ADR-002 `Clock` extension in WS-B — do not scatter `time.Now()` calls.
+- **Mock/interface churn.** Mitigation: regenerate mocks; `tidy-check-all`.
+- **Scope creep into deferred areas.** Synchronizing joins / persistence / new gateways are explicitly N-goals; keep them out.
+
+## 7. References
+
+- [ADR-001 v.3 Execution Model](../design/ADR-001-execution-model.md) — §2 decision, §4 component model, §6 departures (the per-symbol change list this SRD implements), §7 acceptance gate.
+- [SAD-001 v.1 §10 Execution Model](../design/SAD-001-vision-and-architecture.md).
+- [docs/bpmn-spec/semantics/token-flow.md](../bpmn-spec/semantics/token-flow.md) — fork/merge semantics.
+- Deferred companions (out of scope): Persistence & State ADR (per ADR-001 v.3 §4.7); the gateway SRD (synchronizing joins / OR-join).
+
+## Document History
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v.1 | 2026-06-06 | Ruslan Gabitov | Initial Draft. Specifies the Group-A two-layer runtime refactor against ADR-001 v.3; persistence, synchronizing joins / OR-join, Event-Based Gateway, and new elements explicitly out of scope. |

--- a/docs/srd/SRD-001-instance-track-token-refactor.md
+++ b/docs/srd/SRD-001-instance-track-token-refactor.md
@@ -48,7 +48,7 @@ G10. Steps carry **timestamps**, so the path history (G9) is a timeline (per-nod
 ### 2.2 Non-goals (explicitly deferred)
 
 N1. **Persistence / rehydration** — Scope/timer/compensation/error/activity state, the per-node state contract, checkpoints, restart recovery → dedicated Persistence & State ADR (see ADR-001 v.3 §4.7).
-N2. **Real synchronizing-join policies** (Parallel / Inclusive / Complex) and **OR-join semantics** → the gateway SRD. *In scope here:* the full join **mechanism** + the `JoinController` policy interface + per-join accounting, with the pass-through default (matching today's Exclusive / uncontrolled merges) and a fake `JoinController` proving the wait/fire path (FR-12). *Out of scope:* the concrete gateway policies, which will just implement `JoinController` with no change to the loop.
+N2. **Synchronizing joins and the join seam** (Parallel / Inclusive / Complex policies, the `JoinController` / `JoinerContext` seam, OR-join semantics) → the gateway SRD, **built together with the first synchronizing consumer**. *In scope here:* only the **non-synchronizing pass-through** merge (FR-8) — a node with multiple incoming flows is handled by per-track execution; each arriving track continues independently. *Deferred (revised at landing):* the join seam itself (originally FR-12) — building a seam with only a fake consumer was dropped in favour of building it with its real consumer in the gateway SRD. The §4.2 policy/mechanism design is retained as forward conception. See §7 Implementation Summary.
 N3. **Event-Based Gateway** and a `Withdrawn` **producer** → gateway SRD. The token-state projection (G7) defines `Withdrawn`, but nothing produces it in this landing.
 N4. **New BPMN elements** (Parallel/Inclusive/Complex gateways, sub-processes, message correlation, etc.).
 N5. **Public API promotion** — `Token` / `GetTokens` stay in `internal/instance/`; moving execution types to `pkg/` is ADR-003 module-layout work.
@@ -68,7 +68,7 @@ N5. **Public API promotion** — `Token` / `GetTokens` stay in `internal/instanc
 | FR-9 | No regression for implemented elements (G8). | Full existing test suite + `examples/*` build and pass; `make ci` green. |
 | FR-10 | Each track records its step-state transitions in an **append-only list** (record, don't overwrite). `Instance` exposes a **token-flow path history** (e.g. `TokenHistory()`) **derived** from those lists across all tracks (live and ended), stitched by `track.prev` lineage — path, current position, and terminal state are all read from the entries. | For a forked process, the history shows the shared pre-fork path and one path per branch, each with correct parentage and terminal state. |
 | FR-11 | Each step-state-update entry carries a **timestamp**, so timing (per-node entered/duration) is derived from the same list. The time source is an **injectable seam** (deterministic in tests), forward-compatible with the ADR-002 `Clock` extension (not built here). | History timestamps are monotonic non-decreasing; under an injected fixed/fake clock the values are deterministic. |
-| FR-12 | The join **seam** exists: a pure `JoinController` interface (`arrivals + context → wait \| fire(consumed)`); `loop()` consults it on each join-arrival, defaulting to fire-immediately when the node doesn't implement it. Per-join accounting lives in the loop, keyed by node ID. (Real gateway policies deferred — N2.) | Pass-through merge fires immediately; a **fake** synchronizing `JoinController` correctly waits until its set arrives, then fires once and merges the rest. |
+| ~~FR-12~~ | **DEFERRED to the gateway SRD** (revised at landing — N2 / §7). The `JoinController`/`JoinerContext` seam is built with its first synchronizing consumer rather than with a fake one. Group A delivers only the non-synchronizing merge (FR-8). | n/a — superseded. |
 
 **Non-functional**
 
@@ -95,19 +95,20 @@ type Token struct {
 // and timing are ALL derived from these lists — there are no separately
 // maintained projection structures to keep in sync.
 type stepUpdate struct {
-    Node  flow.Node  // the node executed at this step (pointer; the snapshot holds all nodes)
-    State stepState  // step/track state at this transition
-    At    time.Time  // from the injectable time seam (→ ADR-002 Clock later)
+    Node  flow.Node   // the node executed at this step (pointer; the snapshot holds all nodes)
+    State trackState  // track state at this transition (the token-state projection source)
+    At    time.Time   // from the injectable time seam (→ ADR-002 Clock later)
 }
 // each track holds: updates []stepUpdate  +  track.prev (fork lineage). Track owns this
 // list (Option B); live current-position reads are served by a lock-free atomic snapshot.
 
-// track→loop events (the loop's contract) carry the track + node POINTER, not a string ID:
-//   Fork(track, active []*flow.SequenceFlow)
-//   JoinArrival(track, joinNode flow.Node, via *flow.SequenceFlow)
-//   Ended(track, endReason)
-//   Wait(track, node flow.Node, subscription)
-// the loop keys per-join accounting by joinNode.ID() internally.
+// track→loop events (the loop's contract) carry the track + node POINTER, not a string ID.
+// Built in Group A:
+//   Fork(track, active []*flow.SequenceFlow)   // evFork — loop builds one new track per extra flow
+//   Ended(track)                               // evEnded — track's run() returned
+// Deferred:
+//   JoinArrival(...)  → gateway SRD (synchronizing joins)
+//   Wait(...)         → persistence ADR (long-wait release)
 
 func (t *track) Token() Token          // derived: latest update (position + projected token state)
 func (i *Instance) GetTokens() []Token // derived: latest update of each ACTIVE track
@@ -115,12 +116,11 @@ func (i *Instance) TokenHistory() ...  // derived: the update lists of all track
                                        // stitched by track.prev — caller reads path, timing,
                                        // and terminal state straight from the entries
 
-// Join policy seam (§4.2). The loop owns the mechanism (accounting + action);
-// a join node supplies the policy as a PURE method. The Instance implements
-// JoinerContext, handing the policy FACTS (not decisions); the policy computes
-// the verdict — so the deferred Inclusive reachability lives in the policy, not
-// the loop. Group A ships the interface + consult-or-default mechanism + a fake
-// policy test; real gateway policies come later.
+// Join policy seam (§4.2) — DEFERRED to the gateway SRD (revised at landing,
+// see §7). The design below is retained as forward conception: the loop owns
+// the mechanism (accounting + action); a join node supplies the policy as a
+// PURE method; the Instance implements JoinerContext, handing the policy FACTS
+// (not decisions). It is built with its first synchronizing consumer, not now.
 type JoinerContext interface {        // implemented by the Instance; grows as policies need
     JoinNode() flow.Node              // the join being evaluated
     Arrived() []*flow.SequenceFlow    // incoming flows currently holding a token
@@ -169,7 +169,7 @@ Both fork and join are reactions of `Instance.loop()` to events emitted by track
 
 **Policy vs mechanism — who decides the join.** The Instance owns the *mechanism*: it holds the cross-track arrival accounting and performs the action (continue one track, merge/end the others). The *policy* — "is the awaited set complete, and which arrivals are consumed?" — belongs to the join **node** (its gateway type/config), because only the node knows the join semantics and only the process graph defines the expected incoming set. The arriving track cannot decide (it knows only itself; it just reports). So on each join-arrival, `loop()` **consults the node through a pure, read-only `JoinController.EvaluateJoin`**, handing it a `JoinerContext` the Instance implements — **facts only**: the arrived incoming flows now, plus live-track positions / history for the Inclusive rule later. The policy computes a verdict — *wait*, or *fire* with the consumed flows — and the loop acts on it. Facts, not decisions: the ambiguous Inclusive reachability is computed inside the policy from those facts, never by the loop. The node stores nothing; it is a pure policy evaluated against state the Instance supplies (node immutability preserved). Consequently the expected count is **not** hardcoded in the Instance: for a Parallel join it is the node's static incoming flows; for an Inclusive join the node's policy derives it from the live execution.
 
-Group A builds this **whole seam**, not just a hole for it: the `JoinController` policy interface, the loop's consult-or-default mechanism, and the per-join accounting. The default — a node that does **not** implement `JoinController` ⇒ fire immediately — covers today's non-synchronizing merges; a **fake `JoinController`** in tests exercises the wait/fire path so the seam is proven, not dead code. Only the real gateway policies (Parallel/Inclusive/Complex) are deferred; they implement `JoinController` with no change to the loop. The interface is generic (`arrivals + context → wait | fire(consumed)`), so building it now does **not** pull in the deferred OR-join semantics — those live inside a future policy implementation.
+**Deferred at landing (§7):** the join seam — the `JoinController` interface, the consult-or-default mechanism, and per-join accounting — is **not** built in Group A. With no synchronizing consumer yet (Parallel/Inclusive are gateway-SRD), it is built there, with its first real consumer, rather than with only a fake test now. Group A's non-synchronizing merges work via per-track execution (FR-8). The generic design (`arrivals + context → wait | fire(consumed)`) above stands as the forward conception; building it later does not pull in the deferred OR-join semantics — those live inside a future policy implementation.
 
 ### 4.3 Per-area changes
 
@@ -181,7 +181,7 @@ Group A builds this **whole seam**, not just a hole for it: the `JoinController`
 ### 4.4 Milestones (each independently buildable and CI-green)
 
 1. **M1 — infra: time seam + test helpers.** Injectable internal time seam (→ ADR-002 `Clock` later); fake clock + goroutine-leak assert helper. (FR-11 source.)
-2. **M2 — Instance event loop + serialized mutation.** `Instance.loop()` + channel topology becomes the sole mutator of instance state and the fork/join coordinator (§4.2); existing fork path rerouted through an event (still `split`-based here); the `JoinController` seam + consult-or-default join-arrival handling + per-join accounting (pass-through default, fake-policy test — FR-12); drop `RWMutex` on instance state. (FR-4, FR-12)
+2. **M2 — Instance event loop + serialized mutation.** `Instance.loop()` + channel topology becomes the sole mutator of instance state and the fork coordinator; existing fork path rerouted through an event (still `split`-based here); drop `RWMutex` on instance state. (FR-4)
 3. **M3 — step-state list + projections.** Append-only step-state-update list with timestamps; `track.Token()` / `Instance.GetTokens()` / `TokenHistory()` derivations + token-state projection, coexisting with the current token type. (FR-2, 7, 10, 11)
 4. **M4 — fork rework.** The fork-event handler in `loop()` constructs one new track per extra active flow (parent continues on F1, `track.prev` lineage); remove `token.split`; new tracks self-create their token on execution (token type still present). (FR-5)
 5. **M5 — token-type removal.** Remove the stored `token` type + `Instance.tokens` / `addToken` / `tokenConsumed` / `token.inst` / `trk`; token state purely via the M3 projection; completion decided from active tracks. (FR-1, 3, 6)
@@ -201,7 +201,6 @@ Maps to [ADR-001 v.3 §7](../design/ADR-001-execution-model.md):
 | No token registry | Instance exposes tokens only via `GetTokens()`; no `tokens` field; `track.Token()` reflects the current step. |
 | Instance completion | `InstanceCompleted` iff all tracks ended (no token-alive scan). |
 | Non-synchronizing merge | 3 tokens through Exclusive/uncontrolled merge → 3 continuations; none consumed/merged at the node. |
-| Join seam | a node implementing a fake synchronizing `JoinController` waits until its set arrives, then fires once and merges the rest; a node without one fires immediately (pass-through). |
 | Token-state projection | each track/step state maps to the expected `Token.State`. |
 | Termination cascade | Terminate End Event → all track goroutines exit via `ctx.Done()`. |
 | Token path history | After a forked run completes, `TokenHistory()` returns the shared pre-fork path and one path per branch, each with correct lineage and terminal state. |
@@ -219,7 +218,53 @@ Maps to [ADR-001 v.3 §7](../design/ADR-001-execution-model.md):
 - **Mock/interface churn.** Mitigation: regenerate mocks; `tidy-check-all`.
 - **Scope creep into deferred areas.** Synchronizing joins / persistence / new gateways are explicitly N-goals; keep them out.
 
-## 7. References
+## 7. Implementation summary
+
+Landed on branch `refactor/instance-track-token` as the SRD doc commit plus
+four implementation commits:
+
+| Milestone | Commit | Delivers |
+|---|---|---|
+| SRD | `12c7829` | this document |
+| M1 | `414a0ce` | injectable time seam + test helpers (fakeClock, leak assert) |
+| M2 | `dbd1c43` | `Instance.loop()` sole-owner event loop; no locks on lifecycle state; state/track-count via atomics; completion via active-track count (FR-4, FR-6) |
+| M3 | `c25e7a6` | append-only step-state list; `track.Token()` / `GetTokens()` / `TokenHistory()` projections + timestamps, lock-free (FR-2, 7, 10, 11) |
+| M4+M5 | `f86d592` | fork rework (no `split`); removal of the `token` type, `Instance.tokens`, `addToken`, `tokenConsumed`, `stepInfo.tk` (FR-1, 3, 5, 8) |
+
+**Result:** two-layer runtime (Instance + track); "token" is purely a derived
+projection. Files: `internal/instance/{instance,track,token}.go` + tests
+`{clock,leakcheck,m2_loop,m3_projection,m4_fork}_test.go`.
+
+**Deviations from the spec (resolved at landing):**
+
+- **M4 and M5 merged.** A working fork requires track-based completion, which
+  requires removing the token-based stop (`tokenConsumed`), which cascades to
+  deleting the whole token type — so the two milestones are one change-set.
+- **FR-12 (join seam) deferred** to the gateway SRD (N2): a `JoinController`
+  seam with only a fake consumer was dropped in favour of building it with its
+  first synchronizing gateway. The in-scope non-synchronizing merge (FR-8)
+  works via per-track execution. §4.1/§4.2 retain the design as forward
+  conception.
+- **`stepUpdate` records `trackState`** (the token-state projection source),
+  not `stepState` as the §4.1 sketch first showed.
+- **Events built: `evFork` + `evEnded`** only; `JoinArrival` (synchronizing
+  joins) and `Wait` (long-wait release) are deferred to the gateway SRD /
+  persistence ADR.
+- **Added `inst.lastErr` / `LastErr()`** to record a fatal fork-construct error
+  (not in the original sketch).
+- **Pre-run `Token()` returns the zero projection** — the initial `TrackReady`
+  seed was dropped; history is recorded once a track runs (so it uses the
+  running clock and stays deterministic under an injected one).
+
+**Verification (M6):** `make ci` green end to end — tidy, lint (all 6 modules),
+build-all, race tests (all modules), govulncheck clean; fork/projection tests
+race-stressed at `-count=20`; no regression (existing suite + `examples/*`).
+
+**Status:** kept **Draft** on the branch. Per the project pattern (cf. FIX-001)
+and the bilingual rule (translation on Accepted), flip Draft → Accepted and add
+the Russian twin as a **post-merge** step.
+
+## 8. References
 
 - [ADR-001 v.3 Execution Model](../design/ADR-001-execution-model.md) — §2 decision, §4 component model, §6 departures (the per-symbol change list this SRD implements), §7 acceptance gate.
 - [SAD-001 v.1 §10 Execution Model](../design/SAD-001-vision-and-architecture.md).
@@ -231,3 +276,4 @@ Maps to [ADR-001 v.3 §7](../design/ADR-001-execution-model.md):
 | Version | Date | Author | Change |
 |---|---|---|---|
 | v.1 | 2026-06-06 | Ruslan Gabitov | Initial Draft. Specifies the Group-A two-layer runtime refactor against ADR-001 v.3; persistence, synchronizing joins / OR-join, Event-Based Gateway, and new elements explicitly out of scope. |
+| v.1 | 2026-06-07 | Ruslan Gabitov | Landed (M1–M6) and reconciled against the code: §7 Implementation Summary added; M4+M5 merged; FR-12 join seam deferred to the gateway SRD; `stepUpdate` records `trackState`; events `evFork`/`evEnded` (JoinArrival/Wait deferred); `LastErr` added. `make ci` green. Status remains Draft pending merge (Accepted + RU twin post-merge). |

--- a/internal/instance/clock_test.go
+++ b/internal/instance/clock_test.go
@@ -1,0 +1,45 @@
+package instance
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeClock is a deterministic time source for tests — the injectable seam
+// that the ADR-002 Clock extension will later replace (SRD-001 FR-11).
+type fakeClock struct {
+	t time.Time
+}
+
+func newFakeClock(t time.Time) *fakeClock { return &fakeClock{t: t} }
+
+func (f *fakeClock) Now() time.Time { return f.t }
+
+func (f *fakeClock) advance(d time.Duration) { f.t = f.t.Add(d) }
+
+func TestFakeClock(t *testing.T) {
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	fc := newFakeClock(base)
+
+	require.Equal(t, base, fc.Now())
+
+	fc.advance(5 * time.Second)
+	require.Equal(t, base.Add(5*time.Second), fc.Now())
+}
+
+// TestInstanceNowSeam verifies the Instance reads time through its injectable
+// `now` seam rather than calling time.Now directly, so later milestones can
+// inject a deterministic clock.
+func TestInstanceNowSeam(t *testing.T) {
+	base := time.Date(2026, 6, 6, 12, 0, 0, 0, time.UTC)
+	fc := newFakeClock(base)
+
+	inst := &Instance{now: fc.Now}
+
+	require.Equal(t, base, inst.now())
+
+	fc.advance(time.Hour)
+	require.Equal(t, base.Add(time.Hour), inst.now())
+}

--- a/internal/instance/event.go
+++ b/internal/instance/event.go
@@ -1,0 +1,26 @@
+package instance
+
+import "github.com/dr-dobermann/gobpm/pkg/model/flow"
+
+// trackEvent is a message a track sends to the Instance event loop, which is
+// the sole owner of instance lifecycle state. Tracks never mutate that state
+// directly — they emit these and loop() applies them in order.
+type trackEvent struct {
+	// track is the subject: the forking parent for evFork, the ended
+	// track for evEnded.
+	track *track
+	// flows, for evFork, are the extra outgoing flows (beyond the one the
+	// parent continues on) that the loop builds a new track for.
+	flows []*flow.SequenceFlow
+	kind  trackEventKind
+}
+
+// trackEventKind enumerates the track→loop event kinds.
+type trackEventKind uint8
+
+const (
+	// evFork: build one new track per extra active outgoing flow.
+	evFork trackEventKind = iota
+	// evEnded: a track's run() has returned.
+	evEnded
+)

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -93,6 +93,7 @@ type Instance struct {
 	parentEventProducer eventproc.EventProducer
 	parentScope         scope.Scope
 	s                   *snapshot.Snapshot
+	now                 func() time.Time
 	scopes              map[scope.DataPath]map[string]data.Data
 	tracks              map[string]*track
 	rootScope           scope.DataPath
@@ -134,6 +135,7 @@ func New(
 		BaseElement:         *be,
 		state:               Ready,
 		s:                   s,
+		now:                 time.Now,
 		scopes:              map[scope.DataPath]map[string]data.Data{},
 		tracks:              map[string]*track{},
 		tokens:              []*token{},
@@ -228,7 +230,7 @@ func (inst *Instance) Run(
 
 	inst.m.Lock()
 	inst.ctx = ctx
-	inst.startTime = time.Now()
+	inst.startTime = inst.now()
 	inst.m.Unlock()
 
 	if err := inst.runTracks(ctx); err != nil {

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -95,19 +95,20 @@ type Instance struct {
 	rr                  interactor.Registrator
 	parentEventProducer eventproc.EventProducer
 	parentScope         scope.Scope
-	s                   *snapshot.Snapshot
-	now                 func() time.Time
+	tracks              map[string]*track        // owned by loop(); not guarded by m
+	tracksSnap          atomic.Pointer[[]*track] // copy-on-write; lock-free GetTokens/TokenHistory
 	scopes              map[scope.DataPath]map[string]data.Data
-	tracks              map[string]*track // owned by loop(); not guarded by m
-	events              chan trackEvent   // tracks -> loop()
-	loopDone            chan struct{}     // closed when loop() exits
-	rootScope           scope.DataPath
+	s                   *snapshot.Snapshot
+	events              chan trackEvent // tracks -> loop()
+	loopDone            chan struct{}   // closed when loop() exits
+	now                 func() time.Time
 	runtimeScope        scope.DataPath
+	rootScope           scope.DataPath
 	foundation.BaseElement
 	tokens     []*token // guarded by m (removed in M5)
 	trackCount atomic.Int64
-	state      atomic.Uint32 // State; written only by loop(), read via State()
 	m          sync.RWMutex  // guards scopes + tokens (NOT lifecycle state/tracks)
+	state      atomic.Uint32 // written only by loop(), read via State()
 }
 
 // New creates a new Instance from the Snapshot s and sets state to Ready.
@@ -284,6 +285,7 @@ func (inst *Instance) loop(ctx context.Context, initial []*track) {
 
 	spawn := func(t *track) {
 		inst.tracks[t.ID()] = t
+		inst.addToSnap(t)
 		active++
 
 		go func(t *track) {
@@ -338,6 +340,60 @@ func (inst *Instance) loop(ctx context.Context, initial []*track) {
 	}
 
 	inst.setState(Finished)
+}
+
+// addToSnap appends a track to the lock-free tracks snapshot (copy-on-write).
+// Called only from loop() (the single writer); readers Load the snapshot.
+func (inst *Instance) addToSnap(t *track) {
+	old := inst.tracksSnap.Load()
+
+	var base []*track
+	if old != nil {
+		base = *old
+	}
+
+	next := make([]*track, len(base), len(base)+1)
+	copy(next, base)
+	next = append(next, t)
+
+	inst.tracksSnap.Store(&next)
+}
+
+// GetTokens returns the projected tokens of the instance's ACTIVE tracks
+// (those whose token is Alive or WaitForEvent), derived lock-free from the
+// tracks snapshot.
+func (inst *Instance) GetTokens() []Token {
+	snap := inst.tracksSnap.Load()
+	if snap == nil {
+		return nil
+	}
+
+	out := make([]Token, 0, len(*snap))
+	for _, t := range *snap {
+		tok := t.Token()
+		if tok.State == TokenAlive || tok.State == TokenWaitForEvent {
+			out = append(out, tok)
+		}
+	}
+
+	return out
+}
+
+// TokenHistory returns the token-flow path history of the instance — one path
+// per track (live and ended), stitched by track lineage — derived lock-free
+// from the tracks snapshot and each track's recorded transitions.
+func (inst *Instance) TokenHistory() []TokenPath {
+	snap := inst.tracksSnap.Load()
+	if snap == nil {
+		return nil
+	}
+
+	out := make([]TokenPath, 0, len(*snap))
+	for _, t := range *snap {
+		out = append(out, t.path())
+	}
+
+	return out
 }
 
 // createTrack creates all initial tracks of the Instance.

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -70,6 +70,7 @@ const (
 	Canceled
 )
 
+// String returns the human-readable name of the instance state.
 func (s State) String() string {
 	return []string{
 		"Created",
@@ -94,16 +95,20 @@ type Instance struct {
 	rr                  interactor.Registrator
 	parentEventProducer eventproc.EventProducer
 	parentScope         scope.Scope
-	tracks              map[string]*track        // owned by loop(); not guarded by m
-	tracksSnap          atomic.Pointer[[]*track] // copy-on-write; lock-free GetTokens/TokenHistory
-	lastErr             atomic.Pointer[error]    // fatal fork-construct error, if any
-	scopes              map[scope.DataPath]map[string]data.Data
-	s                   *snapshot.Snapshot
-	events              chan trackEvent // tracks -> loop()
-	loopDone            chan struct{}   // closed when loop() exits
-	now                 func() time.Time
-	runtimeScope        scope.DataPath
-	rootScope           scope.DataPath
+	// tracks is the live track registry, owned by loop() (not guarded by m).
+	tracks map[string]*track
+	// tracksSnap is a copy-on-write snapshot for lock-free GetTokens /
+	// TokenHistory reads.
+	tracksSnap atomic.Pointer[[]*track]
+	// lastErr is a fatal fork-construct error, if any.
+	lastErr      atomic.Pointer[error]
+	scopes       map[scope.DataPath]map[string]data.Data
+	s            *snapshot.Snapshot
+	events       chan trackEvent // tracks -> loop()
+	loopDone     chan struct{}   // closed when loop() exits
+	now          func() time.Time
+	runtimeScope scope.DataPath
+	rootScope    scope.DataPath
 	foundation.BaseElement
 	trackCount atomic.Int64
 	m          sync.RWMutex  // guards scopes + tokens (NOT lifecycle state/tracks)
@@ -192,7 +197,9 @@ func (inst *Instance) loadProperties(parentScope scope.Scope) error {
 
 	inst.runtimeScope, err = inst.rootScope.Append(runtimeVars)
 	if err != nil {
-		return fmt.Errorf("couldn't create instance's scope runtime variables data path: %w", err)
+		return fmt.Errorf(
+			"couldn't create instance's scope runtime variables data path: %w",
+			err)
 	}
 
 	inst.scopes[inst.rootScope] = map[string]data.Data{}
@@ -256,21 +263,6 @@ func (inst *Instance) Run(
 	return nil
 }
 
-// trackEvent is a message from a track to the Instance event loop. M2 carries
-// the coarse lifecycle set; M4 refines the fork into an active-flows event.
-type trackEvent struct {
-	track *track               // evEnded: the ended track; evFork: the forking parent
-	flows []*flow.SequenceFlow // evFork: the extra flows to build a track for each
-	kind  trackEventKind
-}
-
-type trackEventKind uint8
-
-const (
-	evFork  trackEventKind = iota // fork: build one new track per extra flow
-	evEnded                       // a track's run() returned
-)
-
 // emit delivers a track event to the loop. It never blocks forever: if the
 // loop has exited or the context is canceled it drops the event.
 func (inst *Instance) emit(ev trackEvent) {
@@ -291,23 +283,30 @@ func (inst *Instance) loop(ctx context.Context, initial []*track) {
 	active := 0
 	stopping := false
 
+	// spawn registers a track, adds it to the read snapshot, counts it
+	// active, and runs it in its own goroutine.
 	spawn := func(t *track) {
 		inst.tracks[t.ID()] = t
 		inst.addToSnap(t)
 		active++
 
+		// run the track and report its end back to the loop.
 		go func(t *track) {
 			t.run(ctx)
 			inst.emit(trackEvent{kind: evEnded, track: t})
 		}(t)
 	}
 
+	// stopAll moves the instance to Stopping (once) and signals every
+	// live track to stop.
 	stopAll := func() {
 		if stopping {
 			return
 		}
+
 		stopping = true
 		inst.setState(Stopping)
+
 		for _, t := range inst.tracks {
 			t.stop()
 		}

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -12,7 +12,6 @@ package instance
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -97,6 +96,7 @@ type Instance struct {
 	parentScope         scope.Scope
 	tracks              map[string]*track        // owned by loop(); not guarded by m
 	tracksSnap          atomic.Pointer[[]*track] // copy-on-write; lock-free GetTokens/TokenHistory
+	lastErr             atomic.Pointer[error]    // fatal fork-construct error, if any
 	scopes              map[scope.DataPath]map[string]data.Data
 	s                   *snapshot.Snapshot
 	events              chan trackEvent // tracks -> loop()
@@ -105,7 +105,6 @@ type Instance struct {
 	runtimeScope        scope.DataPath
 	rootScope           scope.DataPath
 	foundation.BaseElement
-	tokens     []*token // guarded by m (removed in M5)
 	trackCount atomic.Int64
 	m          sync.RWMutex  // guards scopes + tokens (NOT lifecycle state/tracks)
 	state      atomic.Uint32 // written only by loop(), read via State()
@@ -145,7 +144,6 @@ func New(
 		tracks:              map[string]*track{},
 		events:              make(chan trackEvent),
 		loopDone:            make(chan struct{}),
-		tokens:              []*token{},
 		parentScope:         parentScope,
 		parentEventProducer: ep,
 		rr:                  rr,
@@ -217,6 +215,16 @@ func (inst *Instance) setState(newState State) {
 	inst.state.Store(uint32(newState))
 }
 
+// LastErr returns the fatal error that stopped the instance (e.g. a fork
+// whose target node could not be constructed), or nil. Set only by loop().
+func (inst *Instance) LastErr() error {
+	if e := inst.lastErr.Load(); e != nil {
+		return *e
+	}
+
+	return nil
+}
+
 // Run starts the process instance execution. Execution could be stopped by
 // cancel function of the context.
 func (inst *Instance) Run(
@@ -251,16 +259,16 @@ func (inst *Instance) Run(
 // trackEvent is a message from a track to the Instance event loop. M2 carries
 // the coarse lifecycle set; M4 refines the fork into an active-flows event.
 type trackEvent struct {
-	track *track
+	track *track               // evEnded: the ended track; evFork: the forking parent
+	flows []*flow.SequenceFlow // evFork: the extra flows to build a track for each
 	kind  trackEventKind
 }
 
 type trackEventKind uint8
 
 const (
-	evSpawn trackEventKind = iota // register + run a new track (from a fork)
+	evFork  trackEventKind = iota // fork: build one new track per extra flow
 	evEnded                       // a track's run() returned
-	evStop                        // request to stop the instance (no live token)
 )
 
 // emit delivers a track event to the loop. It never blocks forever: if the
@@ -323,18 +331,26 @@ func (inst *Instance) loop(ctx context.Context, initial []*track) {
 
 		case ev := <-inst.events:
 			switch ev.kind {
-			case evSpawn:
-				inst.trackCount.Add(1)
-				spawn(ev.track)
-				if stopping {
-					ev.track.stop()
+			case evFork:
+				for _, f := range ev.flows {
+					nt, err := newTrack(f.Target().Node(), inst, ev.track)
+					if err != nil {
+						inst.lastErr.Store(&err)
+						stopAll()
+
+						break
+					}
+
+					inst.trackCount.Add(1)
+					spawn(nt)
+
+					if stopping {
+						nt.stop()
+					}
 				}
 
 			case evEnded:
 				active--
-
-			case evStop:
-				stopAll()
 			}
 		}
 	}
@@ -531,42 +547,6 @@ func (inst *Instance) getRuntimeVar(name string) (data.Data, error) {
 	}
 
 	return p, nil
-}
-
-// addToken adds a new token into Instance.
-func (inst *Instance) addToken(t *token) {
-	if st := inst.State(); st != Runned {
-		return
-	}
-
-	inst.m.Lock()
-	inst.tokens = append(inst.tokens, t)
-	inst.m.Unlock()
-}
-
-// tokenConsumed checks all tokens of the Instance and if there is
-// no alive token, all runned tracks stopped, and Instance execution finished.
-func (inst *Instance) tokenConsumed(_ *token) {
-	if inst.State() != Runned {
-		return
-	}
-
-	// check if there is any alive token (tokens are guarded by m until M5).
-	inst.m.Lock()
-	anyAlive := slices.ContainsFunc(
-		inst.tokens,
-		func(t *token) bool {
-			return t.state == TokenAlive
-		},
-	)
-	inst.m.Unlock()
-
-	if anyAlive {
-		return
-	}
-
-	// no live token — ask the loop (the sole state owner) to stop the instance.
-	inst.emit(trackEvent{kind: evStop})
 }
 
 // -------------------- exec.EventProducer interface ---------------------------

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/exp/maps"
@@ -45,7 +46,9 @@ const (
 )
 
 // State represents the process instance state.
-type State uint8
+// uint32-backed so it can live in an atomic.Uint32 without a narrowing
+// conversion (the instance's run state is read lock-free via State()).
+type State uint32
 
 const (
 	// Created represents a created instance state.
@@ -95,14 +98,16 @@ type Instance struct {
 	s                   *snapshot.Snapshot
 	now                 func() time.Time
 	scopes              map[scope.DataPath]map[string]data.Data
-	tracks              map[string]*track
+	tracks              map[string]*track // owned by loop(); not guarded by m
+	events              chan trackEvent   // tracks -> loop()
+	loopDone            chan struct{}     // closed when loop() exits
 	rootScope           scope.DataPath
 	runtimeScope        scope.DataPath
 	foundation.BaseElement
-	tokens []*token
-	wg     sync.WaitGroup
-	m      sync.RWMutex
-	state  State
+	tokens     []*token // guarded by m (removed in M5)
+	trackCount atomic.Int64
+	state      atomic.Uint32 // State; written only by loop(), read via State()
+	m          sync.RWMutex  // guards scopes + tokens (NOT lifecycle state/tracks)
 }
 
 // New creates a new Instance from the Snapshot s and sets state to Ready.
@@ -133,16 +138,18 @@ func New(
 
 	inst := Instance{
 		BaseElement:         *be,
-		state:               Ready,
 		s:                   s,
 		now:                 time.Now,
 		scopes:              map[scope.DataPath]map[string]data.Data{},
 		tracks:              map[string]*track{},
+		events:              make(chan trackEvent),
+		loopDone:            make(chan struct{}),
 		tokens:              []*token{},
 		parentScope:         parentScope,
 		parentEventProducer: ep,
 		rr:                  rr,
 	}
+	inst.state.Store(uint32(Ready))
 
 	if err := inst.loadProperties(parentScope); err != nil {
 		return nil, errs.New(
@@ -156,6 +163,10 @@ func New(
 	if err := inst.createTracks(); err != nil {
 		return nil, err
 	}
+
+	// TracksCount reflects all tracks created (initial + forks); seed it with
+	// the initial tracks. The loop adds forks; ended tracks are retained.
+	inst.trackCount.Store(int64(len(inst.tracks)))
 
 	return &inst, nil
 }
@@ -195,18 +206,14 @@ func (inst *Instance) loadProperties(parentScope scope.Scope) error {
 
 // State returns current state of the Instance.
 func (inst *Instance) State() State {
-	inst.m.RLock()
-	defer inst.m.RUnlock()
-
-	return inst.state
+	return State(inst.state.Load())
 }
 
-// updateState sets new state for the Instance.
-func (inst *Instance) updateState(newState State) {
-	inst.m.Lock()
-	defer inst.m.Unlock()
-
-	inst.state = newState
+// setState sets a new instance state. Written only from loop() (the single
+// owner of lifecycle state) and from Run(); State() readers see it via the
+// atomic, so no lock is needed.
+func (inst *Instance) setState(newState State) {
+	inst.state.Store(uint32(newState))
 }
 
 // Run starts the process instance execution. Execution could be stopped by
@@ -220,85 +227,117 @@ func (inst *Instance) Run(
 			errs.C(errorClass, errs.EmptyNotAllowed))
 	}
 
-	if inst.state != Ready {
+	if inst.State() != Ready {
 		return errs.New(
-			errs.M("invalid instance state to run",
-				inst.state),
+			errs.M("invalid instance state to run"),
 			errs.C(errorClass, errs.InvalidState),
-			errs.D("current_state", inst.state))
+			errs.D("current_state", inst.State()))
 	}
 
-	inst.m.Lock()
 	inst.ctx = ctx
 	inst.startTime = inst.now()
-	inst.m.Unlock()
+	inst.setState(Runned)
 
-	if err := inst.runTracks(ctx); err != nil {
-		return err
-	}
+	// initial tracks were built by createTracks() during New; hand them to the
+	// loop, which becomes the sole owner of lifecycle state from here on.
+	initial := maps.Values(inst.tracks)
 
-	// run tracks ending watcher
-	grChan := make(chan struct{})
-	go func() {
-		inst.wg.Wait()
-
-		close(grChan)
-
-		inst.updateState(Finished)
-	}()
+	go inst.loop(ctx, initial)
 
 	return nil
 }
 
-// runTracks runs all tracks of the instance.
-func (inst *Instance) runTracks(ctx context.Context) error {
-	inst.state = Runned
-
-	// run only registered tracks, not the ones created by runned track's forks.
-	tracks := append([]*track{}, maps.Values(inst.tracks)...)
-	for _, t := range tracks {
-		tt := t
-		inst.runSingleTrack(ctx, tt)
-	}
-
-	return nil
+// trackEvent is a message from a track to the Instance event loop. M2 carries
+// the coarse lifecycle set; M4 refines the fork into an active-flows event.
+type trackEvent struct {
+	track *track
+	kind  trackEventKind
 }
 
-// addTrack adds a new track into the instance's track pool.
-// If instance is running, added track also runs.
-func (inst *Instance) addTrack(ctx context.Context, nt *track) error {
-	if nt == nil {
-		return fmt.Errorf("couldn't add empty track to instance %q", inst.ID())
+type trackEventKind uint8
+
+const (
+	evSpawn trackEventKind = iota // register + run a new track (from a fork)
+	evEnded                       // a track's run() returned
+	evStop                        // request to stop the instance (no live token)
+)
+
+// emit delivers a track event to the loop. It never blocks forever: if the
+// loop has exited or the context is canceled it drops the event.
+func (inst *Instance) emit(ev trackEvent) {
+	select {
+	case inst.events <- ev:
+	case <-inst.loopDone:
+	case <-inst.ctx.Done():
 	}
-
-	inst.m.Lock()
-	defer inst.m.Unlock()
-
-	if _, ok := inst.tracks[nt.ID()]; ok {
-		return fmt.Errorf("track from node %q(%s) already registered in instance %q",
-			inst.tracks[nt.ID()].steps[0].node.Name(),
-			inst.tracks[nt.ID()].steps[0].node.ID(),
-			inst.ID())
-	}
-
-	inst.tracks[nt.ID()] = nt
-
-	if inst.state == Runned {
-		inst.runSingleTrack(ctx, nt)
-	}
-
-	return nil
 }
 
-// runSingleTrack starts a new track and add it to instance's WaitGroup.
-func (inst *Instance) runSingleTrack(ctx context.Context, t *track) {
-	inst.wg.Add(1)
+// loop is the single owner of the Instance's lifecycle state (the tracks
+// registry and the run state). Tracks never mutate that state directly — they
+// emit events here, applied in order in this one goroutine, so no lock guards
+// lifecycle state. The instance finishes when all tracks have ended.
+func (inst *Instance) loop(ctx context.Context, initial []*track) {
+	defer close(inst.loopDone)
 
-	go func(t *track) {
-		defer inst.wg.Done()
+	active := 0
+	stopping := false
 
-		t.run(ctx)
-	}(t)
+	spawn := func(t *track) {
+		inst.tracks[t.ID()] = t
+		active++
+
+		go func(t *track) {
+			t.run(ctx)
+			inst.emit(trackEvent{kind: evEnded, track: t})
+		}(t)
+	}
+
+	stopAll := func() {
+		if stopping {
+			return
+		}
+		stopping = true
+		inst.setState(Stopping)
+		for _, t := range inst.tracks {
+			t.stop()
+		}
+	}
+
+	for _, t := range initial {
+		spawn(t)
+	}
+
+	if active == 0 {
+		inst.setState(Finished)
+		return
+	}
+
+	done := ctx.Done()
+	for active > 0 {
+		select {
+		case <-done:
+			done = nil
+			stopAll()
+
+		case ev := <-inst.events:
+			switch ev.kind {
+			case evSpawn:
+				inst.trackCount.Add(1)
+				spawn(ev.track)
+				if stopping {
+					ev.track.stop()
+				}
+
+			case evEnded:
+				active--
+
+			case evStop:
+				stopAll()
+			}
+		}
+	}
+
+	inst.setState(Finished)
 }
 
 // createTrack creates all initial tracks of the Instance.
@@ -400,10 +439,10 @@ func (inst *Instance) getRuntimeVar(name string) (data.Data, error) {
 		d = values.NewVariable(inst.startTime)
 
 	case CurrState:
-		d = values.NewVariable(inst.state)
+		d = values.NewVariable(inst.State())
 
 	case TracksCount:
-		tc := len(inst.tracks)
+		tc := int(inst.trackCount.Load())
 		d = values.NewVariable(tc)
 
 	default:
@@ -452,31 +491,26 @@ func (inst *Instance) addToken(t *token) {
 // tokenConsumed checks all tokens of the Instance and if there is
 // no alive token, all runned tracks stopped, and Instance execution finished.
 func (inst *Instance) tokenConsumed(_ *token) {
-	inst.m.Lock()
-	defer inst.m.Unlock()
-
-	if inst.state != Runned {
+	if inst.State() != Runned {
 		return
 	}
 
-	// check if there is any alive token. If any, then return.
-	if slices.ContainsFunc(
+	// check if there is any alive token (tokens are guarded by m until M5).
+	inst.m.Lock()
+	anyAlive := slices.ContainsFunc(
 		inst.tokens,
 		func(t *token) bool {
 			return t.state == TokenAlive
 		},
-	) {
+	)
+	inst.m.Unlock()
+
+	if anyAlive {
 		return
 	}
 
-	// if there is no alive token, stop the instance.
-	inst.state = Stopping
-
-	go func() {
-		for _, t := range inst.tracks {
-			t.stop()
-		}
-	}()
+	// no live token — ask the loop (the sole state owner) to stop the instance.
+	inst.emit(trackEvent{kind: evStop})
 }
 
 // -------------------- exec.EventProducer interface ---------------------------

--- a/internal/instance/leakcheck_test.go
+++ b/internal/instance/leakcheck_test.go
@@ -1,0 +1,40 @@
+package instance
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// assertNoGoroutineLeak captures the goroutine baseline and returns a check to
+// run at test end (typically via defer). It allows a short settle window for
+// goroutines to unwind. Used by later milestones' -race / leak assertions.
+func assertNoGoroutineLeak(t *testing.T) func() {
+	t.Helper()
+
+	base := runtime.NumGoroutine()
+
+	return func() {
+		t.Helper()
+
+		for range 20 {
+			if runtime.NumGoroutine() <= base {
+				return
+			}
+
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		require.LessOrEqualf(t, runtime.NumGoroutine(), base,
+			"goroutine leak: baseline was %d", base)
+	}
+}
+
+func TestNoGoroutineLeakHelper(t *testing.T) {
+	done := assertNoGoroutineLeak(t)
+	defer done()
+
+	// no-op: a clean test must return to the goroutine baseline.
+}

--- a/internal/instance/m2_loop_test.go
+++ b/internal/instance/m2_loop_test.go
@@ -1,0 +1,75 @@
+package instance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/internal/instance/snapshot"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/stretchr/testify/require"
+)
+
+// buildLinearSnapshot builds a minimal start -> end process (one outgoing
+// flow, no fork): enough to exercise the event loop end to end.
+func buildLinearSnapshot(t *testing.T) *snapshot.Snapshot {
+	t.Helper()
+
+	p, err := process.New("m2-linear")
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{start, end} {
+		require.NoError(t, p.Add(e))
+	}
+
+	_, err = flow.Link(start, end)
+	require.NoError(t, err)
+
+	s, err := snapshot.New(p)
+	require.NoError(t, err)
+
+	return s
+}
+
+// TestM2LinearCompletes verifies the event loop drives a single track to
+// completion: the loop spawns the initial track, the track ends, the instance
+// reaches Finished via the active-track count, and no goroutine leaks. Under
+// -race it also exercises that instance lifecycle state (state, registry) is
+// mutated only in the loop goroutine while State()/trackCount are read
+// concurrently. (The fork / evSpawn path is exercised in M4, once token.split
+// is removed — it currently panics on a >1 split, a pre-existing bug.)
+func TestM2LinearCompletes(t *testing.T) {
+	_ = data.CreateDefaultStates()
+
+	s := buildLinearSnapshot(t)
+	ep := mockeventproc.NewMockEventProducer(t)
+
+	inst, err := New(s, nil, ep, nil)
+	require.NoError(t, err)
+
+	leak := assertNoGoroutineLeak(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	require.NoError(t, inst.Run(ctx))
+
+	require.Eventually(t,
+		func() bool { return inst.State() == Finished },
+		2*time.Second, 5*time.Millisecond,
+		"instance should reach Finished once its single track ends")
+
+	require.EqualValues(t, 1, inst.trackCount.Load())
+
+	cancel()
+	leak()
+}

--- a/internal/instance/m3_projection_test.go
+++ b/internal/instance/m3_projection_test.go
@@ -1,0 +1,120 @@
+package instance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenStateProjection(t *testing.T) {
+	cases := []struct {
+		in   trackState
+		want TokenState
+	}{
+		{TrackReady, TokenAlive},
+		{TrackExecutingStep, TokenAlive},
+		{TrackProcessStepResults, TokenAlive},
+		{TrackWaitForEvent, TokenWaitForEvent},
+		{TrackEnded, TokenConsumed},
+		{TrackMerged, TokenConsumed},
+		{TrackCanceled, TokenConsumed},
+		{TrackFailed, TokenConsumed},
+	}
+
+	for _, c := range cases {
+		require.Equalf(t, c.want, tokenStateFor(c.in),
+			"projection of %s", c.in)
+	}
+}
+
+// TestM3LinearHistory runs a linear instance with a fixed injected clock and
+// checks the derived token path history: it visits both nodes, ends Consumed,
+// has deterministic monotonic timestamps, and no active tokens remain.
+func TestM3LinearHistory(t *testing.T) {
+	_ = data.CreateDefaultStates()
+
+	s := buildLinearSnapshot(t)
+	ep := mockeventproc.NewMockEventProducer(t)
+
+	inst, err := New(s, nil, ep, nil)
+	require.NoError(t, err)
+
+	base := time.Date(2026, 6, 7, 10, 0, 0, 0, time.UTC)
+	inst.now = newFakeClock(base).Now // fixed clock -> deterministic timestamps
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, inst.Run(ctx))
+	require.Eventually(t,
+		func() bool { return inst.State() == Finished },
+		2*time.Second, 5*time.Millisecond)
+
+	// all tokens consumed -> none active
+	require.Empty(t, inst.GetTokens())
+
+	hist := inst.TokenHistory()
+	require.Len(t, hist, 1, "one linear track -> one path")
+
+	p := hist[0]
+	require.Equal(t, "", p.ParentID, "root track has no parent")
+	require.Equal(t, TokenConsumed, p.Terminal)
+	require.NotEmpty(t, p.Steps)
+
+	nodes := map[string]bool{}
+
+	var prev time.Time
+
+	for _, sv := range p.Steps {
+		nodes[sv.Node.Name()] = true
+
+		require.Equal(t, base, sv.At, "fixed clock -> all timestamps equal")
+		require.False(t, sv.At.Before(prev), "timestamps monotonic non-decreasing")
+
+		prev = sv.At
+	}
+
+	require.True(t, nodes["start"], "path visits the start node")
+	require.True(t, nodes["end"], "path visits the end node")
+}
+
+// TestM3ConcurrentReads hammers GetTokens / TokenHistory from another goroutine
+// while the instance runs — under -race this proves the projections are
+// lock-free and safe against the loop mutating the tracks snapshot.
+func TestM3ConcurrentReads(t *testing.T) {
+	_ = data.CreateDefaultStates()
+
+	s := buildLinearSnapshot(t)
+	ep := mockeventproc.NewMockEventProducer(t)
+
+	inst, err := New(s, nil, ep, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = inst.GetTokens()
+				_ = inst.TokenHistory()
+			}
+		}
+	}()
+
+	require.NoError(t, inst.Run(ctx))
+	require.Eventually(t,
+		func() bool { return inst.State() == Finished },
+		2*time.Second, 5*time.Millisecond)
+
+	close(done)
+}

--- a/internal/instance/m4_fork_test.go
+++ b/internal/instance/m4_fork_test.go
@@ -1,0 +1,163 @@
+package instance
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/internal/instance/snapshot"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/stretchr/testify/require"
+)
+
+// buildForkSnapshot builds a process whose start node has two outgoing flows
+// (a fork point):
+//
+//	start ─┬─> end1
+//	       └─> end2
+func buildForkSnapshot(t *testing.T) *snapshot.Snapshot {
+	t.Helper()
+
+	p, err := process.New("m4-fork")
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	end1, err := events.NewEndEvent("end1")
+	require.NoError(t, err)
+
+	end2, err := events.NewEndEvent("end2")
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{start, end1, end2} {
+		require.NoError(t, p.Add(e))
+	}
+
+	_, err = flow.Link(start, end1)
+	require.NoError(t, err)
+
+	_, err = flow.Link(start, end2)
+	require.NoError(t, err)
+
+	s, err := snapshot.New(p)
+	require.NoError(t, err)
+
+	return s
+}
+
+func nodeSet(p TokenPath) map[string]bool {
+	out := map[string]bool{}
+	for _, sv := range p.Steps {
+		out[sv.Node.Name()] = true
+	}
+
+	return out
+}
+
+// TestM4ForkCompletes verifies the reworked fork: the loop builds a new track
+// for the extra flow (no token.split), both tracks complete, and the path
+// history reflects the lineage — the parent path forks into the child.
+func TestM4ForkCompletes(t *testing.T) {
+	_ = data.CreateDefaultStates()
+
+	s := buildForkSnapshot(t)
+	ep := mockeventproc.NewMockEventProducer(t)
+
+	inst, err := New(s, nil, ep, nil)
+	require.NoError(t, err)
+
+	leak := assertNoGoroutineLeak(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	require.NoError(t, inst.Run(ctx))
+
+	require.Eventually(t,
+		func() bool { return inst.State() == Finished },
+		2*time.Second, 5*time.Millisecond,
+		"both forked tracks should complete")
+
+	require.NoError(t, inst.LastErr())
+	require.EqualValues(t, 2, inst.trackCount.Load(), "one fork over two flows -> 2 tracks")
+	require.Empty(t, inst.GetTokens(), "no active tokens after completion")
+
+	hist := inst.TokenHistory()
+	require.Len(t, hist, 2)
+
+	var root, child TokenPath
+
+	for _, p := range hist {
+		if p.ParentID == "" {
+			root = p
+		} else {
+			child = p
+		}
+	}
+
+	require.NotEmpty(t, root.TrackID, "there is a root track")
+	require.Equal(t, root.TrackID, child.ParentID, "the child forked from the root")
+	require.Equal(t, TokenConsumed, root.Terminal)
+	require.Equal(t, TokenConsumed, child.Terminal)
+
+	rootNodes := nodeSet(root)
+	childNodes := nodeSet(child)
+
+	require.True(t, rootNodes["start"], "root visits the start node")
+	require.False(t, childNodes["start"], "child branched after the start node")
+
+	// across both paths, both ends are visited.
+	ends := map[string]bool{}
+	for n := range rootNodes {
+		ends[n] = ends[n] || n == "end1" || n == "end2"
+	}
+
+	for n := range childNodes {
+		ends[n] = ends[n] || n == "end1" || n == "end2"
+	}
+
+	require.True(t, ends["end1"] && ends["end2"], "both end nodes visited across the paths")
+
+	cancel()
+	leak()
+}
+
+// TestM4ForkRace hammers the projections from another goroutine while a
+// forking instance runs — under -race it proves fork + lock-free reads compose.
+func TestM4ForkRace(t *testing.T) {
+	_ = data.CreateDefaultStates()
+
+	s := buildForkSnapshot(t)
+	ep := mockeventproc.NewMockEventProducer(t)
+
+	inst, err := New(s, nil, ep, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan struct{})
+
+	go func() {
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = inst.GetTokens()
+				_ = inst.TokenHistory()
+			}
+		}
+	}()
+
+	require.NoError(t, inst.Run(ctx))
+	require.Eventually(t,
+		func() bool { return inst.State() == Finished },
+		2*time.Second, 5*time.Millisecond)
+
+	close(done)
+}

--- a/internal/instance/token.go
+++ b/internal/instance/token.go
@@ -20,11 +20,15 @@ const (
 	TokenWaitForEvent
 	// TokenConsumed represents a token that has been consumed
 	TokenConsumed
+	// TokenWithdrawn represents a token withdrawn at an Event-Based Gateway
+	// race loss. The value exists for the projection; its producer arrives
+	// with the Event-Based Gateway (gateway SRD).
+	TokenWithdrawn
 )
 
 // Validate checks if the TokenState is valid.
 func (ts TokenState) Validate() error {
-	if ts < TokenAlive || ts > TokenConsumed {
+	if ts < TokenAlive || ts > TokenWithdrawn {
 		return errs.New(
 			errs.M("invalid token state: %d", ts),
 			errs.C(errorClass, errs.InvalidParameter))

--- a/internal/instance/token.go
+++ b/internal/instance/token.go
@@ -1,7 +1,10 @@
 package instance
 
 import (
+	"time"
+
 	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 )
 
 // TokenState represents the current state of a token in the process
@@ -36,6 +39,57 @@ func (ts TokenState) Validate() error {
 	return nil
 }
 
-// The token is no longer a stored object — it exists only as a derived
-// projection (see track.Token() / Instance.GetTokens() / tokenStateFor in
-// track.go). TokenState above is the projected value's type.
+// The token is no longer a stored object — it exists only as the derived
+// projection types below, produced by track.Token() / Instance.GetTokens() /
+// Instance.TokenHistory(). TokenState above is the projected value's type.
+
+// Token is the logical, derived view of a track's current control-flow
+// position — the BPMN "token" as a projection, not a stored object.
+type Token struct {
+	Node  flow.Node
+	State TokenState
+}
+
+// StepVisit is one entry of a token's path history with its timing.
+type StepVisit struct {
+	Node  flow.Node
+	At    time.Time
+	State TokenState
+}
+
+// TokenPath is the recorded path of one token (one track), with lineage.
+type TokenPath struct {
+	TrackID  string
+	ParentID string // immediate parent track (fork origin); "" if root
+	Steps    []StepVisit
+	Terminal TokenState
+}
+
+// stepUpdate is one recorded track-state transition: the node the track was
+// at, the track state it entered, and when. The token state is projected
+// from it; the node + time give the path and its timing.
+type stepUpdate struct {
+	node  flow.Node
+	at    time.Time
+	state trackState
+}
+
+// tokenStateFor projects a track state onto the BPMN token state.
+func tokenStateFor(ts trackState) TokenState {
+	switch ts {
+	case TrackReady, TrackExecutingStep, TrackProcessStepResults:
+		return TokenAlive
+
+	case TrackWaitForEvent:
+		return TokenWaitForEvent
+
+	case TrackEnded, TrackMerged, TrackCanceled, TrackFailed:
+		// Canceled maps to Consumed here; the Withdrawn case
+		// (Event-Based Gateway race loss) is wired with that gateway
+		// (gateway SRD).
+		return TokenConsumed
+
+	default:
+		return TokenInvalid
+	}
+}

--- a/internal/instance/token.go
+++ b/internal/instance/token.go
@@ -2,7 +2,6 @@ package instance
 
 import (
 	"github.com/dr-dobermann/gobpm/pkg/errs"
-	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 )
 
 // TokenState represents the current state of a token in the process
@@ -37,70 +36,6 @@ func (ts TokenState) Validate() error {
 	return nil
 }
 
-type token struct {
-	inst *Instance
-	trk  *track
-	foundation.BaseElement
-	prevs []*token
-	nexts []*token
-	state TokenState
-}
-
-// newToken creates a new token and adds it to the Instance.
-func newToken(inst *Instance, trk *track) *token {
-	if inst == nil {
-		errs.Panic("empty instance on token creation")
-
-		return nil
-	}
-
-	be, err := foundation.NewBaseElement()
-	if err != nil {
-		errs.Panic("failed to create base element for token: " + err.Error())
-	}
-
-	t := token{
-		BaseElement: *be,
-		inst:        inst,
-		trk:         trk,
-		state:       TokenAlive,
-		prevs:       []*token{},
-		nexts:       []*token{},
-	}
-
-	inst.addToken(&t)
-
-	return &t
-}
-
-// updateState sets new valid state of the token
-func (t *token) updateState(newState TokenState) error {
-	if err := newState.Validate(); err != nil {
-		return err
-	}
-
-	t.state = newState
-
-	if t.state == TokenConsumed {
-		t.inst.tokenConsumed(t)
-	}
-
-	return nil
-}
-
-// split creates a new splitCount tokens from the t token.
-// the first token is the token t
-func (t *token) split(splitCount int) []*token {
-	tt := make([]*token, 0, splitCount)
-
-	tt = append(tt, t)
-
-	for i := 1; i < splitCount; i++ {
-		tt[i] = newToken(t.inst, t.trk)
-		tt[i].prevs = t.prevs
-		tt[i].prevs = append(tt[i].prevs, t)
-		t.nexts = append(t.nexts, tt[i])
-	}
-
-	return tt
-}
+// The token is no longer a stored object — it exists only as a derived
+// projection (see track.Token() / Instance.GetTokens() / tokenStateFor in
+// track.go). TokenState above is the projected value's type.

--- a/internal/instance/track.go
+++ b/internal/instance/track.go
@@ -358,7 +358,7 @@ func (t *track) run(
 			return
 		}
 
-		err = t.checkFlows(ctx, nextFlows)
+		err = t.checkFlows(nextFlows)
 		if err != nil {
 			t.lastErr = err
 			t.updateState(TrackFailed)
@@ -451,7 +451,7 @@ func (t *track) finalizeNodeExecution(ctx context.Context, step *stepInfo, _ []*
 // checkFlows processes node outgoing flows.
 // If number of flows is greater than 1 then new tracks with splited token
 // created.
-func (t *track) checkFlows(ctx context.Context, flows []*flow.SequenceFlow) error {
+func (t *track) checkFlows(flows []*flow.SequenceFlow) error {
 	if len(flows) == 0 {
 		t.updateState(TrackEnded)
 		return nil
@@ -500,12 +500,9 @@ func (t *track) checkFlows(ctx context.Context, flows []*flow.SequenceFlow) erro
 
 		nt.steps[0].tk = tokens[i+1]
 
-		if err := t.instance.addTrack(ctx, nt); err != nil {
-			return errs.New(
-				errs.M("couldn't add new track for flow %q", f.ID()),
-				errs.C(errorClass, errs.BulidingFailed),
-				errs.E(err))
-		}
+		// hand the new track to the instance loop — it owns the registry and
+		// spawns the goroutine (track never mutates instance state directly).
+		t.instance.emit(trackEvent{kind: evSpawn, track: nt})
 	}
 
 	return nil

--- a/internal/instance/track.go
+++ b/internal/instance/track.go
@@ -141,7 +141,6 @@ func (ss stepState) String() string {
 // stepInfo keeps information about single track step
 type stepInfo struct {
 	node  flow.Node
-	tk    *token
 	state stepState
 }
 
@@ -372,32 +371,10 @@ func (t *track) inState(ss ...trackState) bool {
 func (t *track) updateState(newState trackState) {
 	t.m.RLock()
 	state := t.state
-	step := t.steps[len(t.steps)-1]
 	t.m.RUnlock()
 
 	if state == newState {
 		return
-	}
-
-	ts := TokenInvalid
-
-	switch newState {
-	case TrackReady, TrackExecutingStep:
-		ts = TokenAlive
-
-	case TrackWaitForEvent:
-		ts = TokenWaitForEvent
-
-	case TrackFailed, TrackEnded, TrackCanceled:
-		ts = TokenConsumed
-	}
-
-	if step.tk != nil {
-		if err := step.tk.updateState(ts); err != nil {
-			errs.Panic(err)
-
-			return
-		}
 	}
 
 	t.m.Lock()
@@ -520,11 +497,6 @@ func (t *track) executeNode(
 }
 
 func (t *track) prepareNodeExecution(ctx context.Context, step *stepInfo) error {
-	// create a new token if track doesn't have yet
-	if step.tk == nil {
-		step.tk = newToken(t.instance, t)
-	}
-
 	t.updateState(TrackExecutingStep)
 	step.state = StepStarted
 	t.record(TrackExecutingStep) // record this node visit (path + timing)
@@ -569,17 +541,19 @@ func (t *track) finalizeNodeExecution(ctx context.Context, step *stepInfo, _ []*
 	return t.uploadOutgoingData(ctx, step.node)
 }
 
-// checkFlows processes node outgoing flows.
-// If number of flows is greater than 1 then new tracks with splited token
-// created.
+// checkFlows processes a node's outgoing flows. The track continues on the
+// first (cyclic-preferred) flow carrying its current token; any remaining
+// flows are a fork — handed to the loop, which builds one new track per extra
+// flow (each new track self-creates its own token on execution). 1:1
+// track:token holds: the parent keeps its single token, no split.
 func (t *track) checkFlows(flows []*flow.SequenceFlow) error {
 	if len(flows) == 0 {
 		t.updateState(TrackEnded)
 		return nil
 	}
 
-	// if outgoing flows has any cyclic on current node then first of them
-	// should be next step of the track
+	// if any outgoing flow is cyclic on the current node, it becomes the
+	// track's next step.
 	nextNode := 0
 	for i, f := range flows {
 		if f.Target().ID() == t.currentStep().node.ID() {
@@ -588,42 +562,26 @@ func (t *track) checkFlows(flows []*flow.SequenceFlow) error {
 		}
 	}
 
-	tokens := t.currentStep().tk.split(len(flows))
-
-	// create a new step for main track and put token from current step
-	// into it.
+	// the track continues on the chosen flow (it carries its single position;
+	// no token object).
 	nextStep := stepInfo{
 		node:  flows[nextNode].Target().Node(),
 		state: StepCreated,
-		tk:    tokens[0],
 	}
-
-	if err := nextStep.tk.updateState(TokenAlive); err != nil {
-		return errs.New(
-			errs.M("couldn't update token state of the main flow"),
-			errs.D("node_name", nextStep.node.Name()),
-			errs.D("node_id", nextStep.node.ID()),
-			errs.D("instance_id", t.instance.ID()),
-			errs.E(err))
-	}
-
 	t.steps = append(t.steps, &nextStep)
 
-	// for every new flow create a new track with new tokens.
-	for i, f := range append(flows[:nextNode], flows[nextNode+1:]...) {
-		nt, err := newTrack(f.Target().Node(), t.instance, t)
-		if err != nil {
-			return errs.New(
-				errs.M("couldn't creaete a new track for flow %q", f.ID()),
-				errs.C(errorClass, errs.BulidingFailed),
-				errs.E(err))
+	// the remaining flows fork: build a fresh slice (don't mutate the caller's)
+	// and hand it to the loop, which constructs the new tracks. The track never
+	// mutates instance state itself.
+	extras := make([]*flow.SequenceFlow, 0, len(flows)-1)
+	for i, f := range flows {
+		if i != nextNode {
+			extras = append(extras, f)
 		}
+	}
 
-		nt.steps[0].tk = tokens[i+1]
-
-		// hand the new track to the instance loop — it owns the registry and
-		// spawns the goroutine (track never mutates instance state directly).
-		t.instance.emit(trackEvent{kind: evSpawn, track: nt})
+	if len(extras) != 0 {
+		t.instance.emit(trackEvent{kind: evFork, track: t, flows: extras})
 	}
 
 	return nil

--- a/internal/instance/track.go
+++ b/internal/instance/track.go
@@ -45,9 +45,9 @@ package instance
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/dr-dobermann/gobpm/internal/eventproc"
 	"github.com/dr-dobermann/gobpm/internal/exec"
@@ -87,6 +87,7 @@ const (
 	TrackFailed
 )
 
+// String returns the human-readable name of the track state.
 func (t trackState) String() string {
 	return []string{
 		"TrackCreated",
@@ -125,6 +126,7 @@ const (
 	StepFailed
 )
 
+// String returns the human-readable name of the step state.
 func (ss stepState) String() string {
 	return []string{
 		"Created",
@@ -161,56 +163,6 @@ type track struct {
 	m      sync.RWMutex
 	state  trackState
 	stopIt bool
-}
-
-// stepUpdate is one recorded track-state transition: which node the track was
-// at, the track state it entered, and when. The token state is projected from
-// it; the node + time give the path and its timing.
-type stepUpdate struct {
-	node  flow.Node
-	at    time.Time
-	state trackState
-}
-
-// Token is the logical, derived view of a track's current control-flow
-// position — the BPMN "token" as a projection, not a stored object.
-type Token struct {
-	Node  flow.Node
-	State TokenState
-}
-
-// StepVisit is one entry of a token's path history with its timing.
-type StepVisit struct {
-	Node  flow.Node
-	At    time.Time
-	State TokenState
-}
-
-// TokenPath is the recorded path of one token (one track), with lineage.
-type TokenPath struct {
-	TrackID  string
-	ParentID string // immediate parent track (fork origin); "" for a root track
-	Steps    []StepVisit
-	Terminal TokenState
-}
-
-// tokenStateFor projects a track state onto the BPMN token state.
-func tokenStateFor(ts trackState) TokenState {
-	switch ts {
-	case TrackReady, TrackExecutingStep, TrackProcessStepResults:
-		return TokenAlive
-
-	case TrackWaitForEvent:
-		return TokenWaitForEvent
-
-	case TrackEnded, TrackMerged, TrackCanceled, TrackFailed:
-		// Canceled maps to Consumed here; the Withdrawn case (Event-Based
-		// Gateway race loss) is wired with that gateway (gateway SRD).
-		return TokenConsumed
-
-	default:
-		return TokenInvalid
-	}
 }
 
 // record appends a track-state transition to the history, copy-on-write, and
@@ -352,18 +304,13 @@ func (t *track) checkNodeType(node flow.Node) error {
 }
 
 // inState checks if track state is equal to any track state from the ss.
+// inState reports whether the track's current state is any of ss.
 func (t *track) inState(ss ...trackState) bool {
 	t.m.RLock()
 	state := t.state
 	t.m.RUnlock()
 
-	for _, s := range ss {
-		if state == s {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(ss, state)
 }
 
 // updateState sets new state for the track if its not in final state.
@@ -496,7 +443,12 @@ func (t *track) executeNode(
 	return nexts, nil
 }
 
-func (t *track) prepareNodeExecution(ctx context.Context, step *stepInfo) error {
+// prepareNodeExecution marks the step executing, loads incoming data, extends
+// scope for data-loader nodes, and runs the node prologue.
+func (t *track) prepareNodeExecution(
+	ctx context.Context,
+	step *stepInfo,
+) error {
 	t.updateState(TrackExecutingStep)
 	step.state = StepStarted
 	t.record(TrackExecutingStep) // record this node visit (path + timing)
@@ -520,7 +472,12 @@ func (t *track) prepareNodeExecution(ctx context.Context, step *stepInfo) error 
 	return t.runNodePrologue(ctx, step.node)
 }
 
-func (t *track) executeNodeCore(ctx context.Context, step *stepInfo, ne exec.NodeExecutor) ([]*flow.SequenceFlow, error) {
+// executeNodeCore runs the node's executor and returns its outgoing flows.
+func (t *track) executeNodeCore(
+	ctx context.Context,
+	step *stepInfo,
+	ne exec.NodeExecutor,
+) ([]*flow.SequenceFlow, error) {
 	step.state = StepExecuting
 
 	nexts, err := ne.Exec(ctx, t.instance)
@@ -531,7 +488,12 @@ func (t *track) executeNodeCore(ctx context.Context, step *stepInfo, ne exec.Nod
 	return nexts, nil
 }
 
-func (t *track) finalizeNodeExecution(ctx context.Context, step *stepInfo, _ []*flow.SequenceFlow) error {
+// finalizeNodeExecution runs the node epilogue and uploads its outgoing data.
+func (t *track) finalizeNodeExecution(
+	ctx context.Context,
+	step *stepInfo,
+	_ []*flow.SequenceFlow,
+) error {
 	if err := t.runNodeEpilogue(ctx, step.node); err != nil {
 		return err
 	}
@@ -658,6 +620,9 @@ func (t *track) uploadOutgoingData(ctx context.Context, n flow.Node) error {
 
 // --------------------- exec.EventProcessor interface -------------------------
 
+// ProcessEvent delivers a fired event to the waiting node, unregisters the
+// node's event definitions, and returns the track to the Ready state so run()
+// resumes it. Implements eventproc.EventProcessor.
 func (t *track) ProcessEvent(
 	ctx context.Context,
 	eDef flow.EventDefinition,

--- a/internal/instance/track.go
+++ b/internal/instance/track.go
@@ -46,6 +46,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/dr-dobermann/gobpm/internal/eventproc"
 	"github.com/dr-dobermann/gobpm/internal/exec"
@@ -150,11 +152,118 @@ type track struct {
 	lastErr  error
 	instance *Instance
 	foundation.BaseElement
-	prev   []*track
+	prev []*track
+	// hist is the append-only list of track-state transitions (SRD-001 M3).
+	// It is written only by this track's goroutine via record() and published
+	// copy-on-write, so token projection / path history / timing are derived
+	// from it lock-free by any reader.
+	hist   atomic.Pointer[[]stepUpdate]
 	steps  []*stepInfo
 	m      sync.RWMutex
 	state  trackState
 	stopIt bool
+}
+
+// stepUpdate is one recorded track-state transition: which node the track was
+// at, the track state it entered, and when. The token state is projected from
+// it; the node + time give the path and its timing.
+type stepUpdate struct {
+	node  flow.Node
+	at    time.Time
+	state trackState
+}
+
+// Token is the logical, derived view of a track's current control-flow
+// position — the BPMN "token" as a projection, not a stored object.
+type Token struct {
+	Node  flow.Node
+	State TokenState
+}
+
+// StepVisit is one entry of a token's path history with its timing.
+type StepVisit struct {
+	Node  flow.Node
+	At    time.Time
+	State TokenState
+}
+
+// TokenPath is the recorded path of one token (one track), with lineage.
+type TokenPath struct {
+	TrackID  string
+	ParentID string // immediate parent track (fork origin); "" for a root track
+	Steps    []StepVisit
+	Terminal TokenState
+}
+
+// tokenStateFor projects a track state onto the BPMN token state.
+func tokenStateFor(ts trackState) TokenState {
+	switch ts {
+	case TrackReady, TrackExecutingStep, TrackProcessStepResults:
+		return TokenAlive
+
+	case TrackWaitForEvent:
+		return TokenWaitForEvent
+
+	case TrackEnded, TrackMerged, TrackCanceled, TrackFailed:
+		// Canceled maps to Consumed here; the Withdrawn case (Event-Based
+		// Gateway race loss) is wired with that gateway (gateway SRD).
+		return TokenConsumed
+
+	default:
+		return TokenInvalid
+	}
+}
+
+// record appends a track-state transition to the history, copy-on-write, and
+// publishes it atomically. Called only from this track's goroutine.
+func (t *track) record(state trackState) {
+	node := t.steps[len(t.steps)-1].node
+
+	old := t.hist.Load()
+
+	var base []stepUpdate
+	if old != nil {
+		base = *old
+	}
+
+	next := make([]stepUpdate, len(base), len(base)+1)
+	copy(next, base)
+	next = append(next, stepUpdate{node: node, state: state, at: t.instance.now()})
+
+	t.hist.Store(&next)
+}
+
+// Token returns the track's current token projection (lock-free).
+func (t *track) Token() Token {
+	h := t.hist.Load()
+	if h == nil || len(*h) == 0 {
+		return Token{}
+	}
+
+	last := (*h)[len(*h)-1]
+
+	return Token{Node: last.node, State: tokenStateFor(last.state)}
+}
+
+// path returns the recorded token path of this track (lock-free).
+func (t *track) path() TokenPath {
+	parent := ""
+	if n := len(t.prev); n != 0 {
+		parent = t.prev[n-1].ID()
+	}
+
+	tp := TokenPath{TrackID: t.ID(), ParentID: parent}
+
+	h := t.hist.Load()
+	if h != nil {
+		for _, u := range *h {
+			ts := tokenStateFor(u.state)
+			tp.Steps = append(tp.Steps, StepVisit{Node: u.node, At: u.at, State: ts})
+			tp.Terminal = ts
+		}
+	}
+
+	return tp
 }
 
 // newTrack creates the new track from the start flow.Node and sets it
@@ -204,6 +313,10 @@ func newTrack(
 		t.prev = append(t.prev, append(prevTrack.prev, prevTrack)...)
 	}
 
+	// History is recorded once the track runs (per-node visits + state
+	// transitions), so it uses the running clock; before Run, Token() returns
+	// the zero projection. checkNodeType below may add a WaitForEvent entry
+	// for event-start nodes.
 	if err := t.checkNodeType(start); err != nil {
 		return nil, err
 	}
@@ -290,6 +403,13 @@ func (t *track) updateState(newState trackState) {
 	t.m.Lock()
 	t.state = newState
 	t.m.Unlock()
+
+	// Per-node Executing entries are recorded in prepareNodeExecution so each
+	// visited node appears even when the track stays in ExecutingStep across
+	// consecutive nodes; here we record the other (wait / terminal) states.
+	if newState != TrackExecutingStep {
+		t.record(newState)
+	}
 }
 
 // currentStep returns current step of the track.
@@ -407,6 +527,7 @@ func (t *track) prepareNodeExecution(ctx context.Context, step *stepInfo) error 
 
 	t.updateState(TrackExecutingStep)
 	step.state = StepStarted
+	t.record(TrackExecutingStep) // record this node visit (path + timing)
 
 	if err := t.loadIncomingData(ctx, step.node); err != nil {
 		return err


### PR DESCRIPTION
Implements SRD-001 against ADR-001 v.3: collapses Instance/track/token to two layers (token = derived projection), single lock-free event loop, fork rework, token-type removal,
lock-free token path history with timing. FR-12 join seam + persistence deferred (see SRD §7). make ci green; full suite race-clean.