### PR TITLE
refactor(covercheck): move gate logic into the tested package; cover …

### DIFF
--- a/cmd/covercheck/main.go
+++ b/cmd/covercheck/main.go
@@ -4,20 +4,16 @@
 //
 // Usage:
 //
-//	covercheck -min 70 -base origin/master -profiles "coverage.txt,runtime/coverage.txt"
+//	covercheck -min 70 -base origin/master -profiles "coverage.txt"
 //
-// It diffs the working tree against the merge-base with -base, reads the given
-// Go coverage profiles, and reports patch coverage. Exit code 1 if below -min.
-// CLI wiring only; the logic lives in internal/covercheck (unit-tested).
+// All logic lives in internal/covercheck (unit-tested to 100%); this is a thin
+// flag-parsing shell.
 package main
 
 import (
 	"flag"
 	"fmt"
 	"os"
-	"os/exec"
-	"sort"
-	"strings"
 
 	"github.com/dr-dobermann/gobpm/internal/covercheck"
 )
@@ -29,143 +25,11 @@ func main() {
 		"comma-separated coverage profile paths")
 	flag.Parse()
 
-	code, err := run(*minPct, *base, splitList(*profiles))
+	code, err := covercheck.RunGate(os.Stdout, *minPct, *base, *profiles)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "covercheck:", err)
 		os.Exit(2)
 	}
 
 	os.Exit(code)
-}
-
-// run computes patch coverage and returns the process exit code.
-func run(minPct float64, base string, profilePaths []string) (int, error) {
-	changedText, err := gitDiff(base)
-	if err != nil {
-		return 0, err
-	}
-
-	changed, err := covercheck.ParseDiff(strings.NewReader(changedText))
-	if err != nil {
-		return 0, err
-	}
-
-	profiles, err := readProfiles(profilePaths)
-	if err != nil {
-		return 0, err
-	}
-
-	res := covercheck.Evaluate(profiles, changed, covercheck.DefaultExcluded)
-	report(res, minPct)
-
-	if res.Ratio()*100 < minPct {
-		return 1, nil
-	}
-
-	return 0, nil
-}
-
-// gitDiff returns the unified=0 Go-file diff from merge-base(base, HEAD) to
-// HEAD — i.e. the committed changes this branch introduces. Using committed
-// state (not the working tree) keeps local `make cover-check` and CI in lockstep
-// (CI runs on the committed PR head). The `base...HEAD` form resolves the
-// merge-base itself.
-func gitDiff(base string) (string, error) {
-	spec := base + "...HEAD"
-
-	// #nosec G204 -- base is a trusted CLI flag (a git ref), not external input.
-	out, err := exec.Command("git", "diff", "--unified=0", spec, "--", "*.go").
-		Output()
-	if err != nil {
-		return "", fmt.Errorf("git diff %s: %w", spec, err)
-	}
-
-	return string(out), nil
-}
-
-// readProfiles parses and merges the given coverage profiles. It errors if none
-// of the paths exist — that means the gate ran without a coverage profile (run
-// `make test-all` first), and silently passing would defeat the gate.
-func readProfiles(paths []string) (map[string][]covercheck.Block, error) {
-	merged := map[string][]covercheck.Block{}
-	found := false
-
-	for _, p := range paths {
-		// #nosec G304 -- p is a trusted CLI flag (a coverage-profile path).
-		f, err := os.Open(p)
-		if err != nil {
-			if os.IsNotExist(err) {
-				continue
-			}
-
-			return nil, err
-		}
-
-		found = true
-
-		blocks, err := covercheck.ParseProfiles(f)
-		_ = f.Close()
-
-		if err != nil {
-			return nil, err
-		}
-
-		for k, v := range blocks {
-			merged[k] = append(merged[k], v...)
-		}
-	}
-
-	if !found {
-		return nil, fmt.Errorf(
-			"no coverage profile found among %v — run `make test-all` first",
-			paths)
-	}
-
-	return merged, nil
-}
-
-// report prints the per-file and total patch coverage.
-func report(res covercheck.Result, minPct float64) {
-	files := make([]string, 0, len(res.PerFile))
-	for f := range res.PerFile {
-		files = append(files, f)
-	}
-
-	sort.Strings(files)
-
-	for _, f := range files {
-		fr := res.PerFile[f]
-		fmt.Printf("  %6.1f%%  %s (%d/%d changed lines)\n",
-			pct(fr.Covered, fr.Coverable), f, fr.Covered, fr.Coverable)
-	}
-
-	verdict := "PASS"
-	if res.Ratio()*100 < minPct {
-		verdict = "FAIL"
-	}
-
-	fmt.Printf("diff-coverage: %.1f%% of %d changed coverable lines "+
-		"(min %.0f%%) — %s\n",
-		res.Ratio()*100, res.Coverable, minPct, verdict)
-}
-
-func pct(covered, coverable int) float64 {
-	if coverable == 0 {
-		return 100
-	}
-
-	return float64(covered) / float64(coverable) * 100
-}
-
-// splitList splits a comma-separated list, dropping empties and whitespace.
-func splitList(s string) []string {
-	var out []string
-
-	for _, p := range strings.Split(s, ",") {
-		if p = strings.TrimSpace(p); p != "" {
-			out = append(out, p)
-		}
-	}
-
-	return out
 }

--- a/internal/covercheck/covercheck.go
+++ b/internal/covercheck/covercheck.go
@@ -7,7 +7,11 @@ package covercheck
 
 import (
 	"bufio"
+	"fmt"
 	"io"
+	"os"
+	"os/exec"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -326,4 +330,151 @@ func DefaultExcluded(path string) bool {
 	default:
 		return false
 	}
+}
+
+// --- gate orchestration (the logic behind cmd/covercheck) ---
+
+// RunGate fetches the committed diff (base...HEAD) and the coverage profiles,
+// then delegates to Gate. It writes the report to w and returns the process exit
+// code: 1 if below minPct, 0 otherwise.
+func RunGate(w io.Writer, minPct float64, base, profilesCSV string) (int, error) {
+	diff, err := GitDiff(base)
+	if err != nil {
+		return 0, err
+	}
+
+	profiles, err := ReadProfiles(splitList(profilesCSV))
+	if err != nil {
+		return 0, err
+	}
+
+	return Gate(w, minPct, diff, profiles)
+}
+
+// Gate computes patch coverage from an already-fetched unified=0 diff and
+// coverage profiles, writes the report to w, and returns the exit code (1 if
+// below minPct). Separated from the git/file I/O so it is unit-testable.
+func Gate(
+	w io.Writer,
+	minPct float64,
+	diff string,
+	profiles map[string][]Block,
+) (int, error) {
+	changed, err := ParseDiff(strings.NewReader(diff))
+	if err != nil {
+		return 0, err
+	}
+
+	res := Evaluate(profiles, changed, DefaultExcluded)
+	Report(w, res, minPct)
+
+	if res.Ratio()*100 < minPct {
+		return 1, nil
+	}
+
+	return 0, nil
+}
+
+// GitDiff returns the unified=0 Go-file diff from merge-base(base, HEAD) to HEAD
+// — the committed changes the branch introduces. Committed state (not the
+// working tree) keeps local `make cover-check` and CI in lockstep. The
+// `base...HEAD` form resolves the merge-base itself.
+func GitDiff(base string) (string, error) {
+	spec := base + "...HEAD"
+
+	// #nosec G204 -- base is a trusted CLI flag (a git ref), not external input.
+	out, err := exec.Command("git", "diff", "--unified=0", spec, "--", "*.go").
+		Output()
+	if err != nil {
+		return "", fmt.Errorf("git diff %s: %w", spec, err)
+	}
+
+	return string(out), nil
+}
+
+// ReadProfiles parses and merges the coverage profiles at the given paths. It
+// errors if none exist — running the gate with no profile must fail loudly
+// (run `make test-all` first), not pass vacuously.
+func ReadProfiles(paths []string) (map[string][]Block, error) {
+	merged := map[string][]Block{}
+	found := false
+
+	for _, p := range paths {
+		// #nosec G304 -- p is a trusted CLI flag (a coverage-profile path).
+		f, err := os.Open(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+
+			return nil, err
+		}
+
+		found = true
+
+		blocks, err := ParseProfiles(f)
+		_ = f.Close()
+
+		if err != nil {
+			return nil, err
+		}
+
+		for k, v := range blocks {
+			merged[k] = append(merged[k], v...)
+		}
+	}
+
+	if !found {
+		return nil, fmt.Errorf(
+			"no coverage profile found among %v — run `make test-all` first",
+			paths)
+	}
+
+	return merged, nil
+}
+
+// Report writes the per-file and total patch coverage to w.
+func Report(w io.Writer, res Result, minPct float64) {
+	files := make([]string, 0, len(res.PerFile))
+	for f := range res.PerFile {
+		files = append(files, f)
+	}
+
+	sort.Strings(files)
+
+	for _, f := range files {
+		fr := res.PerFile[f]
+		_, _ = fmt.Fprintf(w, "  %6.1f%%  %s (%d/%d changed lines)\n",
+			pct(fr.Covered, fr.Coverable), f, fr.Covered, fr.Coverable)
+	}
+
+	verdict := "PASS"
+	if res.Ratio()*100 < minPct {
+		verdict = "FAIL"
+	}
+
+	_, _ = fmt.Fprintf(w, "diff-coverage: %.1f%% of %d changed coverable lines "+
+		"(min %.0f%%) — %s\n", res.Ratio()*100, res.Coverable, minPct, verdict)
+}
+
+// pct is the percentage covered/coverable (100 when nothing is coverable).
+func pct(covered, coverable int) float64 {
+	if coverable == 0 {
+		return 100
+	}
+
+	return float64(covered) / float64(coverable) * 100
+}
+
+// splitList splits a comma-separated list, dropping empties and whitespace.
+func splitList(s string) []string {
+	var out []string
+
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+
+	return out
 }

--- a/internal/covercheck/covercheck_test.go
+++ b/internal/covercheck/covercheck_test.go
@@ -1,6 +1,9 @@
 package covercheck
 
 import (
+	"bytes"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -95,6 +98,181 @@ func TestEvaluateExcludesAndEmpty(t *testing.T) {
 	require.Equal(t, 0, res.Coverable)
 	require.Equal(t, 1.0, res.Ratio(), "no coverable changed lines => pass")
 	require.Empty(t, res.PerFile)
+}
+
+func TestParseProfilesRejectsMalformed(t *testing.T) {
+	// Each malformed line exercises a distinct reject branch in
+	// parseProfileLine / parseRange / lineOf; only the final valid line parses.
+	in := strings.Join([]string{
+		"mode: count",
+		"a.go:1.1,2.2 1",      // != 3 fields
+		"noColon 1 1",         // no colon
+		"a.go:1.1 1 1",        // range has no comma
+		"a.go:x.1,2.2 1 1",    // start line not numeric (lineOf atoi)
+		"a.go:1.1,y.2 1 1",    // end line not numeric
+		"a.go:1,2.2 1 1",      // start has no dot (lineOf)
+		"a.go:1.1,2.2 nn 1",   // numStmts not numeric
+		"a.go:1.1,2.2 1 cc",   // count not numeric
+		"a.go:3.1,4.9 2 5",    // valid
+	}, "\n")
+
+	got, err := ParseProfiles(strings.NewReader(in))
+	require.NoError(t, err)
+	require.Equal(t, map[string][]Block{
+		"a.go": {{StartLine: 3, EndLine: 4, NumStmts: 2, Count: 5}},
+	}, got)
+}
+
+func TestParseDiffEdges(t *testing.T) {
+	in := strings.Join([]string{
+		"@@ -1 +1 @@",       // hunk before any +++ header -> ignored
+		"+++ b/f.go\told",   // path carries a trailing tab-quoted suffix
+		"@@ no plus here @@", // malformed hunk (no +) -> ignored
+		"@@ -2 +x @@",        // new start not numeric (atoi) -> ignored
+		"@@ -0,0 +5 @@",     // new count omitted -> a single line (5)
+	}, "\n")
+
+	got, err := ParseDiff(strings.NewReader(in))
+	require.NoError(t, err)
+	require.Equal(t, map[string][]int{"f.go": {5}}, got)
+}
+
+func TestEvaluateMatchedButNoCoverableLines(t *testing.T) {
+	// The file matches a profile, but its changed lines fall outside every
+	// block (comments/blank) -> Coverable 0 -> the file is skipped entirely.
+	profiles := map[string][]Block{
+		"github.com/x/y/a.go": {{StartLine: 10, EndLine: 12, Count: 1}},
+	}
+	changed := map[string][]int{"a.go": {99, 100}}
+
+	res := Evaluate(profiles, changed, DefaultExcluded)
+	require.Equal(t, 0, res.Coverable)
+	require.Empty(t, res.PerFile)
+}
+
+func TestEvaluateUnmatchedProfileSkipped(t *testing.T) {
+	// A changed file with no matching profile (e.g. a package with no tests)
+	// contributes nothing — it hits the no-profile branch.
+	profiles := map[string][]Block{
+		"github.com/x/y/other.go": {{StartLine: 1, EndLine: 1, Count: 1}},
+	}
+	changed := map[string][]int{"internal/z/untested.go": {1, 2, 3}}
+
+	res := Evaluate(profiles, changed, DefaultExcluded)
+	require.Equal(t, 0, res.Coverable)
+	require.Empty(t, res.PerFile)
+}
+
+func TestEvaluateExactPathMatch(t *testing.T) {
+	// Profile keyed by the exact repo-relative path (no module prefix) still
+	// matches — exercises matchProfile's equality branch.
+	profiles := map[string][]Block{
+		"a.go": {{StartLine: 1, EndLine: 1, Count: 1}},
+	}
+	changed := map[string][]int{"a.go": {1}}
+
+	res := Evaluate(profiles, changed, nil) // nil exclude => no filtering
+	require.Equal(t, FileResult{Covered: 1, Coverable: 1}, res.PerFile["a.go"])
+}
+
+func TestSplitList(t *testing.T) {
+	require.Equal(t, []string{"a", "b", "c"}, splitList("a, b ,,c"))
+	require.Nil(t, splitList("  ,, "))
+}
+
+func TestPct(t *testing.T) {
+	require.Equal(t, 100.0, pct(0, 0))
+	require.Equal(t, 50.0, pct(1, 2))
+}
+
+func TestReadProfiles(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "c.out")
+	require.NoError(t, os.WriteFile(p,
+		[]byte("mode: set\ngithub.com/x/a.go:1.1,2.2 1 1\n"), 0o600))
+
+	// existing + missing path: the missing one is skipped, the existing parsed.
+	got, err := ReadProfiles([]string{p, filepath.Join(dir, "missing.out")})
+	require.NoError(t, err)
+	require.Contains(t, got, "github.com/x/a.go")
+
+	// all paths missing -> error (the gate must not pass vacuously).
+	_, err = ReadProfiles([]string{filepath.Join(dir, "nope.out")})
+	require.Error(t, err)
+
+	// a path under a regular file -> open error that is NOT "not exist".
+	_, err = ReadProfiles([]string{filepath.Join(p, "child")})
+	require.Error(t, err)
+
+	// a directory opens but fails to scan -> ParseProfiles error surfaces.
+	_, err = ReadProfiles([]string{dir})
+	require.Error(t, err)
+}
+
+func TestReport(t *testing.T) {
+	res := Result{
+		Covered:   1,
+		Coverable: 2,
+		PerFile:   map[string]FileResult{"a.go": {Covered: 1, Coverable: 2}},
+	}
+
+	var pass bytes.Buffer
+
+	Report(&pass, res, 40)
+	require.Contains(t, pass.String(), "a.go")
+	require.Contains(t, pass.String(), "PASS")
+
+	var fail bytes.Buffer
+
+	Report(&fail, res, 90)
+	require.Contains(t, fail.String(), "FAIL")
+}
+
+func TestGitDiff(t *testing.T) {
+	// HEAD...HEAD is valid but empty -> no error, empty diff.
+	out, err := GitDiff("HEAD")
+	require.NoError(t, err)
+	require.Empty(t, out)
+
+	// an unresolvable ref -> error.
+	_, err = GitDiff("this-ref-does-not-exist-zzz")
+	require.Error(t, err)
+}
+
+func TestRunGate(t *testing.T) {
+	dir := t.TempDir()
+	prof := filepath.Join(dir, "coverage.txt")
+	require.NoError(t, os.WriteFile(prof, []byte("mode: set\n"), 0o600))
+
+	var buf bytes.Buffer
+
+	// HEAD...HEAD => no changed lines => ratio 100% => pass.
+	code, err := RunGate(&buf, 70, "HEAD", prof)
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
+	require.Contains(t, buf.String(), "PASS")
+
+	// an unreachable floor fails even when nothing is coverable.
+	code, err = RunGate(&buf, 101, "HEAD", prof)
+	require.NoError(t, err)
+	require.Equal(t, 1, code)
+
+	// missing profile => error, not a vacuous pass.
+	_, err = RunGate(&buf, 70, "HEAD", filepath.Join(dir, "none.txt"))
+	require.Error(t, err)
+
+	// unresolvable base ref => git diff error.
+	_, err = RunGate(&buf, 70, "this-ref-does-not-exist-zzz", prof)
+	require.Error(t, err)
+}
+
+func TestGate(t *testing.T) {
+	// a single diff line larger than the scanner buffer makes ParseDiff error,
+	// which Gate surfaces.
+	huge := "+++ b/f.go\n+" + strings.Repeat("x", 1<<20+1) + "\n"
+
+	_, err := Gate(&bytes.Buffer{}, 70, huge, nil)
+	require.Error(t, err)
 }
 
 func TestDefaultExcluded(t *testing.T) {


### PR DESCRIPTION
…to 100%

Fix an untested cmd/covercheck/main.go: the CLI carried real logic (run / gitDiff / readProfiles / report / pct / splitList) sitting at ~0% behind the cmd/ gate-exclusion. Move it all into internal/covercheck (unit-tested) and reduce main.go to a flag-parsing shell.

- internal/covercheck: + RunGate (fetch git diff + profiles), Gate (pure compute, split out so the ParseDiff error path is testable), GitDiff, ReadProfiles, Report(io.Writer), pct, splitList. Package now 100% covered (was 89.5%) — including malformed-profile, diff-edge, no-profile, bad-base, and oversized-line error paths.
- cmd/covercheck/main.go: thin shell — flags -> covercheck.RunGate -> exit.

The cmd/ gate-exclusion is now honest: main has no logic to test; what it used to hold is 100%-covered package code.