### PR TITLE
Feat/srd 013 message handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ examples/parallel-gateway/parallel-gateway
 examples/simple-timer/simple-timer
 examples/timer-event/timer-event
 examples/process-data/process-data
+examples/message-send-receive/message-send-receive

--- a/docs/srd/SRD-013-send-receive-tasks.md
+++ b/docs/srd/SRD-013-send-receive-tasks.md
@@ -52,8 +52,8 @@ ADR-014 decided message handling: messages travel the broker, the EventHub stays
 | # | Requirement |
 |---|---|
 | FR-1 | Remove the `service.Operation` field from `SendTask` and `ReceiveTask` (and the now-unused `service` import). No code references it (§1.1). |
-| FR-2 | New public package **`pkg/model/msgflow`**: a `Publish(ctx, re renv.RuntimeEnvironment, msg *bpmncommon.Message) error` helper — bind `msg` from scope (`service.BindInput`), build a `messaging.Envelope{Name: msg.Name(), Payload: <item value>}`, `re.MessageBroker().Publish`. It imports only public packages (`pkg/messaging`, `pkg/renv`, `pkg/model/{bpmncommon,service,data}`); no cycle. |
-| FR-3 | `SendTask` gains `NewSendTask(name, msg, opts…)`, `Exec(ctx, re) ([]*flow.SequenceFlow, error)` (calls `msgflow.Publish`, returns `Outgoing()`), `Clone()`, `TaskType()→flow.SendTask`, and `var _ exec.NodeExecutor = (*SendTask)(nil)`. |
+| FR-2 | New public package **`pkg/model/msgflow`**: a `Send(ctx, re renv.RuntimeEnvironment, msg *bpmncommon.Message) error` helper — bind `msg` from scope (`service.BindInput`), build a `messaging.Envelope{Name: msg.Name(), Payload: <item value>}`, `re.MessageBroker().Publish`. It imports only public packages (`pkg/messaging`, `pkg/renv`, `pkg/model/{bpmncommon,service,data}`); no cycle. |
+| FR-3 | `SendTask` gains `NewSendTask(name, msg, opts…)`, `Exec(ctx, re) ([]*flow.SequenceFlow, error)` (calls `msgflow.Send`, returns `Outgoing()`), `Clone()`, `TaskType()→flow.SendTask`, and `var _ exec.NodeExecutor = (*SendTask)(nil)`. |
 | FR-4 | New **`MessageWaiter`** (`internal/eventproc/eventhub/waiters/message.go`) mirroring `TimerWaiter`: constructed `(hub, ep, eDef, id, rt renv.EngineRuntime)`; `Service(ctx)` subscribes `rt.MessageBroker().Subscribe(ctx, name, "")` and runs a goroutine; on the first matching `Envelope` it reconstructs a typed `data.Data` for the message's `ItemDefinition`, clones the event definition carrying it, and fires `ep.ProcessEvent` (TimerWaiter's lock discipline), then `hub.RemoveWaiter`; `Stop()`/ctx terminate the goroutine and release the subscription. `waiters.go`'s `CreateWaiter` gains `case flow.TriggerMessage`. |
 | FR-5 | `ReceiveTask` implements `flow.EventNode` (synthesizing a `MessageEventDefinition` from its `Message` so `checkNodeType` registers it and parks the track), `eventproc.EventProcessor` (`ProcessEvent` captures the arrived payload into a per-execution field), and `exec.NodeExecutor` (`Exec` `re.Put`s the captured payload as a Ready datum for the message item, returns `Outgoing()`; the inherited `task.UploadData` pushes it to scope). Constructor `NewReceiveTask`, `Clone`, `TaskType()→flow.ReceiveTask`, interface assertions. |
 | FR-6 | Phase-1 correlation: the broker matches on **message name** (empty correlation key). The producer sets `Envelope.Name = msg.Name()` and `Payload` = the bound item's value; the `MessageWaiter` reconstructs a typed datum from `Payload` using the message's `ItemDefinition`. |
@@ -74,13 +74,13 @@ ADR-014 decided message handling: messages travel the broker, the EventHub stays
 
 ```mermaid
 flowchart LR
-    A["SendTask.Exec"] --> B["msgflow.Publish: BindInput(msg) from scope"]
+    A["SendTask.Exec"] --> B["msgflow.Send: BindInput(msg) from scope"]
     B --> C["Envelope{Name, Payload}"]
     C --> D["re.MessageBroker().Publish"]
     D --> E["return Outgoing()"]
 ```
 
-`SendTask` mirrors `ServiceTask`: it never waits (a request/reply is a send node then a receive node — the diagram shows the wait). `msgflow.Publish` is the shared producer choreography the throw message event will also call (next SRD).
+`SendTask` mirrors `ServiceTask`: it never waits (a request/reply is a send node then a receive node — the diagram shows the wait). `msgflow.Send` is the shared producer choreography the throw message event will also call (next SRD).
 
 ### 4.2 Receive: wait (via MessageWaiter) → capture → bind
 
@@ -104,7 +104,7 @@ The broker's `Payload any` meets the typed data plane at the waiter: the produce
 
 ### 4.4 Milestones (each = one commit, `make ci` green)
 
-- **M1 — drop `Operation`; add `msgflow.Publish`.** Remove the vestigial field from both tasks; add `pkg/model/msgflow` with the `Publish` helper. Pure additions/removals; nothing references the field.
+- **M1 — drop `Operation`; add `msgflow.Send`.** Remove the vestigial field from both tasks; add `pkg/model/msgflow` with the `Send` helper. Pure additions/removals; nothing references the field.
 - **M2 — `SendTask` publishes.** `NewSendTask`, `Exec`, `Clone`, `TaskType`, assertion; unit test against an in-memory broker (publish observed).
 - **M3 — `MessageWaiter`.** `waiters/message.go` + the `TriggerMessage` case; waiter unit test mirroring `timer_test.go` (mock `EventProcessor` + in-mem broker; assert fire + cleanup, no leak).
 - **M4 — `ReceiveTask` waits + binds.** `flow.EventNode` + `eventproc.EventProcessor` + `Exec`; implement the node-level `ProcessEvent` (first real one — verify the timer path still works). Integration test: publish then receive, payload reaches scope.
@@ -112,7 +112,7 @@ The broker's `Payload any` meets the typed data plane at the waiter: the produce
 
 ### 4.5 Tests
 
-`pkg/model/msgflow` (Publish against a fake/in-mem broker), `SendTask.Exec` (publishes the bound payload), `MessageWaiter` (fires on envelope, cleans up — mirrors `timer_test.go`), `ReceiveTask` end-to-end (RegisterEvent → waiter → ProcessEvent → Exec → scope-bound), and the example as smoke. Cover the node-level `ProcessEvent` path (latent until now).
+`pkg/model/msgflow` (Send against a fake/in-mem broker), `SendTask.Exec` (publishes the bound payload), `MessageWaiter` (fires on envelope, cleans up — mirrors `timer_test.go`), `ReceiveTask` end-to-end (RegisterEvent → waiter → ProcessEvent → Exec → scope-bound), and the example as smoke. Cover the node-level `ProcessEvent` path (latent until now).
 
 ## 5. Verification (Definition of Done)
 
@@ -153,4 +153,4 @@ The broker's `Payload any` meets the typed data plane at the waiter: the produce
 
 | Version | Date | Author | Change |
 |---|---|---|---|
-| v.1 | 2026-06-15 | Ruslan Gabitov | Draft. Lands the **task half** of ADR-014 v.1: drop the vestigial `service.Operation` from `SendTask`/`ReceiveTask`; `SendTask` binds its message from scope (`service.BindInput`) and publishes an `Envelope` to `re.MessageBroker()` via a new `pkg/model/msgflow.Publish` helper, then completes; a new `MessageWaiter` (peer of `TimerWaiter`, `TriggerMessage` wired) subscribes the broker and fires `ProcessEvent` on arrival, cleaning up its goroutine+subscription on Stop/ctx; `ReceiveTask` becomes a `flow.EventNode` + `eventproc.EventProcessor` + `exec.NodeExecutor` that parks the track, captures the arrived payload (reconstructed typed per the message item), and binds it to scope on resume via the inherited `task.UploadData` — the first real node-level `ProcessEvent`. Phase-1 correlation = match-by-message-name; `Envelope` carries the item value. Five milestones + a send→receive example. Deferred to follow-up SRDs: throw/catch message events + the `MessageProducer`/`MessageConsumer` interface declarations (second implementor; closes the WS-C3 catch-binding TODO), correlation-key derivation, message-triggered instantiation, and the EventHub `WaitGroup` shutdown (ADR-006's SRD). Implements ADR-014 v.1 (task half). |
+| v.1 | 2026-06-15 | Ruslan Gabitov | Draft. Lands the **task half** of ADR-014 v.1: drop the vestigial `service.Operation` from `SendTask`/`ReceiveTask`; `SendTask` binds its message from scope (`service.BindInput`) and publishes an `Envelope` to `re.MessageBroker()` via a new `pkg/model/msgflow.Send` helper, then completes; a new `MessageWaiter` (peer of `TimerWaiter`, `TriggerMessage` wired) subscribes the broker and fires `ProcessEvent` on arrival, cleaning up its goroutine+subscription on Stop/ctx; `ReceiveTask` becomes a `flow.EventNode` + `eventproc.EventProcessor` + `exec.NodeExecutor` that parks the track, captures the arrived payload (reconstructed typed per the message item), and binds it to scope on resume via the inherited `task.UploadData` — the first real node-level `ProcessEvent`. Phase-1 correlation = match-by-message-name; `Envelope` carries the item value. Five milestones + a send→receive example. Deferred to follow-up SRDs: throw/catch message events + the `MessageProducer`/`MessageConsumer` interface declarations (second implementor; closes the WS-C3 catch-binding TODO), correlation-key derivation, message-triggered instantiation, and the EventHub `WaitGroup` shutdown (ADR-006's SRD). Implements ADR-014 v.1 (task half). |

--- a/docs/srd/SRD-013-send-receive-tasks.md
+++ b/docs/srd/SRD-013-send-receive-tasks.md
@@ -1,0 +1,156 @@
+# SRD-013 — SendTask & ReceiveTask: broker-backed message handling (tasks)
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-06-15 |
+| Owner | Ruslan Gabitov |
+| Implements | [ADR-014 v.1 Message Handling](../design/ADR-014-message-handling.md) |
+
+This SRD lands the **task half** of [ADR-014 v.1](../design/ADR-014-message-handling.md): the `SendTask` and `ReceiveTask` executors. A `SendTask` binds its `Message` from scope and **publishes** it to the `MessageBroker`; a `ReceiveTask` registers a new **`MessageWaiter`** that subscribes to the broker and, on arrival, binds the payload into scope and completes. Phase-1 correlation is **match-by-message-name**. The **throw/catch message events** that share ADR-014's producer/consumer seam are a **separate follow-up SRD**; so are correlation-key derivation and message-triggered instantiation (ADR-014 §2.6–§2.8).
+
+## 1. Background & motivation
+
+### 1.1 Current state (verified against the code)
+
+- **`SendTask`/`ReceiveTask` are field-only stubs** — `pkg/model/activities/send_task.go:8`, `receive_task.go:8`. They hold a `Message`, a vestigial `service.Operation`, an `Implementation` string (and `ReceiveTask.Instantiate`), embed `task`, and implement **no executor** (`grep` for `func (st *SendTask)` / `(rt *ReceiveTask)` → none). The `Operation` field has **zero readers** (`grep .Operation` → only `errs.OperationFailed` and the unrelated `MessageEventDefinition.Operation()`); it is safe to remove (ADR-014 §2.8).
+- **The executor pattern is public (SRD-012).** `pkg/exec.NodeExecutor.Exec(ctx, re renv.RuntimeEnvironment) ([]*flow.SequenceFlow, error)`; the reference is `ServiceTask.Exec` (`service_task.go:75`) which binds via `service.BindInput`, `re.Put`s the result, returns `st.Outgoing()`. The embedded `task` already implements `exec.NodeDataConsumer.LoadData`/`NodeDataProducer.UploadData` (`task.go:84/219`) and the output-association push (`updateOutputs`, `task.go:268`) — so a task inherits full data binding once it gains `Exec`.
+- **The broker exists, name-match is already its behaviour.** `pkg/messaging.MessageBroker` — `Publish(ctx, Envelope) error`, `Subscribe(ctx, name, correlationKey string) (<-chan Envelope, error)`; `Envelope{Payload any; Name string; CorrelationKey string}`. `membroker` buffers undelivered envelopes (subscribe-before-publish per ADR-006 §2.4) and matches name + (empty-or-equal key). An executor reaches it via `re.MessageBroker()` (`pkg/renv.EngineRuntime.MessageBroker()`).
+- **`service.BindInput`** (`pkg/model/service/operation.go:252`) reads a `*bpmncommon.Message`'s item from scope by id (Ready-checked) and returns the bound item — the exact send-side bind-from-scope, reusable.
+- **The MessageWaiter is the missing keystone.** `internal/eventproc/eventhub/waiters/waiters.go:47` `CreateWaiter` switches on `eDef.Type()` with **only** a `flow.TriggerTimer` case; `TriggerMessage` falls through to `ObjectNotFound`. The reference is `TimerWaiter` (`timer.go`): constructed with `(hub, ep, eDef, id, rt renv.EngineRuntime)`; `Service(ctx)` spawns a goroutine; on fire it snapshots processors under lock, releases, calls `ep.ProcessEvent(ctx, eDef)` unlocked, then `hub.RemoveWaiter`. Waiters are registered by `EventHub.RegisterEvent` (`eventhub.go:101`, which calls `w.Service`).
+- **The track's event wait/resume loop is in place.** `track.checkNodeType` (`track.go:279`) registers a `flow.EventNode`'s definitions via `instance.RegisterEvent(track, def)` and parks the track in `TrackWaitForEvent`; `track.ProcessEvent` (`track.go:674`) resumes it on fire — it casts the **current node** to `eventproc.EventProcessor` (`track.go:693`) and calls `node.ProcessEvent`, then unregisters and returns the track to `TrackReady`, after which `Exec` runs. **No real model node implements `eventproc.EventProcessor` today** (the cast is latent, exercised only by mocked timer tests) — `ReceiveTask` will be the first.
+- **Output binding reuse.** A node that `re.Put`s a Ready datum has it pushed to scope by the inherited `task.UploadData` through output associations (`oa.UpdateSource`, `association.go:123`) — the same way `ServiceTask` commits its result. No new association API is needed.
+
+### 1.2 Why
+
+ADR-014 decided message handling: messages travel the broker, the EventHub stays the internal wait machine, and a `MessageWaiter` bridges them. The pieces exist (broker, executor pattern, wait/resume loop, data binding) but `SendTask`/`ReceiveTask` are unrunnable and no `MessageWaiter` exists — so a gobpm process cannot send or receive a message. This SRD lands the task executors and the waiter, giving the engine its first cross-participant capability.
+
+## 2. Goals & scope
+
+### 2.1 Goals (in scope)
+
+- **G1.** Drop the vestigial `service.Operation` field from `SendTask`/`ReceiveTask` (ADR-014 §2.8).
+- **G2.** A `SendTask` is an `exec.NodeExecutor` that binds its `Message` from scope and **publishes** an `Envelope` to `re.MessageBroker()`, then completes (synchronous to its lifecycle, no reply-wait).
+- **G3.** A `MessageWaiter` (peer of `TimerWaiter`) subscribes the broker for a message name and fires the event on arrival; the `TriggerMessage` case is wired into the waiter registry. It cleans up its goroutine + subscription on `Stop`/ctx (no leak).
+- **G4.** A `ReceiveTask` is a `flow.EventNode` + `eventproc.EventProcessor` + `exec.NodeExecutor`: it registers a `MessageWaiter`, parks the track, captures the arrived payload on fire, and on resume binds it into scope (reusing `task.UploadData`) and completes.
+- **G5.** Phase-1 correlation = **match-by-message-name** (the broker's default); the `Envelope` carries the message item's value, and the consumer reconstructs a typed datum for the message's `ItemDefinition`.
+- **G6.** The shared producer choreography lands as a helper in a new public `pkg/model/msgflow` package; a runnable send→receive example demonstrates it.
+
+### 2.2 Non-goals (deferred, each with a named home)
+
+- **Throw/catch message events** + the `MessageProducer`/`MessageConsumer` **interface declarations** — the **next SRD** (the message-events landing). The interfaces gain their second implementor there; SRD-013 ships the *shared choreography helper(s)* the events will also call, but not the (single-implementor, non-polymorphic) interfaces. This also closes `catch_upload_test.go`'s WS-C3 TODO there.
+- **Correlation-key derivation** (CorrelationSubscription → key) — a follow-up Correlation SRD (ADR-014 §2.6/§2.8); the `Envelope.CorrelationKey` field already carries a key.
+- **Message-triggered instantiation** (`ReceiveTask.Instantiate` / start message event spawning an instance) — deferred with the thresher message-routing work (ADR-014 §2.7); the `Instantiate` field stays but is not acted on.
+- **EventHub `WaitGroup` sole-ownership shutdown** (ADR-006 §2.5) — ADR-006's own implementing SRD; SRD-013 only guarantees the `MessageWaiter` cleans up *itself* on `Stop`/ctx.
+- **Service-operation-backed send** — the dropped `Operation` field; re-introduced only when needed (ADR-014 §2.8).
+
+## 3. Requirements
+
+### 3.1 Functional
+
+| # | Requirement |
+|---|---|
+| FR-1 | Remove the `service.Operation` field from `SendTask` and `ReceiveTask` (and the now-unused `service` import). No code references it (§1.1). |
+| FR-2 | New public package **`pkg/model/msgflow`**: a `Publish(ctx, re renv.RuntimeEnvironment, msg *bpmncommon.Message) error` helper — bind `msg` from scope (`service.BindInput`), build a `messaging.Envelope{Name: msg.Name(), Payload: <item value>}`, `re.MessageBroker().Publish`. It imports only public packages (`pkg/messaging`, `pkg/renv`, `pkg/model/{bpmncommon,service,data}`); no cycle. |
+| FR-3 | `SendTask` gains `NewSendTask(name, msg, opts…)`, `Exec(ctx, re) ([]*flow.SequenceFlow, error)` (calls `msgflow.Publish`, returns `Outgoing()`), `Clone()`, `TaskType()→flow.SendTask`, and `var _ exec.NodeExecutor = (*SendTask)(nil)`. |
+| FR-4 | New **`MessageWaiter`** (`internal/eventproc/eventhub/waiters/message.go`) mirroring `TimerWaiter`: constructed `(hub, ep, eDef, id, rt renv.EngineRuntime)`; `Service(ctx)` subscribes `rt.MessageBroker().Subscribe(ctx, name, "")` and runs a goroutine; on the first matching `Envelope` it reconstructs a typed `data.Data` for the message's `ItemDefinition`, clones the event definition carrying it, and fires `ep.ProcessEvent` (TimerWaiter's lock discipline), then `hub.RemoveWaiter`; `Stop()`/ctx terminate the goroutine and release the subscription. `waiters.go`'s `CreateWaiter` gains `case flow.TriggerMessage`. |
+| FR-5 | `ReceiveTask` implements `flow.EventNode` (synthesizing a `MessageEventDefinition` from its `Message` so `checkNodeType` registers it and parks the track), `eventproc.EventProcessor` (`ProcessEvent` captures the arrived payload into a per-execution field), and `exec.NodeExecutor` (`Exec` `re.Put`s the captured payload as a Ready datum for the message item, returns `Outgoing()`; the inherited `task.UploadData` pushes it to scope). Constructor `NewReceiveTask`, `Clone`, `TaskType()→flow.ReceiveTask`, interface assertions. |
+| FR-6 | Phase-1 correlation: the broker matches on **message name** (empty correlation key). The producer sets `Envelope.Name = msg.Name()` and `Payload` = the bound item's value; the `MessageWaiter` reconstructs a typed datum from `Payload` using the message's `ItemDefinition`. |
+| FR-7 | A runnable example (`examples/message-send-receive` or equivalent) starts a process with a `SendTask` and a `ReceiveTask` (and the broker) and shows the message flowing end to end, exit 0. |
+
+### 3.2 Non-functional
+
+| # | Requirement |
+|---|---|
+| NFR-1 | The `MessageWaiter`'s goroutine and broker subscription are released on `Stop()` and ctx-cancel — no goroutine/subscription leak (verified by a waiter test). Existing `internal/instance` / `eventhub` / model / thresher suites pass. |
+| NFR-2 | No payload values in logs — log message name, key, item ids, states only (ADR-010/011/014 masking). |
+| NFR-3 | `make ci` green per milestone; diff-coverage ≥95 % (target 100 %) on touched files. |
+| NFR-4 | `pkg/model/msgflow` imports no `internal/*` (depguard); every new exported symbol carries a doc comment; new constructors validate inputs with self-identifying errors. |
+
+## 4. Design & implementation plan
+
+### 4.1 Send: bind → publish
+
+```mermaid
+flowchart LR
+    A["SendTask.Exec"] --> B["msgflow.Publish: BindInput(msg) from scope"]
+    B --> C["Envelope{Name, Payload}"]
+    C --> D["re.MessageBroker().Publish"]
+    D --> E["return Outgoing()"]
+```
+
+`SendTask` mirrors `ServiceTask`: it never waits (a request/reply is a send node then a receive node — the diagram shows the wait). `msgflow.Publish` is the shared producer choreography the throw message event will also call (next SRD).
+
+### 4.2 Receive: wait (via MessageWaiter) → capture → bind
+
+```mermaid
+flowchart TD
+    R["ReceiveTask: flow.EventNode (synthetic MessageEventDefinition)"]
+    R --> CN["track.checkNodeType -> instance.RegisterEvent(track, def)"]
+    CN --> W["MessageWaiter.Service: broker.Subscribe(name)"]
+    W -->|"Envelope arrives"| F["reconstruct typed data; clone def; ep.ProcessEvent"]
+    F --> TP["track.ProcessEvent -> node.(EventProcessor).ProcessEvent captures payload"]
+    TP --> RES["track -> TrackReady -> ReceiveTask.Exec"]
+    RES --> P["re.Put(payload) -> task.UploadData pushes to scope"]
+    P --> O["return Outgoing()"]
+```
+
+`ReceiveTask` plugs into the **existing** wait/resume loop by being a `flow.EventNode` (so `checkNodeType` registers its synthetic `MessageEventDefinition` and parks the track) and an `eventproc.EventProcessor` (so `track.ProcessEvent`'s node cast at `track.go:693` resolves — `ReceiveTask` is the first real node to implement it). No new track path. The payload travels broker → `MessageWaiter` (reconstructs typed data) → cloned event definition → `ProcessEvent` (captures) → `Exec` (`re.Put`) → inherited `task.UploadData` → scope.
+
+### 4.3 The Envelope payload contract (phase-1)
+
+The broker's `Payload any` meets the typed data plane at the waiter: the producer puts the **value** (`item.Structure().Get(ctx)`); the `MessageWaiter` reconstructs a typed `data.Data` for the message's `ItemDefinition` (it has the def via the `MessageEventDefinition`), so the consumer side sees properly-typed data. The `any` opacity is confined to the broker hop.
+
+### 4.4 Milestones (each = one commit, `make ci` green)
+
+- **M1 — drop `Operation`; add `msgflow.Publish`.** Remove the vestigial field from both tasks; add `pkg/model/msgflow` with the `Publish` helper. Pure additions/removals; nothing references the field.
+- **M2 — `SendTask` publishes.** `NewSendTask`, `Exec`, `Clone`, `TaskType`, assertion; unit test against an in-memory broker (publish observed).
+- **M3 — `MessageWaiter`.** `waiters/message.go` + the `TriggerMessage` case; waiter unit test mirroring `timer_test.go` (mock `EventProcessor` + in-mem broker; assert fire + cleanup, no leak).
+- **M4 — `ReceiveTask` waits + binds.** `flow.EventNode` + `eventproc.EventProcessor` + `Exec`; implement the node-level `ProcessEvent` (first real one — verify the timer path still works). Integration test: publish then receive, payload reaches scope.
+- **M5 — example + DoD.** A send→receive example; smoke it (exit 0); coverage gate.
+
+### 4.5 Tests
+
+`pkg/model/msgflow` (Publish against a fake/in-mem broker), `SendTask.Exec` (publishes the bound payload), `MessageWaiter` (fires on envelope, cleans up — mirrors `timer_test.go`), `ReceiveTask` end-to-end (RegisterEvent → waiter → ProcessEvent → Exec → scope-bound), and the example as smoke. Cover the node-level `ProcessEvent` path (latent until now).
+
+## 5. Verification (Definition of Done)
+
+| # | Check | Expectation |
+|---|---|---|
+| V1 | `SendTask`/`ReceiveTask` have no `Operation` field; no dangling refs; `service` import dropped where unused (FR-1). | green |
+| V2 | `SendTask.Exec` binds its message from scope and publishes an `Envelope` to the broker; returns its outgoing flows (FR-2/3). | green |
+| V3 | `MessageWaiter` subscribes the broker, fires `ProcessEvent` on a matching envelope, and releases its goroutine + subscription on `Stop`/ctx (FR-4, NFR-1); `TriggerMessage` is wired. | green |
+| V4 | `ReceiveTask` registers a waiter, parks the track, captures the payload on fire, and binds it into scope on resume (FR-5); the node-level `ProcessEvent` cast resolves. | green |
+| V5 | Phase-1 name-match: a published message with the receiver's name is delivered; the payload is typed per the message item (FR-6). | green |
+| V6 | A send→receive example runs to exit 0; existing suites pass (FR-7, NFR-1). | green |
+| V7 | `make ci` green; diff-coverage ≥95 % on touched files; `msgflow` imports no internal (NFR-3/4). | pass |
+
+## 6. Risks & regressions
+
+- **First real node-level `ProcessEvent`.** The `track.go:693` cast was latent (mock-only). `ReceiveTask` is the first real implementor — M4 verifies the timer path is unaffected and the cast resolves. If a non-EventProcessor catch node ever reaches that path it errors loudly (existing behaviour).
+- **Waiter subscription/goroutine leak.** A `MessageWaiter` that doesn't release its broker subscription + goroutine on `Stop`/ctx leaks (the §2.5 concern, scoped to per-waiter here). NFR-1's test guards it; the full hub `WaitGroup` ownership is ADR-006's SRD.
+- **Payload typing across the broker `any` hop.** A malformed/mistyped payload surfaces when the waiter reconstructs the typed datum — handled with a classified error, not a silent mis-bind (§4.3).
+- **`MessageEventDefinition` cloner.** The payload-carrying fire needs the def to satisfy `flow.EventDefCloner` (`CloneEventDefinition`); verified at M3/M4 (the def currently has `CloneEvent` — confirm the contract or adapt).
+
+## 7. Implementation summary
+
+*Post-landing placeholder — filled at the final audit with files, V-results, and milestone SHAs.*
+
+## 8. References
+
+- [ADR-014 v.1 Message Handling](../design/ADR-014-message-handling.md) — the decision this lands (broker for send, MessageWaiter for receive, the producer/consumer seam, phase-1 name-match); §2.8 deferrals (Operation field, instantiation, correlation derivation); throw/catch message events share the seam (next SRD).
+- [ADR-006 v.1 Events & Subscriptions](../design/ADR-006-events-and-subscriptions.md) — §2.4 delivery (subscribe-before-publish, broker-buffered) and §2.5 waiter lifecycle the `MessageWaiter` obeys; the hub `WaitGroup` ownership is ADR-006's own SRD.
+- [ADR-012 v.1 Execution Layering](../design/ADR-012-execution-layering.md) — the public `pkg/exec`/`pkg/renv` contracts the executors implement.
+- [SRD-012 v.1 Execution layering](SRD-012-execution-layering.md) — published those contracts; `msgflow` and the executors build on them (sideways).
+- [SRD-011 v.1 Go-operation service reader](SRD-011-go-operation-service-reader.md) — `service.BindInput`, reused by the send-side bind (sideways).
+
+## 9. Open questions
+
+- None. The task scope (send=publish / receive=MessageWaiter-subscribe), `ReceiveTask` as a `flow.EventNode`+`EventProcessor` reusing the wait/resume loop (first real node `ProcessEvent`), per-waiter cleanup (hub `WaitGroup` deferred to ADR-006's SRD), the phase-1 name-match + value-payload contract, and **landing the shared producer choreography as a `msgflow` helper while deferring the `MessageProducer`/`MessageConsumer` interfaces to the message-events SRD** (second implementor) are decided above. Throw/catch message events, correlation-key derivation, and instantiation are deferred (§2.2).
+
+## Document History
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v.1 | 2026-06-15 | Ruslan Gabitov | Draft. Lands the **task half** of ADR-014 v.1: drop the vestigial `service.Operation` from `SendTask`/`ReceiveTask`; `SendTask` binds its message from scope (`service.BindInput`) and publishes an `Envelope` to `re.MessageBroker()` via a new `pkg/model/msgflow.Publish` helper, then completes; a new `MessageWaiter` (peer of `TimerWaiter`, `TriggerMessage` wired) subscribes the broker and fires `ProcessEvent` on arrival, cleaning up its goroutine+subscription on Stop/ctx; `ReceiveTask` becomes a `flow.EventNode` + `eventproc.EventProcessor` + `exec.NodeExecutor` that parks the track, captures the arrived payload (reconstructed typed per the message item), and binds it to scope on resume via the inherited `task.UploadData` — the first real node-level `ProcessEvent`. Phase-1 correlation = match-by-message-name; `Envelope` carries the item value. Five milestones + a send→receive example. Deferred to follow-up SRDs: throw/catch message events + the `MessageProducer`/`MessageConsumer` interface declarations (second implementor; closes the WS-C3 catch-binding TODO), correlation-key derivation, message-triggered instantiation, and the EventHub `WaitGroup` shutdown (ADR-006's SRD). Implements ADR-014 v.1 (task half). |

--- a/docs/srd/SRD-013-send-receive-tasks.md
+++ b/docs/srd/SRD-013-send-receive-tasks.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Draft |
+| Status | Accepted |
 | Version | v.1 |
 | Date | 2026-06-15 |
 | Owner | Ruslan Gabitov |
@@ -135,7 +135,35 @@ The broker's `Payload any` meets the typed data plane at the waiter: the produce
 
 ## 7. Implementation summary
 
-*Post-landing placeholder — filled at the final audit with files, V-results, and milestone SHAs.*
+Landed on `feat/srd-013-message-handling` in five milestones (each one commit,
+`make ci` green). `/check-srd` audit: PASS; all V1–V7 met.
+
+### 7.1 Milestones
+
+| M | Commit | Scope | Tests |
+|---|---|---|---|
+| doc | `66c2a79` | SRD-013 (this doc) | — |
+| M1 | `a0c1454` | drop vestigial `Operation` from both tasks; new `pkg/model/msgflow` with `Send` (bind → `Envelope` → `re.MessageBroker().Publish`) | `msgflow` `Send` 100% |
+| M2 | `99294d6` | `SendTask` executor (`NewSendTask`/`Exec`/`Clone`/`TaskType`/accessors + `exec.NodeExecutor`) | `send_task.go` 100% |
+| M3 | `81b39a8` | `MessageWaiter` (peer of `TimerWaiter`) + `TriggerMessage` wired; payload reconstructed and conveyed via `CloneEvent`; per-waiter cleanup; updates the obsolete eventhub limitation test | `message.go` avg 98.6% (2 unreachable defensive branches) |
+| M4 | `106bb05` | `ReceiveTask` = `flow.EventNode` + `eventproc.EventProcessor` + `exec.NodeExecutor` (first real node `ProcessEvent`); binds payload via inherited `task.UploadData` | `receive_task.go` 97.6% |
+| M5 | `f3a3be0` | runnable `examples/message-send-receive` (own module) + instance integration test; **mid-flow event registration fix** in `internal/instance/track.go` (smoke-surfaced) | `track.go` 100% of changed lines; `message_flow_test.go` (V4 end-to-end + negative) |
+
+### 7.2 Key files
+
+- `pkg/model/msgflow/{msgflow,send}.go` — public producer choreography (`Send`).
+- `pkg/model/activities/{send_task,receive_task}.go` — the two executors.
+- `internal/eventproc/eventhub/waiters/message.go` + `waiters.go` — `MessageWaiter` and its registry wiring.
+- `internal/instance/track.go` — `checkNodeType` reorder (wait-before-register) and `checkFlows` mid-flow registration.
+- `examples/message-send-receive/` — runnable demo.
+
+### 7.3 V-results
+
+V1–V7 all green: `Operation` removed (V1); `SendTask.Exec` publishes (V2); `MessageWaiter` fires + cleans up, `TriggerMessage` wired (V3); `ReceiveTask` parks/captures/binds, node `ProcessEvent` resolves (V4); name-match delivery with typed payload (V5); example exits 0 and the suite is green (V6); `make ci` green, diff-coverage 97.0 % (min 95), `msgflow` imports no internal (V7).
+
+### 7.4 Notable delta vs the draft
+
+The §6 risk "intermediate event nodes" surfaced concretely: a mid-flow `ReceiveTask` reached by the token never registered its event, because `checkNodeType` ran only for a track's initial node (`newTrack`). M5 adds the registration at token-advance (`checkFlows`) and reorders `checkNodeType` to declare `TrackWaitForEvent` before registering (so a broker-buffered message delivered synchronously on subscribe is accepted). Start (no-incoming) nodes are unchanged — they still pre-register via `createTracks`. The `MessageEventDefinition` cloner concern (§6) resolved by using its concrete `CloneEvent` method (the `EventDefCloner` interface is unused in the codebase).
 
 ## 8. References
 

--- a/docs/srd/SRD-013-send-receive-tasks.ru.md
+++ b/docs/srd/SRD-013-send-receive-tasks.ru.md
@@ -1,0 +1,184 @@
+# SRD-013 — SendTask и ReceiveTask: обработка сообщений через брокер (задачи)
+
+| Поле | Значение |
+|---|---|
+| Статус | Принято |
+| Версия | v.1 |
+| Дата | 2026-06-15 |
+| Владелец | Руслан Габитов |
+| Реализует | [ADR-014 v.1 Message Handling](../design/ADR-014-message-handling.md) |
+
+Этот SRD приземляет **task-половину** [ADR-014 v.1](../design/ADR-014-message-handling.md): исполнители `SendTask` и `ReceiveTask`. `SendTask` биндит свой `Message` из scope и **публикует** его в `MessageBroker`; `ReceiveTask` регистрирует новый **`MessageWaiter`**, который подписывается на брокер и по приходу биндит payload в scope и завершается. Корреляция фазы 1 — **match-by-message-name**. **Throw/catch message events**, разделяющие producer/consumer-шов ADR-014, — это **отдельный последующий SRD**; равно как и вывод correlation-key и message-triggered инстанцирование (ADR-014 §2.6–§2.8).
+
+## 1. Контекст и мотивация
+
+### 1.1 Текущее состояние (сверено с кодом)
+
+- **`SendTask`/`ReceiveTask` — заглушки, только поля** — `pkg/model/activities/send_task.go:8`, `receive_task.go:8`. Они держат `Message`, рудиментарный `service.Operation`, строку `Implementation` (и `ReceiveTask.Instantiate`), встраивают `task` и **не реализуют исполнителя** (`grep` по `func (st *SendTask)` / `(rt *ReceiveTask)` → пусто). У поля `Operation` **ноль читателей** (`grep .Operation` → только `errs.OperationFailed` и несвязанный `MessageEventDefinition.Operation()`); его безопасно убрать (ADR-014 §2.8).
+- **Паттерн исполнителя публичен (SRD-012).** `pkg/exec.NodeExecutor.Exec(ctx, re renv.RuntimeEnvironment) ([]*flow.SequenceFlow, error)`; референс — `ServiceTask.Exec` (`service_task.go:75`), который биндит через `service.BindInput`, делает `re.Put` результата и возвращает `st.Outgoing()`. Встроенный `task` уже реализует `exec.NodeDataConsumer.LoadData`/`NodeDataProducer.UploadData` (`task.go:84/219`) и output-association push (`updateOutputs`, `task.go:268`) — так что задача наследует полный data-binding, как только получает `Exec`.
+- **Брокер существует, name-match — уже его поведение.** `pkg/messaging.MessageBroker` — `Publish(ctx, Envelope) error`, `Subscribe(ctx, name, correlationKey string) (<-chan Envelope, error)`; `Envelope{Payload any; Name string; CorrelationKey string}`. `membroker` буферизует недоставленные envelope'ы (subscribe-before-publish по ADR-006 §2.4) и матчит по имени + (пустой-или-равный ключ). Исполнитель достаёт его через `re.MessageBroker()` (`pkg/renv.EngineRuntime.MessageBroker()`).
+- **`service.BindInput`** (`pkg/model/service/operation.go:252`) читает item'а `*bpmncommon.Message` из scope по id (с Ready-проверкой) и возвращает связанный item — это ровно тот send-side bind-from-scope, который переиспользуется.
+- **MessageWaiter — недостающий замковый камень.** `internal/eventproc/eventhub/waiters/waiters.go:47` `CreateWaiter` свитчит по `eDef.Type()` **только** с кейсом `flow.TriggerTimer`; `TriggerMessage` проваливается в `ObjectNotFound`. Референс — `TimerWaiter` (`timer.go`): конструируется с `(hub, ep, eDef, id, rt renv.EngineRuntime)`; `Service(ctx)` поднимает горутину; при срабатывании снимает снапшот процессоров под локом, отпускает, вызывает `ep.ProcessEvent(ctx, eDef)` вне лока, затем `hub.RemoveWaiter`. Waiter'ы регистрируются через `EventHub.RegisterEvent` (`eventhub.go:101`, который зовёт `w.Service`).
+- **Цикл ожидания/возобновления события у трека на месте.** `track.checkNodeType` (`track.go:279`) регистрирует определения `flow.EventNode` через `instance.RegisterEvent(track, def)` и паркует трек в `TrackWaitForEvent`; `track.ProcessEvent` (`track.go:674`) возобновляет его при срабатывании — приводит **текущий узел** к `eventproc.EventProcessor` (`track.go:693`) и вызывает `node.ProcessEvent`, затем снимает регистрацию и возвращает трек в `TrackReady`, после чего исполняется `Exec`. **Ни один реальный модельный узел сегодня не реализует `eventproc.EventProcessor`** (приведение латентно, упражняется лишь mock'нутыми timer-тестами) — `ReceiveTask` станет первым.
+- **Переиспользование output-binding'а.** Узел, который делает `re.Put` Ready-данного, получает его проталкивание в scope унаследованным `task.UploadData` через output-ассоциации (`oa.UpdateSource`, `association.go:123`) — тем же путём, что `ServiceTask` коммитит свой результат. Новый association-API не нужен.
+
+### 1.2 Почему
+
+ADR-014 решил обработку сообщений: сообщения ходят через брокер, EventHub остаётся внутренней машиной ожидания, а `MessageWaiter` их мостит. Части существуют (брокер, паттерн исполнителя, цикл ожидания/возобновления, data-binding), но `SendTask`/`ReceiveTask` неисполнимы и `MessageWaiter` нет — поэтому процесс gobpm не может отправить или принять сообщение. Этот SRD приземляет task-исполнителей и waiter'а, давая движку его первую cross-participant-способность.
+
+## 2. Цели и охват
+
+### 2.1 Цели (в охвате)
+
+- **G1.** Убрать рудиментарное поле `service.Operation` у `SendTask`/`ReceiveTask` (ADR-014 §2.8).
+- **G2.** `SendTask` — это `exec.NodeExecutor`, который биндит свой `Message` из scope и **публикует** `Envelope` в `re.MessageBroker()`, затем завершается (синхронно своему жизненному циклу, без ожидания ответа).
+- **G3.** `MessageWaiter` (равноправный `TimerWaiter`) подписывает брокер на имя сообщения и срабатывает по приходу; кейс `TriggerMessage` подключён в реестр waiter'ов. Он чистит свою горутину + подписку по `Stop`/ctx (без утечки).
+- **G4.** `ReceiveTask` — это `flow.EventNode` + `eventproc.EventProcessor` + `exec.NodeExecutor`: он регистрирует `MessageWaiter`, паркует трек, захватывает пришедший payload при срабатывании, а при возобновлении биндит его в scope (переиспользуя `task.UploadData`) и завершается.
+- **G5.** Корреляция фазы 1 = **match-by-message-name** (дефолт брокера); `Envelope` несёт значение item'а сообщения, а consumer реконструирует типизированное данное для `ItemDefinition` сообщения.
+- **G6.** Разделяемая producer-хореография приземляется хелпером в новом публичном пакете `pkg/model/msgflow`; исполнимый send→receive пример её демонстрирует.
+
+### 2.2 Не-цели (отложено, у каждой именованный дом)
+
+- **Throw/catch message events** + **объявления интерфейсов** `MessageProducer`/`MessageConsumer` — **следующий SRD** (приземление message-events). Интерфейсы получают там своего второго реализатора; SRD-013 поставляет *разделяемый(е) хореографический(е) хелпер(ы)*, которые события тоже будут звать, но не сами (одно-реализаторные, не-полиморфные) интерфейсы. Это также закрывает там WS-C3 TODO из `catch_upload_test.go`.
+- **Вывод correlation-key** (CorrelationSubscription → ключ) — последующий Correlation SRD (ADR-014 §2.6/§2.8); поле `Envelope.CorrelationKey` уже несёт ключ.
+- **Message-triggered инстанцирование** (`ReceiveTask.Instantiate` / start message event, порождающий инстанс) — отложено вместе с message-routing-работой thresher'а (ADR-014 §2.7); поле `Instantiate` остаётся, но не обрабатывается.
+- **EventHub `WaitGroup`-shutdown с единоличным владением** (ADR-006 §2.5) — собственный реализующий SRD ADR-006; SRD-013 гарантирует лишь, что `MessageWaiter` чистит *сам себя* по `Stop`/ctx.
+- **Send на базе service-operation** — убранное поле `Operation`; вновь вводится только при необходимости (ADR-014 §2.8).
+
+## 3. Требования
+
+### 3.1 Функциональные
+
+| # | Требование |
+|---|---|
+| FR-1 | Убрать поле `service.Operation` из `SendTask` и `ReceiveTask` (и теперь неиспользуемый импорт `service`). Код на него не ссылается (§1.1). |
+| FR-2 | Новый публичный пакет **`pkg/model/msgflow`**: хелпер `Send(ctx, re renv.RuntimeEnvironment, msg *bpmncommon.Message) error` — биндит `msg` из scope (`service.BindInput`), строит `messaging.Envelope{Name: msg.Name(), Payload: <item value>}`, вызывает `re.MessageBroker().Publish`. Он импортирует только публичные пакеты (`pkg/messaging`, `pkg/renv`, `pkg/model/{bpmncommon,service,data}`); без цикла. |
+| FR-3 | `SendTask` получает `NewSendTask(name, msg, opts…)`, `Exec(ctx, re) ([]*flow.SequenceFlow, error)` (зовёт `msgflow.Send`, возвращает `Outgoing()`), `Clone()`, `TaskType()→flow.SendTask` и `var _ exec.NodeExecutor = (*SendTask)(nil)`. |
+| FR-4 | Новый **`MessageWaiter`** (`internal/eventproc/eventhub/waiters/message.go`), зеркалящий `TimerWaiter`: конструируется `(hub, ep, eDef, id, rt renv.EngineRuntime)`; `Service(ctx)` подписывается `rt.MessageBroker().Subscribe(ctx, name, "")` и крутит горутину; на первом подходящем `Envelope` реконструирует типизированное `data.Data` для `ItemDefinition` сообщения, клонирует event-определение, несущее его, и срабатывает `ep.ProcessEvent` (lock-дисциплина TimerWaiter), затем `hub.RemoveWaiter`; `Stop()`/ctx завершают горутину и отпускают подписку. `CreateWaiter` в `waiters.go` получает `case flow.TriggerMessage`. |
+| FR-5 | `ReceiveTask` реализует `flow.EventNode` (синтезируя `MessageEventDefinition` из своего `Message`, чтобы `checkNodeType` его зарегистрировал и запарковал трек), `eventproc.EventProcessor` (`ProcessEvent` захватывает пришедший payload в поле per-execution) и `exec.NodeExecutor` (`Exec` делает `re.Put` захваченного payload'а как Ready-данного для item'а сообщения, возвращает `Outgoing()`; унаследованный `task.UploadData` проталкивает его в scope). Конструктор `NewReceiveTask`, `Clone`, `TaskType()→flow.ReceiveTask`, interface-ассерты. |
+| FR-6 | Корреляция фазы 1: брокер матчит по **имени сообщения** (пустой correlation-key). Producer ставит `Envelope.Name = msg.Name()` и `Payload` = значение связанного item'а; `MessageWaiter` реконструирует типизированное данное из `Payload`, используя `ItemDefinition` сообщения. |
+| FR-7 | Исполнимый пример (`examples/message-send-receive` или эквивалент) запускает процесс с `SendTask` и `ReceiveTask` (и брокером) и показывает сообщение, проходящее end-to-end, exit 0. |
+
+### 3.2 Нефункциональные
+
+| # | Требование |
+|---|---|
+| NFR-1 | Горутина и broker-подписка `MessageWaiter` отпускаются по `Stop()` и ctx-cancel — без утечки горутины/подписки (проверено waiter-тестом). Существующие наборы `internal/instance` / `eventhub` / model / thresher проходят. |
+| NFR-2 | Никаких значений payload в логах — логировать только имя сообщения, ключ, id item'ов, состояния (маскирование ADR-010/011/014). |
+| NFR-3 | `make ci` зелёный на каждом milestone; diff-coverage ≥95 % (цель 100 %) на затронутых файлах. |
+| NFR-4 | `pkg/model/msgflow` не импортирует `internal/*` (depguard); каждый новый экспортируемый символ несёт doc-комментарий; новые конструкторы валидируют входы само-идентифицирующими ошибками. |
+
+## 4. Дизайн и план реализации
+
+### 4.1 Send: bind → publish
+
+```mermaid
+flowchart LR
+    A["SendTask.Exec"] --> B["msgflow.Send: BindInput(msg) from scope"]
+    B --> C["Envelope{Name, Payload}"]
+    C --> D["re.MessageBroker().Publish"]
+    D --> E["return Outgoing()"]
+```
+
+`SendTask` зеркалит `ServiceTask`: он никогда не ждёт (request/reply — это send-узел, затем receive-узел — диаграмма показывает ожидание). `msgflow.Send` — это разделяемая producer-хореография, которую будет звать и throw message event (следующий SRD).
+
+### 4.2 Receive: ожидание (через MessageWaiter) → захват → bind
+
+```mermaid
+flowchart TD
+    R["ReceiveTask: flow.EventNode (synthetic MessageEventDefinition)"]
+    R --> CN["track.checkNodeType -> instance.RegisterEvent(track, def)"]
+    CN --> W["MessageWaiter.Service: broker.Subscribe(name)"]
+    W -->|"Envelope arrives"| F["reconstruct typed data; clone def; ep.ProcessEvent"]
+    F --> TP["track.ProcessEvent -> node.(EventProcessor).ProcessEvent captures payload"]
+    TP --> RES["track -> TrackReady -> ReceiveTask.Exec"]
+    RES --> P["re.Put(payload) -> task.UploadData pushes to scope"]
+    P --> O["return Outgoing()"]
+```
+
+`ReceiveTask` встраивается в **существующий** цикл ожидания/возобновления, будучи `flow.EventNode` (чтобы `checkNodeType` зарегистрировал его синтетический `MessageEventDefinition` и запарковал трек) и `eventproc.EventProcessor` (чтобы приведение узла в `track.ProcessEvent` на `track.go:693` разрешилось — `ReceiveTask` первый реальный узел, его реализующий). Нового track-пути нет. Payload идёт брокер → `MessageWaiter` (реконструирует типизированное данное) → клонированное event-определение → `ProcessEvent` (захват) → `Exec` (`re.Put`) → унаследованный `task.UploadData` → scope.
+
+### 4.3 Контракт payload'а Envelope (фаза 1)
+
+`Payload any` брокера встречает типизированный data-plane у waiter'а: producer кладёт **значение** (`item.Structure().Get(ctx)`); `MessageWaiter` реконструирует типизированное `data.Data` для `ItemDefinition` сообщения (определение у него есть через `MessageEventDefinition`), так что consumer-сторона видит корректно типизированные данные. Непрозрачность `any` ограничена брокер-хопом.
+
+### 4.4 Milestones (каждый = один коммит, `make ci` зелёный)
+
+- **M1 — убрать `Operation`; добавить `msgflow.Send`.** Удалить рудиментарное поле из обеих задач; добавить `pkg/model/msgflow` с хелпером `Send`. Чистые добавления/удаления; на поле ничего не ссылается.
+- **M2 — `SendTask` публикует.** `NewSendTask`, `Exec`, `Clone`, `TaskType`, ассерт; юнит-тест против in-memory-брокера (publish наблюдается).
+- **M3 — `MessageWaiter`.** `waiters/message.go` + кейс `TriggerMessage`; юнит-тест waiter'а, зеркалящий `timer_test.go` (mock `EventProcessor` + in-mem-брокер; проверка срабатывания + очистки, без утечки).
+- **M4 — `ReceiveTask` ждёт + биндит.** `flow.EventNode` + `eventproc.EventProcessor` + `Exec`; реализовать node-level `ProcessEvent` (первый реальный — проверить, что timer-путь всё ещё работает). Интеграционный тест: publish, затем receive, payload достигает scope.
+- **M5 — пример + DoD.** Пример send→receive; smoke (exit 0); coverage-гейт.
+
+### 4.5 Тесты
+
+`pkg/model/msgflow` (Send против fake/in-mem-брокера), `SendTask.Exec` (публикует связанный payload), `MessageWaiter` (срабатывает на envelope, чистится — зеркалит `timer_test.go`), `ReceiveTask` end-to-end (RegisterEvent → waiter → ProcessEvent → Exec → bound в scope) и пример как smoke. Покрыть node-level-путь `ProcessEvent` (латентный до сих пор).
+
+## 5. Верификация (Definition of Done)
+
+| # | Проверка | Ожидание |
+|---|---|---|
+| V1 | У `SendTask`/`ReceiveTask` нет поля `Operation`; нет висячих ссылок; импорт `service` убран там, где не используется (FR-1). | зелёный |
+| V2 | `SendTask.Exec` биндит своё сообщение из scope и публикует `Envelope` в брокер; возвращает свои исходящие потоки (FR-2/3). | зелёный |
+| V3 | `MessageWaiter` подписывает брокер, срабатывает `ProcessEvent` на подходящем envelope и отпускает свою горутину + подписку по `Stop`/ctx (FR-4, NFR-1); `TriggerMessage` подключён. | зелёный |
+| V4 | `ReceiveTask` регистрирует waiter, паркует трек, захватывает payload при срабатывании и биндит его в scope при возобновлении (FR-5); node-level-приведение `ProcessEvent` разрешается. | зелёный |
+| V5 | Name-match фазы 1: опубликованное сообщение с именем получателя доставлено; payload типизирован по item'у сообщения (FR-6). | зелёный |
+| V6 | Пример send→receive отрабатывает до exit 0; существующие наборы проходят (FR-7, NFR-1). | зелёный |
+| V7 | `make ci` зелёный; diff-coverage ≥95 % на затронутых файлах; `msgflow` не импортирует internal (NFR-3/4). | pass |
+
+## 6. Риски и регрессии
+
+- **Первый реальный node-level `ProcessEvent`.** Приведение на `track.go:693` было латентным (только mock). `ReceiveTask` — первый реальный реализатор — M4 проверяет, что timer-путь не затронут и приведение разрешается. Если не-EventProcessor catch-узел когда-либо дойдёт до этого пути, он громко ошибётся (существующее поведение).
+- **Утечка подписки/горутины waiter'а.** `MessageWaiter`, не отпускающий свою broker-подписку + горутину по `Stop`/ctx, течёт (вопрос §2.5, здесь ограниченный per-waiter). Тест NFR-1 это охраняет; полное `WaitGroup`-владение хабом — SRD ADR-006.
+- **Типизация payload'а через `any`-хоп брокера.** Некорректный/неправильно типизированный payload всплывает, когда waiter реконструирует типизированное данное — обрабатывается классифицированной ошибкой, не тихим mis-bind'ом (§4.3).
+- **Cloner `MessageEventDefinition`.** Несущее payload срабатывание требует, чтобы определение удовлетворяло `flow.EventDefCloner` (`CloneEventDefinition`); проверяется на M3/M4 (у определения сейчас есть `CloneEvent` — подтвердить контракт или адаптировать).
+
+## 7. Сводка реализации
+
+Приземлено на `feat/srd-013-message-handling` в пяти milestone'ах (каждый — один коммит,
+`make ci` зелёный). Аудит `/check-srd`: PASS; все V1–V7 выполнены.
+
+### 7.1 Milestones
+
+| M | Коммит | Охват | Тесты |
+|---|---|---|---|
+| doc | `66c2a79` | SRD-013 (этот документ) | — |
+| M1 | `a0c1454` | убрать рудиментарный `Operation` из обеих задач; новый `pkg/model/msgflow` с `Send` (bind → `Envelope` → `re.MessageBroker().Publish`) | `msgflow` `Send` 100% |
+| M2 | `99294d6` | исполнитель `SendTask` (`NewSendTask`/`Exec`/`Clone`/`TaskType`/аксессоры + `exec.NodeExecutor`) | `send_task.go` 100% |
+| M3 | `81b39a8` | `MessageWaiter` (равноправный `TimerWaiter`) + подключённый `TriggerMessage`; payload реконструируется и передаётся через `CloneEvent`; per-waiter-очистка; обновляет устаревший eventhub limitation-тест | `message.go` в среднем 98.6% (2 недостижимые защитные ветки) |
+| M4 | `106bb05` | `ReceiveTask` = `flow.EventNode` + `eventproc.EventProcessor` + `exec.NodeExecutor` (первый реальный node-level `ProcessEvent`); биндит payload через унаследованный `task.UploadData` | `receive_task.go` 97.6% |
+| M5 | `f3a3be0` | исполнимый `examples/message-send-receive` (свой модуль) + интеграционный тест instance; **фикс регистрации события mid-flow** в `internal/instance/track.go` (всплыл на smoke) | `track.go` 100% изменённых строк; `message_flow_test.go` (V4 end-to-end + негативный) |
+
+### 7.2 Ключевые файлы
+
+- `pkg/model/msgflow/{msgflow,send}.go` — публичная producer-хореография (`Send`).
+- `pkg/model/activities/{send_task,receive_task}.go` — два исполнителя.
+- `internal/eventproc/eventhub/waiters/message.go` + `waiters.go` — `MessageWaiter` и его подключение в реестр.
+- `internal/instance/track.go` — переупорядочивание `checkNodeType` (wait-before-register) и mid-flow-регистрация в `checkFlows`.
+- `examples/message-send-receive/` — исполнимое демо.
+
+### 7.3 Результаты V
+
+V1–V7 все зелёные: `Operation` убран (V1); `SendTask.Exec` публикует (V2); `MessageWaiter` срабатывает + чистится, `TriggerMessage` подключён (V3); `ReceiveTask` паркует/захватывает/биндит, node `ProcessEvent` разрешается (V4); name-match-доставка с типизированным payload'ом (V5); пример завершается с exit 0 и набор зелёный (V6); `make ci` зелёный, diff-coverage 97.0 % (минимум 95), `msgflow` не импортирует internal (V7).
+
+### 7.4 Заметное отклонение от драфта
+
+Риск §6 «промежуточные event-узлы» проявился конкретно: `ReceiveTask` mid-flow, до которого доходит токен, никогда не регистрировал своё событие, потому что `checkNodeType` отрабатывал только для начального узла трека (`newTrack`). M5 добавляет регистрацию на token-advance (`checkFlows`) и переупорядочивает `checkNodeType`, объявляя `TrackWaitForEvent` до регистрации (так что broker-буферизованное сообщение, доставленное синхронно на subscribe, принимается). Start-узлы (без входящих) не изменены — они всё ещё пред-регистрируются через `createTracks`. Вопрос cloner'а `MessageEventDefinition` (§6) разрешён использованием его конкретного метода `CloneEvent` (интерфейс `EventDefCloner` в кодовой базе не используется).
+
+## 8. Ссылки
+
+- [ADR-014 v.1 Message Handling](../design/ADR-014-message-handling.md) — решение, которое этот SRD приземляет (брокер для send, MessageWaiter для receive, producer/consumer-шов, name-match фазы 1); отложенное в §2.8 (поле Operation, инстанцирование, вывод корреляции); throw/catch message events разделяют шов (следующий SRD).
+- [ADR-006 v.1 Events & Subscriptions](../design/ADR-006-events-and-subscriptions.md) — §2.4 доставка (subscribe-before-publish, broker-буферизация) и §2.5 жизненный цикл waiter'а, которому подчиняется `MessageWaiter`; `WaitGroup`-владение хабом — собственный SRD ADR-006.
+- [ADR-012 v.1 Execution Layering](../design/ADR-012-execution-layering.ru.md) — публичные контракты `pkg/exec`/`pkg/renv`, которые реализуют исполнители.
+- [SRD-012 v.1 Execution layering](SRD-012-execution-layering.ru.md) — опубликовал эти контракты; `msgflow` и исполнители строятся на них (боковая ссылка).
+- [SRD-011 v.1 Go-operation service reader](SRD-011-go-operation-service-reader.ru.md) — `service.BindInput`, переиспользуется send-стороной для bind (боковая ссылка).
+
+## 9. Открытые вопросы
+
+- Нет. Охват задач (send=publish / receive=MessageWaiter-subscribe), `ReceiveTask` как `flow.EventNode`+`EventProcessor`, переиспользующий цикл ожидания/возобновления (первый реальный node `ProcessEvent`), per-waiter-очистка (`WaitGroup` хаба отложен до SRD ADR-006), контракт name-match фазы 1 + value-payload, и **приземление разделяемой producer-хореографии хелпером `msgflow` с отсрочкой интерфейсов `MessageProducer`/`MessageConsumer` до message-events SRD** (второй реализатор) решены выше. Throw/catch message events, вывод correlation-key и инстанцирование отложены (§2.2).
+
+## История документа
+
+| Версия | Дата | Автор | Изменение |
+|---|---|---|---|
+| v.1 | 2026-06-15 | Руслан Габитов | Драфт. Приземляет **task-половину** ADR-014 v.1: убирает рудиментарный `service.Operation` из `SendTask`/`ReceiveTask`; `SendTask` биндит своё сообщение из scope (`service.BindInput`) и публикует `Envelope` в `re.MessageBroker()` через новый хелпер `pkg/model/msgflow.Send`, затем завершается; новый `MessageWaiter` (равноправный `TimerWaiter`, подключён `TriggerMessage`) подписывает брокер и срабатывает `ProcessEvent` по приходу, чистя свою горутину+подписку по Stop/ctx; `ReceiveTask` становится `flow.EventNode` + `eventproc.EventProcessor` + `exec.NodeExecutor`, который паркует трек, захватывает пришедший payload (реконструированный типизированно по item'у сообщения) и биндит его в scope при возобновлении через унаследованный `task.UploadData` — первый реальный node-level `ProcessEvent`. Корреляция фазы 1 = match-by-message-name; `Envelope` несёт значение item'а. Пять milestone'ов + пример send→receive. Отложено в последующие SRD: throw/catch message events + объявления интерфейсов `MessageProducer`/`MessageConsumer` (второй реализатор; закрывает WS-C3 catch-binding TODO), вывод correlation-key, message-triggered инстанцирование и EventHub `WaitGroup`-shutdown (SRD ADR-006). Реализует ADR-014 v.1 (task-половина). |

--- a/examples/message-send-receive/go.mod
+++ b/examples/message-send-receive/go.mod
@@ -1,0 +1,11 @@
+module message-send-receive
+
+go 1.25
+
+toolchain go1.25.11
+
+replace github.com/dr-dobermann/gobpm => ../..
+
+require github.com/dr-dobermann/gobpm v0.0.0-00010101000000-000000000000
+
+require golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d // indirect

--- a/examples/message-send-receive/go.sum
+++ b/examples/message-send-receive/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d h1:N0hmiNbwsSNwHBAvR3QB5w25pUwH4tK0Y/RltD1j1h4=
+golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/message-send-receive/main.go
+++ b/examples/message-send-receive/main.go
@@ -1,0 +1,206 @@
+// Command message-send-receive demonstrates broker-backed message handling
+// (SRD-013 / ADR-014 v.1): a SendTask binds a process property and publishes it
+// to the engine's MessageBroker; downstream a ReceiveTask waits for that message
+// through a MessageWaiter, and on arrival binds the payload into scope, where an
+// output association lands it in a DataObject.
+//
+//	start ─> send-order ─> receive-order ─> confirm ─> end
+//	         (publishes      (waits on the      (signals
+//	          "order         broker, binds       completion)
+//	          placed")        the payload)
+//
+// The tasks live on one track, so the send completes before the receive
+// subscribes; the in-memory broker buffers the published message until then.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	dataobjects "github.com/dr-dobermann/gobpm/pkg/model/data_objects"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/model/service/gooper"
+	"github.com/dr-dobermann/gobpm/pkg/thresher"
+)
+
+const orderID = "ORD-2026-001"
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	if err := data.CreateDefaultStates(); err != nil {
+		return fmt.Errorf("create default states: %w", err)
+	}
+
+	engine, err := thresher.New("message-demo-engine")
+	if err != nil {
+		return fmt.Errorf("create engine: %w", err)
+	}
+
+	// the payload the SendTask reads from the instance scope and publishes.
+	proc, err := process.New("message-demo",
+		data.WithProperties(
+			data.MustProperty("order_out",
+				data.MustItemDefinition(
+					values.NewVariable(orderID),
+					foundation.WithID("order_out")),
+				data.ReadyDataState)))
+	if err != nil {
+		return fmt.Errorf("create process: %w", err)
+	}
+
+	start, err := events.NewStartEvent("start")
+	if err != nil {
+		return fmt.Errorf("create start: %w", err)
+	}
+
+	// SendTask: binds the "order_out" property and publishes it as the
+	// "order placed" message.
+	send, err := activities.NewSendTask("send-order",
+		bpmncommon.MustMessage("order placed",
+			data.MustItemDefinition(values.NewVariable(""),
+				foundation.WithID("order_out"))),
+		activities.WithoutParams())
+	if err != nil {
+		return fmt.Errorf("create send task: %w", err)
+	}
+
+	// ReceiveTask: waits for the "order placed" message and binds its payload
+	// into "order_in", which the output association lands in the DataObject.
+	outParam := data.MustParameter("received order",
+		data.MustItemAwareElement(
+			data.MustItemDefinition(values.NewVariable(""),
+				foundation.WithID("order_in")),
+			data.UnavailableDataState))
+
+	receive, err := activities.NewReceiveTask("receive-order",
+		bpmncommon.MustMessage("order placed",
+			data.MustItemDefinition(values.NewVariable(""),
+				foundation.WithID("order_in"))),
+		activities.WithParameters(data.Output, outParam))
+	if err != nil {
+		return fmt.Errorf("create receive task: %w", err)
+	}
+
+	receivedDO, err := dataobjects.New("received-order",
+		data.MustItemDefinition(values.NewVariable(""),
+			foundation.WithID("order_in")),
+		nil)
+	if err != nil {
+		return fmt.Errorf("create result object: %w", err)
+	}
+
+	if err := receivedDO.AssociateSource(
+		receive, []string{"order_in"}, nil); err != nil {
+		return fmt.Errorf("bind result object: %w", err)
+	}
+
+	// confirm: a trailing ServiceTask that signals completion once the receive
+	// has resumed, so main can read the DataObject without racing the engine.
+	done := make(chan struct{})
+
+	confirmOp, err := gooper.New("confirm-op",
+		func(_ context.Context, _ service.DataReader,
+			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			close(done)
+
+			return nil, nil
+		})
+	if err != nil {
+		return fmt.Errorf("create confirm operation: %w", err)
+	}
+
+	confirm, err := activities.NewServiceTask("confirm", confirmOp,
+		activities.WithoutParams())
+	if err != nil {
+		return fmt.Errorf("create confirm task: %w", err)
+	}
+
+	end, err := events.NewEndEvent("end")
+	if err != nil {
+		return fmt.Errorf("create end: %w", err)
+	}
+
+	for _, e := range []flow.Element{start, send, receive, confirm, end} {
+		if err := proc.Add(e); err != nil {
+			return fmt.Errorf("add element: %w", err)
+		}
+	}
+
+	for _, l := range [][2]flow.Element{
+		{start, send}, {send, receive}, {receive, confirm}, {confirm, end},
+	} {
+		if err := link(l[0], l[1]); err != nil {
+			return err
+		}
+	}
+
+	if err := engine.RegisterProcess(proc); err != nil {
+		return fmt.Errorf("register process: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := engine.Run(ctx); err != nil {
+		return fmt.Errorf("run engine: %w", err)
+	}
+
+	if err := engine.StartProcess(proc.ID()); err != nil {
+		return fmt.Errorf("start process: %w", err)
+	}
+
+	select {
+	case <-done:
+	case <-ctx.Done():
+		return fmt.Errorf("timed out waiting for the message round-trip")
+	}
+
+	// brief grace for the receive producer stage to commit into the DataObject.
+	time.Sleep(200 * time.Millisecond)
+
+	got, ok := receivedDO.Subject().Structure().Get(context.Background()).(string)
+	if !ok || got != orderID {
+		return fmt.Errorf("received-order: want %q, got %v", orderID, got)
+	}
+
+	fmt.Printf("  ✓ send-order published %q\n", orderID)
+	fmt.Printf("  ✓ receive-order bound it into received-order = %q\n", got)
+	fmt.Println("✓ message-demo completed: the message travelled the broker " +
+		"from the SendTask to the ReceiveTask")
+
+	return nil
+}
+
+// link wires src -> trg with a sequence flow.
+func link(src, trg flow.Element) error {
+	s, ok := src.(flow.SequenceSource)
+	if !ok {
+		return fmt.Errorf("%q is not a sequence source", src.Name())
+	}
+
+	t, ok := trg.(flow.SequenceTarget)
+	if !ok {
+		return fmt.Errorf("%q is not a sequence target", trg.Name())
+	}
+
+	if _, err := flow.Link(s, t); err != nil {
+		return fmt.Errorf("link: %w", err)
+	}
+
+	return nil
+}

--- a/internal/eventproc/eventhub/eventhub_message_test.go
+++ b/internal/eventproc/eventhub/eventhub_message_test.go
@@ -2,71 +2,42 @@ package eventhub_test
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
 	"github.com/dr-dobermann/gobpm/internal/enginert"
 	"github.com/dr-dobermann/gobpm/internal/eventproc/eventhub"
-	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/events"
 	"github.com/stretchr/testify/require"
 )
 
-// TestMessageEvents тестирует поддержку Message событий
-// В настоящее время waiters не поддерживает Message события,
-// поэтому эти тесты демонстрируют текущие ограничения
-func TestMessageEvents_CurrentLimitations(t *testing.T) {
-	t.Run("message event registration fails - waiter not implemented", func(t *testing.T) {
-		hub, err := eventhub.New(enginert.Default())
-		require.NoError(t, err)
+// TestMessageEvents covers Message event support: since SRD-013 added the
+// MessageWaiter (ADR-014 v.1), registering a message event now succeeds — the
+// hub builds a MessageWaiter that subscribes the broker. Event propagation to
+// the processor is covered by the waiters package (TestMessageWaiterDelivery)
+// and, end to end through a node, by the ReceiveTask tests.
+func TestMessageEvents(t *testing.T) {
+	t.Run("message event registration succeeds with the MessageWaiter",
+		func(t *testing.T) {
+			hub, err := eventhub.New(enginert.Default())
+			require.NoError(t, err)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		require.NoError(t, hub.Start(ctx))
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			require.NoError(t, hub.Start(ctx))
 
-		mockProcessor := mockeventproc.NewMockEventProcessor(t)
-		mockProcessor.EXPECT().ID().Return("message-processor-id")
+			mockProcessor := mockeventproc.NewMockEventProcessor(t)
+			mockProcessor.EXPECT().ID().Return("message-processor-id").Maybe()
 
-		// Create a message event definition
-		message := bpmncommon.MustMessage("test-message", data.MustItemDefinition(nil))
-		messageEvent, err := events.NewMessageEventDefinition(message, nil)
-		require.NoError(t, err)
+			message := bpmncommon.MustMessage("test-message",
+				data.MustItemDefinition(nil))
+			messageEvent, err := events.NewMessageEventDefinition(message, nil)
+			require.NoError(t, err)
 
-		// Registration should fail because waiters doesn't support Message events yet
-		err = hub.RegisterEvent(mockProcessor, messageEvent)
-		require.Error(t, err)
-
-		// RegisterEvent wraps the builder failure in its own classified
-		// error (FIX-003 §3.2.1) — the caller sees BUILDING_FAILED, and the
-		// inner WAITERS_ERROR/OBJECT_NOT_FOUND chain (the unsupported
-		// trigger) is preserved in the message.
-		var ae *errs.ApplicationError
-
-		require.True(t, errors.As(err, &ae))
-		require.True(t, ae.HasClass(errs.BulidingFailed),
-			"registration failure must be classified BUILDING_FAILED")
-		require.Contains(t, err.Error(), errs.ObjectNotFound,
-			"inner builder error preserved (no matching trigger)")
-		require.Contains(t, err.Error(), "of type Message")
-	})
+			require.NoError(t, hub.RegisterEvent(mockProcessor, messageEvent))
+			require.NoError(t,
+				hub.UnregisterEvent(mockProcessor, messageEvent.ID()))
+		})
 }
-
-// TODO: После добавления поддержки Message событий в waiters package,
-// добавить следующие тесты:
-//
-// func TestMessageEvents_WithWaiterSupport(t *testing.T) {
-//     t.Run("successful message event registration", func(t *testing.T) {
-//         // Test successful registration
-//     })
-//
-//     t.Run("message event propagation", func(t *testing.T) {
-//         // Test event propagation to registered processors
-//     })
-//
-//     t.Run("message event unregistration", func(t *testing.T) {
-//         // Test event unregistration
-//     })
-// }

--- a/internal/eventproc/eventhub/waiters/message.go
+++ b/internal/eventproc/eventhub/waiters/message.go
@@ -1,0 +1,309 @@
+package waiters
+
+import (
+	"context"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/dr-dobermann/gobpm/internal/eventproc"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/messaging"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/renv"
+)
+
+// MessageWaiterError classifies messageWaiter failures.
+const MessageWaiterError = "MESSAGE_WAITER_ERROR"
+
+// messageWaiter bridges the MessageBroker to the EventHub (ADR-014 v.1): it
+// subscribes the broker for its message name and, on the first matching
+// envelope, fires the event (carrying the payload) to the registered
+// processors, then removes itself from the hub. It is one-shot — a single
+// message resumes the waiting node.
+type messageWaiter struct {
+	hub        eventproc.EventHub
+	rt         renv.EngineRuntime
+	eDef       *events.MessageEventDefinition
+	stopCh     chan struct{}
+	name       string
+	id         string
+	processors []eventproc.EventProcessor
+	state      eventproc.EventWaiterState
+	m          sync.Mutex
+}
+
+// NewMessageWaiter builds a messageWaiter for a MessageEventDefinition. It
+// rejects empty dependencies and a non-message event definition.
+func NewMessageWaiter(
+	eh eventproc.EventHub,
+	ep eventproc.EventProcessor,
+	eDefI flow.EventDefinition,
+	id string,
+	rt renv.EngineRuntime,
+) (eventproc.EventWaiter, error) {
+	if ep == nil || eDefI == nil || eh == nil || rt == nil {
+		return nil,
+			errs.New(
+				errs.M("couldn't create a Waiter with empty EventProcessor, "+
+					"EventDefinition, EventHub or EngineRuntime"),
+				errs.C(MessageWaiterError,
+					errs.InvalidParameter, errs.EmptyNotAllowed))
+	}
+
+	eDef, ok := eDefI.(*events.MessageEventDefinition)
+	if !ok {
+		return nil,
+			errs.New(
+				errs.M("not a MessageEventDefinition"),
+				errs.C(MessageWaiterError, errs.TypeCastingError),
+				errs.D("event_definition_type", reflect.TypeOf(eDefI)))
+	}
+
+	msg := eDef.Message()
+	if msg == nil {
+		return nil,
+			errs.New(
+				errs.M("MessageEventDefinition has no message"),
+				errs.C(MessageWaiterError, errs.EmptyNotAllowed),
+				errs.D("event_definition_id", eDef.ID()))
+	}
+
+	id = strings.TrimSpace(id)
+	if id == "" {
+		id = foundation.GenerateID()
+	}
+
+	return &messageWaiter{
+		id:         id,
+		name:       msg.Name(),
+		eDef:       eDef,
+		hub:        eh,
+		rt:         rt,
+		processors: []eventproc.EventProcessor{ep},
+		state:      eventproc.WSReady,
+	}, nil
+}
+
+// ID returns the waiter id.
+func (mw *messageWaiter) ID() string {
+	return mw.id
+}
+
+// EventDefinition returns the message event definition the waiter waits for.
+func (mw *messageWaiter) EventDefinition() flow.EventDefinition {
+	return mw.eDef
+}
+
+// AddEventProcessor adds ep to the waiter's processor list (idempotent).
+func (mw *messageWaiter) AddEventProcessor(ep eventproc.EventProcessor) error {
+	if ep == nil {
+		return errs.New(
+			errs.M("empty EventProcessor isn't allowed"),
+			errs.C(MessageWaiterError, errs.EmptyNotAllowed))
+	}
+
+	mw.m.Lock()
+	defer mw.m.Unlock()
+
+	if idx := slices.Index(mw.processors, ep); idx == -1 {
+		mw.processors = append(mw.processors, ep)
+	}
+
+	return nil
+}
+
+// RemoveEventProcessor removes ep from the waiter's processor list.
+func (mw *messageWaiter) RemoveEventProcessor(ep eventproc.EventProcessor) error {
+	if ep == nil {
+		return errs.New(
+			errs.M("empty EventProcessor isn't allowed"),
+			errs.C(MessageWaiterError, errs.EmptyNotAllowed))
+	}
+
+	mw.m.Lock()
+	defer mw.m.Unlock()
+
+	idx := slices.Index(mw.processors, ep)
+	if idx == -1 {
+		return errs.New(
+			errs.M("event processor isn't registered with the waiter"),
+			errs.C(MessageWaiterError, errs.ObjectNotFound),
+			errs.D("waiter_id", mw.id),
+			errs.D("event_processor_id", ep.ID()))
+	}
+
+	mw.processors = slices.Delete(mw.processors, idx, idx+1)
+
+	return nil
+}
+
+// EventProcessors returns the waiter's registered processors.
+func (mw *messageWaiter) EventProcessors() []eventproc.EventProcessor {
+	mw.m.Lock()
+	defer mw.m.Unlock()
+
+	return mw.processors
+}
+
+// Process isn't used by the messageWaiter: messages arrive through the broker
+// subscription, not through the EventHub propagation path.
+func (mw *messageWaiter) Process(eDef flow.EventDefinition) error {
+	return errs.New(
+		errs.M("messageWaiter doesn't process propagated EventDefinitions"),
+		errs.C(MessageWaiterError, errs.InvalidState),
+		errs.D("event_definition_id", eDef.ID()),
+		errs.D("event_definition_type", eDef.Type()))
+}
+
+// Service subscribes the broker for the waiter's message name and starts the
+// delivery goroutine. The subscription is registered synchronously, so a
+// message published after Service returns is delivered (subscribe-before-
+// publish, ADR-006 v.1 §2.4).
+func (mw *messageWaiter) Service(ctx context.Context) error {
+	if mw.state != eventproc.WSReady {
+		return errs.New(
+			errs.M("waiter isn't ready to start"),
+			errs.C(MessageWaiterError, errs.InvalidState),
+			errs.D("current_state", mw.state))
+	}
+
+	ch, err := mw.rt.MessageBroker().Subscribe(ctx, mw.name, "")
+	if err != nil {
+		mw.state = eventproc.WSFailed
+
+		return errs.New(
+			errs.M("couldn't subscribe to the message broker"),
+			errs.C(MessageWaiterError, errs.OperationFailed),
+			errs.D("message_name", mw.name),
+			errs.E(err))
+	}
+
+	mw.state = eventproc.WSRunned
+	mw.stopCh = make(chan struct{})
+
+	go mw.runMessageService(ctx, ch)
+
+	return nil
+}
+
+// runMessageService waits for the first matching envelope (or a stop/cancel)
+// and resumes the waiting node. The waiter is one-shot: it returns after the
+// first delivered message.
+func (mw *messageWaiter) runMessageService(
+	ctx context.Context,
+	ch <-chan messaging.Envelope,
+) {
+	select {
+	case <-ctx.Done():
+		mw.setState(eventproc.WSStopped)
+
+	case <-mw.stopCh:
+		mw.rt.Logger().Debug("message waiter stopping", "waiter_id", mw.id)
+
+	case env, ok := <-ch:
+		if !ok {
+			mw.setState(eventproc.WSStopped)
+
+			return
+		}
+
+		_ = mw.processMessageEvent(ctx, env)
+	}
+}
+
+// processMessageEvent fires the payload-carrying event to every registered
+// processor, then removes the waiter from the hub.
+func (mw *messageWaiter) processMessageEvent(
+	ctx context.Context,
+	env messaging.Envelope,
+) error {
+	eDef, err := mw.fireDefinition(env)
+	if err != nil {
+		mw.setState(eventproc.WSFailed)
+
+		return err
+	}
+
+	mw.m.Lock()
+	processors := append([]eventproc.EventProcessor(nil), mw.processors...)
+	mw.m.Unlock()
+
+	for _, ep := range processors {
+		if err := ep.ProcessEvent(ctx, eDef); err != nil {
+			mw.setState(eventproc.WSFailed)
+
+			return err
+		}
+	}
+
+	mw.m.Lock()
+	mw.processors = []eventproc.EventProcessor{}
+	mw.state = eventproc.WSEnded
+	mw.m.Unlock()
+
+	_ = mw.hub.RemoveWaiter(mw.eDef.ID()) // ignore error during cleanup
+
+	return nil
+}
+
+// fireDefinition builds the event definition delivered to the processors: the
+// broker payload is reconstructed as a typed, Ready datum for the message's
+// item (ADR-014 v.1 §2.6) and woven into a cloned definition. Phase-1 messages
+// always carry an item (bpmncommon.NewMessage invariant); the datum building
+// uses the Must* constructors as ServiceTask.Exec does on its result path.
+func (mw *messageWaiter) fireDefinition(
+	env messaging.Envelope,
+) (flow.EventDefinition, error) {
+	item := mw.eDef.Message().Item()
+
+	datum := data.MustParameter(item.ID(),
+		data.MustItemAwareElement(
+			data.MustItemDefinition(
+				values.NewVariable(env.Payload),
+				foundation.WithID(item.ID())),
+			data.ReadyDataState))
+
+	return mw.eDef.CloneEvent([]data.Data{datum})
+}
+
+// Stop terminates the delivery goroutine of a running waiter.
+func (mw *messageWaiter) Stop() error {
+	mw.m.Lock()
+	defer mw.m.Unlock()
+
+	if mw.state != eventproc.WSRunned {
+		return errs.New(
+			errs.M("couldn't stop a not-runned waiter"),
+			errs.C(MessageWaiterError, errs.InvalidState),
+			errs.D("current_state", mw.state))
+	}
+
+	mw.state = eventproc.WSStopped
+
+	close(mw.stopCh)
+
+	return nil
+}
+
+// State returns the current waiter state.
+func (mw *messageWaiter) State() eventproc.EventWaiterState {
+	mw.m.Lock()
+	defer mw.m.Unlock()
+
+	return mw.state
+}
+
+// setState updates the waiter state under the lock.
+func (mw *messageWaiter) setState(s eventproc.EventWaiterState) {
+	mw.m.Lock()
+	mw.state = s
+	mw.m.Unlock()
+}
+
+var _ eventproc.EventWaiter = (*messageWaiter)(nil)

--- a/internal/eventproc/eventhub/waiters/message_test.go
+++ b/internal/eventproc/eventhub/waiters/message_test.go
@@ -1,0 +1,250 @@
+package waiters_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/internal/enginert"
+	"github.com/dr-dobermann/gobpm/internal/eventproc"
+	"github.com/dr-dobermann/gobpm/internal/eventproc/eventhub/waiters"
+	"github.com/dr-dobermann/gobpm/pkg/messaging"
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/renv"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// msgEventDef builds a "order placed" MessageEventDefinition carrying an item.
+func msgEventDef(t *testing.T) *events.MessageEventDefinition {
+	t.Helper()
+
+	return events.MustMessageEventDefinition(
+		bpmncommon.MustMessage("order placed",
+			data.MustItemDefinition(values.NewVariable(""),
+				foundation.WithID("order_item"))),
+		nil)
+}
+
+// brokerRT overrides the message broker of an embedded EngineRuntime so a test
+// can drive the subscription channel (closed/erroring) deterministically.
+type brokerRT struct {
+	renv.EngineRuntime
+	broker messaging.MessageBroker
+}
+
+func (b brokerRT) MessageBroker() messaging.MessageBroker { return b.broker }
+
+// closedChBroker returns an already-closed subscription channel.
+type closedChBroker struct{}
+
+func (closedChBroker) Publish(context.Context, messaging.Envelope) error { return nil }
+
+func (closedChBroker) Subscribe(
+	context.Context, string, string,
+) (<-chan messaging.Envelope, error) {
+	ch := make(chan messaging.Envelope)
+	close(ch)
+
+	return ch, nil
+}
+
+// errSubBroker fails on Subscribe.
+type errSubBroker struct{}
+
+func (errSubBroker) Publish(context.Context, messaging.Envelope) error { return nil }
+
+func (errSubBroker) Subscribe(
+	context.Context, string, string,
+) (<-chan messaging.Envelope, error) {
+	return nil, fmt.Errorf("broker down")
+}
+
+func TestNewMessageWaiterErrors(t *testing.T) {
+	ep := mockeventproc.NewMockEventProcessor(t)
+	hub := mockeventproc.NewMockEventHub(t)
+
+	_, err := waiters.NewMessageWaiter(nil, nil, nil, "", nil)
+	require.Error(t, err)
+
+	_, err = waiters.NewMessageWaiter(hub, ep,
+		events.MustSignalEventDefinition(&events.Signal{}), "",
+		enginert.Default())
+	require.Error(t, err)
+}
+
+func TestMessageWaiterCreate(t *testing.T) {
+	ep := mockeventproc.NewMockEventProcessor(t)
+	hub := mockeventproc.NewMockEventHub(t)
+	eDef := msgEventDef(t)
+
+	w, err := waiters.CreateWaiter(hub, ep, eDef, enginert.Default())
+	require.NoError(t, err)
+	require.Equal(t, eventproc.WSReady, w.State())
+	require.NotEmpty(t, w.ID())
+	require.Contains(t, w.EventProcessors(), ep)
+	require.Equal(t, eDef, w.EventDefinition())
+
+	// not running yet → Stop fails, Process is unsupported.
+	require.Error(t, w.Stop())
+	require.Error(t, w.Process(eDef))
+}
+
+func TestMessageWaiterProcessors(t *testing.T) {
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep2 := mockeventproc.NewMockEventProcessor(t)
+	ep2.EXPECT().ID().Return("ep2").Maybe()
+	hub := mockeventproc.NewMockEventHub(t)
+
+	w, err := waiters.NewMessageWaiter(hub, ep, msgEventDef(t), "",
+		enginert.Default())
+	require.NoError(t, err)
+
+	require.Error(t, w.AddEventProcessor(nil))
+	require.NoError(t, w.AddEventProcessor(ep2))
+	require.NoError(t, w.AddEventProcessor(ep2)) // idempotent
+	require.Len(t, w.EventProcessors(), 2)
+
+	require.Error(t, w.RemoveEventProcessor(nil))
+	require.NoError(t, w.RemoveEventProcessor(ep2))
+	require.Error(t, w.RemoveEventProcessor(ep2)) // already gone
+	require.Len(t, w.EventProcessors(), 1)
+}
+
+func TestMessageWaiterDelivery(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	ctx := context.Background()
+	eDef := msgEventDef(t)
+
+	rt := enginert.Default()
+	hub := mockeventproc.NewMockEventHub(t)
+	hub.EXPECT().RemoveWaiter(eDef.ID()).Return(nil).Once()
+
+	done := make(chan flow.EventDefinition, 1)
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().
+		ProcessEvent(mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, ed flow.EventDefinition) error {
+			done <- ed
+
+			return nil
+		})
+
+	w, err := waiters.NewMessageWaiter(hub, ep, eDef, "", rt)
+	require.NoError(t, err)
+	require.NoError(t, w.Service(ctx))
+
+	require.NoError(t, rt.MessageBroker().Publish(ctx,
+		messaging.Envelope{Name: "order placed", Payload: "ORD-9"}))
+
+	select {
+	case ed := <-done:
+		items := ed.GetItemsList()
+		require.Len(t, items, 1)
+		require.Equal(t, "ORD-9", items[0].Structure().Get(ctx))
+	case <-time.After(2 * time.Second):
+		t.Fatal("message was not delivered to the processor")
+	}
+
+	require.Eventually(t, func() bool {
+		return w.State() == eventproc.WSEnded
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestMessageWaiterProcessEventError(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	ctx := context.Background()
+
+	rt := enginert.Default()
+	hub := mockeventproc.NewMockEventHub(t)
+
+	released := make(chan struct{})
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().
+		ProcessEvent(mock.Anything, mock.Anything).
+		RunAndReturn(func(context.Context, flow.EventDefinition) error {
+			close(released)
+
+			return fmt.Errorf("processing failed")
+		})
+
+	w, err := waiters.NewMessageWaiter(hub, ep, msgEventDef(t), "", rt)
+	require.NoError(t, err)
+	require.NoError(t, w.Service(ctx))
+
+	require.NoError(t, rt.MessageBroker().Publish(ctx,
+		messaging.Envelope{Name: "order placed", Payload: "x"}))
+
+	<-released
+	require.Eventually(t, func() bool {
+		return w.State() == eventproc.WSFailed
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestMessageWaiterStop(t *testing.T) {
+	ep := mockeventproc.NewMockEventProcessor(t)
+	hub := mockeventproc.NewMockEventHub(t)
+
+	w, err := waiters.NewMessageWaiter(hub, ep, msgEventDef(t), "",
+		enginert.Default())
+	require.NoError(t, err)
+
+	require.NoError(t, w.Service(context.Background()))
+	require.Error(t, w.Service(context.Background())) // already running
+	require.NoError(t, w.Stop())
+	require.Equal(t, eventproc.WSStopped, w.State())
+}
+
+func TestMessageWaiterContextCancel(t *testing.T) {
+	ep := mockeventproc.NewMockEventProcessor(t)
+	hub := mockeventproc.NewMockEventHub(t)
+
+	w, err := waiters.NewMessageWaiter(hub, ep, msgEventDef(t), "",
+		enginert.Default())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, w.Service(ctx))
+	cancel()
+
+	require.Eventually(t, func() bool {
+		return w.State() == eventproc.WSStopped
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestMessageWaiterClosedChannel(t *testing.T) {
+	ep := mockeventproc.NewMockEventProcessor(t)
+	hub := mockeventproc.NewMockEventHub(t)
+
+	rt := brokerRT{EngineRuntime: enginert.Default(), broker: closedChBroker{}}
+
+	w, err := waiters.NewMessageWaiter(hub, ep, msgEventDef(t), "", rt)
+	require.NoError(t, err)
+	require.NoError(t, w.Service(context.Background()))
+
+	require.Eventually(t, func() bool {
+		return w.State() == eventproc.WSStopped
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestMessageWaiterSubscribeError(t *testing.T) {
+	ep := mockeventproc.NewMockEventProcessor(t)
+	hub := mockeventproc.NewMockEventHub(t)
+
+	rt := brokerRT{EngineRuntime: enginert.Default(), broker: errSubBroker{}}
+
+	w, err := waiters.NewMessageWaiter(hub, ep, msgEventDef(t), "", rt)
+	require.NoError(t, err)
+
+	require.Error(t, w.Service(context.Background()))
+	require.Equal(t, eventproc.WSFailed, w.State())
+}

--- a/internal/eventproc/eventhub/waiters/waiters.go
+++ b/internal/eventproc/eventhub/waiters/waiters.go
@@ -48,6 +48,9 @@ func CreateWaiter(
 	case flow.TriggerTimer:
 		w, err = NewTimeWaiter(eh, ep, eDef, "", rt)
 
+	case flow.TriggerMessage:
+		w, err = NewMessageWaiter(eh, ep, eDef, "", rt)
+
 	default:
 		err = errs.New(
 			errs.M("couldn't find builder for event definition of type %s",

--- a/internal/instance/message_flow_test.go
+++ b/internal/instance/message_flow_test.go
@@ -1,0 +1,199 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/internal/enginert"
+	"github.com/dr-dobermann/gobpm/internal/eventproc"
+	"github.com/dr-dobermann/gobpm/internal/eventproc/eventhub"
+	"github.com/dr-dobermann/gobpm/internal/instance/snapshot"
+	"github.com/dr-dobermann/gobpm/internal/scope"
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/stretchr/testify/require"
+)
+
+// failEventProducer rejects every registration. It is a plain struct (not a
+// reflect-based mock) so it never captures the track argument — passing a
+// mutex-bearing track to a mock whose matcher reflects over it would race the
+// live track (see the RemoveWaiter doc on eventhub.EventHub).
+type failEventProducer struct{}
+
+func (failEventProducer) RegisterEvent(
+	eventproc.EventProcessor, flow.EventDefinition,
+) error {
+	return fmt.Errorf("registration rejected")
+}
+
+func (failEventProducer) UnregisterEvent(
+	eventproc.EventProcessor, string,
+) error {
+	return nil
+}
+
+func (failEventProducer) PropagateEvent(
+	context.Context, flow.EventDefinition,
+) error {
+	return nil
+}
+
+// TestSendReceiveMidFlow is SRD-013 V4: a SendTask publishes a message that a
+// mid-flow ReceiveTask waits for and binds. It exercises the full task half of
+// ADR-014 — SendTask -> broker -> MessageWaiter -> track.ProcessEvent ->
+// ReceiveTask.ProcessEvent -> resume -> Exec -> scope — and the mid-flow event
+// registration (checkFlows -> checkNodeType): the receive has an incoming flow,
+// so it is not a start node and must register its event only when the token
+// reaches it.
+//
+//	start -> send-order -> receive-order -> end
+func TestSendReceiveMidFlow(t *testing.T) {
+	_ = data.CreateDefaultStates()
+
+	p, err := process.New("msg-flow",
+		data.WithProperties(
+			data.MustProperty("order_out",
+				data.MustItemDefinition(values.NewVariable("ORD-7"),
+					foundation.WithID("order_out")),
+				data.ReadyDataState)))
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	send, err := activities.NewSendTask("send-order",
+		bpmncommon.MustMessage("order placed",
+			data.MustItemDefinition(values.NewVariable(""),
+				foundation.WithID("order_out"))),
+		activities.WithoutParams())
+	require.NoError(t, err)
+
+	outParam := data.MustParameter("received order",
+		data.MustItemAwareElement(
+			data.MustItemDefinition(values.NewVariable(""),
+				foundation.WithID("order_in")),
+			data.UnavailableDataState))
+
+	receive, err := activities.NewReceiveTask("receive-order",
+		bpmncommon.MustMessage("order placed",
+			data.MustItemDefinition(values.NewVariable(""),
+				foundation.WithID("order_in"))),
+		activities.WithParameters(data.Output, outParam))
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{start, send, receive, end} {
+		require.NoError(t, p.Add(e))
+	}
+
+	for _, l := range [][2]flow.Element{
+		{start, send}, {send, receive}, {receive, end},
+	} {
+		_, err := flow.Link(l[0].(flow.SequenceSource), l[1].(flow.SequenceTarget))
+		require.NoError(t, err)
+	}
+
+	s, err := snapshot.New(p)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	rt := enginert.Default()
+
+	eh, err := eventhub.New(rt)
+	require.NoError(t, err)
+	require.NoError(t, eh.Start(ctx))
+
+	go func() { _ = eh.Run(ctx) }()
+
+	inst, err := New(s, scope.EmptyDataPath, rt, eh, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, inst.Run(ctx))
+
+	require.Eventually(t,
+		func() bool { return inst.State() == Completed },
+		2*time.Second, 5*time.Millisecond,
+		"the instance must complete the send/receive round-trip")
+	require.NoError(t, inst.LastErr())
+
+	// the received payload reached the container scope on the receive's commit.
+	d, err := inst.dataPlane.GetDataByID(inst.rootScope, "order_in")
+	require.NoError(t, err)
+	require.Equal(t, "ORD-7", d.Value().Get(ctx))
+}
+
+// TestMidFlowEventRegistrationFailureFailsTrack covers the error path of
+// mid-flow event registration: when registering an intermediate event node's
+// event fails, checkNodeType (via checkFlows) propagates the error and the
+// track fails rather than running the node unregistered.
+//
+//	start -> receive (registration fails) -> end
+func TestMidFlowEventRegistrationFailureFailsTrack(t *testing.T) {
+	_ = data.CreateDefaultStates()
+
+	p, err := process.New("msg-flow-fail")
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	receive, err := activities.NewReceiveTask("receive-order",
+		bpmncommon.MustMessage("order placed",
+			data.MustItemDefinition(values.NewVariable(""),
+				foundation.WithID("order_in"))),
+		activities.WithoutParams())
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{start, receive, end} {
+		require.NoError(t, p.Add(e))
+	}
+
+	for _, l := range [][2]flow.Element{{start, receive}, {receive, end}} {
+		_, err := flow.Link(l[0].(flow.SequenceSource), l[1].(flow.SequenceTarget))
+		require.NoError(t, err)
+	}
+
+	s, err := snapshot.New(p)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// the EventProducer rejects the mid-flow registration.
+	inst, err := New(s, scope.EmptyDataPath, enginert.Default(),
+		failEventProducer{}, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, inst.Run(ctx))
+
+	require.Eventually(t, func() bool {
+		snap := inst.tracksSnap.Load()
+		if snap == nil {
+			return false
+		}
+
+		for _, tr := range *snap {
+			if tr.inState(TrackFailed) {
+				return true
+			}
+		}
+
+		return false
+	}, 2*time.Second, 5*time.Millisecond,
+		"the failed mid-flow registration must fail the track")
+}

--- a/internal/instance/track.go
+++ b/internal/instance/track.go
@@ -277,25 +277,32 @@ func newTrack(
 // checkNodeType determines if node awaits for event or human interaction
 // and updates track state on positive comparison.
 func (t *track) checkNodeType(node flow.Node) error {
-	if en, ok := node.(flow.EventNode); ok {
-		edCnt := 0
+	en, ok := node.(flow.EventNode)
+	if !ok {
+		return nil
+	}
 
-		for _, d := range en.Definitions() {
-			if err := t.instance.RegisterEvent(t, d); err != nil {
-				return errs.New(
-					errs.M("couldn't register event definitions"),
-					errs.C(errorClass, errs.BulidingFailed),
-					errs.D("node_id", en.ID()),
-					errs.D("node_name", en.Name()),
-					errs.D("event_definition_id", d.ID()),
-					errs.E(err))
-			}
+	defs := en.Definitions()
+	if len(defs) == 0 {
+		return nil
+	}
 
-			edCnt++
-		}
+	// Declare the wait BEFORE registering: a waiter may deliver an event
+	// synchronously on registration (a MessageWaiter draining a message the
+	// broker already buffered fires at once), and ProcessEvent only accepts an
+	// event while the track is in TrackWaitForEvent. Setting the state first
+	// removes that race; timers, which fire later, are unaffected.
+	t.updateState(TrackWaitForEvent)
 
-		if edCnt != 0 {
-			t.updateState(TrackWaitForEvent)
+	for _, d := range defs {
+		if err := t.instance.RegisterEvent(t, d); err != nil {
+			return errs.New(
+				errs.M("couldn't register event definitions"),
+				errs.C(errorClass, errs.BulidingFailed),
+				errs.D("node_id", en.ID()),
+				errs.D("node_name", en.Name()),
+				errs.D("event_definition_id", d.ID()),
+				errs.E(err))
 		}
 	}
 
@@ -595,6 +602,15 @@ func (t *track) checkFlows(flows []*flow.SequenceFlow) error {
 		state:  StepCreated,
 	}
 	t.steps = append(t.steps, &nextStep)
+
+	// The token continues on this track to nextStep's node. newTrack only
+	// classified the track's initial node, so a mid-flow event node (e.g. a
+	// ReceiveTask reached from an upstream node) must be classified here too —
+	// otherwise it would execute without registering its event or parking the
+	// track. checkNodeType is a no-op for non-event nodes.
+	if err := t.checkNodeType(nextStep.node); err != nil {
+		return err
+	}
 
 	// the remaining flows fork: build a fresh slice (don't mutate the caller's)
 	// and hand it to the loop, which constructs the new tracks. The track never

--- a/pkg/model/activities/receive_task.go
+++ b/pkg/model/activities/receive_task.go
@@ -1,6 +1,19 @@
 package activities
 
-import "github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+import (
+	"context"
+	"strings"
+
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/eventproc"
+	"github.com/dr-dobermann/gobpm/pkg/exec"
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/options"
+	"github.com/dr-dobermann/gobpm/pkg/renv"
+)
 
 // ReceiveTask is a simple Task that is designed to wait for a Message to
 // arrive from an external Participant (relative to the Process). Once the
@@ -12,9 +25,162 @@ import "github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
 // bootstrapped by the receipt of the Message. In order for the Receive Task to
 // instantiate the Process its instantiate attribute MUST be set to true and it
 // MUST NOT have any incoming Sequence Flow.
+//
+// ReceiveTask plugs into the engine's event wait/resume loop: it is a
+// flow.EventNode whose single MessageEventDefinition the track registers (so
+// the track parks in TrackWaitForEvent and a MessageWaiter subscribes the
+// broker), and it is an eventproc.EventProcessor that captures the arrived
+// payload on fire; the captured datum is bound into scope on resume by Exec
+// (ADR-014 v.1).
 type ReceiveTask struct {
-	Message        *bpmncommon.Message
-	Implementation string
+	message        *bpmncommon.Message
+	eDef           *events.MessageEventDefinition
+	received       *data.ItemDefinition
+	implementation string
 	task
-	Instantiate bool
+	instantiate bool
 }
+
+// NewReceiveTask builds a ReceiveTask that waits for msg. A nil msg is rejected.
+func NewReceiveTask(
+	name string,
+	msg *bpmncommon.Message,
+	taskOpts ...options.Option,
+) (*ReceiveTask, error) {
+	name = strings.TrimSpace(name)
+	if err := errs.CheckStr(
+		name, "empty name isn't allowed for the ReceiveTask",
+		errorClass,
+	); err != nil {
+		return nil, err
+	}
+
+	if msg == nil {
+		return nil,
+			errs.New(
+				errs.M("a message should be provided for the ReceiveTask"),
+				errs.C(errorClass, errs.EmptyNotAllowed))
+	}
+
+	t, err := newTask(name, taskOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	eDef, err := events.NewMessageEventDefinition(msg, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReceiveTask{
+			task:    *t,
+			message: msg,
+			eDef:    eDef,
+		},
+		nil
+}
+
+// Message returns the message the task waits for.
+func (rt *ReceiveTask) Message() *bpmncommon.Message {
+	return rt.message
+}
+
+// Implementation returns the technology used to receive the message (empty
+// until a receiving technology beyond the broker is wired).
+func (rt *ReceiveTask) Implementation() string {
+	return rt.implementation
+}
+
+// Instantiate reports whether the task instantiates the process on receipt
+// (deferred — ADR-014 v.1 §2.7; always false in phase-1).
+func (rt *ReceiveTask) Instantiate() bool {
+	return rt.instantiate
+}
+
+// Node returns the task as a flow.Node.
+func (rt *ReceiveTask) Node() flow.Node {
+	return rt
+}
+
+// TaskType returns the BPMN task type.
+func (rt *ReceiveTask) TaskType() flow.TaskType {
+	return flow.ReceiveTask
+}
+
+// Clone returns a per-instance copy of the ReceiveTask as a flow.Node. The
+// captured payload is per-instance runtime state and is not carried over.
+func (rt *ReceiveTask) Clone() flow.Node {
+	clonedMsg := rt.message.Clone()
+
+	return &ReceiveTask{
+		task:           rt.clone(),
+		implementation: rt.implementation,
+		instantiate:    rt.instantiate,
+		message:        clonedMsg,
+		eDef:           events.MustMessageEventDefinition(clonedMsg, nil),
+	}
+}
+
+// Definitions returns the task's single message event definition, so the track
+// registers it and parks waiting for the message. Implements flow.EventNode.
+func (rt *ReceiveTask) Definitions() []flow.EventDefinition {
+	return []flow.EventDefinition{rt.eDef}
+}
+
+// EventClass classifies the receive as an intermediate (mid-process) wait.
+// Implements flow.EventNode.
+func (rt *ReceiveTask) EventClass() flow.EventClass {
+	return flow.IntermediateEventClass
+}
+
+// ProcessEvent captures the payload carried by the fired event definition so
+// Exec can bind it into scope on resume. Implements eventproc.EventProcessor;
+// ReceiveTask is the first model node to handle a fired event.
+func (rt *ReceiveTask) ProcessEvent(
+	_ context.Context,
+	eDef flow.EventDefinition,
+) error {
+	if items := eDef.GetItemsList(); len(items) != 0 {
+		rt.received = items[0]
+	}
+
+	return nil
+}
+
+// Exec binds the received message payload into the execution scope (re.Put;
+// the inherited task.UploadData then pushes it through the output associations)
+// and completes, returning the task's outgoing sequence flows.
+func (rt *ReceiveTask) Exec(
+	_ context.Context,
+	re renv.RuntimeEnvironment,
+) ([]*flow.SequenceFlow, error) {
+	if re == nil {
+		return nil,
+			errs.New(
+				errs.M("no runtime environment"),
+				errs.C(errorClass, errs.EmptyNotAllowed))
+	}
+
+	if rt.received != nil {
+		res := data.MustParameter(rt.received.ID(),
+			data.MustItemAwareElement(rt.received, data.ReadyDataState))
+
+		if err := re.Put(res); err != nil {
+			return nil,
+				errs.New(
+					errs.M("couldn't bind the received message payload"),
+					errs.C(errorClass),
+					errs.E(err),
+					errs.D("receive_task_name", rt.Name()),
+					errs.D("receive_task_id", rt.ID()))
+		}
+	}
+
+	return rt.Outgoing(), nil
+}
+
+var (
+	_ exec.NodeExecutor        = (*ReceiveTask)(nil)
+	_ flow.EventNode           = (*ReceiveTask)(nil)
+	_ eventproc.EventProcessor = (*ReceiveTask)(nil)
+)

--- a/pkg/model/activities/receive_task.go
+++ b/pkg/model/activities/receive_task.go
@@ -1,9 +1,6 @@
 package activities
 
-import (
-	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
-	"github.com/dr-dobermann/gobpm/pkg/model/service"
-)
+import "github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
 
 // ReceiveTask is a simple Task that is designed to wait for a Message to
 // arrive from an external Participant (relative to the Process). Once the
@@ -16,7 +13,6 @@ import (
 // instantiate the Process its instantiate attribute MUST be set to true and it
 // MUST NOT have any incoming Sequence Flow.
 type ReceiveTask struct {
-	Operation      service.Operation
 	Message        *bpmncommon.Message
 	Implementation string
 	task

--- a/pkg/model/activities/receive_task_test.go
+++ b/pkg/model/activities/receive_task_test.go
@@ -1,0 +1,185 @@
+package activities_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/generated/mockrenv"
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func recvMessage(t *testing.T) *bpmncommon.Message {
+	t.Helper()
+
+	return bpmncommon.MustMessage("order placed",
+		data.MustItemDefinition(values.NewVariable(""),
+			foundation.WithID("recv_item")))
+}
+
+// firedDef builds a MessageEventDefinition carrying value under the receive
+// task's item id, as the MessageWaiter delivers it on fire.
+func firedDef(t *testing.T, value any) *events.MessageEventDefinition {
+	t.Helper()
+
+	return events.MustMessageEventDefinition(
+		bpmncommon.MustMessage("order placed",
+			data.MustItemDefinition(values.NewVariable(value),
+				foundation.WithID("recv_item"))),
+		nil)
+}
+
+func TestNewReceiveTask(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	t.Run("happy path",
+		func(t *testing.T) {
+			msg := recvMessage(t)
+
+			rt, err := activities.NewReceiveTask("await", msg,
+				activities.WithoutParams())
+			require.NoError(t, err)
+			require.Equal(t, flow.ReceiveTask, rt.TaskType())
+			require.Equal(t, rt, rt.Node())
+			require.Equal(t, msg, rt.Message())
+			require.Empty(t, rt.Implementation())
+			require.False(t, rt.Instantiate())
+			require.Equal(t, flow.IntermediateEventClass, rt.EventClass())
+
+			defs := rt.Definitions()
+			require.Len(t, defs, 1)
+			require.Equal(t, flow.TriggerMessage, defs[0].Type())
+		})
+
+	t.Run("empty name is rejected",
+		func(t *testing.T) {
+			_, err := activities.NewReceiveTask("  ", recvMessage(t),
+				activities.WithoutParams())
+			require.Error(t, err)
+		})
+
+	t.Run("nil message is rejected",
+		func(t *testing.T) {
+			_, err := activities.NewReceiveTask("await", nil,
+				activities.WithoutParams())
+			require.Error(t, err)
+		})
+
+	t.Run("an invalid task option is rejected",
+		func(t *testing.T) {
+			_, err := activities.NewReceiveTask("await", recvMessage(t),
+				events.WithParallel())
+			require.Error(t, err)
+		})
+}
+
+func TestReceiveTaskClone(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	rt, err := activities.NewReceiveTask("await", recvMessage(t),
+		activities.WithoutParams())
+	require.NoError(t, err)
+
+	cl, ok := rt.Clone().(*activities.ReceiveTask)
+	require.True(t, ok)
+	require.Equal(t, "order placed", cl.Message().Name())
+	require.NotSame(t, rt.Message(), cl.Message())
+	require.Len(t, cl.Definitions(), 1)
+}
+
+func TestReceiveTaskProcessThenExec(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	ctx := context.Background()
+
+	t.Run("captured payload is bound into scope on resume",
+		func(t *testing.T) {
+			rt, err := activities.NewReceiveTask("await", recvMessage(t),
+				activities.WithoutParams())
+			require.NoError(t, err)
+
+			require.NoError(t, rt.ProcessEvent(ctx, firedDef(t, "ORD-5")))
+
+			var put data.Data
+
+			re := mockrenv.NewMockRuntimeEnvironment(t)
+			re.EXPECT().
+				Put(mock.Anything).
+				RunAndReturn(func(dd ...data.Data) error {
+					put = dd[0]
+
+					return nil
+				})
+
+			flows, err := rt.Exec(ctx, re)
+			require.NoError(t, err)
+			require.Empty(t, flows)
+
+			require.Equal(t, "recv_item", put.ItemDefinition().ID())
+			require.Equal(t, "ORD-5", put.Value().Get(ctx))
+		})
+
+	t.Run("without a received message Exec is a no-op completion",
+		func(t *testing.T) {
+			rt, err := activities.NewReceiveTask("await", recvMessage(t),
+				activities.WithoutParams())
+			require.NoError(t, err)
+
+			re := mockrenv.NewMockRuntimeEnvironment(t)
+
+			flows, err := rt.Exec(ctx, re)
+			require.NoError(t, err)
+			require.Empty(t, flows)
+		})
+
+	t.Run("a payload-less event leaves nothing to bind",
+		func(t *testing.T) {
+			rt, err := activities.NewReceiveTask("await", recvMessage(t),
+				activities.WithoutParams())
+			require.NoError(t, err)
+
+			// an event definition with no items.
+			require.NoError(t, rt.ProcessEvent(ctx,
+				events.MustSignalEventDefinition(&events.Signal{})))
+
+			re := mockrenv.NewMockRuntimeEnvironment(t)
+
+			_, err = rt.Exec(ctx, re)
+			require.NoError(t, err)
+		})
+
+	t.Run("nil runtime environment is rejected",
+		func(t *testing.T) {
+			rt, err := activities.NewReceiveTask("await", recvMessage(t),
+				activities.WithoutParams())
+			require.NoError(t, err)
+
+			_, err = rt.Exec(ctx, nil)
+			require.Error(t, err)
+		})
+
+	t.Run("a scope bind failure is wrapped",
+		func(t *testing.T) {
+			rt, err := activities.NewReceiveTask("await", recvMessage(t),
+				activities.WithoutParams())
+			require.NoError(t, err)
+
+			require.NoError(t, rt.ProcessEvent(ctx, firedDef(t, "x")))
+
+			re := mockrenv.NewMockRuntimeEnvironment(t)
+			re.EXPECT().
+				Put(mock.Anything).
+				Return(fmt.Errorf("commit failed"))
+
+			_, err = rt.Exec(ctx, re)
+			require.Error(t, err)
+		})
+}

--- a/pkg/model/activities/send_task.go
+++ b/pkg/model/activities/send_task.go
@@ -1,12 +1,117 @@
 package activities
 
-import "github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+import (
+	"context"
+	"strings"
+
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/exec"
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/msgflow"
+	"github.com/dr-dobermann/gobpm/pkg/model/options"
+	"github.com/dr-dobermann/gobpm/pkg/renv"
+)
 
 // SendTask is a simple Task that is designed to send a Message to an
 // external Participant (relative to the Process). Once the Message has been
 // sent, the Task is completed.
 type SendTask struct {
-	Message        *bpmncommon.Message
-	Implementation string
+	message        *bpmncommon.Message
+	implementation string
 	task
 }
+
+// NewSendTask builds a SendTask that sends msg to the engine's MessageBroker
+// (ADR-014 v.1). A nil msg is rejected.
+func NewSendTask(
+	name string,
+	msg *bpmncommon.Message,
+	taskOpts ...options.Option,
+) (*SendTask, error) {
+	name = strings.TrimSpace(name)
+	if err := errs.CheckStr(
+		name, "empty name isn't allowed for the SendTask",
+		errorClass,
+	); err != nil {
+		return nil, err
+	}
+
+	if msg == nil {
+		return nil,
+			errs.New(
+				errs.M("a message should be provided for the SendTask"),
+				errs.C(errorClass, errs.EmptyNotAllowed))
+	}
+
+	t, err := newTask(name, taskOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SendTask{
+			task:    *t,
+			message: msg,
+		},
+		nil
+}
+
+// Message returns the message the task sends.
+func (st *SendTask) Message() *bpmncommon.Message {
+	return st.message
+}
+
+// Implementation returns the technology used to send the message (empty until
+// a sending technology beyond the broker is wired).
+func (st *SendTask) Implementation() string {
+	return st.implementation
+}
+
+// Node returns the task as a flow.Node.
+func (st *SendTask) Node() flow.Node {
+	return st
+}
+
+// Clone returns a deep copy of the SendTask as a flow.Node.
+func (st *SendTask) Clone() flow.Node {
+	return &SendTask{
+		task:           st.clone(),
+		implementation: st.implementation,
+		message:        st.message.Clone(),
+	}
+}
+
+// TaskType returns the BPMN task type.
+func (st *SendTask) TaskType() flow.TaskType {
+	return flow.SendTask
+}
+
+// Exec sends the task's message to the broker (ADR-014 v.1) and completes,
+// returning the task's outgoing sequence flows.
+func (st *SendTask) Exec(
+	ctx context.Context,
+	re renv.RuntimeEnvironment,
+) ([]*flow.SequenceFlow, error) {
+	if re == nil {
+		return nil,
+			errs.New(
+				errs.M("no runtime environment"),
+				errs.C(errorClass, errs.EmptyNotAllowed))
+	}
+
+	if err := msgflow.Send(ctx, re, st.message); err != nil {
+		return nil,
+			errs.New(
+				errs.M("send task message publication failed"),
+				errs.C(errorClass),
+				errs.E(err),
+				errs.D("send_task_name", st.Name()),
+				errs.D("send_task_id", st.ID()))
+	}
+
+	return st.Outgoing(), nil
+}
+
+var (
+	_ exec.NodeExecutor = (*SendTask)(nil)
+)

--- a/pkg/model/activities/send_task.go
+++ b/pkg/model/activities/send_task.go
@@ -1,16 +1,12 @@
 package activities
 
-import (
-	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
-	"github.com/dr-dobermann/gobpm/pkg/model/service"
-)
+import "github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
 
 // SendTask is a simple Task that is designed to send a Message to an
 // external Participant (relative to the Process). Once the Message has been
 // sent, the Task is completed.
 type SendTask struct {
 	Message        *bpmncommon.Message
-	Operation      service.Operation
 	Implementation string
 	task
 }

--- a/pkg/model/activities/send_task_test.go
+++ b/pkg/model/activities/send_task_test.go
@@ -1,0 +1,148 @@
+package activities_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/generated/mockrenv"
+	"github.com/dr-dobermann/gobpm/pkg/messaging/membroker"
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/stretchr/testify/require"
+)
+
+// sendReadyParam builds a Ready process datum carrying value under id.
+func sendReadyParam(id string, value any) data.Data {
+	return data.MustParameter(id,
+		data.MustItemAwareElement(
+			data.MustItemDefinition(
+				values.NewVariable(value),
+				foundation.WithID(id)),
+			data.ReadyDataState))
+}
+
+func sendMessage(t *testing.T) *bpmncommon.Message {
+	t.Helper()
+
+	return bpmncommon.MustMessage("order placed",
+		data.MustItemDefinition(values.NewVariable(""),
+			foundation.WithID("order_item")))
+}
+
+func TestNewSendTask(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	t.Run("happy path",
+		func(t *testing.T) {
+			msg := sendMessage(t)
+
+			st, err := activities.NewSendTask("notify", msg,
+				activities.WithoutParams())
+			require.NoError(t, err)
+			require.Equal(t, flow.SendTask, st.TaskType())
+			require.Equal(t, st, st.Node())
+			require.Equal(t, msg, st.Message())
+			require.Empty(t, st.Implementation())
+		})
+
+	t.Run("empty name is rejected",
+		func(t *testing.T) {
+			_, err := activities.NewSendTask("  ", sendMessage(t),
+				activities.WithoutParams())
+			require.Error(t, err)
+		})
+
+	t.Run("nil message is rejected",
+		func(t *testing.T) {
+			_, err := activities.NewSendTask("notify", nil,
+				activities.WithoutParams())
+			require.Error(t, err)
+		})
+
+	t.Run("an invalid task option is rejected",
+		func(t *testing.T) {
+			_, err := activities.NewSendTask("notify", sendMessage(t),
+				events.WithParallel())
+			require.Error(t, err)
+		})
+}
+
+func TestSendTaskClone(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	st, err := activities.NewSendTask("notify", sendMessage(t),
+		activities.WithoutParams())
+	require.NoError(t, err)
+
+	cl, ok := st.Clone().(*activities.SendTask)
+	require.True(t, ok)
+	require.Equal(t, "order placed", cl.Message().Name())
+	require.NotSame(t, st.Message(), cl.Message())
+}
+
+func TestSendTaskExec(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	ctx := context.Background()
+
+	t.Run("happy path: the message reaches the broker",
+		func(t *testing.T) {
+			st, err := activities.NewSendTask("notify", sendMessage(t),
+				activities.WithoutParams())
+			require.NoError(t, err)
+
+			broker := membroker.New()
+			ch, err := broker.Subscribe(ctx, "order placed", "")
+			require.NoError(t, err)
+
+			re := mockrenv.NewMockRuntimeEnvironment(t)
+			re.EXPECT().
+				GetDataByID("order_item").
+				Return(sendReadyParam("order_item", "ORD-7"), nil)
+			re.EXPECT().MessageBroker().Return(broker)
+
+			flows, err := st.Exec(ctx, re)
+			require.NoError(t, err)
+			require.Empty(t, flows)
+
+			select {
+			case env := <-ch:
+				require.Equal(t, "order placed", env.Name)
+				require.Equal(t, "ORD-7", env.Payload)
+			default:
+				t.Fatal("no envelope delivered to the subscriber")
+			}
+		})
+
+	t.Run("nil runtime environment is rejected",
+		func(t *testing.T) {
+			st, err := activities.NewSendTask("notify", sendMessage(t),
+				activities.WithoutParams())
+			require.NoError(t, err)
+
+			_, err = st.Exec(ctx, nil)
+			require.Error(t, err)
+		})
+
+	t.Run("a publication failure is wrapped",
+		func(t *testing.T) {
+			st, err := activities.NewSendTask("notify", sendMessage(t),
+				activities.WithoutParams())
+			require.NoError(t, err)
+
+			re := mockrenv.NewMockRuntimeEnvironment(t)
+			re.EXPECT().
+				GetDataByID("order_item").
+				Return(nil, fmt.Errorf("not in scope"))
+
+			_, err = st.Exec(ctx, re)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "publication failed")
+		})
+}

--- a/pkg/model/msgflow/msgflow.go
+++ b/pkg/model/msgflow/msgflow.go
@@ -1,0 +1,10 @@
+// Package msgflow holds the message-flow choreography shared by the BPMN nodes
+// that send and receive messages (ADR-014 v.1). It bridges a node's
+// bpmncommon.Message to the engine's MessageBroker without coupling the node to
+// the broker's wire shape: SendTask uses Send today, and the throw message
+// event will reuse it (the message-events SRD). It imports only public
+// packages, so pkg/model nodes can call it without reaching into internal.
+package msgflow
+
+// errorClass identifies errors raised by the message-flow choreography.
+const errorClass = "MSGFLOW_ERRORS"

--- a/pkg/model/msgflow/send.go
+++ b/pkg/model/msgflow/send.go
@@ -1,0 +1,60 @@
+package msgflow
+
+import (
+	"context"
+
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/messaging"
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/renv"
+)
+
+// Send binds msg's item from the execution scope (service.BindInput) and
+// publishes it to the runtime's MessageBroker as an Envelope keyed by the
+// message name (phase-1 correlation, ADR-014 v.1 §2.6). A message that carries
+// no item is published with a nil payload. Send is the producer choreography
+// shared by SendTask and (later) the throw message event; it names the BPMN
+// intent and hides the broker hop.
+func Send(
+	ctx context.Context,
+	re renv.RuntimeEnvironment,
+	msg *bpmncommon.Message,
+) error {
+	if re == nil {
+		return errs.New(
+			errs.M("msgflow.Send: a nil RuntimeEnvironment isn't allowed"),
+			errs.C(errorClass, errs.InvalidParameter))
+	}
+
+	if msg == nil {
+		return errs.New(
+			errs.M("msgflow.Send: a nil Message isn't allowed"),
+			errs.C(errorClass, errs.InvalidParameter))
+	}
+
+	item, err := service.BindInput(ctx, re, msg)
+	if err != nil {
+		return errs.New(
+			errs.M("msgflow.Send: couldn't bind message %q", msg.Name()),
+			errs.C(errorClass, errs.OperationFailed),
+			errs.E(err))
+	}
+
+	var payload any
+	if item != nil {
+		payload = item.Structure().Get(ctx)
+	}
+
+	if err := re.MessageBroker().Publish(ctx, messaging.Envelope{
+		Name:    msg.Name(),
+		Payload: payload,
+	}); err != nil {
+		return errs.New(
+			errs.M("msgflow.Send: broker rejected message %q", msg.Name()),
+			errs.C(errorClass, errs.OperationFailed),
+			errs.E(err))
+	}
+
+	return nil
+}

--- a/pkg/model/msgflow/send_test.go
+++ b/pkg/model/msgflow/send_test.go
@@ -1,0 +1,131 @@
+package msgflow_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/generated/mockrenv"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/messaging"
+	"github.com/dr-dobermann/gobpm/pkg/messaging/membroker"
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/msgflow"
+	"github.com/stretchr/testify/require"
+)
+
+// errBroker is a MessageBroker whose Publish always fails — it exercises the
+// broker-rejection path of msgflow.Send.
+type errBroker struct{}
+
+func (errBroker) Publish(context.Context, messaging.Envelope) error {
+	return fmt.Errorf("broker down")
+}
+
+func (errBroker) Subscribe(
+	context.Context, string, string,
+) (<-chan messaging.Envelope, error) {
+	return nil, nil
+}
+
+// readyParam builds a Ready process datum carrying value under id.
+func readyParam(id string, value any) data.Data {
+	return data.MustParameter(id,
+		data.MustItemAwareElement(
+			data.MustItemDefinition(
+				values.NewVariable(value),
+				foundation.WithID(id)),
+			data.ReadyDataState))
+}
+
+func TestSend(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	ctx := context.Background()
+
+	t.Run("happy path: bound payload reaches the broker",
+		func(t *testing.T) {
+			msg := bpmncommon.MustMessage("order placed",
+				data.MustItemDefinition(values.NewVariable(""),
+					foundation.WithID("order_item")))
+
+			broker := membroker.New()
+			ch, err := broker.Subscribe(ctx, "order placed", "")
+			require.NoError(t, err)
+
+			re := mockrenv.NewMockRuntimeEnvironment(t)
+			re.EXPECT().
+				GetDataByID("order_item").
+				Return(readyParam("order_item", "ORD-42"), nil)
+			re.EXPECT().MessageBroker().Return(broker)
+
+			require.NoError(t, msgflow.Send(ctx, re, msg))
+
+			select {
+			case env := <-ch:
+				require.Equal(t, "order placed", env.Name)
+				require.Equal(t, "ORD-42", env.Payload)
+			default:
+				t.Fatal("no envelope delivered to the subscriber")
+			}
+		})
+
+	t.Run("nil RuntimeEnvironment is rejected",
+		func(t *testing.T) {
+			msg := bpmncommon.MustMessage("ping",
+				data.MustItemDefinition(values.NewVariable(""),
+					foundation.WithID("ping_item")))
+
+			err := msgflow.Send(ctx, nil, msg)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "RuntimeEnvironment")
+		})
+
+	t.Run("nil Message is rejected",
+		func(t *testing.T) {
+			re := mockrenv.NewMockRuntimeEnvironment(t)
+
+			err := msgflow.Send(ctx, re, nil)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "Message")
+		})
+
+	t.Run("a scope-bind failure is wrapped",
+		func(t *testing.T) {
+			msg := bpmncommon.MustMessage("order placed",
+				data.MustItemDefinition(values.NewVariable(""),
+					foundation.WithID("order_item")))
+
+			re := mockrenv.NewMockRuntimeEnvironment(t)
+			re.EXPECT().
+				GetDataByID("order_item").
+				Return(nil, fmt.Errorf("not in scope"))
+
+			err := msgflow.Send(ctx, re, msg)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "bind message")
+
+			var appErr *errs.ApplicationError
+			require.ErrorAs(t, err, &appErr)
+		})
+
+	t.Run("a broker rejection is wrapped",
+		func(t *testing.T) {
+			msg := bpmncommon.MustMessage("order placed",
+				data.MustItemDefinition(values.NewVariable(""),
+					foundation.WithID("order_item")))
+
+			re := mockrenv.NewMockRuntimeEnvironment(t)
+			re.EXPECT().
+				GetDataByID("order_item").
+				Return(readyParam("order_item", "ORD-42"), nil)
+			re.EXPECT().MessageBroker().Return(errBroker{})
+
+			err := msgflow.Send(ctx, re, msg)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "broker rejected")
+		})
+}


### PR DESCRIPTION
Implements the task half of ADR-014 v.1. A SendTask binds its Message from scope and publishes it to the MessageBroker; a ReceiveTask registers a new MessageWaiter that subscribes the broker and,
on arrival, binds the payload into scope and completes. Phase-1 correlation = match-by-message-name.

ADR-014's message-events half (throw/catch + the MessageProducer/MessageConsumer seam interfaces), correlation-key derivation, and message-triggered instantiation are deferred to a named
follow-up SRD. ADR-014 stays Draft until that lands.

What's in

- Drop the vestigial service.Operation field from both tasks (zero readers).
- pkg/model/msgflow.Send — public producer choreography (BindInput → Envelope → re.MessageBroker().Publish), shared by SendTask now and the throw event later. Public because public model nodes
call it and depguard forbids pkg/model → internal; the broker/waiter machinery stays internal.
- SendTask executor (publishes, completes — no reply-wait).
- MessageWaiter (peer of TimerWaiter; TriggerMessage wired) — subscribes the broker, reconstructs the payload as a typed datum, fires ProcessEvent, cleans up its goroutine + subscription on
Stop/ctx.
- ReceiveTask = flow.EventNode + eventproc.EventProcessor + exec.NodeExecutor — the first real node-level ProcessEvent; binds the payload via the inherited task.UploadData.
- Engine fix (internal/instance/track.go, surfaced by the example's smoke run): intermediate event nodes now register when the token reaches them (checkFlows → checkNodeType), and checkNodeType
declares TrackWaitForEvent before registering. Start (no-incoming) nodes are unchanged — they still pre-register at instance start.
- Runnable examples/message-send-receive (own module) + an instance integration test.

Verification

- make ci green — diff-coverage 97.0% (min 95), golangci-lint clean, race tests pass, govulncheck clean.
- All 6 examples smoke to exit 0.
- /check-srd audit: PASS (all FR/NFR wired, §6 tests present, DoD V1–V7 met, cross-doc pins upward/version-pinned).
- SRD-013 Accepted + RU twin.
