### PR TITLE
Fix misspellings in EventDefinition doc comments

### DIFF
--- a/pkg/model/events/definition.go
+++ b/pkg/model/events/definition.go
@@ -27,8 +27,8 @@ func newDefinition(baseOpts ...options.Option) (*definition, error) {
 
 // GetItemList returns a list of data.ItemDefinition the EventDefinition
 // is based on.
-// If EventDefiniton isn't based on any data.ItemDefiniton, empty list
-// wil be returned.
+// If EventDefinition isn't based on any data.ItemDefinition, empty list
+// will be returned.
 func (d *definition) GetItemsList() []*data.ItemDefinition {
 	// by default an empty list of items returned
 	return []*data.ItemDefinition{}

--- a/pkg/model/events/error.go
+++ b/pkg/model/events/error.go
@@ -63,8 +63,8 @@ func (eed *ErrorEventDefinition) CheckItemDefinition(iDefID string) bool {
 
 // GetItemsList returns a list of data.ItemDefinition the EventDefinition
 // is based on.
-// If EventDefiniton isn't based on any data.ItemDefiniton, empty list
-// wil be returned.
+// If EventDefinition isn't based on any data.ItemDefinition, empty list
+// will be returned.
 func (eed *ErrorEventDefinition) GetItemsList() []*data.ItemDefinition {
 	if eed.err.Structure() == nil {
 		return []*data.ItemDefinition{}

--- a/pkg/model/events/escalation.go
+++ b/pkg/model/events/escalation.go
@@ -140,8 +140,8 @@ func (eed *EscalationEventDefinition) CheckItemDefinition(iDefID string) bool {
 
 // GetItemsList returns a list of data.ItemDefinition the EventDefinition
 // is based on.
-// If EventDefiniton isn't based on any data.ItemDefiniton, empty list
-// wil be returned.
+// If EventDefinition isn't based on any data.ItemDefinition, empty list
+// will be returned.
 func (eed *EscalationEventDefinition) GetItemsList() []*data.ItemDefinition {
 	idd := make([]*data.ItemDefinition, 0, 1)
 

--- a/pkg/model/events/message.go
+++ b/pkg/model/events/message.go
@@ -87,8 +87,8 @@ func (med *MessageEventDefinition) CheckItemDefinition(iDefID string) bool {
 
 // GetItemsList returns a list of data.ItemDefinition the EventDefinition
 // is based on.
-// If EventDefiniton isn't based on any data.ItemDefiniton, empty list
-// wil be returned.
+// If EventDefinition isn't based on any data.ItemDefinition, empty list
+// will be returned.
 func (med *MessageEventDefinition) GetItemsList() []*data.ItemDefinition {
 	idd := make([]*data.ItemDefinition, 0, 1)
 

--- a/pkg/model/events/signal.go
+++ b/pkg/model/events/signal.go
@@ -123,8 +123,8 @@ func (sed *SignalEventDefinition) CheckItemDefinition(iDefID string) bool {
 
 // GetItemList returns a list of data.ItemDefinition the EventDefinition
 // is based on.
-// If EventDefiniton isn't based on any data.ItemDefiniton, empty list
-// wil be returned.
+// If EventDefinition isn't based on any data.ItemDefinition, empty list
+// will be returned.
 func (sed *SignalEventDefinition) GetItemList() []*data.ItemDefinition {
 	idd := make([]*data.ItemDefinition, 0, 1)
 

--- a/pkg/model/flow/events.go
+++ b/pkg/model/flow/events.go
@@ -55,8 +55,8 @@ type EventDefinition interface {
 	// Type returns the trigger of the event definition.
 	Type() EventTrigger
 
-	// If EventDefiniton isn't based on any data.ItemDefiniton, empty list
-	// wil be returned.
+	// If EventDefinition isn't based on any data.ItemDefinition, empty list
+	// will be returned.
 	GetItemsList() []*data.ItemDefinition
 }
 


### PR DESCRIPTION
Corrects 'Definiton'->'Definition' and 'wil'->'will' in the shared GetItemsList doc comment across 6 event-definition files. Comments only; build + make lint green.