### PR TITLE
FIX-002: StartProcess deadlock + event-start Created-guard + timer-event example (+ RU twins)

### DIFF
--- a/docs/design/ADR-002-extension-architecture.ru.md
+++ b/docs/design/ADR-002-extension-architecture.ru.md
@@ -1,0 +1,687 @@
+# ADR-002 — Архитектура расширений
+
+| Поле | Значение |
+|---|---|
+| Статус | Принято |
+| Версия | v.1 |
+| Дата | 2026-06-09 |
+| Владелец | Руслан Габитов |
+| Замещает | — |
+| Уточняет | [SAD-001 v.1 §11 Extension Model](SAD-001-vision-and-architecture.md) |
+
+> EN-оригинал — канонический: [ADR-002-extension-architecture.md](ADR-002-extension-architecture.md). Этот файл — его перевод (twin).
+
+## 1. Контекст
+
+SAD-001 §11 назвал каталог расширений и сказал «Go-идиоматично: интерфейсы + функциональные опции». Этот ADR фиксирует набор интерфейсов, паттерн сборки, разделение public/internal, политику реализаций-по-умолчанию и конвенции для adapter-модулей.
+
+Текущий код уже содержит частичную поверхность расширений, в основном в `internal/`:
+
+| Существующий интерфейс | Расположение | Роль |
+|---|---|---|
+| `EventHub`, `EventProducer`, `EventProcessor`, `EventWaiter` | `internal/eventproc/eventproc.go` | Модель распределения событий |
+| `Scope`, `NodeDataLoader`, `NodeDataConsumer`, `NodeDataProducer` | `internal/scope/scope.go` | Иерархическое скоупирование данных |
+| `RuntimeEnvironment` (композит из `Scope + InstanceID + EventProducer + RenderRegistrator`) | `internal/renv/renv.go` | Контекст-«мешок» на каждый instance |
+| `Interactor`, `Registrator`, `RenderController` | `internal/interactor/interactor.go` | Абстракция взаимодействия с человеком |
+| `FormalExpression`, `Source`, `PropertyAdder` | `pkg/model/data/` | Интеграция BPMN-выражений / данных |
+
+Фасад движка:
+
+- `pkg/thresher/thresher.go` экспонирует `Thresher.New(id string)` — конструктор с одним аргументом; **нет способа внедрить расширения при конструировании**.
+- `Thresher` запускает реестр инстансов + регистрацию событий, но не имеет точки внедрения Repository, Logger, Tracer, Clock или любой другой инфраструктуры.
+
+**Отсутствующие точки расширения** (по SAD-001 §11): `Repository`, `Logger`, `Tracer`, `MetricsRecorder`, `Clock`, `MessageBroker`, `AuthorizationProvider`, `WorkerDispatcher`. Ни у одного из них пока нет интерфейса нигде.
+
+Решение ниже устанавливает каталог, разделение public/internal, паттерн сборки и то, как существующая поверхность расширений эволюционирует, чтобы вписаться в него.
+
+## 2. Решение
+
+**Двухслойная модель расширений. Расширения уровня движка регистрируются однократно при конструировании `Thresher` через функциональные опции; контекст уровня instance (существующий `RuntimeEnvironment`) собирается на каждый instance из расширений уровня движка плюс концерны, скоупированные по instance. Все интерфейсы расширений живут в `pkg/`; реализации-по-умолчанию поставляются в ядре; production-реализации живут в модулях `adapters/*` по SAD-001 §9.2.**
+
+Сводная таблица:
+
+| Концерн                     | Механизм                                                                                                                                                                |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Владение каталогом расширений | Этот ADR определяет полный набор. Будущие дополнения изменяют этот ADR (bump версии).                                                                                   |
+| Public-поверхность              | Каждый заменяемый интерфейс живёт в `pkg/`; точная раскладка подпакетов отложена в ADR-003.                                                                                |
+| Internal-only поверхность       | «Клей» реализации (например, `EventWaiter`, `NodeDataLoader`) остаётся в `internal/`.                                                                                        |
+| Сборка                    | `thresher.New(id string, opts ...thresher.Option) (*Thresher, error)` + функциональные опции. Вызов без опций `thresher.New("id")` даёт рабочий движок — каждая опция просто переопределяет дефолт. **Нет отдельного конструктора `NewDefault`**; дефолты и есть дефолты. |
+| Композиция на каждый instance    | Существующий интерфейс `RuntimeEnvironment` — который Instance уже реализует — **расширяется** новыми методами-сервисами уровня движка. Track получает одну внешнюю ссылку при конструировании: свой владеющий `*Instance`. Места вызова из track'а единообразны: `t.inst.Scope().GetData(...)` для instance-локального состояния и `t.inst.Logger().Info(...)` для сервисов движка. Instance-локальные поля принадлежат напрямую Instance; методы уровня движка на Instance — однострочные делегаты к конфигу движка. Рантайм-значения принадлежат движку (Engine), экспонируются через Instance посредством композиции. |
+| Кросс-адаптерная композиция   | Адаптеры НЕ зависят от пакетов друг друга. По умолчанию адаптер **разделяет ресурсы движка через внедрённый `EngineRuntime`** (опциональный хук `RuntimeAware` — §3.5 Паттерн C / §8.3): например, AuthZ использует `rt.Repository()`, если ему явно не дали собственный. Пользователь МОЖЕТ **разделить** их, передав опцию на уровне адаптера. См. §3.5 / §4.6. |
+| Политика реализаций-по-умолчанию         | Дефолты уровня движка поставляются в ядре, видимые-по-умолчанию (Logger = `slog.Default()` по политике проекта); production подменяет через опции `WithXxx`, тянущие из `adapters/*`. |
+| Контракт стабильности          | Каждый публичный интерфейс расширения — semver-стабильный контракт, как только он Принят. Ломающие изменения → новый ADR + bump версии.                                                    |
+
+## 3. Рассмотренные альтернативы
+
+### 3.1 Механизм загрузки плагинов
+
+| Вариант | Описание | Вердикт |
+|---|---|---|
+| **Go-пакет `plugin` (.so-файлы)** | Движок dlopen()-ит shared-объекты в рантайме; пользователи компилируют свой плагин отдельно. | Отклонено. Поддержка Mac/Windows частичная; совместимость версий хрупкая; конфликтует с ценностным предложением статичных бинарников Go; неидиоматично. |
+| **Generic-интерфейсы + связывание на этапе компиляции** — выбрано | Пользователи реализуют Go-интерфейсы; передают реализации в конструктор движка; стандартный `go build` производит один бинарник. | Выбрано. Нативный Go-паттерн; работает на всех платформах; отлаживаемость и наблюдаемость — обычная Go-семантика. |
+| **gRPC sidecar-плагины (стиль Hashicorp)** | Плагины — отдельные процессы, общение с которыми идёт через gRPC. | Отклонено для v.1. Тяжеловесно; вводит IPC-режимы отказа для того, что по сути является in-process библиотекой. Может быть переоценено для distribution-истории слоя рантайма (по [SAD-001 §13](SAD-001-vision-and-architecture.md)), но не для ядра. |
+
+### 3.2 Паттерн сборки
+
+| Вариант | Описание | Вердикт |
+|---|---|---|
+| **Паттерн Builder** (`thresher.NewBuilder().WithLogger(l).Build()`) | Fluent builder-API | Отклонено. Больше церемонии; сложнее добавлять опции, не ломая набор методов билдера; менее Go-идиоматично. |
+| **Config-структура** (`thresher.New(cfg Config)`) | Единая config-структура, держащая всё | Отклонено. Вынуждает пользователей конструировать (и zero-инициализировать или частично заполнять) толстую структуру; скрывает, какие поля обязательны, а какие опциональны; слияние дефолтов неуклюже. |
+| **Функциональные опции** — выбрано | `thresher.New(id, WithLogger(l), WithRepository(r), ...)` | Выбрано. Идиоматичный Go; тривиально добавлять новые опции без слома API; каждая опция самодокументируема; дефолты явны. |
+| **Цепочка методов после конструирования** (`thresher.New(...).WithLogger(l)`) | Мутирующие builder-методы после конструирования | Отклонено. Состояние движка хрупкое во время мутации; риск гонок; позволяет частично сконфигурированному движку стартовать. |
+
+### 3.3 Разделение public/internal для существующих интерфейсов
+
+| Вариант | Описание | Вердикт |
+|---|---|---|
+| **Держать все расширения в `internal/`** | Внешние пользователи не могут их реализовать; только внутрипроектное использование | Отклонено. Сводит на нет видение embeddable + extensible из SAD-001. |
+| **Перенести ВСЕ существующие интерфейсы в `pkg/`** | Оптовый перенос | Отклонено. Некоторые (`EventWaiter`, `NodeDataLoader`) — это «клей» реализации, тесно связанный с внутренностями движка; экспонировать их как контракты стабильности — это over-commitment. |
+| **Выборочно экспонировать то, что является настоящей точкой расширения** — выбрано | Промоутим интерфейсы, которые пользователи реально заменяют; «клей» реализации держим приватным | Выбрано. По §4 ниже. |
+
+### 3.4 Локальность реализации-по-умолчанию
+
+| Вариант | Описание | Вердикт |
+|---|---|---|
+| **Все дефолты в ядре; `New` применяет их, опции переопределяют** — выбрано | `thresher.New(id)` без опций даёт рабочий движок со всеми связанными дефолтами; каждый `WithXxx(...)` переопределяет один дефолт | Выбрано. Использование «из коробки» — основной путь; адаптеры тянутся по необходимости. Нет отдельной функции `NewDefault` — `New` И ЕСТЬ дефолт. |
+| **Без дефолтов; пользователь обязан связать всё** | Ядро поставляет только интерфейсы; каждое расширение явно | Отклонено. В худшем случае — связывание 10 расширений ради примера `Hello World`. Ломает цель usability «из коробки» из SAD-001. |
+| **Дефолты в модуле `gobpm-defaults`** | Дефолты живут в отдельном sibling-модуле | Отклонено. Добавляет накладные расходы модуля без реального выигрыша; пользователи всё равно хотят `New` без опций в ядре. |
+
+### 3.5 Композиция зависимостей адаптера
+
+Когда адаптеру нужен сервис, который движок уже держит (например, AuthZ-адаптер, который хочет персистить свою политику в том же хранилище, что использует движок), общий случай должен быть **разделением без церемонии**, с явным **разделением (split)** по желанию. Варианты:
+
+| Вариант | Описание | Вердикт |
+|---|---|---|
+| **A. Рантайм service-locator на конкретном движке** | Адаптер держит ссылку на конкретный `*Thresher` и вызывает `engine.Repository()` в рантайме. | Отклонено. Связывает адаптер с конкретным типом движка; магия «откуда это берётся?»; трудно подделать в изоляции. |
+| **B. Явная композиция пользователем** | Пользователь конструирует разделяемый ресурс один раз и продёргивает его и в адаптер, и в движок. | Валидно — оставлено как вариант полной изоляции. Наиболее явный; но это церемония для общего случая «просто разделить дефолт движка». |
+| **C. Внедрённый интерфейс `EngineRuntime`** — выбрано | Движок внедряет свой разрешённый `EngineRuntime` (core-*интерфейс* — §4.3) в адаптеры, которые opt-in через опциональный хук `RuntimeAware` (§8.3), на этапе сборки `thresher.New`. Адаптер тянет любую зависимость, которая ему явно не дана, из рантайма (`rt.Repository()`); явная опция на уровне адаптера её переопределяет (split). | Выбрано. По умолчанию = адаптер разделяет ресурсы движка без связывания; split = собственная опция адаптера. Хэндл — это core-интерфейс, внедрённый при сборке (не конкретный движок, тянутый в рантайме), так что адаптер остаётся unit-тестируемым — подделайте `EngineRuntime`. Это сохраняет удобство Варианта A, растворяя его возражение про связывание/тестируемость. |
+
+Пример (Паттерн C):
+
+```go
+// Default — AuthZ shares the engine's repository, zero ceremony.
+// casbin.Authorizer implements RuntimeAware; the engine injects its
+// EngineRuntime at New, and the adapter uses rt.Repository() for its storage.
+authz, _ := casbin.NewAuthorizer()
+engine, _ := thresher.New("my-engine",
+    thresher.WithRepository(repo),                 // the app's default repo
+    thresher.WithAuthorizationProvider(authz),     // engine injects EngineRuntime -> authz uses repo
+)
+
+// Split — give AuthZ its own store explicitly; the engine skips the injection.
+authz, _ := casbin.NewAuthorizer(casbin.WithStorage(otherRepo))
+engine, _ := thresher.New("my-engine",
+    thresher.WithRepository(repo),
+    thresher.WithAuthorizationProvider(authz),     // authz uses otherRepo, not repo
+)
+```
+
+Адаптер импортирует только core-интерфейсы `EngineRuntime` + `Repository` — никогда не конкретный движок, никогда другой адаптер. Пользователь сохраняет полный контроль, чтобы разделить через собственную опцию адаптера.
+
+## 4. Детали решения
+
+### 4.1 Двухслойная модель расширений
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                      Engine-level extensions                      │
+│  (registered once at thresher.New via functional options;         │
+│   scope = all instances of the engine; lifetime = engine lifetime)│
+│                                                                   │
+│  Repository, Logger, Tracer, MetricsRecorder, Clock,              │
+│  MessageBroker, ExpressionEngine, AuthorizationProvider,          │
+│  WorkerDispatcher                                                 │
+└────────────────────────────┬─────────────────────────────────────┘
+                             │ flows down into per-instance context
+                             v
+┌──────────────────────────────────────────────────────────────────┐
+│              Instance-level context (RuntimeEnvironment)          │
+│   (composed per Process Instance from engine-level extensions +   │
+│    instance-scoped state; lifetime = instance lifetime)           │
+│                                                                   │
+│  Scope (instance-rooted)                                          │
+│  InstanceID                                                       │
+│  EventProducer (instance-scoped projection of EventHub)           │
+│  RenderRegistrator (instance-scoped human-interaction registrator)│
+│  (+ engine-level extensions accessible by reference)              │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+`RuntimeEnvironment` уровня instance — это то, что узлы видят во время исполнения. По двухслойной модели из [ADR-001 v.4](ADR-001-execution-model.md) (Instance + track; token — проекция шага track'а), он передаётся в track'и; track'и читают его для lookup'ов по scope, продукции событий и т.д.
+
+### 4.2 Каталог расширений уровня движка
+
+| Интерфейс | Назначение | Реализация-по-умолчанию | Статус относительно текущего кода |
+|---|---|---|---|
+| `Repository` | Персистит состояние Process Instance, историю, inbox сообщений, подписки ожидания. Фундамент save/restore по ADR-001 v.4 §4.7 (инварианты рантайма) + Persistence & State ADR. | in-memory (недолговечная) | НОВЫЙ — не существует |
+| `Logger` (core-интерфейс; `*slog.Logger` удовлетворяет ему напрямую) | Структурированное логирование | `slog.Default()` — видимый по умолчанию по [памяти проекта](../../) | НОВЫЙ |
+| `Tracer` (в форме OTel, определён в ядре — **без импорта OTel**) | Спаны распределённой трассировки | **no-op** (спаны стоят аллокацию на каждое событие, инертны без бэкенда); opt-in в in-memory кольцо последних спанов или `adapters/otel/` | НОВЫЙ |
+| `MetricsRecorder` (в форме OTel, определён в ядре — **без импорта OTel**) | Инструменты counter / histogram / gauge | **in-memory запрашиваемый реестр** — видимый по умолчанию, дешёвый, с ограничением числа series, `Snapshot()` для тестов/диагностики; подмена на no-op или `adapters/otel/` | НОВЫЙ |
+| `Clock` | Текущее время + sleep (тестируемость таймеров) | wall clock (`time.Now`) | НОВЫЙ |
+| `MessageBroker` | Inbox входящих Message; маршрутизация корреляции по [docs/bpmn-spec/semantics/correlation.md](../bpmn-spec/semantics/correlation.md) | in-memory inbox | НОВЫЙ |
+| `ExpressionEngine` | Вычисляет `FormalExpression` (BPMN conditionExpression, условия gateway, кардинальность MI и т.д.) | простой Go-нативный evaluator | РАСШИРЯЕТ — `data.FormalExpression` существует; движок оборачивает |
+| `AuthorizationProvider` | Авторизует чувствительные операции (старт Process, claim UserTask, отмена Instance, …) | «разрешить всё» | НОВЫЙ |
+| `WorkerDispatcher` | Диспетчеризует подходящие Task (ServiceTask / GlobalTask) удалённым воркерам по [SAD-001 §13.2](SAD-001-vision-and-architecture.md) | in-process локальное исполнение | НОВЫЙ |
+| `EventHub` | Центральное распределение событий (существующий богатый интерфейс) | in-memory hub (текущая реализация) | **INTERNAL** — execution-обвязка, не точка расширения: нет use-case'а подмены (distribution живёт на границах — `MessageBroker`/`Repository`/`WorkerDispatcher`), а его контракт несёт тонкости внутренней корректности из FIX-001. Остаётся в `internal/eventproc`; будущий ADR может промоутить его, если когда-нибудь понадобится подключаемый hub (internal→public не ломает; обратное — ломает). |
+| `TaskDistributor` | Маршрутизация UserTask людям (композит концернов `Renderer` + `Registrator`) | текущая реализация `internal/interactor` | **ОТЛОЖЕНО** — кластер `Interactor`/`Registrator` сцеплен и навязывает выбор слоения model→tasks; промоушн (и переименование `Registrator → TaskDistributor`) принадлежит выделенному **ADR взаимодействия с человеком** (ADR-001 v.4 §9). Не входит в набор контрактов скелета; внутренний кластер остаётся как есть. |
+
+**Принцип проектирования интерфейсов.** Держаться как можно ближе к устоявшемуся индустриальному интерфейсу; обобщать дальше только тогда, когда нет единственного очевидного кандидата.
+
+- **`Logger`** — есть один очевидный Go-стандарт (`log/slog`). Поэтому core-`Logger` — это маленький leveled-интерфейс (`Debug`/`Info`/`Warn`/`Error(msg string, args ...any)`), которому **`*slog.Logger` удовлетворяет напрямую**, так что дефолт — `slog.Default()` без обёртки, а не-slog логгеры тоже можно подключить.
+- **`Tracer` / `MetricsRecorder`** — OpenTelemetry — де-факто стандарт, поэтому core-интерфейсы **смоделированы по форме OTel-API** (start/end/attributes/record-error спана; инструменты counter/histogram/gauge). Чтобы сохранить ядро только-stdlib-плюс-`uuid` (SAD-001 G2), ядро **не импортирует** OTel-модули — оно определяет интерфейсы в форме OTel, а реальные OTel-типы живут только в `adapters/otel/` как тонкий pass-through.
+
+**Телеметрия по умолчанию — выбрана по стоимости сигнала (не сплошной no-op).** Сплошной no-op оставляет zero-config движок слепым (против политики наблюдаемости); дефолт на основе логирования превращает метрики в текст лога, который надо распарсивать обратно (мусор в потоке логов). Поэтому дефолты различаются по сигналу:
+
+- **Метрики → in-memory запрашиваемый реестр, включён по умолчанию.** Атомарные counter'ы + gauge'и текущего значения + histogram'ы с фиксированными bucket'ами, читаемые через `Snapshot()`. Инкременты — наносекунды, а footprint ограничен — но он **ограничивает общее число series** (имя counter'а × набор label'ов), отбрасывая-и-предупреждая-однократно за порогом, так что label'ы высокой кардинальности (`process_id`, `instance_id`) не могут заставить его расти неограниченно. Видим по умолчанию, структурирован (не выскребается из логов) и тривиально проверяем в тестах. Подмена на no-op для тишины или на `adapters/otel/` для production.
+- **Трассировка → no-op по умолчанию.** Спан стоит аллокацию на каждое событие и инертен без потребляющего бэкенда, так что всегда-включённая трассировка — это ровно тот «мусор, сконфигурированный по умолчанию», которого надо избегать. Ограниченное in-memory **кольцо последних спанов** (последние N, запрашиваемые) поставляется как однострочный opt-in для dev/debug, рядом с реальным `adapters/otel/`.
+- **Персистентная (DB) телеметрия** — это production-адаптер (`adapters/sqlstore`), **никогда не core-дефолт** — она добавила бы зависимость от драйвера и росла бы неограниченно; embedder выбирает это хранилище осознанно.
+
+**In-memory дефолты ограничены (cross-cutting принцип).** Cap на число series метрик — это один частный случай правила, управляющего *каждым* in-memory дефолтом: он ограничивает собственный рост и **отбрасывает/вытесняет и предупреждает однократно** за порогом, а не растёт без предела и не падает молча. Видимый-и-ограниченный бьёт и молчаливый, и неограниченный; production подменяет на долговечный/внешний адаптер, который владеет retention. Конкретно:
+
+- `Repository` (in-mem) — вытесняет терминальные Instance и их историю за порогом retention.
+- `MessageBroker` (in-mem inbox) — ограничивает inbox / истекает по TTL некоррелированные сообщения.
+- `WorkerDispatcher` (in-process) — ограниченный пул воркеров, не неограниченная горутина-на-задачу.
+
+Точный порог и политика вытеснения для каждого решаются в landing-SRD соответствующего расширения (скелет SRD-004 поставляет cap на число series метрик; остальное приземляется со своей execution-обвязкой). **`AuthorizationProvider` — исключение** — его дефолтный вопрос не про рост, а про *security posture*: дефолт «разрешить всё» делегирует авторизацию хост-приложению, с «запретить всё» как opt-in для закрытой системы. Это решается, когда приземляется enforcement авторизации, не здесь.
+
+### 4.3 Интерфейс RuntimeEnvironment — расширен; Instance — это реализация
+
+Существующий `RuntimeEnvironment` в `internal/renv/renv.go` уже структурирован правильно: это интерфейс, и `Instance` — это тип, который его реализует. Track получает ровно одну внешнюю ссылку при конструировании — свой владеющий `*Instance` — и достаёт всё, что ему нужно, через неё.
+
+**Этот ADR просто расширяет существующий интерфейс RuntimeEnvironment новыми сервисами уровня движка.** Без структурного рефакторинга отношения Instance/track; без второй ссылки для track'а; без forwarding-accessor'а.
+
+Есть **два tier'а**: разрешённая конфигурация уровня движка/сервера
+(`EngineRuntime`) и контекст исполнения уровня instance
+(`RuntimeEnvironment`), который встраивает первый.
+
+```go
+// EngineRuntime is the PUBLIC piece, promoted to pkg/ (path per ADR-003). The
+// instance-level RuntimeEnvironment below STAYS in internal/renv — it embeds
+// internal types — and embeds the public EngineRuntime.
+
+// EngineRuntime — engine/server-level: the Thresher's RESOLVED extension set
+// (the wired services). Thresher owns/implements it. Adapters receive it (§3.5);
+// RuntimeEnvironment embeds it so tracks keep one uniform call style.
+type EngineRuntime interface {
+    Logger() Logger                              // core interface; *slog.Logger satisfies it
+    Tracer() Tracer
+    MetricsRecorder() MetricsRecorder
+    Clock() Clock
+    Repository() Repository
+    ExpressionEngine() expression.Engine         // type is expression.Engine (avoids stutter)
+    MessageBroker() MessageBroker
+    AuthorizationProvider() AuthorizationProvider
+    WorkerDispatcher() WorkerDispatcher
+    // NOTE: EventHub is NOT here — it is internal execution plumbing, not an
+    // extension point (no substitution use-case; distribution lives at the
+    // boundaries: MessageBroker/Repository/WorkerDispatcher). The engine builds
+    // its internal hub itself. Likewise human-task interaction (today's
+    // instance-level RenderRegistrator, the would-be engine-level
+    // TaskDistributor) is deferred to a dedicated human-interaction ADR
+    // (ADR-001 v.4 §9); the internal interactor cluster stays as-is.
+}
+
+// RuntimeEnvironment — instance-level execution context: engine services
+// (embedded) + instance-local state. Instance implements it. It STAYS internal
+// (it embeds internal scope.Scope and exposes internal EventProducer /
+// RenderRegistrator); only the embedded EngineRuntime is public.
+type RuntimeEnvironment interface {
+    EngineRuntime                                // engine/server services (embedded, public)
+    scope.Scope                                  // data scoping rooted at this instance (internal)
+    InstanceID() string                          // instance identity
+    EventProducer() EventProducer                // instance-scoped event production (internal)
+    RenderRegistrator() interactor.Registrator   // human interaction (internal; promotion deferred)
+}
+```
+
+Instance получает методы сервисов движка **бесплатно**, встраивая значение
+`EngineRuntime` Thresher'а; он лишь добавляет свои instance-локальные методы. Без per-method
+делегатов.
+
+```go
+// internal/instance/instance.go (existing struct, extended)
+type Instance struct {
+    renv.EngineRuntime           // embedded: the Thresher's resolved EngineRuntime (public)
+    id          string
+    scope       scope.Scope
+    eventProd   EventProducer
+    rr          interactor.Registrator   // human interaction (internal; promotion deferred)
+    // ... per ADR-001 v.4
+}
+
+// Instance-local — direct (engine-level methods are promoted from the embedded
+// EngineRuntime, so Logger()/Repository()/Clock()/... need no code here).
+func (i *Instance) InstanceID() string                      { return i.id }
+func (i *Instance) Scope() scope.Scope                      { return i.scope }
+func (i *Instance) EventProducer() EventProducer            { return i.eventProd }
+func (i *Instance) RenderRegistrator() interactor.Registrator { return i.rr }
+```
+
+Места вызова из track'а единообразны: одна ссылка, один стиль вызова для всего.
+
+```go
+type track struct {
+    inst *Instance                       // the ONLY external object track gets at construction
+    // ... per ADR-001 v.4
+}
+
+// Uniform call style — track doesn't need to know which call is "instance" vs "engine":
+t.inst.Scope().GetData(...)              // instance-local — Instance returns its own field
+t.inst.ID()                              // instance-local
+t.inst.Logger().Info(...)                // engine service — promoted from embedded EngineRuntime
+t.inst.Clock().Now()                     // engine service — promoted from embedded EngineRuntime
+t.inst.Repository()                      // engine service — promoted from embedded EngineRuntime
+```
+
+**Обоснование модели одна-ссылка / Instance-как-RE** (по указанию пользователя):
+
+- Track'у уже нужна ссылка на Instance (для скоупированных по instance концернов вроде `Scope` и `ID`). Добавление ВТОРОЙ ссылки для сервисов движка дублирует обвязку без выигрыша.
+- Instance — естественная точка композиции — он знает instance И держит ссылку на конфиг движка.
+- У track'а всегда лишь одна внешняя зависимость: его владеющий Instance. Проще для новых контрибьюторов, проще для тестирования, проще в обвязке горутин по ADR-001 v.4.
+- «Instance для исполнения, не для хранения рантайм-значений» удовлетворяется композицией: Instance **встраивает `EngineRuntime` Thresher'а** (держателя разрешённых значений); методы уровня движка промоутятся из него, а не переопределяются. Рантайм-значения принадлежат движку (`EngineRuntime`); Instance экспонирует их через встраивание.
+
+Существующий паттерн (Instance реализует RuntimeEnvironment) сохранён; вклад этого ADR в него — лишь расширенный интерфейс (дополнительный набор методов уровня движка).
+
+### 4.4 Паттерн сборки (функциональные опции)
+
+`thresher.New(id, ...Option)` — единственный конструктор. Без опций даёт рабочий движок со всеми дефолтами; каждая опция переопределяет один дефолт.
+
+```go
+// Zero-config — defaults applied internally; works out of the box
+engine, _ := thresher.New("my-engine-id")
+
+// Custom configuration — options override individual defaults
+engine, _ := thresher.New("my-engine-id",
+    thresher.WithRepository(postgresRepo),
+    thresher.WithLogger(slog.New(otelHandler)),
+    thresher.WithTracer(otelTracer),
+    thresher.WithMetricsRecorder(prometheusRecorder),
+    thresher.WithClock(realClock),
+    thresher.WithMessageBroker(redisBroker),
+    thresher.WithAuthorizationProvider(authz),
+    thresher.WithWorkerDispatcher(grpcDispatcher),
+)
+```
+
+Каждый `WithXxx` — это `thresher.Option`, возвращающий замыкание, которое мутирует внутреннюю config-структуру во время `New()`. Опции НЕ имеют зависимости от порядка, если это явно не задокументировано; если `WithXxx` встречается несколько раз для одного и того же расширения, побеждает последний (last-write семантика; стандартная конвенция функциональных опций).
+
+Внутри `New` инициализирует конфиг значениями по умолчанию, применяет каждую переданную опцию по порядку, затем логирует разрешённую конфигурацию:
+
+```go
+func New(id string, opts ...Option) (*Thresher, error) {
+    cfg := defaultConfig()           // ALL defaults wired here
+    for _, opt := range opts {
+        opt(&cfg)                    // override per option
+    }
+    t, err := assemble(id, cfg)
+    if err != nil {
+        return nil, err
+    }
+    t.logStartupConfig()             // INFO line — see §4.4.1
+    return t, nil
+}
+```
+
+Этот паттерн означает, что «дефолт» — внутренняя деталь реализации `New`, а не обращённый к пользователю альтернативный конструктор. Публичный API — одна функция.
+
+#### 4.4.1 Логирование стартовой конфигурации
+
+После того как `New` завершает связывание, Thresher эмитит одну лог-строку уровня INFO через сконфигурированный `Logger`, суммируя разрешённое связывание расширений. Это даёт ops однострочный ответ на вопрос «с чем сконфигурирован этот движок?» в момент конструирования.
+
+Формат (иллюстративный — финальная структура фиксируется при реализации):
+
+```
+INFO thresher.starting
+     id=my-engine
+     repository=*memrepo.Repository
+     logger=*slog.Logger(JSONHandler)
+     tracer=noop.Tracer
+     metricsRecorder=noop.MetricsRecorder
+     clock=*systemclock.Clock
+     messageBroker=*membroker.Broker
+     expressionEngine=*goexpr.Engine
+     authorizationProvider=*allowall.Provider
+     workerDispatcher=*inproc.Dispatcher
+```
+
+Каждое значение — это Go-тип связанной реализации. Лог-строка структурирована (slog-атрибуты), а не вольная проза — нижестоящие процессоры логов могут pivot'иться по индивидуальным типам расширений.
+
+Поведение:
+
+- Уровень INFO по умолчанию. Строка молчит только в том случае, если пользователь явно сконфигурирует Logger, отбрасывающий INFO-вывод. Это согласуется с политикой наблюдаемости проекта «видимо-по-умолчанию» ([память: политика наблюдаемости](../../)).
+- Эмитится ровно один раз на вызов `New`, после применения опций, но до того, как движок начнёт принимать работу.
+- Обязательна, не опциональна. Нет опции `WithoutStartupConfigLog()` — заглушить её — ответственность пользователя через конфигурацию его Logger.
+
+### 4.5 Политика реализаций-по-умолчанию
+
+Каждый интерфейс уровня движка имеет дефолт, который:
+
+- **Logger**: `slog.Default()` (видим по умолчанию по политике проекта — случайная тишина хуже случайного шума).
+- **Tracer, MetricsRecorder, AuthorizationProvider**: no-op. «Видимо-по-умолчанию» не применяется, потому что Go stdlib не имеет разумного дефолта для них; пользователи делают opt-in через адаптеры.
+- **Repository, MessageBroker**: in-memory, недолговечные. Подходят для тестов / встроенного недолгоживущего использования; production подменяет через адаптер.
+- **Clock**: wall clock. Тесты внедряют поддельный clock для зависящего от времени поведения BPMN (Timer-события).
+- **WorkerDispatcher**: in-process локальное исполнение. Позиция «distribution через opt-in» из SAD-001 §13.
+- **ExpressionEngine**: минимальный Go-нативный evaluator, поддерживающий простые выражения; пользователи подключают JUEL / FEEL / и т.д. через адаптер.
+- **EventHub**: остаётся internal (`internal/eventproc/eventhub`) — execution-обвязка, не публичное расширение (см. §4.2).
+- **TaskDistributor**: отложен — кластер `internal/interactor` остаётся internal до ADR взаимодействия с человеком (см. §4.2).
+
+Дефолты упакованы в ядро. Adapter-модули (`adapters/*`) предоставляют production-реализации.
+
+### 4.6 Конвенции adapter-модулей
+
+По multi-module монорепо SAD-001 §9.2:
+
+- Каждый адаптер — собственный Go-модуль: `github.com/dr-dobermann/gobpm/adapters/<name>` со своим `go.mod`.
+- Адаптер ОБЯЗАН реализовывать один или более публичных интерфейсов расширений из ядра (`pkg/`).
+- Адаптер НЕ ДОЛЖЕН импортировать пакет любого другого адаптера. Это правило **no-cross-adapter-imports**.
+- Адаптер МОЖЕТ брать свои зависимости по умолчанию из внедрённого `EngineRuntime` (§3.5 Паттерн C / §8.3 `RuntimeAware`) и/или принимать явные опции на уровне адаптера для их переопределения (split). В любом случае он зависит только от core-интерфейсов (`EngineRuntime`, `Repository`, …), никогда — от другого адаптера или конкретного движка — правило no-cross-imports соблюдается.
+- Адаптер ДОЛЖЕН (SHOULD) декларировать свою минимальную совместимую версию ядра через `replace`-free пиннинг в своём `go.mod`.
+- Тесты адаптера ДОЛЖНЫ (SHOULD) проверять против контракта, опубликованного в этом ADR (например, реализация `Repository` должна проходить тот же conformance-набор тестов, что проходит in-memory дефолт).
+- Адаптеры ОБЯЗАНЫ предпочитать **pure-Go embedded** реализации сервис-зависимым, чтобы сохранить ценностное предложение embeddable-библиотеки у ядра. Сервис-зависимые адаптеры (gRPC sidecar'ы, внешние HTTP-сервисы) разрешены, но ДОЛЖНЫ (SHOULD) быть чётко помечены как таковые.
+
+Начальные цели для адаптеров (иллюстративные; не написаны в v.1 этого ADR):
+
+- `adapters/postgres/` → `Repository` (pure-Go через `lib/pq` или `pgx`)
+- `adapters/otel/` → `Tracer`, `MetricsRecorder` (pure-Go OpenTelemetry SDK)
+- `adapters/oidc/` → identity-claims (питает контекст `AuthorizationProvider`)
+- `adapters/casbin/` → `AuthorizationProvider` (casbin — pure-Go in-process по умолчанию; сервисный режим — opt-in и не рекомендуемый путь для embedded-использования)
+- Альтернатива Simple-RBAC → `AuthorizationProvider` (меньший embedded-вариант для проектов, которым не нужен полный язык политик casbin)
+- `adapters/redis-broker/` → `MessageBroker` (сервис-зависимый — пометили бы как таковой)
+- `adapters/nats-broker/` → `MessageBroker` (сервис-зависимый)
+- `adapters/feel/` → `ExpressionEngine` (FEEL-evaluator, pure-Go)
+
+Выбор AuthZ-адаптера заслуживает краткой заметки: **casbin** на самом деле pure-Go и работает in-process по умолчанию; режим «casbin как сервис» — opt-in вариант развёртывания, не единственный путь. Так что `adapters/casbin/` вписывается в предпочтение «pure-Go embedded». Меньшие альтернативы (`gorbac`, кастомный RBAC, embedded OPA) — равно валидные выборы и должны быть доступны — точка расширения AuthZ — это интерфейс, а не какая-то конкретная реализация.
+
+### 4.7 Стабильность и версионирование
+
+Как только этот ADR Принят и интерфейсы опубликованы в `pkg/`:
+
+- Каждый публичный интерфейс расширения — **semver-стабильный контракт**. Мажорная версия core-модуля `gobpm` выражает стабильность интерфейсов.
+- **Обратно-совместимые добавления** (новые методы на новом интерфейсе, новые опции) — MINOR-bump версии.
+- **Ломающие изменения** (изменение сигнатур методов существующего интерфейса, удаление расширения) требуют нового ADR (или изменённой версии этого) И MAJOR-bump версии.
+- Адаптеры декларируют диапазон совместимых версий ядра; несовпадение мажорной версии — ошибка на этапе компиляции.
+
+До-1.0 (где мы сейчас): эволюция интерфейсов свободнее по semver-конвенции Go. Дисциплина выше включается на v1.0.0.
+
+## 5. Концепция против текущего кода — намеренные отклонения
+
+| Тема | Текущий код | Этот ADR | Требуемое изменение |
+|---|---|---|---|
+| Конструктор движка | `Thresher.New(id string)` — без опций | `Thresher.New(id, opts ...Option)` — единственный конструктор; без опций применяет все дефолты; каждая опция переопределяет один дефолт. Нет `NewDefault`. | Добавить тип `Option`. Добавить реализации функциональных опций для каждого расширения уровня движка. Отрефакторить `New`, чтобы он инициализировал дефолты внутренне, затем применял опции. |
+| Разделение EngineRuntime / RuntimeEnvironment | `RuntimeEnvironment` (internal) со встраиванием `scope.Scope`, `InstanceID()`, `EventProducer()`, `RenderRegistrator()` | **Выделить `EngineRuntime`** (accessor'ы расширений уровня движка: `Logger`, `Tracer`, `MetricsRecorder`, `Clock`, `Repository`, `ExpressionEngine`, `MessageBroker`, `AuthorizationProvider`, `WorkerDispatcher`) → **public** (`pkg/`, путь по ADR-003), реализуемый `Thresher`. `RuntimeEnvironment` **остаётся internal**, встраивает публичный `EngineRuntime` и сохраняет `scope.Scope`/`InstanceID()`/`EventProducer()`/`RenderRegistrator()` (все internal-типизированные). `EventHub`/`EventProducer` и взаимодействие с человеком остаются internal. | Промоутить только `EngineRuntime` в `pkg/`; оставить `RuntimeEnvironment` в `internal/renv`. |
+| Instance-как-реализация-RE | Уже сделано в текущем коде | Сохранено; track видит только `*Instance` и вызывает единообразный набор методов | Без изменения отношений — Instance продолжает реализовывать (расширенный) интерфейс RuntimeEnvironment. Добавить новые методы-делегаты уровня движка в Instance, каждый форвардит в конфиг движка. |
+| Стартовое логирование Thresher | Нет стартового логирования | Thresher эмитит одну структурированную лог-строку уровня INFO, суммирующую разрешённое связывание расширений, на каждый успешный вызов `New` (§4.4.1) | Добавить метод `logStartupConfig` в Thresher. Обязательное поведение; нельзя отказаться (пользователь заглушает через конфиг своего Logger при желании). |
+| Интерфейс Repository | Не существует | Определить `Repository` в `pkg/` с методами checkpoint / load / list-in-flight по ADR-001 v.4 §4.7 + Persistence & State ADR | Реализовать in-memory дефолт. Добавить в конфиг `Thresher`. |
+| Logger / Tracer / MetricsRecorder | Не существуют | `Logger` = slog-удовлетворяемый core-интерфейс; `Tracer`/`MetricsRecorder` = core-интерфейсы в форме OTel (без импорта OTel — SAD-001 G2) | Дефолты: `slog.Default()` Logger; **in-memory запрашиваемый реестр** Metrics (с cap на series, `Snapshot()`); **no-op** Tracer (in-mem кольцо спанов + OTel — opt-in). Реальный OTel в `adapters/otel/`. |
+| Clock | Не существует | Определить интерфейс `Clock` в `pkg/` | Реализовать wall-clock дефолт. Внедрить в обработку Timer-событий. |
+| MessageBroker | Не существует | Определить в `pkg/` по [bpmn-spec/semantics/correlation.md](../bpmn-spec/semantics/correlation.md) | Реализовать in-memory inbox дефолт. |
+| AuthorizationProvider | Не существует | Определить в `pkg/`; точки-хуки на чувствительных операциях | Реализовать allow-all дефолт. Идентифицировать места вызова hook-point'ов. |
+| WorkerDispatcher | Не существует | Определить в `pkg/` по [SAD-001 §13.2](SAD-001-vision-and-architecture.md) | Реализовать in-process dispatch дефолт. |
+| ExpressionEngine | Частично: `data.FormalExpression` в `pkg/model/data/` | Обернуть вычисление `FormalExpression` в интерфейс `ExpressionEngine` на уровне `pkg/` | Промоутить / добавить ExpressionEngine. Дефолт использует существующий Go-evaluator. |
+| EventHub | `internal/eventproc.EventHub` (внешне нереализуемый) | **Остаётся internal** — execution-обвязка, не точка расширения (§4.2) | Без изменений. |
+| TaskDistributor / RenderRegistrator | `internal/interactor.Registrator` + экосистема `Renderer` | **Отложено** в выделенный ADR взаимодействия с человеком (ADR-001 v.4 §9) — кластер сцеплен и навязывает выбор слоения model→tasks | Без изменений в скелете; внутренний кластер и `RenderRegistrator()` остаются как есть. |
+| Расположение RuntimeEnvironment | `internal/renv` | Перенести в `pkg/` (вероятно `pkg/renv`) | Перенести. Обновить Instance + track, чтобы импортировать из нового расположения. |
+| Документация расширений | Разбросана по комментариям в коде | Единый канонический каталог расширений в этом ADR | Поддерживать этот ADR как источник истины каталога. |
+
+**Как это приземляется (разрешает порядок с §7).** Отклонения реализуются вместе — только в **минимальном / дефолтном поведении** — в **одном фундаментальном SRD** («скелет расширений»): каждый интерфейс определён в `pkg/`, каждый со своей упакованной реализацией-по-умолчанию, сборка через функциональные опции, расширенный `RuntimeEnvironment` и стартовая лог-строка, связанные так, чтобы движок работал end-to-end на сегодняшней поддержке BPMN. **Этот ADR переходит из Draft в Accepted, когда тот единственный SRD приземляется и его тесты из §7 проходят** (не раньше — см. §7). Production-адаптеры и глубина на каждый интерфейс (долговечный Repository, реальный MessageBroker, FEEL ExpressionEngine, удалённый WorkerDispatcher, …) следуют как более поздние, отдельно гейтируемые SRD. Точные пути пакетов (где в `pkg/` живёт каждый интерфейс) отложены в ADR-003 Module Layout.
+
+## 6. Последствия
+
+### 6.1 Плюсы
+
+- **Usability «из коробки» сохранён.** `thresher.New(id)` без опций даёт рабочий движок одним вызовом (дефолты и есть дефолты; нет отдельного `NewDefault`).
+- **Матрица расширений задокументирована.** Будущие контрибьюторы и авторы адаптеров имеют единый источник истины о том, что подключаемо.
+- **Go-идиоматично.** Никаких фреймворков, никаких DI-контейнеров, никаких загрузчиков плагинов — только интерфейсы + функциональные опции.
+- **Стабильная public-поверхность.** Публичные интерфейсы в `pkg/` несут semver-контракт; внутренняя реализация может свободно эволюционировать.
+- **Экосистема адаптеров включена.** Чёткий контракт на то, что поставляют adapter-модули и как они декларируют совместимость.
+- **Наблюдаемость видима-по-умолчанию.** Согласуется с политикой проекта; случайная тишина избегается.
+
+### 6.2 Минусы
+
+- **Больше public-поверхности для сопровождения.** 10+ интерфейсов расширений становятся контрактами стабильности на v1.0. Каждое изменение интерфейса требует осторожности.
+- **Реализации-по-умолчанию, упакованные в ядро, раздувают поверхность core-модуля.** Смягчается тем, что дефолты держатся маленькими и хорошо изолированными (один файл на дефолт).
+- **Именование интерфейсов будет следовать индустриальным конвенциям.** Некоторые имена несут исторический багаж (`Registrator`, а также `WorkerDispatcher` / `TaskDistributor` из SAD против альтернатив вроде `ServiceTaskExecutor`). Переименование интерфейсов расширений к устоявшемуся индустриальному словарю на фазе реализации **принято и ожидаемо** — они не заморожены как контракты, пока этот ADR не Принят. **Исключение — конкретный тип движка остаётся `Thresher`:** он намеренно характерен; `Server` и `Engine` слишком обобщённые, чтобы именовать тип, и зарезервированы как *ролевые* слова (например, интерфейс `EngineRuntime` уровня движка — «рантайм-контракт движка»), никогда — собственное имя типа.
+- **Некоторые текущие internal-хелперы переезжают в `pkg/`** — став публичными, их нельзя отрефакторить без изменения ADR.
+
+### 6.3 Влияние на смежные решения
+
+- **ADR-003 Module Layout**: определяет, где именно живёт каждый интерфейс в дереве подкаталогов `pkg/`. Вероятные кандидаты: `pkg/extension/` (единый подпакет) или один подпакет на концерн (`pkg/persistence`, `pkg/observability`, `pkg/auth`, `pkg/expression` и т.д.).
+- **ADR-004 Runtime Environment Contract**: слой рантайма связывает production-grade адаптеры (postgres + otel + oidc + casbin + …) в движок через эти опции расширений.
+- **ADR-001 Execution Model (v.3)**: `Repository` — это интерфейс персистентности, на который нацелены инварианты рантайма из ADR-001 v.4 §4.7 (и Persistence & State ADR). `Logger` / `Tracer` / `MetricsRecorder` потребляют рантайм-поток событий instance — единый поток `trackEvent` и выраженное в токенах представление, выведенное из него (ADR-001 v.4 §4.3).
+
+## 7. Verification
+
+Как мы узнаем, что архитектура расширений работает:
+
+| Что | Как |
+|---|---|
+| **New без опций работает end-to-end** | Интеграционный тест: `thresher.New("test").Run(ctx)`; зарегистрировать процесс; стартовать instance; проверить, что он завершается. Дефолты связаны внутренне; нулевая конфигурация со стороны пользователя. |
+| **Функциональные опции компонуются без проблем порядка** | Тест: сконструировать движок со всеми 10 опциями `WithXxx` в случайном порядке; убедиться, что результирующее состояние движка идентично. |
+| **Каждая опция переопределяет дефолт** | Тест на каждую опцию: сконструировать с `WithLogger(custom)`; убедиться, что Logger движка — это `custom`, а не `slog.Default()`. Повторить для каждого интерфейса. |
+| **Last-write семантика** | Тест: передать `WithLogger(A), WithLogger(B)`; убедиться, что движок использует B. |
+| **Кросс-адаптерная композиция** | Тест (с реальным/поддельным `RuntimeAware`-адаптером): без опции хранилища AuthZ-адаптер использует `Repository` движка через внедрённый `EngineRuntime` (дефолтное разделение); с `WithStorage(otherRepo)` он использует вместо этого его (split). Проверяет §3.5 Паттерн C / §8.3. |
+| **Стартовая лог-строка конфигурации** | Тест: сконструировать движок с Logger, который захватывает записи. Убедиться: эмитится ровно одна запись уровня INFO с ключом `thresher.starting`, содержащая атрибуты для каждого расширения уровня движка (`repository`, `logger`, `tracer`, `metricsRecorder`, `clock`, `messageBroker`, `expressionEngine`, `authorizationProvider`, `workerDispatcher`) со значениями, совпадающими с именами типов связанных реализаций. Проверяет §4.4.1. |
+| **Instance реализует RuntimeEnvironment** | Тест на type assertion: `var _ RuntimeEnvironment = (*Instance)(nil)`. Проверка на этапе компиляции, что Instance удовлетворяет расширенному интерфейсу. |
+| **Делегаты сервисов движка на Instance** | Тест на каждый метод: сконструировать движок с кастомным Logger (или Clock, или Repository, …); породить Instance; убедиться, что `instance.Logger()` (и т.д.) возвращает то же значение, что держит конфиг движка. Проверяет корректность однострочных делегатов. |
+| **Реализации-по-умолчанию соответствуют контракту публичного интерфейса** | Conformance-тест: in-memory Repository дефолт проходит тот же conformance-набор, что прошёл бы гипотетический postgres Repository. То же для MessageBroker и т.д. |
+| **Движок без опционального расширения всё равно работает** | Smoke-тест: опустить каждый опциональный `WithXxx`; убедиться, что движок `New(id)` без опций работает. |
+| **Изоляция adapter-модуля** | Когда adapter-модули существуют: импорт только `core` НЕ протягивает транзитивно зависимости `adapters/*`. Проверяется через `go mod graph`. |
+| **Композиция RuntimeEnvironment корректна** | Тест: породить Instance; убедиться, что его `RuntimeEnvironment.Logger()` — это Logger движка; убедиться, что `Scope` укоренён в instance; убедиться, что `EventProducer` скоупирован по instance. |
+
+**Гейт приёмки** (Draft → Accepted): эти тесты ОБЯЗАНЫ существовать и проходить против **фундаментального SRD скелета расширений** (§5) — реализации только-дефолты. Две **зависящие-от-адаптера** строки (*кросс-адаптерная композиция*, *изоляция adapter-модуля*) могут запуститься только тогда, когда существует реальный adapter-модуль; они отложены до SRD первого адаптера и **не** требуются для приёмки этого ADR. Пока SRD скелета не приземлился и его применимые тесты не прошли, ADR остаётся в Draft.
+
+## 8. Рекомендации по enterprise-готовности
+
+Эта секция фиксирует cross-cutting лучшие практики для авторов адаптеров и production-развёртываний. Они рекомендательные — не нормативные — но каждая закрывает класс операционного отказа, наблюдаемый в реальных развёртываниях BPM-движков. Рекомендации написаны в предположении, что проект движется из research-фазы в production-фазу использования.
+
+### 8.1 Конвенции наблюдаемости
+
+Консистентный словарь наблюдаемости через Logger, Tracer и MetricsRecorder — это разница между «диагностировать за минуты» и «диагностировать за дни». Стандартизируйте три вещи:
+
+**Ключи атрибутов Logger** (slog-конвенции; стабильные, документированные имена):
+
+| Атрибут | Всегда присутствует в | Пример значения |
+|---|---|---|
+| `gobpm.engine_id` | Всех записях, эмитированных движком | `"my-engine"` |
+| `gobpm.instance_id` | Записях, скоупированных по instance | UUID |
+| `gobpm.process_id` | Записях, скоупированных по instance | `"order-fulfillment"` |
+| `gobpm.track_id` | Записях, скоупированных по track | UUID |
+| `gobpm.token_id` | Записях, связанных с token | UUID |
+| `gobpm.node_id` | Записях исполнения узла | `"ServiceTask_ChargeCard"` |
+| `gobpm.element_type` | Записях исполнения узла | `"ServiceTask"` |
+| `trace_id`, `span_id` | Когда Tracer связан (OTel-совместимо) | hex-строки |
+| `tenant_id` | Когда tenancy связан (по ADR-004) | идентификатор тенанта |
+
+Эти ключи появляются в production-логах с первого дня. Пропуск их при разработке в research-фазе создаёт слепые зоны, бьющие сильно во время первого реального production-инцидента.
+
+**О выборе стандарта трассировки.** OpenTelemetry — единственный жизнеспособный открытый стандарт распределённой трассировки на данный момент. Предшественники (OpenTracing, OpenCensus) слились в OTel; вендор-специфичные SDK (Datadog APM, агент New Relic Go) несут lock-in. Мы определяем собственный интерфейс `Tracer` в `pkg/` (по §4.2), а не реэкспортируем типы OTel напрямую — это сохраняет свободу подменить бэкенд трассировки, если ландшафт изменится, и держит `core` свободным от зависимостей по SAD-001 G2. Дефолтный `Tracer`-адаптер оборачивает OTel; пользователи, которым нужен другой бэкенд, пишут собственный адаптер. Сигнатуры методов интерфейса `Tracer` ДОЛЖНЫ (SHOULD) зеркалить словарь спанов OTel (start span, set attributes, record error, end), чтобы минимизировать impedance-mismatch.
+
+**Иерархия спанов Tracer** (отображает дерево исполнения BPMN в спаны в стиле OTel):
+
+```
+thresher.engine.run
+  └─ thresher.instance.run        (per Process Instance)
+       └─ thresher.track.execute  (per track per ADR-001 v.4)
+            └─ thresher.step      (per node visited)
+                 └─ child spans   (HTTP / DB / etc. — user code)
+```
+
+Каждый спан ДОЛЖЕН (SHOULD) нести те же ключи атрибутов, что и атрибуты logger из §8.1. Стандартные семантические конвенции OTel `process.*`, `db.*`, `http.*` применяются для внешних вызовов внутри узла. Статус спана: ERROR при отказе track'а; восстановление через прерывающее boundary-событие сбрасывает в OK с audit-trail, отмечающим исходную ошибку.
+
+**Именование метрик** (Prometheus / OTel-выровненное, префикс `gobpm_*`):
+
+| Метрика | Тип | Label'ы |
+|---|---|---|
+| `gobpm_instances_active` | Gauge | `engine_id`, `process_id` |
+| `gobpm_instances_completed_total` | Counter | `engine_id`, `process_id`, `outcome` (`normal` / `terminated` / `failed`) |
+| `gobpm_tokens_active` | Gauge | `engine_id`, `process_id` |
+| `gobpm_track_duration_seconds` | Histogram | `engine_id`, `process_id`, `element_type` |
+| `gobpm_repository_op_duration_seconds` | Histogram | `op` (`checkpoint` / `load` / `list_inflight`) |
+| `gobpm_message_correlation_attempts_total` | Counter | `outcome` (`matched` / `no_match` / `ambiguous`) |
+| `gobpm_authz_decisions_total` | Counter | `outcome` (`allow` / `deny` / `error`) |
+
+Адаптеры МОГУТ регистрировать собственные метрики под суб-пространством имён своего адаптера (например, `gobpm_postgres_connection_pool_busy`) через тот же `MetricsRecorder`.
+
+### 8.2 Операционные ожидания от адаптеров
+
+Production-grade адаптеры несут операционное бремя, которого нет у in-memory дефолтов. Документирование этих ожиданий заранее предотвращает ловушку «интеграционные тесты проходят, но в проде падает».
+
+**Repository:**
+- Connection pooling. Connect-disconnect на каждый вызов умирает под нагрузкой.
+- Таймауты на каждую операцию. Зависшая БД НЕ ДОЛЖНА блокировать движок неограниченно. Таймаут и проброс ошибки в error-путь движка.
+- Идемпотентные операции checkpoint. Повторный прогон checkpoint для одного `(instance_id, state_version)` ОБЯЗАН давать то же персистированное состояние.
+- Инструментарий миграции схемы. Адаптер ДОЛЖЕН (SHOULD) поставлять явный `Migrate(ctx)`, а не авто-применять при старте — production-развёртывания часто хотят ручной контроль.
+- Экспозиция метрики здоровья пула. Операторам нужно видеть исчерпание пула, прежде чем оно станет outage.
+
+**MessageBroker:**
+- Семантика доставки ОБЯЗАНА быть задокументирована. «At-least-once» — это пол; «exactly-once» требует документированного механизма дедупликации.
+- Сопоставление по корреляции — работа движка; адаптер НЕ ДОЛЖЕН делать фильтрацию на уровне корреляции.
+- Прибытия не-по-порядку ОБЯЗАНЫ толерироваться движком. Адаптеры МОГУТ enforce'ить порядок для конкретных паттернов, но НЕ ДОЛЖНЫ предполагать, что движок полагается на него.
+- Dead-letter маршрутизация для некоррелируемых сообщений — production-адаптеры ДОЛЖНЫ (SHOULD) предоставлять; дефолтный in-memory МОЖЕТ опустить.
+
+**AuthorizationProvider:**
+- Кэширование решений с коротким TTL (~60с типично). Политики меняются не на каждый запрос.
+- API сброса кэша для сценариев изменения политики.
+- Fail-closed при ошибке адаптера (deny, не allow). Документировать явно.
+- Метрика решений (`gobpm_authz_decisions_total{outcome}`) для видимости ops.
+
+**WorkerDispatcher:**
+- Отслеживание heartbeat / liveness воркеров. Отказавший воркер → re-dispatch на здоровый.
+- Маршрутизация по capability — воркер регистрирует, что он может исполнять; диспетчер сопоставляет.
+- Per-task таймаут, enforce'имый диспетчером, а не движком — движок не знает SLA удалённых воркеров.
+
+### 8.3 Опциональные интерфейсы побочных возможностей
+
+Некоторым адаптерам нужна интеграция жизненного цикла с движком. Вместо перегрузки core-интерфейсов расширений определите опциональные интерфейсы, которые движок детектит через type assertion:
+
+```go
+// pkg/extension (or wherever the contracts live)
+
+// Optional — adapters that need explicit startup
+type Starter interface {
+    Start(ctx context.Context) error
+}
+
+// Optional — adapters that need explicit shutdown
+type Stopper interface {
+    Stop(ctx context.Context) error
+}
+
+// Optional — adapters that expose health
+type HealthChecker interface {
+    HealthCheck(ctx context.Context) error
+}
+
+// Optional — adapters that want the engine's resolved services. The engine
+// injects its EngineRuntime (§4.3) at New; the adapter uses it to default any
+// dependency it wasn't explicitly configured with (e.g. rt.Repository()).
+// See §3.5 Pattern C.
+type RuntimeAware interface {
+    UseRuntime(rt EngineRuntime)
+}
+
+// Optional — adapters that declare their cluster-mode compatibility
+type ClusterAware interface {
+    // ClusterCompatibility returns whether this adapter is safe to use when
+    // the runtime is configured in cluster mode. On false, reason explains
+    // why (e.g., "in-memory; state not shared across nodes"). The runtime
+    // refuses to start in cluster mode if any wired adapter declares (false, _).
+    // Adapters that don't implement this interface get a startup warning in
+    // cluster mode (compatibility undeclared); they're not blocked.
+    ClusterCompatibility() (compatible bool, reason string)
+}
+```
+
+Когда Thresher конструируется и работает, он детектит, реализует ли каждое зарегистрированное расширение один из этих, и интегрирует соответственно:
+- `UseRuntime` вызывается во время `New`, после того как движок разрешает свой конфиг, на каждом связанном адаптере, который его реализует — передавая `EngineRuntime` движка, чтобы адаптер мог взять свои зависимости по умолчанию из движка (§3.5 Паттерн C).
+- `Start` вызывается во время setup'а `Run` до того, как инстансы принимаются.
+- `Stop` вызывается во время остановки движка после того, как все инстансы дренированы или завершены.
+- `HealthCheck` экспонируется слоем рантайма (по ADR-004) для liveness/readiness эндпоинтов.
+- `ClusterCompatibility` запрашивается слоем рантайма при старте, когда активен cluster-режим; любой возврат `(false, reason)` — жёсткий отказ старта. (Содержательный дизайн кластера живёт в будущем ADR-008; по [SAD-001 §13.5](SAD-001-vision-and-architecture.md).)
+
+Адаптеры, которые их не реализуют, просто работают. Это progressive enhancement — маленькие адаптеры остаются простыми; большие адаптеры получают хуки жизненного цикла, когда они им нужны.
+
+### 8.4 Contract-тестирование адаптеров
+
+Единственный самый эффективный инструмент для удержания реализаций адаптеров честными: **каждый адаптер проходит тот же conformance-набор тестов, что и in-memory дефолт.**
+
+Это стандартный Go-паттерн тестирования — без нового фреймворка, без специальной инфраструктуры. Каждый публичный интерфейс расширения поставляется вместе с опубликованным conformance-хелпером: обычной экспортированной функцией, которая принимает `*testing.T` и фабричную функцию для тестируемой реализации, затем прогоняет контракт через subtest'ы. Тесты адаптера — однострочники, вызывающие хелпер.
+
+```go
+// Core publishes a conformance helper alongside each extension interface.
+// (Exact package location per ADR-003 Module Layout — uses standard Go
+// testing.T + table-driven subtests; no special framework.)
+func RepositoryConformance(t *testing.T, factory func() Repository) {
+    // covers the full Repository contract:
+    // checkpoint, load, list-in-flight, idempotency, concurrent access,
+    // error paths, large-payload handling, …
+}
+
+// Adapter test code is trivial:
+func TestPostgresRepository(t *testing.T) {
+    RepositoryConformance(t, func() Repository {
+        return postgres.NewRepository(testConnString)
+    })
+}
+```
+
+Устоявшиеся Go-проекты используют ровно этот паттерн (`database/sql/driver/driverstest`, `golang.org/x/oauth2/internal/tokenstest` и т.д.). Стандартная идиома, без изобретения велосипеда. Conformance-хелпер — это просто экспортированный тестовый код.
+
+Каждый мажорный тип расширения ДОЛЖЕН (SHOULD) иметь опубликованный conformance-хелпер: `RepositoryConformance`, `MessageBrokerConformance`, `LoggerConformance`, `ClockConformance` и т.д. Точное расположение пакета отложено в ADR-003 Module Layout — но он живёт в test-импортируемом расположении (вероятно подпакет `*_test_helpers` или аналогичное Go-идиоматичное разделение).
+
+### 8.5 Разделение audit- и ops-событий
+
+Два различных концерна выводятся из **единого** in-memory рантайм-потока событий (ADR-001 v.4 §4.3 — `trackEvent`, track → loop; нет второго live-канала). Это два *представления* этого потока, а не два канала:
+
+| Концерн | Представление / источник | Долговечность | Примеры |
+|---|---|---|---|
+| **Audit-события** — комплаенс, не-должны-теряться | **BPMN-наблюдаемое, выраженное в токенах представление**, выведенное из потока (split / merged / waiting / consumed / withdrawn — ADR-001 v.4 §4.3) | Долговечны; требуется персистентный подписчик | «Пользователь X сделал claim UserTask Y», «Процесс стартован Z», «Авторизация отклонена: user=A action=cancel resource=instance/123» |
+| **Ops-события** — диагностика, потеря-приемлема | **сырые переходы track/step** (`trackEvent` + конечный автомат track'а — ADR-001 v.4 §4.2/§4.3) | Best-effort; подписчики Logger/Tracer/MetricsRecorder | «track вошёл в TrackExecutingStep», «StepPrologued завершён», «fork породил новый track» |
+
+Audit-подписчики ДОЛЖНЫ (SHOULD) использовать долговечный транспорт (DB-запись на событие, Kafka с ack и т.д.). Ops-подписчики МОГУТ использовать best-effort транспорт (in-memory каналы, UDP, fire-and-forget).
+
+Смешивание двух (audit-поля включены в ops-логи; ops-шум включён в audit-trail) создаёт комплаенс-трение (аудиторы не хотят ops-шума) и ops-трение (audit-канал становится слишком тихим, чтобы по нему диагностировать).
+
+**Заметка (переоснована на двухслойной модели).** Ранний драфт ADR-002 отображал «TokenEvent = audit / TrackEvent = ops» на тогда-предварительную трёхслойную модель ADR-001; ADR-001 v.4 свернул до двух слоёв (token — проекция, не хранимый объект / отдельный канал событий). Поэтому разделение переформулировано выше как **два выведенных представления одного потока `trackEvent`** — audit = выраженная в токенах проекция, ops = сырые переходы track/step. Различия withdrawn/merged и любые будущие комплаенс-релевантные состояния токена (например, «claimed», «delegated», «escalated») производятся ADR'ами gateway/events ([ADR-005](ADR-005-gateways-and-joins.md)/[ADR-006](ADR-006-events-and-subscriptions.md)); audit-представление расширяется по мере их приземления. Граница предварительна, не зафиксирована.
+
+### 8.6 Обратная совместимость, депрекация и чувствительные данные
+
+**Дисциплина обратной совместимости** (после-1.0; ослаблена до-1.0):
+
+- **Только-добавление изменений** публичных интерфейсов — новые методы на новых интерфейсах, новые опции. Minor-bump версии.
+- **Стабильность поведения** — изменение того, что существующий метод возвращает на существующих входах, — это ломающее изменение, даже если сигнатура неизменна.
+- **Путь депрекации** — вместо удаления метода пометить `// Deprecated:` с версией удаления. Держать депрецированный метод как минимум одну минорную версию после введения замены.
+- **Согласование версий адаптеров** — адаптеры декларируют min-compatible-core через build-теги или ограничения `go.mod`; рантайм детектит несовпадение и отказывается стартовать.
+
+Запекайте дисциплину рано — дооснащать её после жалобы реального пользователя сложнее, чем начать с неё.
+
+**Обработка чувствительных данных**:
+
+Переменные BPMN-процесса могут нести PII / регулируемые данные. Движок сам не классифицирует; классификация, редакция, шифрование — ответственности адаптера.
+
+- `Logger`-адаптеры ДОЛЖНЫ (SHOULD) поддерживать политику редакции на уровне полей (например, `gobpm.process_variable.customer_email` редактируется на INFO; полностью на DEBUG с требуемым разрешением вызывающего).
+- `Repository`-адаптеры ДОЛЖНЫ (SHOULD) поддерживать encryption-at-rest для колонки переменных / эквивалентного хранилища.
+- Audit-подписчики ДОЛЖНЫ (SHOULD) поддерживать неизменяемый append-only режим для комплаенс-контекстов (SOC2, GDPR, HIPAA).
+- Выраженное в токенах audit-представление (выведенное из потока `trackEvent` — §8.5) — естественный audit-фид; движку не нужно знать, какие поля чувствительны — audit-адаптер применяет собственную классификацию по организационной политике.
+
+Это разделение позволяет одному рантайму обслуживать и развёртывания «классификация не нужна» (внутренняя автоматизация), и «требуется строгая классификация» (регулируемые приложения, обращённые к клиенту) без изменений на уровне движка.
+
+## 9. Ссылки
+
+- [SAD-001 Vision & Architecture](SAD-001-vision-and-architecture.md) — §11 Extension Model (этот ADR уточняет); §6 Quality Attributes; §13 Distribution & Scale (предварительно)
+- [ADR-001 v.4 Execution Model](ADR-001-execution-model.md) — рантайм, который это расширяет: §4.7 инварианты рантайма, которые персистит Repository (+ Persistence & State ADR для долговечного checkpoint/rehydrate); §4.3 единый поток `trackEvent` + выведенное выраженное в токенах представление, которое потребляют Logger / Tracer / MetricsRecorder / audit-подписчики
+- [docs/bpmn-spec/semantics/correlation.md](../bpmn-spec/semantics/correlation.md) — контракт MessageBroker для корреляции Message
+- [docs/bpmn-spec/semantics/data.md](../bpmn-spec/semantics/data.md) — интеграция ExpressionEngine (вычисление FormalExpression)
+- Существующий код:
+  - `pkg/thresher/thresher.go` — текущий фасад движка
+  - `internal/eventproc/eventproc.go` — существующие интерфейсы распределения событий (EventHub и т.д.)
+  - `internal/scope/scope.go` — существующий интерфейс Scope
+  - `internal/renv/renv.go` — существующий композит RuntimeEnvironment
+  - `internal/interactor/interactor.go` — существующая абстракция взаимодействия с человеком
+  - `pkg/model/data/` — FormalExpression и связанные типы модели
+
+## История документа
+
+| Версия | Дата | Автор | Изменение |
+|---|---|---|---|
+| v.1 | 2026-06-09 | Руслан Габитов | **Принято.** Архитектура расширений приземлена через [SRD-004](../srd/SRD-004-extension-skeleton.md) (тот единственный фундаментальный SRD скелета): девять контрактов расширений уровня движка в `pkg/` с упакованными дефолтами, сборка через функциональные опции, разделение публичного `EngineRuntime` / внутреннего `RuntimeEnvironment` и `ExpressionEngine`/`Clock`, связанные в исполнение. Ключевые решения свёрнуты в этот Draft до приёмки (без построчных строк): `EventHub` оставлен internal (не точка расширения); взаимодействие с человеком `TaskDistributor` отложено в собственный ADR; телеметрия с дефолтами по стоимости; принцип ограниченных-in-memory-дефолтов (§4.2); кросс-адаптерная композиция через внедрённый `EngineRuntime` (§3.5 Паттерн C). Набор приёмки только-дефолты из §7 зелёный (`make ci`). Пины ADR-001 подняты v.3 → v.4. RU-twin отложен (batched). |

--- a/docs/fix/FIX-002-event-start-registration-lifecycle.md
+++ b/docs/fix/FIX-002-event-start-registration-lifecycle.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Draft |
+| Status | Accepted |
 | Version | v.1 |
 | Date | 2026-06-09 |
 | Owner | Ruslan Gabitov |
@@ -165,7 +165,37 @@ The 8 s budget gives the 5 s `timeDate` timer room to fire and the instance to c
 
 ## 8. Implementation summary
 
-> ⚠️ TODO: filled at landing — files/lines, V-results, commit SHA.
+Landed on branch `fix/event-start-registration` (off `master`). RC1 + RC2 are engine fixes; RC3 is the example fix.
+
+**Changes**
+
+- **RC1** — `internal/instance/instance.go:574-580` (`RegisterEvent`): the `Active`-only guard became `is := inst.State(); if is != Created && is != Active { … "instance is terminal…" }`, permitting construction-time (`Created`) and runtime (`Active`) registration and refusing only terminal instances.
+- **RC2** — `pkg/thresher/thresher.go` (`StartProcess`, ~:358-380): the engine mutex now wraps only the `t.snapshots[processID]` lookup (`:373-374`) and is released before `t.launchInstance(s)`; the started-check uses `t.State()` instead of an unguarded `t.state` read.
+- **RC3** — `examples/timer-event/main.go:106` (`context.WithTimeout(…, 8s)` + `defer cancel()`) and `:126` (plain `<-ctx.Done()` → `Process completed`).
+
+**Tests added**
+
+- `internal/instance/register_event_test.go` — `TestRegisterEventAllowsCreated` (V1), `TestRegisterEventRejectsTerminal` (V2).
+- `pkg/thresher/thresher_process_test.go` — `TestStartProcess_NoReentrantDeadlock` (V3, timeout-guarded).
+
+**Verification results**
+
+| # | Result |
+|---|---|
+| V1 | 🟢 a `Created` instance registers an event-start definition — passes. |
+| V2 | 🟢 a terminal instance is still refused — passes. |
+| V3 | 🟢 `StartProcess` returns without a re-entrant deadlock — passes. |
+| V4 | 🟢 `examples/basic-process` exit 0. |
+| V5 | 🟢 `examples/timer-event` exit 0; timer fires ~5 s; prints `Process completed`. |
+| V6 | 🟢 `make ci` green (lint 0 issues, race tests, diff-coverage 100 % of 10 touched lines, govulncheck); `examples/simple-timer` exit 0. |
+
+**Milestone commits**
+
+- `b7af364` — M1 (RC1): `RegisterEvent` permits non-terminal states + V1/V2 tests.
+- `0ffa77a` — M2 (RC2): `StartProcess` releases `t.m` before `launchInstance` + V3 test.
+- `adddea3` — doc: add RC3, disprove RC4.
+- `004319e` — M3 (RC3): `examples/timer-event` cancelable context.
+- (`9d3e947` — original RCA-completion doc commit on the branch.)
 
 ## 9. Open questions
 
@@ -175,4 +205,4 @@ The 8 s budget gives the 5 s `timeDate` timer room to fire and the instance to c
 
 | Version | Date | Author | Change |
 |---|---|---|---|
-| v.1 | 2026-06-09 | Ruslan Gabitov | Draft. `StartProcess` deadlocks via three defects: **RC1** — `RegisterEvent` requires `Active` but event-start nodes register during `New` (`Created`); **RC2** — `StartProcess` holds `t.m` across `launchInstance`, which re-locks it (re-entrant `sync.Mutex` deadlock — hits `basic-process` directly via `launchInstance:403`, and `timer-event` via `Thresher.State()`); **RC3** — `examples/timer-event` waits on `context.Background().Done()` (nil channel), so it deadlocks after the timer correctly fires. Fix: permit non-terminal states for registration (RC1) + narrow `StartProcess` to release `t.m` before `launchInstance` (RC2) + give the example a cancelable context (RC3). Both broken examples in scope. (RCA expanded across Draft amendments while reproducing the deadlock: first guard-only → RC1+RC2; then, after measuring the panic at 5.01 s, an RC4 "engine doesn't schedule the timer" hypothesis was disproven and the remaining failure attributed to RC3, the example. Draft amendments, no separate rows.) |
+| v.1 | 2026-06-09 | Ruslan Gabitov | Accepted (landed). `StartProcess` deadlocks via three defects: **RC1** — `RegisterEvent` requires `Active` but event-start nodes register during `New` (`Created`); **RC2** — `StartProcess` holds `t.m` across `launchInstance`, which re-locks it (re-entrant `sync.Mutex` deadlock — hits `basic-process` directly via `launchInstance:403`, and `timer-event` via `Thresher.State()`); **RC3** — `examples/timer-event` waits on `context.Background().Done()` (nil channel), so it deadlocks after the timer correctly fires. Fix: permit non-terminal states for registration (RC1) + narrow `StartProcess` to release `t.m` before `launchInstance` (RC2) + give the example a cancelable context (RC3). Both broken examples in scope. (RCA expanded across Draft amendments while reproducing the deadlock: first guard-only → RC1+RC2; then, after measuring the panic at 5.01 s, an RC4 "engine doesn't schedule the timer" hypothesis was disproven and the remaining failure attributed to RC3, the example. Draft amendments, no separate rows.) |

--- a/docs/fix/FIX-002-event-start-registration-lifecycle.md
+++ b/docs/fix/FIX-002-event-start-registration-lifecycle.md
@@ -1,4 +1,4 @@
-# FIX-002 — Event-start registration rejected by the Created-state guard
+# FIX-002 — StartProcess deadlock: re-entrant engine mutex + event-start Created-guard
 
 | Field | Value |
 |---|---|
@@ -10,46 +10,56 @@
 
 ## 1. Symptoms
 
-Any process whose **start node is an event** (timer / message / signal start) fails to *construct* — `StartProcess` returns a building error, the instance is never created:
+Every `StartProcess` call **deadlocks** (`fatal error: all goroutines are asleep - deadlock!`). Two examples surface it — both call `engine.StartProcess`:
 
-```
-Failed to start process: couldn't create an Instance for process "…"
-  Error: couldn't register event definitions
-    node_name: timer-start
-    Error: instance isn't active (current state: Created)
-      requester_id: …
-```
+- **`examples/basic-process`** (plain Start → ServiceTask → End): deadlocks, no useful output.
+- **`examples/timer-event`** (timer **on the start event**): first fails to *construct* —
 
-Reproduced by `examples/timer-event` (exit 1). `examples/simple-timer` works only because its start node is a plain Start event and the timer is reached *after* the instance is running; `timer-event` puts the timer **on the start event itself**, so registration happens at construction.
+  ```
+  Failed to start process: couldn't create an Instance for process "…"
+    Error: couldn't register event definitions
+      node_name: timer-start
+      Error: instance isn't active (current state: Created)
+  ```
 
-This is currently masked from CI because CI only **builds** the example modules, never **runs** them (`make build-all` has no run step) — see §5.
+  and once that construction-time guard is relaxed, it then **deadlocks** like basic-process.
+
+`examples/simple-timer` does **not** call `StartProcess` (only `RegisterProcess` + `Run`), so it hits neither path and exits cleanly — which is why it looked "fine".
+
+Masked from CI because CI only **builds** the example modules, never **runs** them (`make build-all` has no run step) — see §5.
 
 ## 2. Root-cause analysis
 
-Event-start registration happens during `instance.New`, while the instance is still `Created`, but `RegisterEvent` requires `Active`.
+There are **two** defects on the `StartProcess` path. A plain process hits RC2; an event-start process hits RC1 first, then RC2.
 
-1. `instance.New` builds the initial tracks and leaves the instance in `Created`:
-   - `internal/instance/instance.go:161` — `inst.state.Store(uint32(Created))`
-   - `internal/instance/instance.go:159` — `createTracks()` is called inside `New`.
-2. `createTracks` → `newTrack` for each entry node:
-   - `internal/instance/instance.go:436` — `newTrack(n, inst, nil)`
-3. `newTrack` calls `checkNodeType`, which **registers the node's event definitions** for an event node:
-   - `internal/instance/track.go:271` — `t.checkNodeType(start)`
-   - `internal/instance/track.go:281-293` — `if en, ok := node.(flow.EventNode); ok { for _, d := range en.Definitions() { t.instance.RegisterEvent(t, d) … "couldn't register event definitions" } }`
-4. `Instance.RegisterEvent` rejects any non-`Active` state:
-   - `internal/instance/instance.go:570-576` — `is := inst.State(); if is != Active { return errs.New(errs.M("instance isn't active (current state: %s)", is), …) }`
-5. The instance only becomes `Active` later, in `Run`:
-   - `internal/instance/instance.go:260` — `inst.setState(Active)` (after `New` has already returned).
+### RC1 — `RegisterEvent` rejects construction-time registration (`Created`)
 
-So construction-time registration (step 3, state `Created`) hits the `Active`-only guard (step 4) and fails.
+Event-start nodes register their definitions during `instance.New`, while the instance is `Created`, but `Instance.RegisterEvent` requires `Active`:
 
-**Why it regressed.** The `Active`-only guard was introduced with the ADR-001 v.4 lifecycle reconciliation (`Created → Active`). It is *too strict*: it conflates "don't register on a **finished** instance" (correct) with "don't register during **construction**" (wrong — that is exactly when event-start nodes must register). Before the guard, construction-time registration worked.
+- `instance.go:161` — `New` leaves state `Created`; `createTracks()` runs inside `New` (`instance.go:172`).
+- `track.go:271` / `track.go:281-293` — `newTrack` → `checkNodeType` registers an event node's definitions: `t.instance.RegisterEvent(t, d)` ("couldn't register event definitions").
+- `instance.go:570-576` — `is := inst.State(); if is != Active { return "instance isn't active (current state: Created)" }`.
+- `instance.go:260` — the instance only becomes `Active` later, in `Run`.
+
+The `Active`-only guard (added with the ADR-001 v.4 `Created→Active` reconciliation) is too strict: it conflates "don't register on a **finished** instance" (correct) with "don't register during **construction**" (wrong — that's exactly when event-start nodes register).
+
+### RC2 — re-entrant `Thresher.m` deadlocks `StartProcess` (the deeper bug)
+
+`StartProcess` holds the engine mutex **across** `launchInstance`, which re-acquires the same non-reentrant `sync.Mutex`:
+
+- `thresher.go:368-378` — `StartProcess` does `t.m.Lock(); defer t.m.Unlock()`, then `return t.launchInstance(s)` — still holding `t.m`.
+- `thresher.go:403` — `launchInstance` itself does `t.m.Lock()` (instance registry) → **re-entrant self-deadlock**. This is `basic-process` (no event-start needed).
+- For an event-start process the deadlock surfaces earlier: with RC1 relaxed, `instance.New` → `RegisterEvent` → `Thresher.RegisterEvent` (`thresher.go:266`) → `Thresher.State()` (`thresher.go:184`, `t.m.Lock()`) → deadlock. This is `timer-event`.
+
+Observed deadlock stack (RC1 relaxed): `main → StartProcess(:378, holds t.m) → launchInstance → instance.New → createTracks → newTrack → checkNodeType → Instance.RegisterEvent(:597) → Thresher.RegisterEvent(:266) → Thresher.State(:184) → sync.Mutex.Lock [blocked forever]`. `sync.Mutex` is not reentrant; the second acquire on the same goroutine blocks. `simple-timer` avoids it only because it never calls `StartProcess`.
 
 ## 3. Solution
 
-### 3.1 Chosen — permit registration in non-terminal states
+Both RCs must be fixed; either alone leaves a broken example.
 
-`RegisterEvent` should reject registration only on a **terminal** instance (`Completed` / `Terminating` / `Terminated`), and permit it while the instance is being built or is running (`Created` or `Active`). The lifecycle enum is ordered `Created(0) < Active(1) < Completed(2) < Terminating(3) < Terminated(4)` (`instance.go:56-67`).
+### 3.1 — RC1: permit registration in non-terminal states
+
+`Instance.RegisterEvent` rejects only a **terminal** instance; permit `Created`/`Active`. Enum order: `Created(0) < Active(1) < Completed(2) < Terminating(3) < Terminated(4)` (`instance.go:56-67`).
 
 ```go
 // internal/instance/instance.go — RegisterEvent
@@ -62,21 +72,43 @@ if is != Created && is != Active {
 }
 ```
 
-Rationale: event registration is legitimate both at construction (start events) and at runtime (boundary / intermediate catch events register when their track reaches them — `Active`). It must be refused only once the instance can no longer act on a fired event (terminal). The EventHub is already started by `Thresher.Run` before any `StartProcess`/`launchInstance` (FIX-001), so the hub accepts the registration; only the instance-state guard was blocking. Minimal change, restores the pre-guard behavior, keeps the protective intent (no registration on a done instance).
+Registration is legitimate at construction (start events) and at runtime (boundary / intermediate catch events, `Active`); refuse only when the instance can no longer act on a fired event (terminal). The EventHub is already started by `Thresher.Run` (FIX-001), so the hub accepts it; only this guard blocked.
 
-### 3.2 Alternatives considered
+### 3.2 — RC2: `StartProcess` must not hold `t.m` across `launchInstance`
 
-- **Defer event-start registration to first track execution (after `Active`).** Move `checkNodeType`'s `RegisterEvent` out of `newTrack` into the loop, so registration always happens while `Active`. **Rejected for this FIX** — more invasive (changes *when* the engine subscribes; a start event must be subscribed before it can be triggered, so the registration would have to move into the loop's first step with careful ordering), higher regression risk, and it does not better serve the protective intent than 3.1. Worth revisiting only if a future ADR-006 change makes runtime-only subscription the rule.
-- **Special-case the start phase (a `registering` sub-state / a "building" flag).** Adds lifecycle surface for no semantic gain over "non-terminal". Rejected.
+Narrow the engine lock to the snapshot lookup; release it before `launchInstance` (which takes `t.m` itself for the registry):
+
+```go
+// pkg/thresher/thresher.go — StartProcess
+func (t *Thresher) StartProcess(processID string) error {
+    if t.State() != Started { return /* not started */ }
+
+    t.m.Lock()
+    s, ok := t.snapshots[processID]
+    t.m.Unlock()
+    if !ok { return /* not found */ }
+
+    return t.launchInstance(s) // launchInstance locks t.m on its own
+}
+```
+
+This removes **both** re-entrancy paths: the direct `launchInstance:403` re-lock (basic-process) and the `State()` re-lock during event-start registration (timer-event). Also replace the unguarded `t.state` read at `thresher.go:361` with `t.State()`.
+
+### 3.3 Alternatives considered
+
+- **Make `Thresher.State()` lock-free (atomic state), like `Instance`.** Removes the `State()` re-entry (timer-event) but NOT the direct `launchInstance:403` re-lock (basic-process) — insufficient alone. A reasonable *complementary* hardening; optional, can follow.
+- **Recursive mutex.** Rejected — not idiomatic in Go; re-entrant locking masks design problems.
+- **Defer event-start registration to first track execution (after `Active`).** Rejected for RC1 — more invasive, and orthogonal to RC2 (which would still deadlock basic-process).
 
 ## 4. Verification
 
 | # | Check | Expectation |
 |---|---|---|
-| V1 | Unit: a fresh `Created` instance with an event-start node registers its definition without error. | `RegisterEvent` succeeds on `Created`. |
-| V2 | Unit: `RegisterEvent` on a `Completed`/`Terminated` instance still errors. | Guard preserved for terminal states. |
-| V3 | `examples/timer-event` runs to completion (the timer fires). | exit 0; no "instance isn't active". |
-| V4 | No regression: `make ci` (race tests + diff-coverage) green; `examples/simple-timer` still runs. | All existing instance/eventhub tests pass. |
+| V1 | Unit: a `Created` instance registers an event-start definition without error (RC1). | succeeds on `Created`. |
+| V2 | Unit: `RegisterEvent` on a terminal (`Completed`/`Terminated`) instance still errors (RC1). | guard preserved. |
+| V3 | Unit/integration: `StartProcess` of a plain process **and** of an event-start process returns without deadlock (RC2). | no re-entrant lock; `t.m` not held across `launchInstance`. |
+| V4 | `examples/basic-process` **and** `examples/timer-event` run to completion. | exit 0; no deadlock, no "instance isn't active". |
+| V5 | No regression: `make ci` green (race tests + diff-coverage + vuln); `examples/simple-timer` still runs. | all existing tests pass. |
 
 ## 5. Prevention
 
@@ -84,8 +116,9 @@ Rationale: event registration is legitimate both at construction (start events) 
 
 ## 6. Regressions / scope notes
 
-- `examples/basic-process` has a **separate** failure (a deadlock from a no-implementation `ServiceTask` plus `launchInstance`'s cancel/run semantics) — **not** covered by this FIX. It is addressed separately; this FIX is scoped to the event-start-registration lifecycle bug.
-- The guard change must not weaken the terminal-state protection (V2).
+- **`examples/basic-process` is in scope** — it is the same RC2 re-entrancy (earlier mis-attributed to a no-op `ServiceTask`). Both broken examples are fixed by §3.1 + §3.2.
+- The guard change (§3.1) must not weaken terminal-state protection (V2).
+- Narrowing the `StartProcess` lock (§3.2) must keep the snapshot read and the registry write each mutex-guarded — just not held across `launchInstance`. Concurrent `StartProcess` calls remain safe.
 
 ## 7. Related
 
@@ -105,4 +138,4 @@ Rationale: event registration is legitimate both at construction (start events) 
 
 | Version | Date | Author | Change |
 |---|---|---|---|
-| v.1 | 2026-06-09 | Ruslan Gabitov | Initial Draft. Event-start nodes fail to register at construction because `RegisterEvent` requires `Active` but registration happens during `New` (`Created`). Fix: permit non-terminal states (`Created`/`Active`), reject only terminal. |
+| v.1 | 2026-06-09 | Ruslan Gabitov | Draft. `StartProcess` deadlocks via two defects: **RC1** — `RegisterEvent` requires `Active` but event-start nodes register during `New` (`Created`); **RC2** — `StartProcess` holds `t.m` across `launchInstance`, which re-locks it (re-entrant `sync.Mutex` deadlock — hits `basic-process` directly via `launchInstance:403`, and `timer-event` via `Thresher.State()`). Fix: permit non-terminal states for registration (RC1) + narrow `StartProcess` to release `t.m` before `launchInstance` (RC2). Both broken examples in scope. (RCA expanded from the initial guard-only draft after reproducing the deadlock — Draft amendment, no separate row.) |

--- a/docs/fix/FIX-002-event-start-registration-lifecycle.md
+++ b/docs/fix/FIX-002-event-start-registration-lifecycle.md
@@ -13,24 +13,25 @@
 Every `StartProcess` call **deadlocks** (`fatal error: all goroutines are asleep - deadlock!`). Two examples surface it — both call `engine.StartProcess`:
 
 - **`examples/basic-process`** (plain Start → ServiceTask → End): deadlocks, no useful output.
-- **`examples/timer-event`** (timer **on the start event**): first fails to *construct* —
+- **`examples/timer-event`** (timer **on the start event**): peels back in three layers.
+  1. First fails to *construct* (RC1) —
 
-  ```
-  Failed to start process: couldn't create an Instance for process "…"
-    Error: couldn't register event definitions
-      node_name: timer-start
-      Error: instance isn't active (current state: Created)
-  ```
+     ```
+     Failed to start process: couldn't create an Instance for process "…"
+       Error: couldn't register event definitions
+         node_name: timer-start
+         Error: instance isn't active (current state: Created)
+     ```
+  2. Once that construction-time guard is relaxed, it deadlocks in `StartProcess` exactly like basic-process (RC2).
+  3. With RC1+RC2 fixed, `StartProcess` succeeds, the timer **fires correctly at 5 s**, the service task runs and the instance completes — then the *example* deadlocks (RC3): the deadlock panic lands at **5.01 s** (measured), the moment the timer fires and the engine's last worker goroutine exits, leaving only the example's `main` and `eventHub.Run` blocked on `context.Background().Done()` (a nil channel).
 
-  and once that construction-time guard is relaxed, it then **deadlocks** like basic-process.
-
-`examples/simple-timer` does **not** call `StartProcess` (only `RegisterProcess` + `Run`), so it hits neither path and exits cleanly — which is why it looked "fine".
+`examples/simple-timer` does **not** call `StartProcess` (only `RegisterProcess` + `Run`), so it hits neither engine path and exits cleanly — which is why it looked "fine".
 
 Masked from CI because CI only **builds** the example modules, never **runs** them (`make build-all` has no run step) — see §5.
 
 ## 2. Root-cause analysis
 
-There are **two** defects on the `StartProcess` path. A plain process hits RC2; an event-start process hits RC1 first, then RC2.
+There are **three** independent defects. Two are in the engine on the `StartProcess` path (RC1, RC2); the third is in an example (RC3) and only surfaced once RC1+RC2 were fixed. A plain process hits RC2; an event-start process hits RC1 first, then RC2, then (for `timer-event`) RC3.
 
 ### RC1 — `RegisterEvent` rejects construction-time registration (`Created`)
 
@@ -53,9 +54,26 @@ The `Active`-only guard (added with the ADR-001 v.4 `Created→Active` reconcili
 
 Observed deadlock stack (RC1 relaxed): `main → StartProcess(:378, holds t.m) → launchInstance → instance.New → createTracks → newTrack → checkNodeType → Instance.RegisterEvent(:597) → Thresher.RegisterEvent(:266) → Thresher.State(:184) → sync.Mutex.Lock [blocked forever]`. `sync.Mutex` is not reentrant; the second acquire on the same goroutine blocks. `simple-timer` avoids it only because it never calls `StartProcess`.
 
+### RC3 — `examples/timer-event` waits on a nil channel (example bug, not the engine)
+
+With RC1+RC2 fixed the engine runs the process correctly, but the *example* can never terminate:
+
+- `examples/timer-event/main.go:106` — `ctx := context.Background()` is handed to `engine.Run(ctx)`.
+- `examples/timer-event/main.go:123-127` — `main` then blocks on `select { case <-ctx.Done(): … }`. `context.Background().Done()` returns `nil`, so this waits on a nil channel forever (the "Press Ctrl+C to exit" banner implies a signal handler that the example never installs).
+- `eventhub.go:93` — `EventHub.Run` likewise blocks on `<-ctx.Done()` (same `Background` ctx, nil channel) for the hub's lifetime — normal, it is just the shutdown wait.
+
+So once the timer has fired and the instance has completed, the only two live goroutines are `main` and `eventHub.Run`, both parked on a nil channel; Go's runtime detects "all goroutines are asleep" and panics.
+
+**The engine is proven sound — there is no engine-side timer-delivery defect.** Evidence:
+
+- The deadlock panic lands at **5.01 s** (`time` measured on the built binary) — exactly the timer's `timeDate` (`time.Now().Add(5*time.Second)`, `main.go:37/39`). The timer fired, the one-shot waiter ran `processTimerEvent` and exited (`timer.go:248` `go runTimerService` → fire → `RemoveWaiter`), which is why the goroutine dump shows it gone — not because it never started.
+- Replacing the example's wait with a cancelable `context.WithTimeout(…, 8s)` makes the program print `Process completed` and exit 0, with no engine change.
+
+`examples/basic-process` does not have RC3 — it returns from `main` after `StartProcess` rather than parking on `ctx.Done()`, which is why it already runs to completion once RC2 is fixed.
+
 ## 3. Solution
 
-Both RCs must be fixed; either alone leaves a broken example.
+RC1 and RC2 are engine fixes; RC3 is an example fix. All three are needed for both broken examples to run.
 
 ### 3.1 — RC1: permit registration in non-terminal states
 
@@ -94,7 +112,23 @@ func (t *Thresher) StartProcess(processID string) error {
 
 This removes **both** re-entrancy paths: the direct `launchInstance:403` re-lock (basic-process) and the `State()` re-lock during event-start registration (timer-event). Also replace the unguarded `t.state` read at `thresher.go:361` with `t.State()`.
 
-### 3.3 Alternatives considered
+### 3.3 — RC3: give `examples/timer-event` a terminating wait
+
+Hand `engine.Run` a cancelable context and wait on it (so the program exits cleanly after the timer fires), instead of parking `main` on `context.Background().Done()`:
+
+```go
+// examples/timer-event/main.go
+ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+defer cancel()
+err = engine.Run(ctx)
+// …
+<-ctx.Done() // bounded; the 5 s timer fires well within the window
+fmt.Println("Process completed")
+```
+
+The 8 s budget gives the 5 s `timeDate` timer room to fire and the instance to complete before the context cancels. Using a plain `<-ctx.Done()` (not a one-case `select`) also clears a `gosimple S1000` lint. Engine code is untouched.
+
+### 3.4 Alternatives considered
 
 - **Make `Thresher.State()` lock-free (atomic state), like `Instance`.** Removes the `State()` re-entry (timer-event) but NOT the direct `launchInstance:403` re-lock (basic-process) — insufficient alone. A reasonable *complementary* hardening; optional, can follow.
 - **Recursive mutex.** Rejected — not idiomatic in Go; re-entrant locking masks design problems.
@@ -107,8 +141,9 @@ This removes **both** re-entrancy paths: the direct `launchInstance:403` re-lock
 | V1 | Unit: a `Created` instance registers an event-start definition without error (RC1). | succeeds on `Created`. |
 | V2 | Unit: `RegisterEvent` on a terminal (`Completed`/`Terminated`) instance still errors (RC1). | guard preserved. |
 | V3 | Unit/integration: `StartProcess` of a plain process **and** of an event-start process returns without deadlock (RC2). | no re-entrant lock; `t.m` not held across `launchInstance`. |
-| V4 | `examples/basic-process` **and** `examples/timer-event` run to completion. | exit 0; no deadlock, no "instance isn't active". |
-| V5 | No regression: `make ci` green (race tests + diff-coverage + vuln); `examples/simple-timer` still runs. | all existing tests pass. |
+| V4 | `examples/basic-process` runs to completion (RC2). | exit 0; no deadlock, no "instance isn't active". |
+| V5 | `examples/timer-event` runs to completion (RC1+RC2 engine, RC3 example): the timer fires at ~5 s, the instance completes, and the program exits. | exit 0; prints `Process completed`; no deadlock panic. |
+| V6 | No regression: `make ci` green (race tests + diff-coverage + vuln); `examples/simple-timer` still runs. | all existing tests pass. |
 
 ## 5. Prevention
 
@@ -116,9 +151,11 @@ This removes **both** re-entrancy paths: the direct `launchInstance:403` re-lock
 
 ## 6. Regressions / scope notes
 
-- **`examples/basic-process` is in scope** — it is the same RC2 re-entrancy (earlier mis-attributed to a no-op `ServiceTask`). Both broken examples are fixed by §3.1 + §3.2.
+- **`examples/basic-process` is in scope** — it is the same RC2 re-entrancy (earlier mis-attributed to a no-op `ServiceTask`); fixed by §3.1 + §3.2.
+- **`examples/timer-event` needs all three** — the engine fixes (§3.1 + §3.2) plus the example fix (§3.3). An RC4 "engine never schedules the timer" hypothesis was **investigated and disproven**: the timer fires at exactly 5.01 s, so the only remaining defect is the example's nil-channel wait.
 - The guard change (§3.1) must not weaken terminal-state protection (V2).
 - Narrowing the `StartProcess` lock (§3.2) must keep the snapshot read and the registry write each mutex-guarded — just not held across `launchInstance`. Concurrent `StartProcess` calls remain safe.
+- RC3 (§3.3) is an example-only change; no engine behavior changes.
 
 ## 7. Related
 
@@ -138,4 +175,4 @@ This removes **both** re-entrancy paths: the direct `launchInstance:403` re-lock
 
 | Version | Date | Author | Change |
 |---|---|---|---|
-| v.1 | 2026-06-09 | Ruslan Gabitov | Draft. `StartProcess` deadlocks via two defects: **RC1** — `RegisterEvent` requires `Active` but event-start nodes register during `New` (`Created`); **RC2** — `StartProcess` holds `t.m` across `launchInstance`, which re-locks it (re-entrant `sync.Mutex` deadlock — hits `basic-process` directly via `launchInstance:403`, and `timer-event` via `Thresher.State()`). Fix: permit non-terminal states for registration (RC1) + narrow `StartProcess` to release `t.m` before `launchInstance` (RC2). Both broken examples in scope. (RCA expanded from the initial guard-only draft after reproducing the deadlock — Draft amendment, no separate row.) |
+| v.1 | 2026-06-09 | Ruslan Gabitov | Draft. `StartProcess` deadlocks via three defects: **RC1** — `RegisterEvent` requires `Active` but event-start nodes register during `New` (`Created`); **RC2** — `StartProcess` holds `t.m` across `launchInstance`, which re-locks it (re-entrant `sync.Mutex` deadlock — hits `basic-process` directly via `launchInstance:403`, and `timer-event` via `Thresher.State()`); **RC3** — `examples/timer-event` waits on `context.Background().Done()` (nil channel), so it deadlocks after the timer correctly fires. Fix: permit non-terminal states for registration (RC1) + narrow `StartProcess` to release `t.m` before `launchInstance` (RC2) + give the example a cancelable context (RC3). Both broken examples in scope. (RCA expanded across Draft amendments while reproducing the deadlock: first guard-only → RC1+RC2; then, after measuring the panic at 5.01 s, an RC4 "engine doesn't schedule the timer" hypothesis was disproven and the remaining failure attributed to RC3, the example. Draft amendments, no separate rows.) |

--- a/docs/fix/FIX-002-event-start-registration-lifecycle.ru.md
+++ b/docs/fix/FIX-002-event-start-registration-lifecycle.ru.md
@@ -1,0 +1,210 @@
+# FIX-002 — Дедлок StartProcess: повторный (re-entrant) мьютекс движка + guard на Created для стартового события
+
+> Перевод. Канонична английская версия: [FIX-002-event-start-registration-lifecycle.md](FIX-002-event-start-registration-lifecycle.md). При расхождении приоритет у английского текста.
+
+| Поле | Значение |
+|---|---|
+| Статус | Принято |
+| Версия | v.1 |
+| Дата | 2026-06-09 |
+| Владелец | Руслан Габитов |
+| Связанные | [ADR-001 v.4 §4.2 Execution Model](../design/ADR-001-execution-model.md) (жизненный цикл); [ADR-006 v.1 Events & Subscriptions](../design/ADR-006-events-and-subscriptions.md); [FIX-001](FIX-001-thresher-eventhub-startup-race.md) (разделение EventHub на Start/Run) |
+
+## 1. Симптомы
+
+Каждый вызов `StartProcess` **уходит в дедлок** (`fatal error: all goroutines are asleep - deadlock!`). Это проявляют два примера — оба вызывают `engine.StartProcess`:
+
+- **`examples/basic-process`** (простой Start → ServiceTask → End): дедлок, без полезного вывода.
+- **`examples/timer-event`** (таймер **на стартовом событии**): раскрывается в три слоя.
+  1. Сначала падает на *построении* (RC1) —
+
+     ```
+     Failed to start process: couldn't create an Instance for process "…"
+       Error: couldn't register event definitions
+         node_name: timer-start
+         Error: instance isn't active (current state: Created)
+     ```
+  2. Как только этот guard на этапе построения ослаблен, происходит дедлок в `StartProcess` ровно как у basic-process (RC2).
+  3. С исправленными RC1+RC2 `StartProcess` отрабатывает, таймер **корректно срабатывает на 5 с**, выполняется service task и инстанс завершается — после чего в дедлок уходит *сам пример* (RC3): паника дедлока приходит на **5.01 с** (замерено), в момент срабатывания таймера, когда последняя рабочая горутина движка завершается, оставляя только `main` примера и `eventHub.Run`, заблокированные на `context.Background().Done()` (nil-канал).
+
+`examples/simple-timer` **не** вызывает `StartProcess` (только `RegisterProcess` + `Run`), поэтому не задевает ни один путь движка и завершается корректно — почему он и выглядел «рабочим».
+
+Скрыто от CI, потому что CI только **собирает** модули примеров, но никогда их не **запускает** (`make build-all` не имеет шага запуска) — см. §5.
+
+## 2. Анализ первопричин
+
+Существуют **три** независимых дефекта. Два — в движке на пути `StartProcess` (RC1, RC2); третий — в примере (RC3) и проявился только после исправления RC1+RC2. Простой процесс задевает RC2; процесс со стартовым событием задевает сначала RC1, затем RC2, затем (для `timer-event`) RC3.
+
+### RC1 — `RegisterEvent` отвергает регистрацию на этапе построения (`Created`)
+
+Узлы со стартовым событием регистрируют свои определения во время `instance.New`, пока инстанс в состоянии `Created`, но `Instance.RegisterEvent` требует `Active`:
+
+- `instance.go:161` — `New` оставляет состояние `Created`; `createTracks()` выполняется внутри `New` (`instance.go:172`).
+- `track.go:271` / `track.go:281-293` — `newTrack` → `checkNodeType` регистрирует определения событийного узла: `t.instance.RegisterEvent(t, d)` («couldn't register event definitions»).
+- `instance.go:570-576` — `is := inst.State(); if is != Active { return "instance isn't active (current state: Created)" }`.
+- `instance.go:260` — инстанс становится `Active` только позже, в `Run`.
+
+Guard «только `Active`» (добавленный вместе с согласованием `Created→Active` из ADR-001 v.4) слишком строг: он смешивает «не регистрировать на **завершённом** инстансе» (корректно) с «не регистрировать во время **построения**» (неверно — именно тогда и регистрируются узлы со стартовым событием).
+
+### RC2 — повторный (re-entrant) `Thresher.m` приводит `StartProcess` к дедлоку (более глубокий баг)
+
+`StartProcess` удерживает мьютекс движка **сквозь** `launchInstance`, который повторно захватывает тот же неперевходимый `sync.Mutex`:
+
+- `thresher.go:368-378` — `StartProcess` делает `t.m.Lock(); defer t.m.Unlock()`, затем `return t.launchInstance(s)` — всё ещё удерживая `t.m`.
+- `thresher.go:403` — `launchInstance` сам делает `t.m.Lock()` (реестр инстансов) → **повторный самодедлок**. Это `basic-process` (стартовое событие не нужно).
+- Для процесса со стартовым событием дедлок проявляется раньше: с ослабленным RC1 `instance.New` → `RegisterEvent` → `Thresher.RegisterEvent` (`thresher.go:266`) → `Thresher.State()` (`thresher.go:184`, `t.m.Lock()`) → дедлок. Это `timer-event`.
+
+Наблюдаемый стек дедлока (RC1 ослаблен): `main → StartProcess(:378, удерживает t.m) → launchInstance → instance.New → createTracks → newTrack → checkNodeType → Instance.RegisterEvent(:597) → Thresher.RegisterEvent(:266) → Thresher.State(:184) → sync.Mutex.Lock [заблокирован навсегда]`. `sync.Mutex` неперевходим; второй захват в той же горутине блокируется. `simple-timer` избегает этого только потому, что никогда не вызывает `StartProcess`.
+
+### RC3 — `examples/timer-event` ждёт на nil-канале (баг примера, не движка)
+
+С исправленными RC1+RC2 движок выполняет процесс корректно, но *сам пример* не может завершиться:
+
+- `examples/timer-event/main.go:106` — `ctx := context.Background()` передаётся в `engine.Run(ctx)`.
+- `examples/timer-event/main.go:123-127` — `main` затем блокируется на `select { case <-ctx.Done(): … }`. `context.Background().Done()` возвращает `nil`, поэтому это ожидание на nil-канале навсегда (баннер «Press Ctrl+C to exit» подразумевает обработчик сигнала, который пример никогда не устанавливает).
+- `eventhub.go:93` — `EventHub.Run` так же блокируется на `<-ctx.Done()` (тот же `Background` ctx, nil-канал) на всё время жизни хаба — это нормально, это просто ожидание остановки.
+
+Таким образом, после того как таймер сработал и инстанс завершился, остаются только две живые горутины — `main` и `eventHub.Run`, обе припаркованы на nil-канале; рантайм Go фиксирует «all goroutines are asleep» и паникует.
+
+**Движок доказанно корректен — дефекта доставки таймера на стороне движка нет.** Доказательства:
+
+- Паника дедлока приходит на **5.01 с** (`time` замерено на собранном бинарнике) — ровно `timeDate` таймера (`time.Now().Add(5*time.Second)`, `main.go:37/39`). Таймер сработал, одноразовый waiter выполнил `processTimerEvent` и завершился (`timer.go:248` `go runTimerService` → срабатывание → `RemoveWaiter`), поэтому в дампе горутин его нет — не потому, что он не стартовал.
+- Замена ожидания в примере на отменяемый `context.WithTimeout(…, 8s)` приводит к тому, что программа печатает `Process completed` и завершается с кодом 0, без изменений движка.
+
+`examples/basic-process` не имеет RC3 — он возвращается из `main` после `StartProcess`, а не паркуется на `ctx.Done()`, поэтому уже отрабатывает до конца после исправления RC2.
+
+## 3. Решение
+
+RC1 и RC2 — исправления движка; RC3 — исправление примера. Все три нужны, чтобы оба сломанных примера заработали.
+
+### 3.1 — RC1: разрешить регистрацию в нетерминальных состояниях
+
+`Instance.RegisterEvent` отвергает только **терминальный** инстанс; разрешает `Created`/`Active`. Порядок enum: `Created(0) < Active(1) < Completed(2) < Terminating(3) < Terminated(4)` (`instance.go:56-67`).
+
+```go
+// internal/instance/instance.go — RegisterEvent
+is := inst.State()
+if is != Created && is != Active {
+    return errs.New(
+        errs.M("instance is terminal, can't register events (state: %s)", is),
+        errs.C(errorClass, errs.InvalidState),
+        errs.D("requester_id", proc.ID()))
+}
+```
+
+Регистрация законна на построении (стартовые события) и в рантайме (граничные / промежуточные перехватывающие события, `Active`); отказывать нужно только когда инстанс уже не может реагировать на сработавшее событие (терминальное состояние). EventHub уже запущен `Thresher.Run` (FIX-001), поэтому хаб его принимает; блокировал только этот guard.
+
+### 3.2 — RC2: `StartProcess` не должен удерживать `t.m` сквозь `launchInstance`
+
+Сузить блокировку движка до поиска снапшота; освободить её до `launchInstance` (который сам берёт `t.m` для реестра):
+
+```go
+// pkg/thresher/thresher.go — StartProcess
+func (t *Thresher) StartProcess(processID string) error {
+    if t.State() != Started { return /* not started */ }
+
+    t.m.Lock()
+    s, ok := t.snapshots[processID]
+    t.m.Unlock()
+    if !ok { return /* not found */ }
+
+    return t.launchInstance(s) // launchInstance locks t.m on its own
+}
+```
+
+Это убирает **оба** пути повторного входа: прямой re-lock `launchInstance:403` (basic-process) и re-lock `State()` во время регистрации стартового события (timer-event). Также заменить незащищённое чтение `t.state` в `thresher.go:361` на `t.State()`.
+
+### 3.3 — RC3: дать `examples/timer-event` завершаемое ожидание
+
+Передать `engine.Run` отменяемый контекст и ждать на нём (чтобы программа корректно завершилась после срабатывания таймера), вместо парковки `main` на `context.Background().Done()`:
+
+```go
+// examples/timer-event/main.go
+ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+defer cancel()
+err = engine.Run(ctx)
+// …
+<-ctx.Done() // bounded; the 5 s timer fires well within the window
+fmt.Println("Process completed")
+```
+
+Бюджет в 8 с даёт 5-секундному таймеру `timeDate` время сработать, а инстансу — завершиться до отмены контекста. Использование простого `<-ctx.Done()` (а не `select` с одним case) также снимает линт `gosimple S1000`. Код движка не тронут.
+
+### 3.4 Рассмотренные альтернативы
+
+- **Сделать `Thresher.State()` без блокировки (atomic-состояние), как у `Instance`.** Убирает повторный вход через `State()` (timer-event), но НЕ прямой re-lock `launchInstance:403` (basic-process) — сама по себе недостаточна. Разумное *дополнительное* усиление; опционально, можно сделать позже.
+- **Рекурсивный мьютекс.** Отклонено — неидиоматично для Go; повторная блокировка маскирует проблемы дизайна.
+- **Отложить регистрацию стартового события до первого выполнения трека (после `Active`).** Отклонено для RC1 — более инвазивно и ортогонально RC2 (который всё равно бы дедлочил basic-process).
+
+## 4. Верификация
+
+| # | Проверка | Ожидание |
+|---|---|---|
+| V1 | Юнит: инстанс в `Created` регистрирует определение стартового события без ошибки (RC1). | успех на `Created`. |
+| V2 | Юнит: `RegisterEvent` на терминальном (`Completed`/`Terminated`) инстансе по-прежнему возвращает ошибку (RC1). | guard сохранён. |
+| V3 | Юнит/интеграция: `StartProcess` для простого процесса **и** для процесса со стартовым событием возвращается без дедлока (RC2). | нет повторной блокировки; `t.m` не удерживается сквозь `launchInstance`. |
+| V4 | `examples/basic-process` отрабатывает до конца (RC2). | код 0; нет дедлока, нет «instance isn't active». |
+| V5 | `examples/timer-event` отрабатывает до конца (движок RC1+RC2, пример RC3): таймер срабатывает на ~5 с, инстанс завершается, программа выходит. | код 0; печатает `Process completed`; нет паники дедлока. |
+| V6 | Без регрессий: `make ci` зелёный (race-тесты + diff-coverage + vuln); `examples/simple-timer` по-прежнему работает. | все существующие тесты проходят. |
+
+## 5. Предотвращение
+
+- **CI запускает примеры, а не только собирает их.** Весь этот класс отказов скрылся из-за того, что `make build-all` никогда не выполняет модули примеров. Добавить шаг CI (и `make`-таргет), который запускает каждый пример с таймаутом и проверяет код выхода 0. Заведено как follow-up; см. [[project_examples_runtime_broken]].
+
+## 6. Регрессии / заметки по объёму
+
+- **`examples/basic-process` в объёме** — это та же повторная блокировка RC2 (ранее ошибочно списанная на пустой `ServiceTask`); исправляется §3.1 + §3.2.
+- **`examples/timer-event` требует всех трёх** — исправления движка (§3.1 + §3.2) плюс исправление примера (§3.3). Гипотеза RC4 «движок никогда не планирует таймер» была **исследована и опровергнута**: таймер срабатывает ровно на 5.01 с, так что единственный оставшийся дефект — ожидание примера на nil-канале.
+- Изменение guard (§3.1) не должно ослаблять защиту терминального состояния (V2).
+- Сужение блокировки `StartProcess` (§3.2) должно сохранить защиту мьютексом и чтения снапшота, и записи в реестр — просто не удерживать её сквозь `launchInstance`. Конкурентные вызовы `StartProcess` остаются безопасными.
+- RC3 (§3.3) — изменение только примера; поведение движка не меняется.
+
+## 7. Связанное
+
+- [ADR-001 v.4 §4.2](../design/ADR-001-execution-model.md) — жизненный цикл (`Created → Active → Completed`, `Terminating → Terminated`), guard которого исправляет этот фикс.
+- [ADR-006 v.1](../design/ADR-006-events-and-subscriptions.md) — семантика доставки событий / подписок (будущий владелец тайминга регистрации).
+- [FIX-001](FIX-001-thresher-eventhub-startup-race.md) — установил, что EventHub запускается до регистрации инстансами.
+
+## 8. Сводка по реализации
+
+Залендено в ветке `fix/event-start-registration` (от `master`). RC1 + RC2 — исправления движка; RC3 — исправление примера.
+
+**Изменения**
+
+- **RC1** — `internal/instance/instance.go:574-580` (`RegisterEvent`): guard «только `Active`» стал `is := inst.State(); if is != Created && is != Active { … "instance is terminal…" }`, разрешая регистрацию на построении (`Created`) и в рантайме (`Active`) и отказывая только терминальным инстансам.
+- **RC2** — `pkg/thresher/thresher.go` (`StartProcess`, ~:358-380): мьютекс движка теперь оборачивает только поиск `t.snapshots[processID]` (`:373-374`) и освобождается до `t.launchInstance(s)`; проверка started использует `t.State()` вместо незащищённого чтения `t.state`.
+- **RC3** — `examples/timer-event/main.go:106` (`context.WithTimeout(…, 8s)` + `defer cancel()`) и `:126` (простой `<-ctx.Done()` → `Process completed`).
+
+**Добавленные тесты**
+
+- `internal/instance/register_event_test.go` — `TestRegisterEventAllowsCreated` (V1), `TestRegisterEventRejectsTerminal` (V2).
+- `pkg/thresher/thresher_process_test.go` — `TestStartProcess_NoReentrantDeadlock` (V3, защищён таймаутом).
+
+**Результаты верификации**
+
+| # | Результат |
+|---|---|
+| V1 | 🟢 инстанс в `Created` регистрирует определение стартового события — проходит. |
+| V2 | 🟢 терминальный инстанс по-прежнему отвергается — проходит. |
+| V3 | 🟢 `StartProcess` возвращается без повторной блокировки — проходит. |
+| V4 | 🟢 `examples/basic-process` код 0. |
+| V5 | 🟢 `examples/timer-event` код 0; таймер срабатывает ~5 с; печатает `Process completed`. |
+| V6 | 🟢 `make ci` зелёный (lint 0 проблем, race-тесты, diff-coverage 100 % по 10 затронутым строкам, govulncheck); `examples/simple-timer` код 0. |
+
+**Коммиты по майлстоунам**
+
+- `b7af364` — M1 (RC1): `RegisterEvent` разрешает нетерминальные состояния + тесты V1/V2.
+- `0ffa77a` — M2 (RC2): `StartProcess` освобождает `t.m` до `launchInstance` + тест V3.
+- `adddea3` — doc: добавлен RC3, опровергнут RC4.
+- `004319e` — M3 (RC3): отменяемый контекст в `examples/timer-event`.
+- (`9d3e947` — исходный коммит документа с завершённым RCA в ветке.)
+
+## 9. Открытые вопросы
+
+- Ничего блокирующего. (Должен ли тайминг регистрации в итоге переехать в runtime-only — это вопрос ADR-006, не данного FIX.)
+
+## История документа
+
+| Версия | Дата | Автор | Изменение |
+|---|---|---|---|
+| v.1 | 2026-06-09 | Руслан Габитов | Принято (залендено). `StartProcess` уходит в дедлок из-за трёх дефектов: **RC1** — `RegisterEvent` требует `Active`, но узлы со стартовым событием регистрируются во время `New` (`Created`); **RC2** — `StartProcess` удерживает `t.m` сквозь `launchInstance`, который повторно её захватывает (дедлок повторного неперевходимого `sync.Mutex` — задевает `basic-process` напрямую через `launchInstance:403`, а `timer-event` через `Thresher.State()`); **RC3** — `examples/timer-event` ждёт на `context.Background().Done()` (nil-канал), поэтому уходит в дедлок после того, как таймер корректно сработал. Исправление: разрешить нетерминальные состояния для регистрации (RC1) + сузить `StartProcess`, чтобы освобождать `t.m` до `launchInstance` (RC2) + дать примеру отменяемый контекст (RC3). Оба сломанных примера в объёме. (RCA расширялся через Draft-правки по ходу воспроизведения дедлока: сначала только guard → RC1+RC2; затем, после замера паники на 5.01 с, гипотеза RC4 «движок не планирует таймер» была опровергнута, а оставшийся отказ отнесён к RC3, примеру. Draft-правки, без отдельных строк.) |

--- a/docs/srd/SRD-004-extension-skeleton.ru.md
+++ b/docs/srd/SRD-004-extension-skeleton.ru.md
@@ -1,0 +1,190 @@
+# SRD-004 — Скелет расширений (минимальная/дефолтная реализация ADR-002)
+
+| Поле | Значение |
+|---|---|
+| Статус | Принято |
+| Версия | v.1 |
+| Дата | 2026-06-09 |
+| Владелец | Руслан Габитов |
+| Реализует | [ADR-002 v.1 Extension Architecture](../design/ADR-002-extension-architecture.md) |
+| Уточняет | [SAD-001 v.1 §11 Extension Model](../design/SAD-001-vision-and-architecture.md) |
+
+> EN-оригинал — канонический: [SRD-004-extension-skeleton.md](SRD-004-extension-skeleton.md). Этот файл — его перевод (twin).
+
+Этот SRD приземляет **фундаментальный скелет расширений** из [ADR-002](../design/ADR-002-extension-architecture.md): каждый контракт расширения определён в `pkg/`, каждый — со **встроенным дефолтом** (только дефолтное поведение — без production-адаптеров), сборка через функциональные опции на `thresher.New`, **разделение `EngineRuntime`/`RuntimeEnvironment`** и стартовая лог-строка — связано так, чтобы движок с нулём опций исполнял сегодняшний BPMN end-to-end. Завершение этого SRD закрывает приёмочный гейт §7 ADR-002 (строки только-дефолтов) и переводит ADR-002 → Accepted.
+
+## 1. Предпосылки и мотивация
+
+### 1.1 Текущее состояние (сверено с кодом)
+
+- **У конструктора движка нет точки инъекции** — `func New(id string) (*Thresher, error)` (`pkg/thresher/thresher.go:116`); один аргумент, без опций.
+- **`RuntimeEnvironment` — внутренний, с четырьмя методами** — `internal/renv/renv.go:12`: встраивает `scope.Scope`; `InstanceID() string`; `EventProducer() eventproc.EventProducer`; `RenderRegistrator() interactor.Registrator`.
+- **`Instance` его уже реализует** — `internal/instance/instance.go:821` (`var _ renv.RuntimeEnvironment = (*Instance)(nil)`), с методами `InstanceID()` / `EventProducer()` / `RenderRegistrator()` (`instance.go:803/808/813`).
+- **`EventHub` — внутренний** — `internal/eventproc/eventproc.go:47` (`EventHub`, `EventProducer`, `EventProcessor`); снаружи не реализуем.
+- **Человеческое взаимодействие — внутреннее** — `internal/interactor` (экосистема `Registrator`, `Renderer`); достигается через `RenderRegistrator()`.
+- **Выражения — модельный тип** — `pkg/model/data/expression.go:72` (`FormalExpression`); вычисляются напрямую, не за интерфейсом уровня движка.
+- **Нет точек расширения инфраструктуры** — `Repository`, `Logger`, `Tracer`, `MetricsRecorder`, `Clock`, `MessageBroker`, `AuthorizationProvider`, `WorkerDispatcher` нигде не существуют (по ADR-002 §1).
+
+### 1.2 Почему
+
+ADR-002 (согласован с ADR-001 v.4) — это утверждённая архитектура расширений, но ничего из неё ещё не построено. По ADR-002 §5/§7 расхождения приземляются **вместе, на минимальном/дефолтном поведении, в этом одном фундаментальном SRD**; ADR-002 переходит в Accepted, когда тесты §7 этого SRD проходят. Production-адаптеры и глубина по каждому интерфейсу — это более поздние, отдельно гейтированные SRD.
+
+## 2. Цели и область
+
+### 2.1 Цели (в области)
+
+- **G1.** Определить все 9 контрактов расширений в `pkg/` (по ADR-002 §4.2): `Logger` (slog-совместимый core-интерфейс — `*slog.Logger` реализует его напрямую), OTel-образные `Tracer`/`MetricsRecorder` (смоделированы по OTel API, но **core не импортирует OTel** — SAD-001 G2), интерфейсы `Clock`, `Repository`, `MessageBroker`, `ExpressionEngine`, `AuthorizationProvider`, `WorkerDispatcher`. **`EventHub` остаётся внутренним** — это исполнительная обвязка, а не точка расширения (нет use-case'а подстановки; ADR-002 §4.2). **`TaskDistributor` отложен** — кластер человеческого взаимодействия `internal/interactor` взаимосвязан и вынуждает выбор слоистости model→tasks, поэтому его промоут (и переименование `Registrator → TaskDistributor`) едет на выделенном ADR человеческого взаимодействия (ADR-001 v.4 §9), не на этом скелете.
+- **G2.** Поставить в core **встроенный дефолт** для каждого: `slog.Default()` Logger · **no-op `Tracer`** (с in-memory кольцом недавних span'ов, доступным как opt-in) · **in-memory запрашиваемый, с лимитом на серии `MetricsRecorder`** (`Snapshot()` для тестов/диагностики) · `Clock` по системным часам · in-memory недолговечный `Repository` · in-memory inbox `MessageBroker` · Go-native `ExpressionEngine` (обёртка существующего вычислителя) · allow-all `AuthorizationProvider` · in-process `WorkerDispatcher`. (`EventHub` остаётся внутренним — это не дефолт публичного контракта; внутренний кластер interactor отложен.)
+- **G3.** **Сборка через функциональные опции** — `thresher.New(id string, opts ...Option) (*Thresher, error)`; `defaultConfig()` связывает все дефолты; каждый `WithXxx` переопределяет один; семантика last-write; **нет `NewDefault`**. `New(id)` с нулём опций даёт рабочий движок.
+- **G4.** **Стартовая лог-строка** — одна INFO-запись `thresher.starting`, перечисляющая разрешённую обвязку (по ADR-002 §4.4.1).
+- **G5.** **Выделить `EngineRuntime` + расширить `RuntimeEnvironment`** (ADR-002 §4.3): определить интерфейс уровня движка/сервера `EngineRuntime` (разрешённые сервисы), реализуемый `Thresher`, **промоутнутый в `pkg/`** (публичный, путь по ADR-003); `RuntimeEnvironment` **остаётся в `internal/renv`** (он встраивает внутренние `scope.Scope`/`EventProducer`/`RenderRegistrator`) и **встраивает публичный `EngineRuntime`** + instance-local; `RenderRegistrator()` **сохранён как есть** (промоут человеческого взаимодействия отложен — ADR-001 v.4 §9); `Instance` **встраивает** `EngineRuntime` Thresher'а (методы движка промоутнуты — без per-method делегатов) и добавляет свои instance-local методы; точки вызова из track'а остаются единообразными (`t.inst.X()`).
+- **G6.** **Подключить к текущему исполнению** расширения, которые сегодняшний BPMN действительно задействует: маршрутизировать вычисление `FormalExpression` через `ExpressionEngine`; брать время из `Clock` (обработка таймеров) вместо `time.Now`; использовать настроенный `Logger`. (`EventHub` — внутренний и уже подключён.) Движок исполняет текущий набор элементов без изменений.
+- **G7.** **Без изменения внешнего поведения** для реализованных элементов (None Start/End, Service/User задачи, Exclusive-шлюз, sequence flow вкл. условия/default, timer-события): существующие тесты проходят без изменений и `make ci` зелёный. Ранее работавший пример (`examples/simple-timer`) по-прежнему запускается. **У `examples/timer-event` и `examples/basic-process` есть предсуществующий сбой, появившийся до SRD-004 (сломаны на master — регистрация event-start против lifecycle-гарда `Created` и дедлок на блокирующей задаче) — отслеживается [FIX-002](../fix/FIX-002-event-start-registration-lifecycle.md) и вне гейта этого SRD.**
+
+### 2.2 Не-цели (явно отложено)
+
+- **N1.** **Production-адаптеры** (`adapters/*` — postgres, otel, casbin, FEEL, redis/nats брокеры, …) → более поздние SRD по ADR-002 §4.6.
+- **N2.** **Точки подключения в исполнении для ещё не задействованных сервисов.** `Repository`, `MessageBroker`, `AuthorizationProvider`, `WorkerDispatcher` **определены + с дефолтами + доступны** через движок и `RuntimeEnvironment`, но их точки вызова **не** подключены в этом SRD — ни одна текущая фича BPMN их пока не требует:
+  - точки вызова checkpoint/load/rehydrate `Repository` → ADR Persistence & State (ADR-001 v.4 §4.7).
+  - маршрутизация корреляции `MessageBroker` → SRD корреляции сообщений.
+  - применение `AuthorizationProvider` на чувствительных операциях → SRD авторизации.
+  - удалённый диспатч `WorkerDispatcher` → SRD распределения (по SAD-001 §13.2).
+  Скелет делает их присутствующими и переопределяемыми; *вызов* их — вне области.
+- **N3.** **Финальные пути пакетов `pkg/`** — ADR-003 владеет точной раскладкой. Этот SRD размещает интерфейсы по предложенной ADR-003 раскладке per-concern; пути **предварительны** до приземления ADR-003 (позднейший перенос — механическое переименование).
+- **N4.** **Хук инъекции в адаптер `RuntimeAware`** (ADR-002 §3.5 Pattern C / §8.3) — скелет **определяет** `EngineRuntime` и `RuntimeEnvironment`, но адаптеров для инъекции нет, поэтому хук `UseRuntime(EngineRuntime)` и его обвязка на этапе сборки приземляются с первым реальным адаптером.
+- **N5.** **Хелперы контракт-тестов адаптеров, опциональные интерфейсы побочных способностей (`Starter`/`Stopper`/…), осведомлённость о кластере** (ADR-002 §8.3/§8.4) — приземляются с первым реальным адаптером.
+- **N6.** **Промоут взаимодействия человек-задача.** Кластер `internal/interactor` (`Registrator`/`Interactor`/`RenderController`) остаётся внутренним; переименование `Registrator → TaskDistributor` и любое раскрытие на уровне движка едут на выделенном **ADR человеческого взаимодействия** (ADR-001 v.4 §9). Скелет поставляет **10** контрактов, а существующий `RenderRegistrator()` уровня instance не тронут.
+
+## 3. Требования
+
+### 3.1 Функциональные
+
+| # | Требование | Приёмка |
+|---|---|---|
+| FR-1 | 9 контрактов существуют в `pkg/` (G1). `EventHub` остаётся внутренним (ADR-002 §4.2); `TaskDistributor` отложен (ADR человеческого взаимодействия). | `grep` находит каждый интерфейс под `pkg/`; сборка проходит; реализации в `internal/` импортируют интерфейсы из `pkg/`. |
+| FR-2 | У каждого контракта есть встроенный core-дефолт (G2). | Дефолтное значение существует и удовлетворяет своему интерфейсу; конструируется через `defaultConfig()`. |
+| FR-3 | `thresher.New(id, opts ...Option)`; ноль опций работает; `WithXxx` переопределяет; last-write; нет `NewDefault`. | `New("x")` запускается; `WithLogger(a),WithLogger(b)` ⇒ b; нет символа `NewDefault`. |
+| FR-4 | Одна INFO-лог-строка `thresher.starting` перечисляет каждое разрешённое расширение движка по типу реализации. | Тест с capture-логгером: ровно одна запись, ключ `thresher.starting`, атрибуты по ADR-002 §4.4.1. |
+| FR-5 | `EngineRuntime` (сервисы движка) определён в **публичном** `pkg/renv`, реализован `Thresher`; `RuntimeEnvironment` **остаётся внутренним**, встраивает его + instance-local (вкл. сохранённый `RenderRegistrator()`); `Instance` **встраивает** `EngineRuntime` Thresher'а. | `var _ renv.EngineRuntime = (*Thresher)(nil)` (публичный) и `var _ internalrenv.RuntimeEnvironment = (*Instance)(nil)`. |
+| FR-6 | `Instance` встраивает `EngineRuntime` Thresher'а (методы движка промоутнуты, без per-method делегатов); track достигает сервисов через свой единственный `*Instance`. | Тест по каждому методу: `instance.Logger()` (и т.д.) == настроенное значение движка. |
+| FR-7 | `ExpressionEngine`, `Clock`, `Logger` подключены в текущее исполнение (G6): `FormalExpression` вычисляется через `ExpressionEngine`; время таймера через `Clock`. (`EventHub` — внутренний и уже подключён.) | Тесты override-and-observe: кастомный `ExpressionEngine`/`Clock` — именно тот, что используется во время исполнения. |
+| FR-8 | `Repository`/`MessageBroker`/`AuthorizationProvider`/`WorkerDispatcher` определены, с дефолтами и достижимы через движок/RE, но **не** вызываются исполнением (N2). | Они конструируемы и доступны (`instance.Repository()` и т.д.); ни одна точка вызова в исполнении их пока не ссылается. |
+| FR-9 | Без регрессий для реализованных элементов (G7). | Существующие тесты `internal/instance` + движка и `examples/*` проходят без изменений; `make ci` зелёный. |
+
+### 3.2 Нефункциональные
+
+| # | Требование | Приёмка |
+|---|---|---|
+| NFR-1 | Без гонок под детектором. | `make ci` (с гейтом гонок) зелёный. |
+| NFR-2 | Тронутые/созданные файлы соответствуют стандарту покрытия (≥80%, цель 100%; гейт `covercheck`). | `make cover-check` PASS на diff'е. |
+| NFR-3 | `core` не получает ни одной runtime-зависимости вне stdlib (SAD-001 G2). Соблюдается даже для телеметрии: `Tracer`/`MetricsRecorder` OTel-*образны*, но core **не** импортирует OTel (ADR-002 §4.2); реальные типы OTel живут в `adapters/otel/`. | `go mod graph` не показывает новых внешних core-зависимостей (дефолты только stdlib; `slog` — stdlib; нет `go.opentelemetry.io/*` в core). |
+| NFR-4 | Видимая по умолчанию observability сохранена (дефолт Logger — `slog.Default()`). | Движок с нулём опций логирует в дефолтный handler. |
+
+## 4. Дизайн и план реализации
+
+### 4.1 Формы (иллюстративно; точные пути `pkg/` — по ADR-003)
+
+```go
+// Конфиг уровня движка держит разрешённые расширения (по одному на интерфейс).
+type thresherConfig struct {
+    logger      Logger          // slog-satisfiable interface; default slog.Default()
+    tracer      Tracer          // OTel-shaped, core-defined (no OTel import); default no-op
+    metrics     MetricsRecorder // default = in-memory queryable, series-capped registry
+    clock       Clock
+    repository  Repository
+    msgBroker   MessageBroker
+    exprEngine  expression.Engine
+    authz       AuthorizationProvider
+    dispatcher  WorkerDispatcher
+    // EventHub is NOT here — it stays internal (ADR-002 §4.2); the Thresher
+    // constructs its internal hub itself, not via an option.
+}
+
+type Option func(*thresherConfig)
+
+func WithLogger(l Logger) Option { return func(c *thresherConfig) { c.logger = l } }  // *slog.Logger satisfies Logger
+// … one per extension …
+
+func New(id string, opts ...Option) (*Thresher, error) {
+    cfg := defaultConfig()          // all defaults wired
+    for _, o := range opts { o(&cfg) }
+    t, err := assemble(id, cfg)
+    if err != nil { return nil, err }
+    t.logStartupConfig()            // §4.4.1
+    return t, nil
+}
+```
+
+По ADR-002 §4.3 сервисы движка выделены в интерфейс **`EngineRuntime`**, который реализует `Thresher` (возвращая разрешённые значения `thresherConfig`); `RuntimeEnvironment` (остаётся внутренним; в `pkg/` промоутнут только `EngineRuntime`) **встраивает `EngineRuntime`** + instance-local методы; `Instance` **встраивает** `EngineRuntime` Thresher'а (методы движка промоутнуты — без per-method делегатов) и сохраняет свои instance-local методы. Точки вызова из track'а не меняются по стилю (`t.inst.Clock().Now()`).
+
+### 4.2 Вехи (каждая независимо собираема + CI-зелёная)
+
+1. **M1 — Observability + Clock.** Интерфейсы `Logger` (slog-совместимый), OTel-образные `Tracer`/`MetricsRecorder` (без импорта OTel), `Clock` + дефолты: `slog.Default()` Logger, **no-op Tracer**, **in-memory запрашиваемый реестр Metrics с лимитом серий**, `Clock` по системным часам — плюс opt-in in-memory кольцо недавних span'ов Tracer для dev/тестов. Чистые leaf-пакеты; обвязки движка пока нет. Тесты дефолтов/конформанса (вкл. `Snapshot()` реестра + поведение лимита серий).
+2. **M2 — Stateful-листья.** Интерфейсы `Repository`, `MessageBroker`, `AuthorizationProvider`, `WorkerDispatcher` + дефолты (in-mem / in-mem inbox / allow-all / in-proc). Определены + протестированы; пока не вызываются (N2).
+3. **M3 — ExpressionEngine.** `ExpressionEngine` (интерфейс `pkg/model/expression`, оборачивающий вычислитель `FormalExpression`) + Go-native дефолт (`pkg/model/expression/goexpr`). Только определение + дефолт; маршрутизация точек вызова — M5/G6. `EventHub` **остаётся внутренним** (ADR-002 §4.2), а `TaskDistributor` **отложен** (ADR-001 v.4 §9) — ни один не промоутится, поэтому M3 — чистое добавление нового пакета без churn'а импортёров.
+4. **M4 — Сборка.** `thresherConfig` + `Option` + `WithXxx` (по одному на расширение) + рефакторинг `New(id, opts...)` + `defaultConfig()` + `logStartupConfig()` (§4.4.1). Нет `NewDefault`.
+5. **M5 — EngineRuntime + RuntimeEnvironment.** Промоут `EngineRuntime` (сервисы движка) в **публичный `pkg/renv`**, реализуемый `Thresher`; `RuntimeEnvironment` **остаётся в `internal/renv`**, встраивает публичный `EngineRuntime` и сохраняет `RenderRegistrator()` как есть; `Instance` встраивает `EngineRuntime` Thresher'а; перенаправить импорты; **подключить ExpressionEngine + Clock в исполнение** (G6).
+6. **M6 — Приёмка.** Применимый набор ADR-002 §7 (zero-option New e2e, опции compose/override/last-write, стартовый лог, Instance-implements-RE, делегаты, конформанс дефолтов, композиция RE) + examples проходят + `make ci` зелёный + `cover-check` PASS. Flip **ADR-002 + SRD-004 → Accepted** + RU-twin'ы.
+
+Последовательность: листья (M1/M2) и промоуты (M3) определяют контракты+дефолты без связи с движком; сборка (M4) подключает их в `New`; расширение RE (M5) раскрывает их через `Instance` и подключает исполняемые; M6 верифицирует + принимает.
+
+## 5. Верификация (Definition of Done)
+
+Отображается на [ADR-002 §7](../design/ADR-002-extension-architecture.md) (строки только-дефолтов; зависящие от адаптеров строки отложены на первый SRD адаптера):
+
+| Тест | Утверждает |
+|---|---|
+| Zero-option New e2e | `thresher.New("t")` регистрирует + исполняет процесс до завершения со всеми дефолтами. |
+| Опции compose / override / last-write | все `WithXxx` в случайном порядке ⇒ одно состояние; каждая переопределяет свой дефолт; побеждает последняя запись. |
+| Лог стартового конфига | ровно одна INFO `thresher.starting` с атрибутом на каждое расширение движка = подключённый тип реализации. |
+| Thresher реализует EngineRuntime; Instance реализует RuntimeEnvironment | `var _ renv.EngineRuntime = (*Thresher)(nil)` и `var _ renv.RuntimeEnvironment = (*Instance)(nil)`. |
+| Делегаты сервисов движка | `instance.X()` == X из конфига движка, по каждому методу. |
+| Конформанс дефолтов | in-memory дефолт `Repository` (и прочие) проходят тест дефолтного поведения. |
+| Обвязка исполняемых расширений | кастомный `ExpressionEngine`/`Clock` — именно тот, что используется во время исполнения (FR-7). |
+| Без регрессий | существующий набор проходит без изменений; `examples/simple-timer` запускается; `make ci` зелёный; `cover-check` PASS. (`timer-event`/`basic-process` предсломаны — FIX-002, вне области.) |
+
+**DoD:** все FR/NFR выполнены; таблица выше зелёная; `make ci` + `cover-check` зелёные; ADR-002 §7 (применимые строки) выполнены. **Достигнуто 2026-06-09** — ADR-002 + SRD-004 переведены в Accepted. RU-twin'ы **отложены** (батчатся до того, как осядет работа по FIX-002 / примерам, по политике bilingual-docs).
+
+## 6. Риски и регрессии
+
+- **Перенос RuntimeEnvironment (`internal/renv`→`pkg/renv`) задевает импорты.** Митигация: M5 — отдельная веха; перенаправить всех импортёров; гейты `make ci`.
+- **Косвенность ExpressionEngine меняет путь вычисления.** Митигация: дефолт оборачивает *существующий* вычислитель; тест переопределения FR-7 + набор без регрессий (G7).
+- **Расползание области в точки подключения N2.** Repository/MessageBroker/AuthZ/WorkerDispatcher — только определение-и-дефолт; не подключать точки вызова здесь.
+- **Предварительные пути пакетов (ADR-003).** Митигация: пути по предложенной ADR-003 раскладке; позднейший перенос механический.
+- **Расползание зависимостей `core`.** Митигация: все дефолты только stdlib; проверка `go mod graph` NFR-3.
+
+## 7. Итог реализации
+
+Приземлено на ветке `feat/extension-skeleton`, по одному commit'у на веху:
+
+- **M1** `91a2fdf` — `pkg/observability` (`Logger`/`Tracer`/`MetricsRecorder` + `noop`/`memmetrics`/`memtrace`) + `pkg/clock` (`Clock` + `syscl`/`clocktest`).
+- **M2** `8d7e291` — `pkg/repository` (+`memrepo`), `pkg/messaging` (`MessageBroker` +`membroker`), `pkg/auth` (+`allowall`), `pkg/tasks` (`WorkerDispatcher` +`localdispatcher`); ограниченные дефолты, определены-но-не-вызываются (N2).
+- **M3** `ef77485` — `pkg/model/expression.Engine` (+`goexpr` дефолт).
+- **M4** `beaf13c` — функциональные опции `pkg/thresher` (девять `WithXxx`) + `defaultConfig` + `New(id, opts...)` + стартовый лог; отвержение nil-опций усилено в `e5cb184`.
+- **M5** `ffc534b` — `pkg/renv.EngineRuntime` (публичный); `RuntimeEnvironment` встраивает его (внутренний); `thresherConfig` и `Instance` реализуют/встраивают его; EventHub + ожидатели таймеров инъектируются им; `ExpressionEngine` + `Clock` подключены в точки вызова exclusive-шлюза и таймера. `internal/enginert` предоставляет дефолтный рантайм для тестов.
+
+**Отклонения от исходного плана (все согласованы по ходу):** `EventHub` остаётся внутренним (не точка расширения); `TaskDistributor` человеческого взаимодействия отложен на свой ADR (N6); `EngineRuntime` — разделяемое значение, инъектируемое в instance'ы и EventHub (Решение B, без цикла импортов); дефолты телеметрии распределены по стоимости (in-mem метрики включены по умолчанию, no-op трейсер); принцип ограниченных in-memory дефолтов (ADR-002 §4.2).
+
+**V-результаты (2026-06-09):** `make ci` зелёный — tidy / lint (0 проблем × 6 модулей) / build-all (вкл. examples) / race `test-all` / `cover-check` / govulncheck. Diff-покрытие 99.5% изменённых строк (3 непокрытых — недостижимая ошибочная ветка `eventhub.New`). Набор только-дефолтов ADR-002 §7 зелёный. `examples/simple-timer` исполняется end-to-end. `examples/timer-event` и `examples/basic-process` предсломаны (FIX-002) — исключены из G7.
+
+## 8. Ссылки
+
+- [ADR-002 v.1 Extension Architecture](../design/ADR-002-extension-architecture.md) — §3.5 межадаптерная композиция (EngineRuntime / Pattern C), §4.2 каталог, §4.3 EngineRuntime + RuntimeEnvironment, §4.4 сборка, §4.5 дефолты, §5 расхождения, §7 приёмочный гейт (этот SRD закрывает строки только-дефолтов), §8.3 `RuntimeAware`.
+- [ADR-001 v.4 Execution Model](../design/ADR-001-execution-model.md) — §4.7 инварианты рантайма (цель Repository); §4.3 поток событий (потребители EventHub/Logger).
+- [ADR-003 v.1 Module Layout](../design/ADR-003-module-layout.md) — финальные пути `pkg/` (здесь предварительны).
+- [SAD-001 v.1 §11 Extension Model](../design/SAD-001-vision-and-architecture.md); §9.2 multi-module; G2 minimal-core-deps.
+- Существующий код: `pkg/thresher/thresher.go:116`; `internal/renv/renv.go:12`; `internal/eventproc/eventproc.go:47`; `internal/interactor/`; `pkg/model/data/expression.go:72`; `internal/instance/instance.go:803-821`.
+
+## 9. Открытые вопросы
+
+1. **Группировка пакета observability** — один `pkg/observability` (Logger/Tracer/MetricsRecorder) против отдельных `pkg/logger`,`pkg/tracer`,`pkg/metrics`? ADR-003 §3.2 предпочитает «один подпакет на цельный concern». **Разрешено предварительно:** группировать как `pkg/observability` для цельных стоков; финальное решение едет на ADR-003. Подтвердить на M1.
+2. **Размещение `MetricsRecorder`?** **Разрешено:** `MetricsRecorder()` — метод на `EngineRuntime` (ADR-002 §4.3); поскольку `RuntimeEnvironment` встраивает `EngineRuntime`, он достижим и со стороны движка (`Thresher`), и со стороны instance (`Instance`) без особых случаев.
+3. **Форма интерфейса `ExpressionEngine`** — минимальный `Evaluate(expr data.FormalExpression, scope scope.Scope) (any, error)`? **Разрешено предварительно:** зеркалить сигнатуру вызова текущего вычислителя, чтобы дефолт был тонкой обёрткой; зафиксировать точную сигнатуру на M3 из точек вызова.
+4. **Дефолтная реализация телеметрии** — no-op против видимой против log-backed? **Разрешено (дизайн-обсуждение):** дефолты различаются по стоимости сигнала (ADR-002 §4.2). **Метрики** по умолчанию — in-memory, с лимитом серий, запрашиваемый реестр (видимый по умолчанию по политике observability; `Snapshot()` делает тесты тривиальными — logtel не нужен). **Трейсинг** по умолчанию no-op (span — это аллокация на событие, инертная без бэкенда) с in-memory кольцом недавних span'ов как однострочный opt-in. Персистентный SQL-сток телеметрии — будущий production-адаптер (`adapters/sqlstore`), никогда не core-дефолт. Прежняя идея log-backed телеметрии **отброшена** (она превращает метрики в лог-текст, который надо парсить обратно).
+
+## История документа
+
+| Версия | Дата | Автор | Изменение |
+|---|---|---|---|
+| v.1 (Accepted) | 2026-06-09 | Руслан Габитов | **Принято.** Все вехи (M1–M5) приземлены; `make ci` зелёный; набор только-дефолтов ADR-002 §7 пройден; diff-покрытие 99.5%. G7 выполнено для существующих тестов + `simple-timer`; `timer-event`/`basic-process` предсломаны, выведены в FIX-002. RU-twin отложен (батчится). Пред-приёмочная Draft-итерация свёрнута без per-round строк. Пины ADR-001 подняты v.3 → v.4. |
+| v.1 | 2026-06-08 | Руслан Габитов | Первый Draft. Фундаментальный скелет расширений для ADR-002 — 9 контрактов в `pkg/` + встроенные дефолты, сборка через функциональные опции, разделение `EngineRuntime` (публичный) / `RuntimeEnvironment` (внутренний) (Thresher реализует `EngineRuntime`; `RuntimeEnvironment` встраивает его; `Instance` встраивает его), стартовый лог; исполняемые расширения (ExpressionEngine/Clock/Logger) подключены, остальные только определение-и-дефолт (N2); `EventHub` остаётся внутренним (не точка расширения); инъекция в адаптер `RuntimeAware` отложена (N4); человеческое взаимодействие/`TaskDistributor` отложено на свой ADR (N6). Закрывает строки только-дефолтов ADR-002 §7 при приземлении. |

--- a/examples/timer-event/main.go
+++ b/examples/timer-event/main.go
@@ -103,7 +103,8 @@ func main() {
 	}
 
 	// Start engine
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 8*time.Second)
+	defer cancel()
 	err = engine.Run(ctx)
 	if err != nil {
 		log.Fatal("Failed to start engine:", err)
@@ -117,12 +118,11 @@ func main() {
 
 	fmt.Printf("Timer process '%s' started successfully with ID: %s\n",
 		proc.Name(), proc.ID())
-	fmt.Println("Timer will trigger after 5 seconds, repeating 3 times...")
-	fmt.Println("Press Ctrl+C to exit")
+	fmt.Println("Timer will trigger after 5 seconds...")
+	fmt.Println("Waiting up to 8s for the timer event...")
 
-	// Keep the program running to see timer events
-	select {
-	case <-ctx.Done():
-		fmt.Println("Process completed")
-	}
+	// Block until the engine context is canceled (timeout above); the 5s
+	// timer fires and the instance completes well within the window.
+	<-ctx.Done()
+	fmt.Println("Process completed")
 }

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -567,10 +567,14 @@ func (inst *Instance) RegisterEvent(
 	proc eventproc.EventProcessor,
 	eDef flow.EventDefinition,
 ) error {
+	// Event registration is legitimate while the instance is being built
+	// (Created — start-event nodes register here) or running (Active — boundary
+	// / intermediate catch events); it is refused only on a terminal instance
+	// that can no longer act on a fired event (FIX-002 RC1).
 	is := inst.State()
-	if is != Active {
+	if is != Created && is != Active {
 		return errs.New(
-			errs.M("instance isn't active (current state: %s)",
+			errs.M("instance is terminal, can't register events (state: %s)",
 				is),
 			errs.C(errorClass, errs.InvalidState),
 			errs.D("requester_id", proc.ID()))

--- a/internal/instance/register_event_test.go
+++ b/internal/instance/register_event_test.go
@@ -1,0 +1,42 @@
+package instance
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/generated/mockflow"
+)
+
+// FIX-002 RC1: event-start nodes register during instance.New (Created), so
+// RegisterEvent must permit non-terminal states and refuse only terminal ones.
+
+func TestRegisterEventAllowsCreated(t *testing.T) {
+	ep := mockeventproc.NewMockEventProducer(t)
+	proc := mockeventproc.NewMockEventProcessor(t)
+	eDef := mockflow.NewMockEventDefinition(t)
+
+	ep.EXPECT().RegisterEvent(proc, eDef).Return(nil)
+
+	inst := &Instance{parentEventProducer: ep}
+	inst.setState(Created)
+
+	require.NoError(t, inst.RegisterEvent(proc, eDef))
+}
+
+func TestRegisterEventRejectsTerminal(t *testing.T) {
+	ep := mockeventproc.NewMockEventProducer(t)
+	proc := mockeventproc.NewMockEventProcessor(t)
+	eDef := mockflow.NewMockEventDefinition(t)
+
+	// Used only when the guard builds its error detail.
+	proc.EXPECT().ID().Return("p-1").Maybe()
+
+	inst := &Instance{parentEventProducer: ep}
+	inst.setState(Terminated)
+
+	// Guard rejects before delegating, so ep.RegisterEvent is never called
+	// (no EXPECT set — testify fails if it is).
+	require.Error(t, inst.RegisterEvent(proc, eDef))
+}

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -358,17 +358,22 @@ func (t *Thresher) RegisterProcess(
 // StartProcess runs process with processId without any event even if
 // process awaits them.
 func (t *Thresher) StartProcess(processID string) error {
-	if t.state != Started {
+	if st := t.State(); st != Started {
 		return errs.New(
 			errs.M("thresher isn't started"),
 			errs.C(errorClass, errs.InvalidState),
-			errs.D("current_state", t.state.String()))
+			errs.D("current_state", st.String()))
 	}
 
+	// Hold the engine lock only for the snapshot lookup; release it BEFORE
+	// launchInstance. launchInstance (and, for event-start nodes, the
+	// construction-time RegisterEvent -> Thresher.State()) re-acquire t.m, which
+	// would self-deadlock a non-reentrant mutex if held across them (FIX-002
+	// RC2).
 	t.m.Lock()
-	defer t.m.Unlock()
-
 	s, ok := t.snapshots[processID]
+	t.m.Unlock()
+
 	if !ok {
 		return errs.New(
 			errs.M("couldn't find snapshot for process ID %q", processID),

--- a/pkg/thresher/thresher_process_test.go
+++ b/pkg/thresher/thresher_process_test.go
@@ -3,7 +3,10 @@ package thresher_test
 import (
 	"context"
 	"testing"
+	"time"
 
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/dr-dobermann/gobpm/pkg/model/process"
 	"github.com/dr-dobermann/gobpm/pkg/thresher"
 	"github.com/stretchr/testify/require"
@@ -60,4 +63,44 @@ func TestThresher_ProcessManagement(t *testing.T) {
 	// Note: Testing actual process start would require complex setup with
 	// proper Process, Nodes, Flows, etc. We'll focus on error paths and
 	// basic validation for now.
+}
+
+// TestStartProcess_NoReentrantDeadlock guards FIX-002 RC2: StartProcess must
+// not hold t.m across launchInstance (which re-acquires it), or it self-
+// deadlocks on the non-reentrant mutex.
+func TestStartProcess_NoReentrantDeadlock(t *testing.T) {
+	th, err := thresher.New("deadlock-test")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	// Minimal runnable process: Start -> End.
+	proc, err := process.New("p")
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	require.NoError(t, proc.Add(start))
+	require.NoError(t, proc.Add(end))
+
+	_, err = flow.Link(start, end)
+	require.NoError(t, err)
+
+	require.NoError(t, th.RegisterProcess(proc))
+
+	done := make(chan error, 1)
+	go func() { done <- th.StartProcess(proc.ID()) }()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("StartProcess deadlocked (FIX-002 RC2: re-entrant t.m)")
+	}
 }


### PR DESCRIPTION
FIX-002 (Accepted): RC1 RegisterEvent permits non-terminal states; RC2 StartProcess releases t.m before launchInstance (re-entrant mutex); RC3 timer-event uses a cancelable context; RC4
  disproven. make ci green, diff-coverage 100% on touched lines, all 3 examples exit 0. Also adds RU twins for FIX-002, ADR-002, SRD-004.