### PR TITLE
Fix/timer catch broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,15 @@ engine, _ := thresher.New("demo-engine")
 proc, _ := process.New("demo-process")
 start, _ := events.NewStartEvent("start")
 
-// A ServiceTask runs your Go code: wrap a functor as the operation's
-// implementation. The operation carries no in/out messages (nil, nil) —
-// no data mapping needed, the functor just runs inside the process.
-work, _ := gooper.New(
-    func(ctx context.Context, _ *data.ItemDefinition) (*data.ItemDefinition, error) {
+// A ServiceTask runs your Go code: gooper.New builds the operation straight
+// from a functor. The functor receives a read-only DataReader (process data
+// and engine runtime variables) and its optional bound input message — nil
+// here, since this operation declares no messages — and returns its result.
+op, _ := gooper.New("hello",
+    func(_ context.Context, _ service.DataReader, _ *data.ItemDefinition) (*data.ItemDefinition, error) {
         fmt.Println("  ▶ hello from inside the process")
         return nil, nil
     })
-op, _ := service.NewOperation("hello", nil, nil, work)
 task, _ := activities.NewServiceTask("work", op, activities.WithoutParams())
 
 end, _ := events.NewEndEvent("end")

--- a/docs/fix/FIX-004-timer-catch-broadcast.md
+++ b/docs/fix/FIX-004-timer-catch-broadcast.md
@@ -1,0 +1,226 @@
+# FIX-004 «Concurrent timer-catch instances share one waiter — a timer fires them all»
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft v.1 (2026-06-17, branch `fix/timer-catch-broadcast`, not yet implemented).
+**Date:** 2026-06-17.
+**Author:** Ruslan Gabitov.
+**Branch:** `fix/timer-catch-broadcast` (one focused defect — the timer event definition gains per-instance identity, exactly as the message definition did in SRD-017).
+**Paired doc:** none (a point fix; the per-instance-eDef-identity mechanism is the SRD-017 precedent — see §7).
+**Upstream:** [SRD-017 v.1](../srd/SRD-017-conversation-token-threading.md) (the message-scoped precedent — `CloneForInstance`, §4.3); [ADR-006 v.1](../design/ADR-006-events-and-subscriptions.md) (the EventHub waiter model); [ADR-009 v.1](../design/ADR-009-per-instance-node-graph.md) (each instance owns a private node-graph clone).
+
+**Grounded in (internal artifacts):**
+- SRD-017 fixed this **for message event definitions only** (`MessageEventDefinition.CloneForInstance`, M3a) and explicitly deferred the non-message types to "its own FIX" (SRD-017 §4.3 final note). This is that FIX.
+- Every claim below re-verified against `master` at `221ea3f` (post-SRD-017 merge) — line numbers are current.
+
+## §1 Symptoms
+
+### §1.1 Symptom: a single timer occurrence resumes every concurrent instance waiting on the same timer catch
+
+Two (or more) running instances of the same process, each parked at the same
+intermediate **timer** catch event, share **one** EventHub waiter. When the
+timer fires, the waiter resumes **all** of them at once — instead of each
+instance's own timer resuming only that instance. This is wrong per BPMN
+(§10.5: a catch event resumes the token in *its* process instance) and it is
+non-deterministic from the operator's view: N instances complete on one timer.
+
+It is the exact analogue of the message broadcast bug SRD-017 fixed, but for
+timers — and it is currently **masked** because no test runs two concurrent
+instances parked on the same timer catch.
+
+```
+instance A ─┐
+            ├─ both parked at intermediate timer catch "wait-15m" (same eDef id)
+instance B ─┘
+   timer fires once  ─▶  ONE shared waiter ─▶ fireDefinition → resumes A AND B
+```
+
+In code: a timer intermediate catch is registered through
+`internal/instance/track.go:310` (`t.instance.RegisterEvent(t, d)`); the
+EventHub keys waiters by `eDef.ID()` and **merges** a second registration of
+the same id onto the existing waiter via `AddEventProcessor`
+(`internal/eventproc/eventhub/eventhub.go:173`). Because both instances' timer
+eDefs carry the **same** id (see §2), they land on one waiter; when it fires it
+loops every registered processor — both tracks.
+
+## §2 Root Cause Analysis
+
+### §2.1 `Event.clone()` shares non-message event definitions by reference
+
+Each instance owns a private clone of the node graph (ADR-009). Node cloning
+runs through `Event.clone()` (`pkg/model/events/event.go:161`), whose
+`cloneDefsForInstance` (`event.go:175`) gives a **fresh per-instance id only to
+definitions implementing the optional `CloneForInstance` interface**:
+
+```go
+func cloneDefsForInstance(defs []flow.EventDefinition) []flow.EventDefinition {
+	out := make([]flow.EventDefinition, len(defs))
+	for i, d := range defs {
+		if c, ok := d.(interface {
+			CloneForInstance() flow.EventDefinition
+		}); ok {
+			out[i] = c.CloneForInstance()
+			continue
+		}
+		out[i] = d            // <-- shared by reference: same id across instances
+	}
+	return out
+}
+```
+
+Only `MessageEventDefinition` implements `CloneForInstance`
+(`pkg/model/events/message.go:155`, added by SRD-017 M3a). `TimerEventDefinition`
+(`pkg/model/events/timer.go:11`) does **not** — so every instance's clone keeps
+the **template** timer eDef (the `out[i] = d` branch), i.e. the same
+`eDef.ID()`. The EventHub then merges them onto one waiter (§1.1).
+
+### §2.2 Timer is the only non-message type that can actually collide today
+
+An IntermediateCatchEvent permits conditional / signal / timer triggers
+(`pkg/model/events/intermediate_catch.go:18` `intermediateCatchTriggers`), but
+the waiter factory builds a waiter for **only** timer and message:
+
+```go
+// internal/eventproc/eventhub/waiters/waiters.go (CreateWaiter)
+case flow.TriggerTimer:   w, err = NewTimeWaiter(eh, ep, eDef, "", rt)
+case flow.TriggerMessage: w, err = NewMessageWaiter(eh, ep, eDef, "", rt, true)
+default:                  err = ... "couldn't find builder for ... %s"
+```
+
+So a **signal** or **conditional** catch can be *modelled* but **fails to
+register a waiter** (the `default` error) — it cannot wait in-instance, so it
+cannot hit this bug. Message is already fixed (SRD-017). **Timer is therefore
+the only catchable, waiter-backed, non-message event definition that exhibits
+the broadcast** — making this FIX timer-scoped.
+
+### §2.3 Why no test caught it
+
+`grep` of the timer tests (`internal/eventproc/eventhub/eventhub_timer_test.go`,
+`pkg/model/events/*timer*_test.go`) shows none registers **two** processors on
+one timer eDef and asserts only one fires; the per-instance-identity canary
+(`pkg/model/events/clone_for_instance_test.go`) covers **message** only
+(`TestMessageReceiverPerInstanceClone`). The gap is the absence of a
+timer-distinct-id / no-broadcast assertion.
+
+## §3 Solution
+
+### §3.1 Alternatives considered
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| A. Add `CloneForInstance` to **`TimerEventDefinition`** (structural, mirroring `message.go:155`) | One method; no `Event.clone` change (its optional-interface check already applies it); no `flow.EventDefinition` interface change; no mock regen; matches the SRD-017 pattern exactly | Per-type (must be repeated when another catchable type gains a waiter) | ✅ chosen |
+| B. Add `CloneForInstance` to the **`flow.EventDefinition` interface** (force every impl) | Compile-time guarantee every eDef is per-instance | Touches ~10 eDef impls + the interface + `mockflow` regen, for types that **cannot** wait today (no waiter builder) — churn with no current payoff (YAGNI) | ❌ rejected (revisit if/when many types become catchable) |
+| C. Key EventHub waiters by `(eDefID, processorID)` instead of `eDefID` | Fixes all event types at once, no model change | Ripples the FIX-003-hardened removal core (`WaiterFired`/`RemoveWaiter`/`UnregisterEvent` all key by `eDefID`); larger blast radius for a one-type bug | ❌ rejected |
+
+Option A is the minimal, precedent-consistent fix for the one type that is
+actually affected.
+
+### §3.2 Changes by file
+
+#### §3.2.1 `pkg/model/events/timer.go` — `CloneForInstance` with a fresh id
+
+```go
+// CloneForInstance returns a per-instance copy of the TimerEventDefinition with
+// a FRESH id, sharing the (immutable) timer expressions by reference. Node
+// cloning (Event.clone) uses it so each process instance's timer catch registers
+// a DISTINCT EventHub waiter: without it concurrent instances waiting on the same
+// timer would share one waiter and a single timer occurrence would resume them
+// all (FIX-004; the timer analogue of MessageEventDefinition.CloneForInstance,
+// SRD-017 §4.3). A timer carries no payload, so there is no fire-path CloneEvent
+// to keep id-stable — only the registration identity must be per-instance.
+func (ted *TimerEventDefinition) CloneForInstance() flow.EventDefinition {
+	return &TimerEventDefinition{
+		definition:   definition{BaseElement: *foundation.MustBaseElement()},
+		timeDate:     ted.timeDate,
+		timeCycle:    ted.timeCycle,
+		timeDuration: ted.timeDuration,
+	}
+}
+```
+
+Adds the `foundation` import to `timer.go`. No other production change:
+`Event.clone`'s `cloneDefsForInstance` already routes any `CloneForInstance`
+implementer through the fresh-id path (§2.1), so the timer clone becomes
+per-instance automatically.
+
+## §4 Verification
+
+Current coverage in the test dir:
+- unit: timer waiter delivery / lifecycle exist, but **no** per-instance-identity
+  or two-instance-no-broadcast assertion for timers (§2.3).
+- the message canary (`TestMessageReceiverPerInstanceClone`) is the shape to mirror.
+
+### §4.1 Regression tests (mandatory)
+
+#### §4.1.1 `TestTimerReceiverPerInstanceClone`
+
+**New:** `pkg/model/events/clone_for_instance_test.go` (alongside the message one).
+
+| Test | Setup | Assertion |
+|---|---|---|
+| `TestTimerReceiverPerInstanceClone` | an `IntermediateCatchEvent` with a `TimerEventDefinition`; `Clone()` it twice | the two clones' timer-eDef ids **differ** from each other and from the template (mirrors the message canary) |
+| `TestTimerEventDefinitionCloneForInstance` | `CloneForInstance()` on a timer eDef twice | each yields a fresh id; the timer expressions are shared by reference |
+
+#### §4.1.2 Two-instance no-broadcast (engine-level, if tractable)
+
+A `pkg/thresher` or `internal/instance` test: two instances of a process with an
+intermediate timer catch, a short timer; assert each instance resumes
+**independently** (the timer firing for one does not complete the other).
+(Evaluate during implementation; the §4.1.1 distinct-id canary is the primary
+proof — distinct ids ⇒ distinct waivers ⇒ no shared fire, by the EventHub keying.)
+
+## §5 Prevention
+
+- **Doc comment** on `TimerEventDefinition.CloneForInstance` names the invariant
+  (per-instance registration identity) and the canary test.
+- **Forward note (the real prevention):** the per-instance-identity requirement
+  applies to **every catchable event definition that gains a waiter builder**.
+  Today only timer + message have builders (`CreateWaiter`, §2.2). When a future
+  change adds a `CreateWaiter` case for signal / conditional / etc., it MUST also
+  add `CloneForInstance` to that eDef type — else it reintroduces this broadcast
+  bug. Record this next to the `CreateWaiter` switch as a comment so the
+  requirement is visible at the point of change.
+
+## §6 Regressions / side-effects
+
+### §6.1 Timer fire-path
+A timer carries no payload and has no `CloneEvent` (it is not a
+`flow.EventDefCloner`), so it fires the **registered** (now per-instance) eDef
+as-is — which still matches its own waiter. Existing timer-waiter delivery tests
+(`eventhub_timer_test.go`) guard that a timer still fires its instance.
+
+### §6.2 What may rely on the old (shared-id) behaviour
+`grep` for any code that looks up a timer by the *template* eDef id across
+instances → none expected (the EventHub map is per-registration; `WaiterFired`/
+`UnregisterEvent` use the live eDef id, which is now per-instance, exactly as for
+the message fix). Re-run the audit grep pre-landing.
+
+### §6.3 Rollback path
+Single-commit revert (the method + its test); no migration, no data.
+
+## §7 Related
+
+- [SRD-017 v.1](../srd/SRD-017-conversation-token-threading.md) — the message
+  precedent (`CloneForInstance`, M3a, §4.3) and the explicit deferral this FIX
+  closes. Sideways (FIX → SRD).
+- [ADR-006 v.1](../design/ADR-006-events-and-subscriptions.md) — the EventHub
+  waiter model (keying by eDef id; the hub owns removal).
+- [ADR-009 v.1](../design/ADR-009-per-instance-node-graph.md) — each instance
+  owns a private node-graph clone; per-instance eDef identity is the natural
+  completion of that principle for catchable definitions.
+- **Promote-to-ADR candidate:** if/when several event types become catchable,
+  the "every waiter-backed catch definition is per-instance" rule should be
+  stated once (an ADR or SAD note) rather than per-type.
+
+## §8 Implementation summary (fill AFTER landing)
+
+> ⚠️ TODO: fill AFTER landing — stage commit SHA(s), V-results, empirical deltas.
+
+## §9 Open questions
+
+None. Scope is **timer-only** (the sole non-message catchable, waiter-backed
+event definition — §2.2): add `TimerEventDefinition.CloneForInstance` (fresh
+per-instance id, expressions shared), mirroring the message fix, with a
+distinct-id canary test and a forward-note tying future `CreateWaiter` cases to
+the per-instance-identity requirement. Signal/conditional and the broad
+interface-method approach are explicitly out of scope until those types gain
+waiter builders (§3.1 B).

--- a/docs/fix/FIX-004-timer-catch-broadcast.md
+++ b/docs/fix/FIX-004-timer-catch-broadcast.md
@@ -1,7 +1,7 @@
 # FIX-004 «Concurrent timer-catch instances share one waiter — a timer fires them all»
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft v.1 (2026-06-17, branch `fix/timer-catch-broadcast`, not yet implemented).
+**Status:** Accepted v.1 (2026-06-18, branch `fix/timer-catch-broadcast`, implemented).
 **Date:** 2026-06-17.
 **Author:** Ruslan Gabitov.
 **Branch:** `fix/timer-catch-broadcast` (one focused defect — the timer event definition gains per-instance identity, exactly as the message definition did in SRD-017).
@@ -211,9 +211,46 @@ Single-commit revert (the method + its test); no migration, no data.
   the "every waiter-backed catch definition is per-instance" rule should be
   stated once (an ADR or SAD note) rather than per-type.
 
-## §8 Implementation summary (fill AFTER landing)
+## §8 Implementation summary (stage-by-stage actual landings + deltas vs draft)
 
-> ⚠️ TODO: fill AFTER landing — stage commit SHA(s), V-results, empirical deltas.
+### §8.1 Stages by commit (branch `fix/timer-catch-broadcast`)
+
+| Stage | Commit | Scope | Tests |
+|---|---|---|---|
+| doc | `fb683ac` | FIX-004 document | — |
+| M1 | `b98c069` | `TimerEventDefinition.CloneForInstance` (timer.go) + `foundation` import; forward-note at the `CreateWaiter` switch (waiters.go); two canary tests (clone_for_instance_test.go) | `TestTimerEventDefinitionCloneForInstance`, `TestTimerReceiverPerInstanceClone` |
+
+Landed exactly as the §3.2 draft: one method, no `Event.clone` / interface /
+mock change. `cloneDefsForInstance`'s existing optional-interface check applied
+the new method automatically — the receiver canary proves it through the real
+clone path.
+
+### §8.2 Verification results
+
+- `make ci` (CI-parity gate): **PASS** — tidy / golangci-lint (incl.
+  fieldalignment, misspell) / build / `-race` tests / diff-coverage / govulncheck
+  all green. `TimerEventDefinition.CloneForInstance` measured **100%** covered.
+- All 9 runnable examples exit 0, including the timer examples `simple-timer`
+  and `timer-event` (timers still fire correctly — no fire-path regression,
+  confirming §6.1).
+- The existing `TestNonMessageDefSharedOnClone` (signal stays shared) still
+  passes — only the timer type flipped to per-instance, as intended.
+
+### §8.3 Empirical findings — where reality diverged from the §3 draft
+
+None. The fix landed as designed; the only authoring adjustments were
+US-spelling (`analogue`→`analog`) and comment line-wrapping for the project's
+80-column / misspell lints — no behavioural delta.
+
+### §8.4 Backlog (out of FIX-004 scope)
+
+- Signal / conditional intermediate catches: when they gain a `CreateWaiter`
+  builder, each MUST also implement `CloneForInstance` (see the §5 forward-note),
+  or this broadcast class reappears for them.
+- The two-instance engine-level no-broadcast assertion (§4.1.2) was covered by
+  the distinct-id canary rather than a dedicated thresher test — a future
+  integration test could exercise it end-to-end if a broader event-broadcast
+  suite is built.
 
 ## §9 Open questions
 

--- a/docs/fix/FIX-004-timer-catch-broadcast.ru.md
+++ b/docs/fix/FIX-004-timer-catch-broadcast.ru.md
@@ -1,0 +1,276 @@
+# FIX-004 «Параллельные экземпляры на одном timer-catch делят один waiter — таймер срабатывает у всех»
+
+> Перевод. Канонична английская версия: [FIX-004-timer-catch-broadcast.md](FIX-004-timer-catch-broadcast.md). При расхождении приоритет у английского текста.
+
+**Тип:** FIX (одноразовый багфикс; после приземления не переписывается).
+**Статус:** Приземлён v.1 (2026-06-18, ветка `fix/timer-catch-broadcast`, реализован).
+**Дата:** 2026-06-18.
+**Автор:** Руслан Габитов.
+**Ветка:** `fix/timer-catch-broadcast` (один точечный дефект — определение timer-события получает идентичность per-instance, ровно как message-определение в SRD-017).
+**Парный документ:** нет (точечная правка; механизм per-instance-идентичности eDef — прецедент SRD-017, см. §7).
+**Вышестоящее:** [SRD-017 v.1](../srd/SRD-017-conversation-token-threading.md) (message-прецедент — `CloneForInstance`, §4.3); [ADR-006 v.1](../design/ADR-006-events-and-subscriptions.md) (модель waiter'ов EventHub); [ADR-009 v.1](../design/ADR-009-per-instance-node-graph.md) (каждый экземпляр владеет приватной копией графа узлов).
+
+**Обосновано (внутренние артефакты):**
+- SRD-017 исправил это **только для message-определений событий** (`MessageEventDefinition.CloneForInstance`, M3a) и явно отложил не-message типы в «собственный FIX» (SRD-017 §4.3, финальная заметка). Это и есть тот FIX.
+- Каждое утверждение ниже перепроверено по `master` на `221ea3f` (после мержа SRD-017) — номера строк актуальны.
+
+## §1 Симптомы
+
+### §1.1 Симптом: одно срабатывание таймера возобновляет каждый параллельный экземпляр, ожидающий на том же timer-catch
+
+Два (или больше) запущенных экземпляра одного процесса, каждый припаркован на
+одном и том же промежуточном **timer**-catch-событии, делят **один** waiter
+EventHub. Когда таймер срабатывает, waiter возобновляет их **все** разом —
+вместо того чтобы таймер каждого экземпляра возобновлял только этот экземпляр.
+Это неверно по BPMN (§10.5: catch-событие возобновляет токен в *своём*
+экземпляре процесса) и недетерминированно с точки зрения оператора: N
+экземпляров завершаются по одному таймеру.
+
+Это точный аналог message-broadcast-бага, который исправил SRD-017, но для
+таймеров — и он сейчас **замаскирован**, потому что ни один тест не запускает
+два параллельных экземпляра, припаркованных на одном timer-catch.
+
+```
+instance A ─┐
+            ├─ both parked at intermediate timer catch "wait-15m" (same eDef id)
+instance B ─┘
+   timer fires once  ─▶  ONE shared waiter ─▶ fireDefinition → resumes A AND B
+```
+
+В коде: промежуточный timer-catch регистрируется через
+`internal/instance/track.go:310` (`t.instance.RegisterEvent(t, d)`); EventHub
+ключует waiter'ы по `eDef.ID()` и **сливает** повторную регистрацию того же id
+на существующий waiter через `AddEventProcessor`
+(`internal/eventproc/eventhub/eventhub.go:173`). Поскольку timer-eDef обоих
+экземпляров несут **одинаковый** id (см. §2), они попадают на один waiter; при
+срабатывании он проходит по всем зарегистрированным процессорам — обоим трекам.
+
+## §2 Анализ первопричины
+
+### §2.1 `Event.clone()` делит не-message определения событий по ссылке
+
+Каждый экземпляр владеет приватной копией графа узлов (ADR-009). Клонирование
+узлов идёт через `Event.clone()` (`pkg/model/events/event.go:161`), чей
+`cloneDefsForInstance` (`event.go:175`) выдаёт **свежий per-instance id только
+определениям, реализующим опциональный интерфейс `CloneForInstance`**:
+
+```go
+func cloneDefsForInstance(defs []flow.EventDefinition) []flow.EventDefinition {
+	out := make([]flow.EventDefinition, len(defs))
+	for i, d := range defs {
+		if c, ok := d.(interface {
+			CloneForInstance() flow.EventDefinition
+		}); ok {
+			out[i] = c.CloneForInstance()
+			continue
+		}
+		out[i] = d            // <-- shared by reference: same id across instances
+	}
+	return out
+}
+```
+
+Только `MessageEventDefinition` реализует `CloneForInstance`
+(`pkg/model/events/message.go:155`, добавлено в SRD-017 M3a).
+`TimerEventDefinition` (`pkg/model/events/timer.go:11`) — **нет**, поэтому копия
+каждого экземпляра сохраняет **шаблонный** timer-eDef (ветка `out[i] = d`), т.е.
+тот же `eDef.ID()`. EventHub затем сливает их на один waiter (§1.1).
+
+### §2.2 Таймер — единственный не-message тип, который сегодня реально может коллизировать
+
+IntermediateCatchEvent допускает триггеры conditional / signal / timer
+(`pkg/model/events/intermediate_catch.go:18` `intermediateCatchTriggers`), но
+фабрика waiter'ов строит waiter **только** для timer и message:
+
+```go
+// internal/eventproc/eventhub/waiters/waiters.go (CreateWaiter)
+case flow.TriggerTimer:   w, err = NewTimeWaiter(eh, ep, eDef, "", rt)
+case flow.TriggerMessage: w, err = NewMessageWaiter(eh, ep, eDef, "", rt, true)
+default:                  err = ... "couldn't find builder for ... %s"
+```
+
+Так что **signal**- или **conditional**-catch можно *смоделировать*, но он
+**не зарегистрирует waiter** (ветка `default`-ошибки) — он не может ждать
+in-instance, значит не может попасть в этот баг. Message уже исправлен
+(SRD-017). **Таймер, следовательно, — единственное catchable, обеспеченное
+waiter'ом, не-message определение события, демонстрирующее broadcast** — что и
+делает этот FIX timer-scoped.
+
+### §2.3 Почему ни один тест не поймал это
+
+`grep` timer-тестов (`internal/eventproc/eventhub/eventhub_timer_test.go`,
+`pkg/model/events/*timer*_test.go`) показывает: ни один не регистрирует **два**
+процессора на одном timer-eDef и не утверждает, что сработал только один;
+канарейка per-instance-идентичности
+(`pkg/model/events/clone_for_instance_test.go`) покрывает **только** message
+(`TestMessageReceiverPerInstanceClone`). Пробел — отсутствие утверждения
+timer-distinct-id / no-broadcast.
+
+## §3 Решение
+
+### §3.1 Рассмотренные альтернативы
+
+| Альтернатива | За | Против | Решение |
+|---|---|---|---|
+| A. Добавить `CloneForInstance` в **`TimerEventDefinition`** (структурно, по образцу `message.go:155`) | Один метод; без правки `Event.clone` (его проверка опционального интерфейса уже применяет его); без правки интерфейса `flow.EventDefinition`; без regen мок; точно по образцу SRD-017 | Per-type (повторять при появлении waiter'а у другого catchable-типа) | ✅ выбрано |
+| B. Добавить `CloneForInstance` в **интерфейс `flow.EventDefinition`** (обязать каждую реализацию) | Compile-time-гарантия, что каждый eDef per-instance | Затрагивает ~10 реализаций eDef + интерфейс + regen `mockflow`, ради типов, которые **не могут** ждать сегодня (нет builder'а waiter'а) — churn без текущей выгоды (YAGNI) | ❌ отклонено (вернуться, когда catchable станут многие типы) |
+| C. Ключевать waiter'ы EventHub по `(eDefID, processorID)` вместо `eDefID` | Чинит все типы событий сразу, без правки модели | Задевает закалённое FIX-003 ядро удаления (`WaiterFired`/`RemoveWaiter`/`UnregisterEvent` все ключуют по `eDefID`); больший радиус поражения ради бага одного типа | ❌ отклонено |
+
+Вариант A — минимальная, согласованная с прецедентом правка для единственного
+реально затронутого типа.
+
+### §3.2 Изменения по файлам
+
+#### §3.2.1 `pkg/model/events/timer.go` — `CloneForInstance` со свежим id
+
+```go
+// CloneForInstance returns a per-instance copy of the TimerEventDefinition with
+// a FRESH id, sharing the (immutable) timer expressions by reference. Node
+// cloning (Event.clone) uses it so each process instance's timer catch registers
+// a DISTINCT EventHub waiter: without it concurrent instances waiting on the same
+// timer would share one waiter and a single timer occurrence would resume them
+// all (FIX-004; the timer analog of MessageEventDefinition.CloneForInstance,
+// SRD-017 §4.3). A timer carries no payload, so there is no fire-path CloneEvent
+// to keep id-stable — only the registration identity must be per-instance.
+func (ted *TimerEventDefinition) CloneForInstance() flow.EventDefinition {
+	return &TimerEventDefinition{
+		definition:   definition{BaseElement: *foundation.MustBaseElement()},
+		timeDate:     ted.timeDate,
+		timeCycle:    ted.timeCycle,
+		timeDuration: ted.timeDuration,
+	}
+}
+```
+
+Добавляет импорт `foundation` в `timer.go`. Других продакшн-изменений нет:
+`cloneDefsForInstance` из `Event.clone` уже маршрутизирует любую реализацию
+`CloneForInstance` через путь свежего id (§2.1), так что timer-копия становится
+per-instance автоматически.
+
+## §4 Верификация
+
+Текущее покрытие в каталоге тестов:
+- unit: доставка / жизненный цикл timer-waiter'а есть, но **нет** утверждения
+  per-instance-идентичности или two-instance-no-broadcast для таймеров (§2.3).
+- message-канарейка (`TestMessageReceiverPerInstanceClone`) — образец для
+  повторения.
+
+### §4.1 Регрессионные тесты (обязательны)
+
+#### §4.1.1 `TestTimerReceiverPerInstanceClone`
+
+**Новое:** `pkg/model/events/clone_for_instance_test.go` (рядом с message-тестом).
+
+| Тест | Установка | Утверждение |
+|---|---|---|
+| `TestTimerReceiverPerInstanceClone` | `IntermediateCatchEvent` с `TimerEventDefinition`; `Clone()` дважды | id двух копий timer-eDef **различаются** между собой и с шаблоном (по образцу message-канарейки) |
+| `TestTimerEventDefinitionCloneForInstance` | `CloneForInstance()` на timer-eDef дважды | каждый даёт свежий id; timer-выражения делятся по ссылке |
+
+#### §4.1.2 Two-instance no-broadcast (уровень движка, если выполнимо)
+
+Тест `pkg/thresher` или `internal/instance`: два экземпляра процесса с
+промежуточным timer-catch, короткий таймер; утверждать, что каждый экземпляр
+возобновляется **независимо** (срабатывание таймера у одного не завершает
+другого). (Оценить при реализации; distinct-id-канарейка §4.1.1 — основное
+доказательство: различные id ⇒ различные waiter'ы ⇒ нет общего срабатывания,
+по ключеванию EventHub.)
+
+## §5 Предотвращение
+
+- **Doc-комментарий** на `TimerEventDefinition.CloneForInstance` называет
+  инвариант (per-instance-идентичность регистрации) и канарейку.
+- **Заметка на будущее (реальное предотвращение):** требование
+  per-instance-идентичности применимо к **каждому catchable-определению
+  события, получающему builder waiter'а**. Сегодня builder'ы есть только у
+  timer + message (`CreateWaiter`, §2.2). Когда будущее изменение добавит
+  case `CreateWaiter` для signal / conditional / и т.п., оно ОБЯЗАНО добавить и
+  `CloneForInstance` этому типу eDef — иначе вновь вводит этот broadcast-баг.
+  Зафиксировать это рядом со switch'ем `CreateWaiter` комментарием, чтобы
+  требование было видно в точке изменения.
+
+## §6 Регрессии / побочные эффекты
+
+### §6.1 Путь срабатывания таймера
+Таймер не несёт payload и не имеет `CloneEvent` (он не `flow.EventDefCloner`),
+так что срабатывает на **зарегистрированном** (теперь per-instance) eDef
+как есть — что по-прежнему совпадает с его собственным waiter'ом.
+Существующие тесты доставки timer-waiter'а (`eventhub_timer_test.go`) страхуют,
+что таймер по-прежнему срабатывает у своего экземпляра.
+
+### §6.2 Что может полагаться на старое (shared-id) поведение
+`grep` любого кода, ищущего таймер по *шаблонному* eDef id между экземплярами →
+не ожидается (карта EventHub per-registration; `WaiterFired`/`UnregisterEvent`
+используют живой eDef id, который теперь per-instance, ровно как для
+message-фикса). Перепрогнать audit-grep перед приземлением.
+
+### §6.3 Путь отката
+Откат одним коммитом (метод + его тест); без миграции, без данных.
+
+## §7 Связанное
+
+- [SRD-017 v.1](../srd/SRD-017-conversation-token-threading.md) —
+  message-прецедент (`CloneForInstance`, M3a, §4.3) и явный отлог, который
+  этот FIX закрывает. Вбок (FIX → SRD).
+- [ADR-006 v.1](../design/ADR-006-events-and-subscriptions.md) — модель
+  waiter'ов EventHub (ключевание по eDef id; удалением владеет hub).
+- [ADR-009 v.1](../design/ADR-009-per-instance-node-graph.md) — каждый
+  экземпляр владеет приватной копией графа узлов; per-instance-идентичность
+  eDef — естественное завершение этого принципа для catchable-определений.
+- **Кандидат на повышение до ADR:** если/когда catchable станут несколько типов
+  событий, правило «каждое обеспеченное waiter'ом catch-определение —
+  per-instance» стоит сформулировать единожды (ADR или заметка SAD), а не
+  per-type.
+
+## §8 Сводка реализации (постадийные фактические приземления + отличия от черновика)
+
+### §8.1 Стадии по коммитам (ветка `fix/timer-catch-broadcast`)
+
+| Стадия | Коммит | Объём | Тесты |
+|---|---|---|---|
+| doc | `fb683ac` | документ FIX-004 | — |
+| M1 | `b98c069` | `TimerEventDefinition.CloneForInstance` (timer.go) + импорт `foundation`; заметка на будущее у switch'а `CreateWaiter` (waiters.go); две канарейки (clone_for_instance_test.go) | `TestTimerEventDefinitionCloneForInstance`, `TestTimerReceiverPerInstanceClone` |
+
+Приземлено ровно по черновику §3.2: один метод, без правки `Event.clone` /
+интерфейса / мок. Существующая проверка опционального интерфейса в
+`cloneDefsForInstance` применила новый метод автоматически — receiver-канарейка
+доказывает это через реальный путь клонирования.
+
+### §8.2 Результаты верификации
+
+- `make ci` (CI-parity-гейт): **PASS** — tidy / golangci-lint (вкл.
+  fieldalignment, misspell) / build / `-race`-тесты / diff-coverage /
+  govulncheck все зелёные. `TimerEventDefinition.CloneForInstance` измерен на
+  **100%** покрытия.
+- Все 9 запускаемых примеров выходят с кодом 0, включая timer-примеры
+  `simple-timer` и `timer-event` (таймеры по-прежнему срабатывают корректно —
+  нет регрессии пути срабатывания, подтверждает §6.1).
+- Существующий `TestNonMessageDefSharedOnClone` (signal остаётся shared)
+  по-прежнему проходит — на per-instance перешёл только timer-тип, как и
+  задумано.
+
+### §8.3 Эмпирические находки — где реальность разошлась с черновиком §3
+
+Нет. Фикс приземлился по проекту; единственные авторские правки —
+US-орфография (`analogue`→`analog`) и перенос строк комментария под
+80-колоночный / misspell-линтеры проекта — без поведенческой разницы.
+
+### §8.4 Бэклог (вне объёма FIX-004)
+
+- Signal / conditional промежуточные catch'и: когда получат builder
+  `CreateWaiter`, каждый ОБЯЗАН также реализовать `CloneForInstance` (см.
+  заметку на будущее §5), иначе этот класс broadcast'а вернётся для них.
+- Two-instance уровня движка no-broadcast-утверждение (§4.1.2) покрыто
+  distinct-id-канарейкой, а не отдельным thresher-тестом — будущий
+  интеграционный тест мог бы прогонять его end-to-end, если будет собран
+  более широкий набор тестов broadcast'а событий.
+
+## §9 Открытые вопросы
+
+Нет. Объём — **только timer** (единственное не-message catchable, обеспеченное
+waiter'ом определение события — §2.2): добавить
+`TimerEventDefinition.CloneForInstance` (свежий per-instance id, выражения
+делятся), по образцу message-фикса, с distinct-id-канарейкой и заметкой на
+будущее, связывающей будущие case'ы `CreateWaiter` с требованием
+per-instance-идентичности. Signal/conditional и подход с широким
+интерфейс-методом явно вне объёма, пока эти типы не получат builder'ы waiter'ов
+(§3.1 B).

--- a/internal/eventproc/eventhub/waiters/waiters.go
+++ b/internal/eventproc/eventhub/waiters/waiters.go
@@ -44,6 +44,12 @@ func CreateWaiter(
 		err error
 	)
 
+	// NOTE: timer and message are the only catchable triggers with a waiter
+	// builder. Any future case added here (signal, conditional, …) MUST also
+	// give its EventDefinition a CloneForInstance method (see
+	// MessageEventDefinition / TimerEventDefinition), or concurrent instances
+	// waiting on it will share one waiter and a single occurrence will resume
+	// them all (the FIX-004 / SRD-017 per-instance-identity rule).
 	switch eDef.Type() {
 	case flow.TriggerTimer:
 		w, err = NewTimeWaiter(eh, ep, eDef, "", rt)

--- a/pkg/model/events/clone_for_instance_test.go
+++ b/pkg/model/events/clone_for_instance_test.go
@@ -1,14 +1,69 @@
 package events_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
 	"github.com/dr-dobermann/gobpm/pkg/model/events"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/stretchr/testify/require"
 )
+
+// newTimerEDef builds a date-only TimerEventDefinition for the clone tests.
+func newTimerEDef(t *testing.T) *events.TimerEventDefinition {
+	t.Helper()
+
+	return events.MustTimerEventDefinition(
+		goexpr.Must(nil,
+			data.MustItemDefinition(
+				values.NewVariable(time.Now().Add(time.Second))),
+			func(_ context.Context, _ data.Source) (data.Value, error) {
+				return values.NewVariable(time.Now().Add(time.Second)), nil
+			}),
+		nil, nil)
+}
+
+// TestTimerEventDefinitionCloneForInstance verifies CloneForInstance yields a
+// fresh id on each call (FIX-004) while sharing the timer expression by
+// reference.
+func TestTimerEventDefinitionCloneForInstance(t *testing.T) {
+	data.CreateDefaultStates()
+
+	ted := newTimerEDef(t)
+
+	c1 := ted.CloneForInstance()
+	c2 := ted.CloneForInstance()
+
+	require.NotEqual(t, ted.ID(), c1.ID(), "clone must have a fresh id")
+	require.NotEqual(t, c1.ID(), c2.ID(), "each clone must have a distinct id")
+
+	// the immutable timer expression is shared by reference, not copied.
+	require.Same(t, ted.Time(), c1.(*events.TimerEventDefinition).Time(),
+		"timer expression must be shared with the template")
+}
+
+// TestTimerReceiverPerInstanceClone verifies that cloning a timer-catch node
+// gives each clone a distinct timer-eDef id, so concurrent instances register
+// distinct EventHub waiters (no shared-waiter broadcast — FIX-004).
+func TestTimerReceiverPerInstanceClone(t *testing.T) {
+	data.CreateDefaultStates()
+
+	ted := newTimerEDef(t)
+
+	start, err := events.NewStartEvent("start", events.WithTimerTrigger(ted))
+	require.NoError(t, err)
+
+	id1 := start.Clone().(flow.EventNode).Definitions()[0].ID()
+	id2 := start.Clone().(flow.EventNode).Definitions()[0].ID()
+
+	require.NotEqual(t, ted.ID(), id1, "cloned timer eDef must have a fresh id")
+	require.NotEqual(t, id1, id2, "two instances must get distinct timer eDef ids")
+}
 
 // TestMessageEventDefinitionCloneForInstance verifies CloneForInstance yields a
 // fresh id on each call (SRD-017 §4.3) while sharing the message by reference.

--- a/pkg/model/events/timer.go
+++ b/pkg/model/events/timer.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 	"github.com/dr-dobermann/gobpm/pkg/model/options"
 )
 
@@ -86,6 +87,25 @@ func MustTimerEventDefinition(
 	}
 
 	return ted
+}
+
+// CloneForInstance returns a per-instance copy of the TimerEventDefinition
+// with a FRESH id, sharing the (immutable) timer expressions by reference.
+// Node cloning (Event.clone) uses it so each process instance's timer catch
+// registers a DISTINCT EventHub waiter (keyed by eDef id): without it
+// concurrent instances waiting on the same timer would share one waiter and a
+// single timer occurrence would resume them all (FIX-004; the timer analog of
+// MessageEventDefinition.CloneForInstance). A timer carries no payload, so
+// there is no fire-path CloneEvent to keep the id stable — only the
+// registration identity must be per-instance. Canary:
+// TestTimerReceiverPerInstanceClone.
+func (ted *TimerEventDefinition) CloneForInstance() flow.EventDefinition {
+	return &TimerEventDefinition{
+		definition:   definition{BaseElement: *foundation.MustBaseElement()},
+		timeDate:     ted.timeDate,
+		timeCycle:    ted.timeCycle,
+		timeDuration: ted.timeDuration,
+	}
 }
 
 // Time return the Timer's time.


### PR DESCRIPTION
FIX-004 — concurrent timer-catch instances share one waiter

Problem

Two or more running instances of the same process, each parked at the same intermediate timer catch event, shared a single EventHub waiter. One timer occurrence resumed them all instead of each
instance's own timer resuming only that instance — the timer analogue of the message broadcast bug SRD-017 fixed. It was masked because no test ran two concurrent instances parked on one timer
catch.

Root cause

Event.clone/cloneDefsForInstance freshens an event definition's id per instance only for definitions implementing the optional CloneForInstance interface; SRD-017 added it to
MessageEventDefinition alone. TimerEventDefinition was shared by reference → same id → EventHub merged concurrent timer catches onto one waiter. Timer is the only affected type:
signal/conditional catches have no CreateWaiter builder (they cannot wait in-instance), and message is already fixed.

Fix

Add TimerEventDefinition.CloneForInstance() — a fresh-id copy sharing the immutable timer expressions by reference, mirroring MessageEventDefinition.CloneForInstance. No Event.clone, interface,
or mock change. A forward-note at the CreateWaiter switch records that any future trigger gaining a waiter builder must also add CloneForInstance.

Tests

- TestTimerEventDefinitionCloneForInstance — fresh id per call, expression shared.
- TestTimerReceiverPerInstanceClone — cloned timer catch gets distinct per-instance eDef ids (the broadcast canary).
- TestNonMessageDefSharedOnClone (signal stays shared) still passes.

Verification

make ci green (lint incl. fieldalignment/misspell, build, -race, diff-coverage, govulncheck); CloneForInstance 100% covered; all 9 examples exit 0, including simple-timer and timer-event.

Also in this PR (docs-only)

- README gooper quick-start updated to the current gofunc API: gooper.New(name, functor) builds the service.Operation directly; the functor takes a read-only DataReader; the old
service.NewOperation wrap is removed (the snippet now matches examples/basic-process).

Doc: docs/fix/FIX-004-timer-catch-broadcast.md (Accepted v.1) + RU twin.
