### PR TITLE
feat(thresher): print startup banner, version and per-module config

### DIFF
--- a/pkg/thresher/buildinfo.go
+++ b/pkg/thresher/buildinfo.go
@@ -1,0 +1,87 @@
+package thresher
+
+import "runtime/debug"
+
+// version is the engine's semantic version. It may be overridden at build time
+// with -ldflags "-X github.com/dr-dobermann/gobpm/pkg/thresher.version=v1.2.3".
+// When left empty the toolchain-embedded module version is used instead.
+var version = "v0.1.1"
+
+// banner is the engine wordmark printed at startup, one log record per line. A
+// raw literal keeps the backslashes literal; the lone backtick on line 3 is
+// spliced in as an interpreted segment (a raw literal cannot contain one).
+const banner = `           ___ ___ __  __
+  __ _ ___| _ ) _ \  \/  |
+ / _` + "`" + ` / _ \ _ \  _/ |\/| |
+ \__, \___/___/_| |_|  |_|
+ |___/`
+
+// separator closes the startup block, setting the banner and resolved
+// configuration apart from the application log that follows.
+const separator = "────────────────────────────────────────────────────────────"
+
+// buildInfo holds the version-control metadata baked into the binary by the Go
+// toolchain (the vcs.* build settings, present for builds made from a repo).
+type buildInfo struct {
+	version  string
+	revision string
+	revTime  string
+	modified bool
+}
+
+// readBuildInfo resolves the engine version and the last commit recorded in the
+// binary. ReadBuildInfo yields a nil info when build data is unavailable (e.g. a
+// build outside a git tree); buildInfoFrom degrades that to "unknown" rather
+// than failing, so startup logging never blocks New.
+func readBuildInfo() buildInfo {
+	info, _ := debug.ReadBuildInfo()
+
+	return buildInfoFrom(version, info)
+}
+
+// buildInfoFrom derives the build metadata from a version string and the
+// toolchain build info. It is the pure, testable core of readBuildInfo: a nil
+// info, or absent vcs.* settings, resolve to "unknown".
+func buildInfoFrom(ver string, info *debug.BuildInfo) buildInfo {
+	bi := buildInfo{
+		version:  ver,
+		revision: "unknown",
+		revTime:  "unknown",
+	}
+
+	if info == nil {
+		return bi
+	}
+
+	if bi.version == "" && info.Main.Version != "" {
+		bi.version = info.Main.Version
+	}
+
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			bi.revision = s.Value
+		case "vcs.time":
+			bi.revTime = s.Value
+		case "vcs.modified":
+			bi.modified = s.Value == "true"
+		}
+	}
+
+	return bi
+}
+
+// shortRevision returns the abbreviated commit hash, suffixed with "-dirty" when
+// the working tree carried uncommitted changes at build time.
+func (b buildInfo) shortRevision() string {
+	rev := b.revision
+	if len(rev) > 7 {
+		rev = rev[:7]
+	}
+
+	if b.modified {
+		rev += "-dirty"
+	}
+
+	return rev
+}

--- a/pkg/thresher/buildinfo_test.go
+++ b/pkg/thresher/buildinfo_test.go
@@ -1,0 +1,76 @@
+package thresher
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestShortRevision(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		bi   buildInfo
+		want string
+	}{
+		{
+			name: "long revision truncated to seven chars",
+			bi:   buildInfo{revision: "f9bf034ca1c660f65605913b66eccc09276faadb"},
+			want: "f9bf034",
+		},
+		{
+			name: "dirty tree gets suffix",
+			bi:   buildInfo{revision: "f9bf034ca1c660f", modified: true},
+			want: "f9bf034-dirty",
+		},
+		{
+			name: "short unknown revision left intact",
+			bi:   buildInfo{revision: "unknown"},
+			want: "unknown",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.bi.shortRevision(); got != tc.want {
+				t.Fatalf("shortRevision() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestBuildInfoFromNilInfo(t *testing.T) {
+	bi := buildInfoFrom("v1.2.3", nil)
+
+	if bi.version != "v1.2.3" || bi.revision != "unknown" || bi.revTime != "unknown" {
+		t.Fatalf("nil info should degrade to unknown, got %+v", bi)
+	}
+}
+
+func TestBuildInfoFromSettings(t *testing.T) {
+	info := &debug.BuildInfo{
+		Main: debug.Module{Version: "v9.9.9"},
+		Settings: []debug.BuildSetting{
+			{Key: "vcs.revision", Value: "f9bf034ca1c660f"},
+			{Key: "vcs.time", Value: "2026-06-13T18:50:42Z"},
+			{Key: "vcs.modified", Value: "true"},
+			{Key: "unrelated", Value: "ignored"},
+		},
+	}
+
+	// An empty version falls back to the main module version; the vcs.* settings
+	// populate revision/time/modified.
+	bi := buildInfoFrom("", info)
+
+	if bi.version != "v9.9.9" {
+		t.Fatalf("empty version should fall back to Main.Version, got %q", bi.version)
+	}
+
+	if bi.revision != "f9bf034ca1c660f" || bi.revTime != "2026-06-13T18:50:42Z" || !bi.modified {
+		t.Fatalf("vcs settings not applied: %+v", bi)
+	}
+}
+
+func TestReadBuildInfoNeverEmpty(t *testing.T) {
+	bi := readBuildInfo()
+
+	if bi.version == "" || bi.revision == "" || bi.revTime == "" {
+		t.Fatalf("readBuildInfo left a field empty: %+v", bi)
+	}
+}

--- a/pkg/thresher/options_test.go
+++ b/pkg/thresher/options_test.go
@@ -3,6 +3,7 @@ package thresher
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/dr-dobermann/gobpm/pkg/auth/allowall"
@@ -111,9 +112,9 @@ func TestZeroOptionNewWorks(t *testing.T) {
 // capHandler captures emitted slog records.
 type capHandler struct{ records []slog.Record }
 
-func (h *capHandler) Enabled(context.Context, slog.Level) bool  { return true }
-func (h *capHandler) WithAttrs([]slog.Attr) slog.Handler        { return h }
-func (h *capHandler) WithGroup(string) slog.Handler             { return h }
+func (h *capHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h *capHandler) WithAttrs([]slog.Attr) slog.Handler       { return h }
+func (h *capHandler) WithGroup(string) slog.Handler            { return h }
 func (h *capHandler) Handle(_ context.Context, r slog.Record) error {
 	h.records = append(h.records, r)
 
@@ -127,29 +128,28 @@ func TestStartupConfigLog(t *testing.T) {
 		t.Fatalf("New: %v", err)
 	}
 
-	if len(h.records) != 1 {
-		t.Fatalf("records = %d, want exactly 1", len(h.records))
+	// The startup config is printed line by line: the banner, build metadata
+	// and one record per resolved module. Collect every message and assert the
+	// human-readable lines are present, all at INFO level.
+	var msgs []string
+	for _, rec := range h.records {
+		if rec.Level != slog.LevelInfo {
+			t.Fatalf("record %q at %v, want INFO", rec.Message, rec.Level)
+		}
+
+		msgs = append(msgs, rec.Message)
 	}
 
-	rec := h.records[0]
-	if rec.Message != "thresher.starting" || rec.Level != slog.LevelInfo {
-		t.Fatalf("record = %q @ %v, want \"thresher.starting\" @ INFO", rec.Message, rec.Level)
-	}
-
-	keys := map[string]bool{}
-	rec.Attrs(func(a slog.Attr) bool {
-		keys[a.Key] = true
-
-		return true
-	})
+	joined := strings.Join(msgs, "\n")
 
 	for _, want := range []string{
-		"id", "repository", "logger", "tracer", "metricsRecorder", "clock",
-		"messageBroker", "expressionEngine", "authorizationProvider",
-		"workerDispatcher",
+		"version:", "last commit:", "thresher id:", "configuration:",
+		"repository:", "logger:", "tracer:", "metricsRecorder:", "clock:",
+		"messageBroker:", "expressionEngine:", "authorizationProvider:",
+		"workerDispatcher:",
 	} {
-		if !keys[want] {
-			t.Fatalf("startup log missing attr %q (got %v)", want, keys)
+		if !strings.Contains(joined, want) {
+			t.Fatalf("startup log missing line %q (got %v)", want, msgs)
 		}
 	}
 }

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -162,22 +162,38 @@ func New(id string, opts ...Option) (*Thresher, error) {
 	return t, nil
 }
 
-// logStartupConfig emits one INFO record naming every resolved engine-level
-// extension by its implementation type, so the wiring is visible at startup
-// (ADR-002 §4.4.1).
+// logStartupConfig prints the engine banner, build metadata and every resolved
+// engine-level extension on its own INFO line, so the full wiring is readable at
+// startup instead of crammed into one dense record (ADR-002 §4.4.1).
 func (t *Thresher) logStartupConfig() {
-	t.cfg.logger.Info("thresher.starting",
-		"id", t.id,
-		"repository", fmt.Sprintf("%T", t.cfg.repository),
-		"logger", fmt.Sprintf("%T", t.cfg.logger),
-		"tracer", fmt.Sprintf("%T", t.cfg.tracer),
-		"metricsRecorder", fmt.Sprintf("%T", t.cfg.metrics),
-		"clock", fmt.Sprintf("%T", t.cfg.clock),
-		"messageBroker", fmt.Sprintf("%T", t.cfg.msgBroker),
-		"expressionEngine", fmt.Sprintf("%T", t.cfg.exprEngine),
-		"authorizationProvider", fmt.Sprintf("%T", t.cfg.authz),
-		"workerDispatcher", fmt.Sprintf("%T", t.cfg.dispatcher),
-	)
+	log := t.cfg.logger
+	bi := readBuildInfo()
+
+	for line := range strings.SplitSeq(banner, "\n") {
+		log.Info(line)
+	}
+
+	log.Info("GoBPM — BPMN v2 process engine")
+	log.Info(fmt.Sprintf("version:     %s", bi.version))
+	log.Info(fmt.Sprintf("last commit: %s (%s)", bi.shortRevision(), bi.revTime))
+	log.Info(fmt.Sprintf("thresher id: %s", t.id))
+
+	module := func(name string, impl any) {
+		log.Info(fmt.Sprintf("  %-22s %T", name+":", impl))
+	}
+
+	log.Info("configuration:")
+	module("repository", t.cfg.repository)
+	module("logger", t.cfg.logger)
+	module("tracer", t.cfg.tracer)
+	module("metricsRecorder", t.cfg.metrics)
+	module("clock", t.cfg.clock)
+	module("messageBroker", t.cfg.msgBroker)
+	module("expressionEngine", t.cfg.exprEngine)
+	module("authorizationProvider", t.cfg.authz)
+	module("workerDispatcher", t.cfg.dispatcher)
+
+	log.Info(separator)
 }
 
 // State returns current state of the Threasher.


### PR DESCRIPTION
## Why

On start, the thresher logged its resolved configuration as one dense `slog` record — `thresher.starting` with nine `key=value` attributes on a single line. It is unreadable in a terminal and gives no version or build provenance.

## What

Startup logging is now emitted line by line at INFO:

- the `goBPM` wordmark banner;
- `version:` — engine semantic version;
- `last commit:` — short revision (`-dirty` when the tree was modified) and commit time;
- `thresher id:`;
- `configuration:` followed by one aligned `name: <impl-type>` line per resolved extension (repository, logger, tracer, metricsRecorder, clock, messageBroker, expressionEngine, authorizationProvider, workerDispatcher);
- a horizontal-rule separator closing the block, setting the startup output apart from the application log that follows.

Version and last commit come from the toolchain-embedded VCS build settings (`vcs.revision` / `vcs.time` / `vcs.modified`) via `runtime/debug.ReadBuildInfo`. Missing data degrades to `unknown`, so startup logging never blocks `New`. The version defaults to a package var overridable with `-ldflags "-X …/pkg/thresher.version=…"`.

## Sample output

```
level=INFO msg="           ___ ___ __  __"
level=INFO msg="  __ _ ___| _ ) _ \\  \\/  |"
level=INFO msg=" / _` / _ \\ _ \\  _/ |\\/| |"
level=INFO msg=" \\__, \\___/___/_| |_|  |_|"
level=INFO msg=" |___/"
level=INFO msg="GoBPM — BPMN v2 process engine"
level=INFO msg="version:     v0.1.1"
level=INFO msg="last commit: f9bf034-dirty (2026-06-13T18:50:42Z)"
level=INFO msg="thresher id: MegaThresher"
level=INFO msg=configuration:
level=INFO msg="  repository:            *memrepo.Repo"
...
level=INFO msg="  workerDispatcher:      *localdispatcher.Dispatcher"
level=INFO msg=────────────────────────────────────────────────────────────
```

## Notes

- The commit reflects the **main module's** VCS (the binary being built): gobpm's own commit when run from the repo, the host application's commit when gobpm is embedded as a dependency. A library cannot recover its own commit from a consumer's binary at runtime.

## Tests

- `TestStartupConfigLog` updated to the line-by-line format.
- New `buildinfo_test.go` covers `shortRevision` (truncation / dirty / short-intact) and `buildInfoFrom` (nil info, empty-version fallback, vcs.* settings) — the parsing was split out of `readBuildInfo` so its branches are deterministically testable.
- `make ci` green; diff-coverage 100% of changed lines; touched files gofmt-clean.

## Files

- `pkg/thresher/buildinfo.go` (new) — banner, separator, build-info resolution.
- `pkg/thresher/thresher.go` — rewritten `logStartupConfig`.
- `pkg/thresher/options_test.go` — updated assertion.
- `pkg/thresher/buildinfo_test.go` (new) — helper tests.
