### PR TITLE
Feat/instance control lifecycle

### DIFF
--- a/docs/srd/SRD-019-instance-control-lifecycle.md
+++ b/docs/srd/SRD-019-instance-control-lifecycle.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Draft |
+| Status | Accepted |
 | Version | v.1 |
 | Date | 2026-06-18 |
 | Owner | Ruslan Gabitov |
@@ -303,10 +303,57 @@ Internal support: `internal/instance` — `Run` derives `inst.cancel`; `Instance
 
 ## 10. Implementation summary
 
-> ⚠️ TODO: fill AFTER landing — commits, key files, V-results, deltas vs this draft.
+Landed on `feat/instance-control-lifecycle` (off `master`): four milestones,
+each a single commit, plus a tangential example enhancement.
+
+### 10.1 Milestones (commits)
+
+| M | Commit | Scope | Tests |
+|---|---|---|---|
+| M1 | `a35012a` | Instance cancel: `inst.cancel` derived in `Run`, `Instance.Cancel()`; `InstanceHandle.Cancel(ctx)` (request + ctx-bounded wait, idempotent); reserved `Suspend`/`Resume` → `ErrNotImplemented` | `TestInstanceHandleCancel`, `TestCancelCtxBounded`, `TestSuspendResumeReserved`, `TestInstanceCancel` (internal) |
+| M2 | `0c1ffab` | `EventHub.Shutdown(ctx)` waiter drain: `EventWaiter.Done()` + hub `Shutdown`; timer/message waiters close a `done` channel on goroutine exit; `started bool` replaced by a `hubState` enum | `TestEventHubShutdownDrainsWaiters` (-race), `TestShutdownRemovesOnStopError`, `TestShutdownCtxBounded`; waiter `Done()` checks in timer/message tests |
+| M3 | `75dcde6` | `Thresher.Shutdown(ctx)` + terminal `Stopped` state; `Run` derives `t.engineCancel` (the cascade master switch); guards in `Run`/`StartProcess`/`RegisterProcess` | `TestThresherShutdown`, `TestThresherShutdownCtxBounded` |
+| M4 | `f3ee4a3` | Discovery + release: `Instances(filter)`+`InstanceFilter`, `Forget(ids...)` (batch all-or-nothing), `Starters()`+`StarterInfo`; `UnregisterProcess` doc note | `TestInstancesFilter`, `TestForget`, `TestStarters`, `TestUnregisterProcessWithLiveInstance` |
+
+Plus `ba32f4e` — the basic example reads a property + `RUNTIME/STARTED_AT`
+through the gofunc's `DataReader` (split per the >80-line example rule);
+tangential to this SRD, bundled in this branch's example phase.
+
+### 10.2 Key files
+
+- `pkg/thresher/handle.go` — `Cancel`/`Suspend`/`Resume` + `ErrNotImplemented`.
+- `pkg/thresher/thresher.go` — `Stopped` state, `engineCancel`, `Shutdown`, guards.
+- `pkg/thresher/discovery.go` (new) — `InstanceFilter`, `Instances`, `Forget`, `StarterInfo`, `Starters`.
+- `internal/instance/instance.go` — `inst.cancel` + `Instance.Cancel()`.
+- `internal/eventproc/eventproc.go` — `EventWaiter.Done()` + `EventHub.Shutdown` on the interfaces.
+- `internal/eventproc/eventhub/eventhub.go` — `hubState` enum, `EventHub.Shutdown`, registration guard.
+- `internal/eventproc/eventhub/waiters/{timer,message}.go` — `done` channel + `Done()`.
+
+### 10.3 Verification
+
+- `make ci` green: tidy, lint (incl. fieldalignment), build, `-race`,
+  **diff-coverage 96.8% of 189 changed lines (≥95)**, govulncheck.
+- Touched-function coverage all ≥80% (most 100%; `Shutdown` 96%, `Run` 87%,
+  `RegisterProcess` 96%).
+- All 9 examples smoke-run exit 0.
+- NFR-2 (no waiter goroutine outlives the hub) proven under `-race`.
+
+### 10.4 Deltas vs the draft
+
+- **`StarterInfo` fields.** The draft first sketched `{ProcessID, Trigger, Manual}`;
+  shipped as `{ProcessID, StartNode, Trigger}` — a **manual-start process registers
+  no starter**, so a listed starter is always auto-start (no `Manual` field). §6/FR-7b
+  reconciled in `f3ee4a3`.
+- **Waiter-drain test names.** §7's single `TestShutdownDrainsWaiters` landed as
+  `TestEventHubShutdownDrainsWaiters` (real-timer `-race` drain) +
+  `TestShutdownRemovesOnStopError` (the Stop-error-still-removed half) +
+  `TestShutdownCtxBounded`; same coverage, split for clarity.
+- **EventHub lifecycle.** M2 replaced the `started bool` with a `hubState` enum
+  (`notStarted`/`started`/`stopped`) so the shutdown flag can't form an invalid
+  started-and-stopped combination — a small refinement beyond the draft.
 
 ## Document History
 
 | Version | Date | Author | Change |
 |---|---|---|---|
-| v.1 | 2026-06-18 | Ruslan Gabitov | Draft. Lands the control + engine-lifecycle slice of ADR-013 v.1 (§2.3/§2.5) and realizes the open part of ADR-006 v.1 §2.5: `InstanceHandle.Cancel(ctx)` (instance self-cancel via a `Run`-derived `inst.cancel`, request + ctx-bounded wait, idempotent) + reserved `Suspend`/`Resume`; `Thresher.Shutdown(ctx)` (new terminal `Stopped` state, cancel + settle running instances, drain the hub); `EventHub.Shutdown(ctx)` (hub `sync.WaitGroup` over waiter `Service` goroutines, ctx-bounded wait, remove-even-on-`Stop`-error); `Thresher.Forget(ids ...string)` (batch, all-or-nothing release of terminal instances) + `Instances(filter)` discovery (one function, `InstancesAll`/`InstancesRunning`/`InstancesCompleted`) + `Starters() []StarterInfo` (event-start registrations, which have no instance yet) + `UnregisterProcess` documented (live instances keep running). Code-grounded against `pkg/thresher`, `internal/instance`, `internal/eventproc/eventhub`. Sibling of SRD-018 v.1 (observe). Implements ADR-013 v.1; realizes ADR-006 v.1 §2.5; refs ADR-001 v.5, ADR-002 v.2. |
+| v.1 | 2026-06-18 | Ruslan Gabitov | Accepted. Lands the control + engine-lifecycle slice of ADR-013 v.1 (§2.3/§2.5) and realizes the open part of ADR-006 v.1 §2.5: `InstanceHandle.Cancel(ctx)` (instance self-cancel via a `Run`-derived `inst.cancel`, request + ctx-bounded wait, idempotent) + reserved `Suspend`/`Resume`; `Thresher.Shutdown(ctx)` (new terminal `Stopped` state, cancel + settle running instances, drain the hub); `EventHub.Shutdown(ctx)` (hub `sync.WaitGroup` over waiter `Service` goroutines, ctx-bounded wait, remove-even-on-`Stop`-error); `Thresher.Forget(ids ...string)` (batch, all-or-nothing release of terminal instances) + `Instances(filter)` discovery (one function, `InstancesAll`/`InstancesRunning`/`InstancesCompleted`) + `Starters() []StarterInfo` (event-start registrations, which have no instance yet) + `UnregisterProcess` documented (live instances keep running). Code-grounded against `pkg/thresher`, `internal/instance`, `internal/eventproc/eventhub`. Sibling of SRD-018 v.1 (observe). Implements ADR-013 v.1; realizes ADR-006 v.1 §2.5; refs ADR-001 v.5, ADR-002 v.2. |

--- a/docs/srd/SRD-019-instance-control-lifecycle.md
+++ b/docs/srd/SRD-019-instance-control-lifecycle.md
@@ -1,0 +1,310 @@
+# SRD-019 — Instance control & engine lifecycle: Cancel, Shutdown, waiter drain
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-06-18 |
+| Owner | Ruslan Gabitov |
+| Implements | [ADR-013 v.1 Instance Observability & Control](../design/ADR-013-instance-observability.md) |
+
+This SRD lands the **control + engine-lifecycle** slice of [ADR-013 v.1](../design/ADR-013-instance-observability.md)
+(§2.3 coarse control, §2.5 engine lifecycle) and **realizes the still-open part of
+[ADR-006 v.1 §2.5](../design/ADR-006-events-and-subscriptions.md)** — the
+`WaitGroup`-synchronized EventHub waiter shutdown that `Thresher.Shutdown`
+consumes. It is the sibling of the already-merged observe slice
+([SRD-018 v.1](SRD-018-instance-observe-handle.md), the pull handle + observer
+event stream). Coarse, explicit, engine-mediated control: `InstanceHandle.Cancel`
+(+ reserved `Suspend`/`Resume`), `Thresher.Shutdown`, `Thresher.Forget`, and the
+already-present `UnregisterProcess` documented + lightly hardened.
+
+## 1. Background & motivation
+
+### 1.1 Current state (verified against the code)
+
+- **No way to cancel a running instance.** `InstanceHandle` (`pkg/thresher/handle.go:16`)
+  is read-only (SRD-018: `ID/State/Tokens/History/Data/WaitCompletion/Observe`); it
+  has no `Cancel`. The instance has **no own cancel and no `Cancel()`/`Terminate()`
+  method** — termination is driven only by **ctx-cancel**: `Instance.Run(ctx)` stores
+  `inst.ctx = ctx` (`internal/instance/instance.go:558-585`); the loop observes
+  `ctx.Done()` → `stopAll()` → `setState(Terminating)` → tracks stop →
+  `setState(Terminated)` + `close(loopDone)` (`instance.go:603-688`). The only holder
+  of an instance's cancel is the Thresher: `launchInstance` does
+  `ctx, cancel := context.WithCancel(t.ctx)` and stores `instanceReg{stop: cancel, …}`
+  (`thresher.go:679,696`; `instanceReg` at `thresher.go:97-102`) — never invoked today.
+- **No `Thresher.Shutdown`.** The `State` enum is `Invalid / NotStarted / Started /
+  Paused` (`thresher.go:58-95`) — **no `Stopped`**. `Run(ctx)` sets `Started`, calls
+  `eventHub.Start(ctx)` synchronously then spawns `go eventHub.Run(ctx)`
+  (`thresher.go:245-299`); `StartProcess` guards `st != Started`
+  (`thresher.go:623-647`). There is **no graceful stop**: no Thresher `Shutdown`/`Stop`.
+- **EventHub has no shutdown and no `WaitGroup`** (the open ADR-006 §2.5 item).
+  `EventHub` (`internal/eventproc/eventhub/eventhub.go:31-38`) holds `waiters
+  map[string]EventWaiter` + `m sync.RWMutex` + `started`; **no `sync.WaitGroup`, no
+  `Shutdown`/`Close`**. `Run(ctx)` just blocks on `<-ctx.Done()` (`eventhub.go:86-96`).
+  Each waiter's `Service(ctx)` spawns a background goroutine (timer:
+  `waiters/timer.go:245-276`) and `Stop()` signals it (`timer.go:369-385`). Nothing
+  **waits** for those goroutines to exit on stop → a stop leaves live goroutines.
+- **Sole-hub waiter ownership is already in place** (FIX-003): a waiter reports a
+  terminal fire via `hub.WaiterFired(eDefID)` and **does not remove itself**; the hub
+  owns removal (`eventhub.go:343` `WaiterFired`, `:318` `RemoveWaiter`, `:214`
+  `UnregisterEvent`). The double-close / TOCTOU / double-removal defects (audit
+  1.3/1.5/2.5-ownership) are **fixed**; what remains of ADR-006 §2.5 is the
+  **synchronized drain**.
+- **`UnregisterProcess` exists but doesn't consider live instances**
+  (`thresher.go:450-491`): it removes the `snapshots`/`starters` entries and
+  unregisters starters from the hub, with **no check** for running instances of that
+  process. The `snapshots` map is freed only here (audit 2.2). The `instances` map
+  (`thresher.go:651` `Instance(id)` lookup) is **never pruned** — completed instances
+  accumulate.
+
+### 1.2 Problem
+
+A host can observe a running instance (SRD-018) but cannot **act**: no cancel, no
+graceful engine shutdown, no way to release a finished instance, and the EventHub
+leaks waiter goroutines on stop (ADR-006 §2.5 open). This SRD adds the coarse,
+explicit, engine-mediated control + lifecycle ADR-013 §2.3/§2.5 decided, and the
+waiter drain ADR-006 §2.5 needs.
+
+## 2. Decision
+
+- **`InstanceHandle.Cancel(ctx)`** requests termination and blocks (ctx-bounded) until
+  the instance is terminal. The **instance gains its own cancel**: `Run` derives
+  `inst.ctx, inst.cancel = context.WithCancel(ctx)` and exposes `Cancel()`; the handle
+  calls it, then waits on the existing `Done()`/`loopDone`. Termination still runs the
+  proven ADR-001 cascade (Active→Terminating→Terminated). `Suspend`/`Resume` are
+  **declared but reserved** (return a sentinel error) — they need the deferred `Paused`
+  subsystem (ADR-013 §2.3).
+- **`Thresher.Shutdown(ctx)`** is graceful, engine-mediated: flip to a new terminal
+  **`Stopped`** state (so `StartProcess`/`RegisterProcess`/`Run` reject), cancel every
+  running instance and wait (ctx-bounded) for them to settle, then drain the EventHub.
+- **`EventHub.Shutdown(ctx)`** (realizes ADR-006 §2.5): stop every waiter and **wait
+  for their goroutines to exit** via a hub `sync.WaitGroup`, bounded by ctx; remove
+  every waiter from the registry **even if its `Stop()` errors** (no leak); unblock the
+  hub `Run`.
+- **Instance discovery + release.** A single **`Instances(filter)`**
+  (`InstancesAll` / `InstancesRunning` / `InstancesCompleted`) lists tracked instance
+  ids by liveness (the host reads each one's state via `Instance(id)`);
+  **`Thresher.Forget(ids ...string)`** releases
+  **terminal** instances in bulk — all-or-nothing (a live or unknown id is an error;
+  none are removed on error) — the explicit release for the kept-for-observability
+  instances. Because **event-start registrations have no instance to look up yet**,
+  they get their own listing — **`Starters() []StarterInfo`** — a read-only projection
+  of the registered starters (process + trigger event + start mode). **`UnregisterProcess`**
+  keeps its current behaviour (remove definition +
+  starters; **live instances keep running** against their built snapshot) — now
+  documented, with a note that finished instances are released via `Forget`/`Shutdown`.
+
+Control is coarse and visible (operator action through the engine's state machine),
+never a hidden per-node listener (ADR-013 §4, ADR-011).
+
+## 3. Functional requirements
+
+- **FR-1 — instance cancel.** `InstanceHandle.Cancel(ctx context.Context)
+  (InstanceState, error)` requests termination and blocks until the instance reaches a
+  terminal state or `ctx` is done; returns the terminal state (+ `ctx.Err()` on
+  timeout). Idempotent (a second `Cancel`, or `Cancel` of an already-terminal instance,
+  is a no-op returning the terminal state).
+- **FR-2 — instance self-cancel hook.** `internal/instance`: `Run` derives an internal
+  cancellable context (`inst.cancel`); `Instance.Cancel()` cancels it (idempotent),
+  driving the loop's existing `ctx.Done()` cascade to `Terminating`→`Terminated`. The
+  Thresher's parent ctx (`instanceReg.stop`, engine ctx) still cascades.
+- **FR-3 — reserved suspend/resume.** `InstanceHandle.Suspend(ctx)` / `Resume(ctx)`
+  exist and return a stable **`ErrNotImplemented`** sentinel (reserved for the `Paused`
+  subsystem; the contract is fixed now, ADR-013 §2.3).
+- **FR-4 — engine graceful shutdown.** `Thresher.Shutdown(ctx context.Context) error`:
+  (a) transition to `Stopped` (so further `StartProcess`/`RegisterProcess`/`Run` are
+  rejected); (b) cancel every running instance and wait (ctx-bounded) for them to
+  settle; (c) call `EventHub.Shutdown(ctx)`; return the first error / `ctx.Err()` on
+  deadline. Idempotent.
+- **FR-5 — `Stopped` state.** Add `Stopped` to the Thresher `State` enum;
+  `StartProcess` (`thresher.go:623`), `RegisterProcess`, and `Run` reject when `Stopped`.
+- **FR-6 — EventHub synchronized shutdown.** `EventHub.Shutdown(ctx context.Context)
+  error` stops every registered waiter, **waits for their `Service` goroutines to exit**
+  via a hub `sync.WaitGroup` bounded by `ctx`, and removes every waiter from the registry
+  **even when a `Stop()` returns an error** (logged, never leaked). It unblocks the hub
+  `Run` and rejects further registration. The waiter `Service` goroutine signals exit to
+  the hub (it already holds a `hub` reference and calls `WaiterFired`).
+- **FR-7 — forget finished instances (batch).** `Thresher.Forget(ids ...string) error`
+  removes the listed **terminal** instances from the `instances` map, **all-or-nothing**:
+  it first validates every id (known **and** terminal) and removes none if any is
+  unknown or still-live, returning an error naming the offending id. `Forget("x")`
+  (single) and `Forget(Instances(InstancesCompleted)...)` (sweep) both work.
+- **FR-7a — instance discovery.** A single `Thresher.Instances(filter InstanceFilter)
+  []string` lists tracked instance ids by an `InstanceFilter` enum:
+  `InstancesAll` (every tracked), `InstancesRunning` (non-terminal — Created/Active/
+  Terminating), `InstancesCompleted` (terminal — Completed/Terminated; the list that
+  feeds batch `Forget`). Read-only, snapshot-consistent under the engine mutex.
+- **FR-7b — starter discovery.** `Thresher.Starters() []StarterInfo` lists the
+  registered **event-start** registrations (the `starters` map) — each a process awaiting
+  an event, with **no instance yet**, so they cannot appear under `Instances`.
+  `StarterInfo` is a read-only projection of the internal `instanceStarter` (the process
+  it would instantiate, the trigger event-definition it waits on, and the auto/manual
+  start mode); exact fields are pinned against `instanceStarter` at implementation.
+- **FR-8 — unregister with live instances.** `UnregisterProcess` (`thresher.go:450`)
+  removes the definition + starters and **leaves any live instances running** (current
+  behaviour, now documented); the per-process `snapshots` entry is freed.
+
+## 4. Non-functional requirements
+
+- **NFR-1 — coarse, engine-mediated control.** Cancel/Shutdown act through the
+  instance/engine state machines (ctx-cancel cascade, `setState`), never a back door;
+  no mutating per-node listener (ADR-013 §4).
+- **NFR-2 — no goroutine leak on shutdown.** After `EventHub.Shutdown` returns
+  (within `ctx`), no waiter `Service` goroutine outlives the hub; a failed `Stop()`
+  still removes the waiter (NFR realizes ADR-006 §2.5).
+- **NFR-3 — bounded + idempotent.** `Cancel`/`Shutdown` honour `ctx` deadlines and are
+  idempotent (safe to call twice / after terminal); report stragglers rather than hang.
+- **NFR-4 — concurrency-safe.** Map mutations (`instances`/`snapshots`/`waiters`) stay
+  under their existing mutexes; the cancel cascade stays the single-owner loop model
+  (ADR-001); no new lock on the observation/execution hot path.
+- **NFR-5 — coverage.** Touched files finish ≥80% (target 100%) diff-coverage; `make
+  ci` green (`-race` especially — shutdown is concurrency-heavy).
+
+## 5. Path analysis (alternatives)
+
+- **Cancel via instance self-cancel (chosen) vs the handle holding `instanceReg.stop`.**
+  Chosen: the instance owns its cancel (`inst.cancel` derived in `Run`), `Cancel()`
+  triggers it. The handle (which holds `*instance.Instance`) calls `inst.Cancel()` — no
+  thresher round-trip, termination is handle-local, and the engine's parent-ctx cascade
+  is untouched. Rejected handle-holds-thresher-cancel: couples the handle to thresher
+  internals and needs a lookup.
+- **`Cancel(ctx)` request-and-wait (chosen) vs fire-and-forget.** Chosen: request +
+  ctx-bounded wait for terminal, returning the state — symmetric with `WaitCompletion`,
+  gives the caller confirmation. Fire-and-forget would force a separate `WaitCompletion`.
+- **EventHub drain via hub `WaitGroup` + waiter goroutine-exit signal (chosen) vs
+  synchronous `Stop()` (block until the goroutine exits).** Chosen: the hub `Add`s when
+  it starts a waiter and the waiter's goroutine `Done`s on exit (mirrors the existing
+  waiter→hub `WaiterFired` callback); `Shutdown` `Stop`s all then `Wait`s bounded by ctx.
+  Rejected synchronous-`Stop`: changes every waiter's `Stop()` semantics and serialises
+  the drain.
+- **Instance retention: keep + `Forget` (chosen) vs auto-evict on completion vs keep
+  forever.** Chosen (product decision): completed instances stay looked-up-able
+  (`Instance(id)`/`Observe`/`State` work post-completion — ADR-013's live in-memory
+  model), with an explicit `Forget(id)` + `Shutdown` to release. Rejected auto-evict:
+  loses post-completion observation; rejected keep-forever: unbounded with no release.
+- **`Stopped` as a new terminal state (chosen) vs reusing `NotStarted`.** Chosen: a
+  distinct terminal `Stopped` so a shut-down engine is not mistaken for a re-runnable
+  fresh one.
+- **Discovery: one `Instances(filter)` (chosen) vs three methods
+  (`Instances`/`RunningInstances`/`CompletedInstances`).** Chosen: a single function
+  with a named `InstanceFilter` enum (`InstancesAll`/`InstancesRunning`/
+  `InstancesCompleted`) — a 3-way filter, not a boolean, so one function reads cleaner
+  than three and extends if liveness categories grow. Starters are listed **separately**
+  via `Starters() []StarterInfo` rather than as a fourth `InstanceFilter` value, because
+  a starter is **not an instance** (no instance id, no lifecycle state) — folding it into
+  `Instances()` would mean returning ids that don't resolve via `Instance(id)`.
+- **`Forget(ids ...string)` batch, all-or-nothing (chosen) vs single-id / partial.**
+  Chosen: variadic batch (single-id still works) with validate-all-then-remove, so a
+  bad id in a sweep leaves the map untouched and the error is actionable.
+- **`UnregisterProcess` allows live instances (chosen) vs reject / cancel-them.** Chosen
+  (product decision): remove definition + starters, leave live instances running against
+  their built snapshot; simplest, no coupling of unregister to termination. The host uses
+  `Shutdown`/`Cancel`/`Forget` for instance lifecycle.
+
+## 6. API (public surface, `pkg/thresher`)
+
+```go
+// On the existing read-only handle (SRD-018), control is added:
+func (h *InstanceHandle) Cancel(ctx context.Context) (InstanceState, error)
+func (h *InstanceHandle) Suspend(ctx context.Context) error // reserved -> ErrNotImplemented
+func (h *InstanceHandle) Resume(ctx context.Context) error  // reserved -> ErrNotImplemented
+
+// Engine lifecycle:
+func (t *Thresher) Shutdown(ctx context.Context) error
+
+// Instance discovery + release:
+type InstanceFilter uint8
+const (
+	InstancesAll       InstanceFilter = iota // every tracked instance
+	InstancesRunning                          // non-terminal (Created/Active/Terminating)
+	InstancesCompleted                        // terminal (Completed/Terminated)
+)
+func (t *Thresher) Instances(filter InstanceFilter) []string
+func (t *Thresher) Forget(ids ...string) error // batch, terminal-only, all-or-nothing
+
+// Event-start registrations (no instance yet) — fields pinned at implementation:
+type StarterInfo struct {
+	ProcessID string // the process a matching event instantiates
+	Trigger   string // the event-definition it waits on (e.g. message name/id)
+	Manual    bool   // manual-start mode (auto-instantiation opted out)
+}
+func (t *Thresher) Starters() []StarterInfo
+
+// New thresher state (terminal):
+const Stopped State = /* iota after Paused */
+
+// Reserved-feature sentinel:
+var ErrNotImplemented = errs.New(/* "feature reserved, not yet implemented" */)
+```
+
+Internal support: `internal/instance` — `Run` derives `inst.cancel`; `Instance.Cancel()`
+(idempotent). `internal/eventproc/eventhub` — `EventHub.Shutdown(ctx) error` + a hub
+`sync.WaitGroup`; waiters signal `Service`-goroutine exit to the hub (e.g. a
+`hub.waiterDone()` callback paired with `wg.Add(1)` at `registerWaiter`'s
+`w.Service(eh.ctx)`).
+
+## 7. Test plan
+
+- **`TestInstanceHandleCancel`** — `Cancel(ctx)` on a parked/long-running instance drives
+  it to `Terminated`; a second `Cancel` and a `Cancel` of a completed instance are no-ops
+  returning the terminal state (FR-1, FR-2).
+- **`TestCancelCtxBounded`** — `Cancel` with a short ctx against an instance that won't
+  settle returns `ctx.Err()` and a non-terminal state (FR-1).
+- **`TestSuspendResumeReserved`** — both return `ErrNotImplemented` (FR-3).
+- **`TestThresherShutdown`** — `Shutdown(ctx)` cancels running instances, flips to
+  `Stopped`, and closes the hub; `StartProcess`/`RegisterProcess`/`Run` then reject;
+  idempotent on a second call (FR-4, FR-5).
+- **`TestShutdownDrainsWaiters`** (`-race`) — with a registered timer waiter,
+  `EventHub.Shutdown` returns only after the waiter goroutine exits (no leak); a waiter
+  whose `Stop()` errors is still removed (FR-6, NFR-2).
+- **`TestForget`** — `Forget(ids...)` removes completed instances in bulk (subsequent
+  `Instance(id)` → false); is **all-or-nothing** — a batch containing a live or unknown
+  id removes none and errors naming it (FR-7).
+- **`TestInstancesFilter`** — `Instances(InstancesAll/InstancesRunning/InstancesCompleted)`
+  returns the right id sets across a run (a parked instance under Running, a finished one
+  under Completed, both under All); `Forget(Instances(InstancesCompleted)...)` sweeps the
+  finished ones (FR-7a).
+- **`TestStarters`** — a process registered with a message-start event appears in
+  `Starters()` with its process id + trigger; manual-start mode is reflected; a process
+  with no event-start has no starter entry (FR-7b).
+- **`TestUnregisterProcessWithLiveInstance`** — `UnregisterProcess` succeeds with a live
+  instance still running; the definition is gone but the instance completes (FR-8).
+- Internal `internal/eventproc/eventhub` + `internal/instance` units for
+  `EventHub.Shutdown` / `Instance.Cancel` (cross-package coverage attribution).
+
+## 8. Cross-document consistency
+
+- **Implements** [ADR-013 v.1](../design/ADR-013-instance-observability.md) §2.3
+  (coarse control), §2.5 (engine lifecycle: `Shutdown`/`UnregisterProcess`).
+- **Realizes** [ADR-006 v.1 §2.5](../design/ADR-006-events-and-subscriptions.md) — the
+  `WaitGroup`-synchronized waiter shutdown + no-leak-on-`Stop` (the sole-ownership half
+  already landed via FIX-003).
+- [ADR-001 v.5](../design/ADR-001-execution-model.md) — the generic ctx-cancellation
+  cascade `Cancel` triggers (Active→Terminating→Terminated).
+- [ADR-002 v.2](../design/ADR-002-extension-architecture.md) — the §4.7 public-API
+  surface these methods join.
+- [SRD-018 v.1](SRD-018-instance-observe-handle.md) — the observe slice this builds the
+  control surface onto (sibling).
+- References up/sideways, version-pinned; no downward refs (ADR-013/ADR-006 do not cite
+  SRD-019).
+
+## 9. Definition of Done
+
+- FR-1…FR-8 wired and exercised by the §7 tests (incl. a `-race` waiter-drain test).
+- `InstanceHandle.Cancel`/`Suspend`/`Resume`, `Thresher.Shutdown`/`Forget`, the
+  `Stopped` state + guards, and `EventHub.Shutdown` + the hub `WaitGroup` all present.
+- No waiter goroutine outlives `EventHub.Shutdown` (NFR-2) — proven under `-race`.
+- `make ci` green (tidy, lint incl. fieldalignment, build, `-race`, diff-coverage ≥95,
+  govulncheck); touched files ≥80% (target 100%).
+- All 9 examples smoke-run exit 0 (control/shutdown didn't regress the happy path).
+- §10 filled; status → Accepted; RU twin added; linked docs synced.
+
+## 10. Implementation summary
+
+> ⚠️ TODO: fill AFTER landing — commits, key files, V-results, deltas vs this draft.
+
+## Document History
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v.1 | 2026-06-18 | Ruslan Gabitov | Draft. Lands the control + engine-lifecycle slice of ADR-013 v.1 (§2.3/§2.5) and realizes the open part of ADR-006 v.1 §2.5: `InstanceHandle.Cancel(ctx)` (instance self-cancel via a `Run`-derived `inst.cancel`, request + ctx-bounded wait, idempotent) + reserved `Suspend`/`Resume`; `Thresher.Shutdown(ctx)` (new terminal `Stopped` state, cancel + settle running instances, drain the hub); `EventHub.Shutdown(ctx)` (hub `sync.WaitGroup` over waiter `Service` goroutines, ctx-bounded wait, remove-even-on-`Stop`-error); `Thresher.Forget(ids ...string)` (batch, all-or-nothing release of terminal instances) + `Instances(filter)` discovery (one function, `InstancesAll`/`InstancesRunning`/`InstancesCompleted`) + `Starters() []StarterInfo` (event-start registrations, which have no instance yet) + `UnregisterProcess` documented (live instances keep running). Code-grounded against `pkg/thresher`, `internal/instance`, `internal/eventproc/eventhub`. Sibling of SRD-018 v.1 (observe). Implements ADR-013 v.1; realizes ADR-006 v.1 §2.5; refs ADR-001 v.5, ADR-002 v.2. |

--- a/docs/srd/SRD-019-instance-control-lifecycle.md
+++ b/docs/srd/SRD-019-instance-control-lifecycle.md
@@ -137,9 +137,10 @@ never a hidden per-node listener (ADR-013 §4, ADR-011).
 - **FR-7b — starter discovery.** `Thresher.Starters() []StarterInfo` lists the
   registered **event-start** registrations (the `starters` map) — each a process awaiting
   an event, with **no instance yet**, so they cannot appear under `Instances`.
-  `StarterInfo` is a read-only projection of the internal `instanceStarter` (the process
-  it would instantiate, the trigger event-definition it waits on, and the auto/manual
-  start mode); exact fields are pinned against `instanceStarter` at implementation.
+  `StarterInfo` is a read-only projection of the internal `instanceStarter`: the process
+  it would instantiate, the start node fired on a match, and the message it waits on. A
+  **manual-start** process registers no starter, so every listed starter is auto-start
+  (no `Manual` field needed).
 - **FR-8 — unregister with live instances.** `UnregisterProcess` (`thresher.go:450`)
   removes the definition + starters and **leaves any live instances running** (current
   behaviour, now documented); the per-process `snapshots` entry is freed.
@@ -222,11 +223,12 @@ const (
 func (t *Thresher) Instances(filter InstanceFilter) []string
 func (t *Thresher) Forget(ids ...string) error // batch, terminal-only, all-or-nothing
 
-// Event-start registrations (no instance yet) — fields pinned at implementation:
+// Event-start registrations (no instance yet). A manual-start process registers
+// no starter, so a listed starter is always auto-start (hence no Manual field).
 type StarterInfo struct {
 	ProcessID string // the process a matching event instantiates
-	Trigger   string // the event-definition it waits on (e.g. message name/id)
-	Manual    bool   // manual-start mode (auto-instantiation opted out)
+	StartNode string // the start node fired on a match
+	Trigger   string // the message the starter waits on
 }
 func (t *Thresher) Starters() []StarterInfo
 

--- a/docs/srd/SRD-019-instance-control-lifecycle.ru.md
+++ b/docs/srd/SRD-019-instance-control-lifecycle.ru.md
@@ -1,0 +1,375 @@
+# SRD-019 — Управление экземпляром и жизненный цикл движка: Cancel, Shutdown, дренаж waiter'ов
+
+| Поле | Значение |
+|---|---|
+| Статус | Принято |
+| Версия | v.1 |
+| Дата | 2026-06-18 |
+| Владелец | Руслан Габитов |
+| Реализует | [ADR-013 v.1 Instance Observability & Control](../design/ADR-013-instance-observability.ru.md) |
+
+Этот SRD приземляет срез **управления + жизненного цикла движка** из
+[ADR-013 v.1](../design/ADR-013-instance-observability.ru.md) (§2.3 грубое
+управление, §2.5 жизненный цикл движка) и **реализует ещё открытую часть
+[ADR-006 v.1 §2.5](../design/ADR-006-events-and-subscriptions.ru.md)** —
+синхронизированную через `WaitGroup` остановку waiter'ов EventHub, которую
+потребляет `Thresher.Shutdown`. Это близнец уже влитого среза наблюдения
+([SRD-018 v.1](SRD-018-instance-observe-handle.ru.md) — pull-ручка + поток
+событий наблюдателя). Грубое, явное, опосредованное движком управление:
+`InstanceHandle.Cancel` (+ зарезервированные `Suspend`/`Resume`),
+`Thresher.Shutdown`, `Thresher.Forget` и уже существующий `UnregisterProcess`,
+задокументированный и слегка укреплённый.
+
+## 1. Контекст и мотивация
+
+### 1.1 Текущее состояние (проверено по коду)
+
+- **Нет способа отменить работающий экземпляр.** `InstanceHandle`
+  (`pkg/thresher/handle.go:16`) только для чтения (SRD-018:
+  `ID/State/Tokens/History/Data/WaitCompletion/Observe`); у него нет `Cancel`.
+  У экземпляра **нет собственной отмены и метода `Cancel()`/`Terminate()`** —
+  завершение управляется только **ctx-cancel**: `Instance.Run(ctx)` сохраняет
+  `inst.ctx = ctx` (`internal/instance/instance.go:558-585`); цикл наблюдает
+  `ctx.Done()` → `stopAll()` → `setState(Terminating)` → остановка треков →
+  `setState(Terminated)` + `close(loopDone)` (`instance.go:603-688`).
+  Единственный держатель отмены экземпляра — Thresher: `launchInstance` делает
+  `ctx, cancel := context.WithCancel(t.ctx)` и хранит `instanceReg{stop: cancel, …}`
+  (`thresher.go:679,696`; `instanceReg` в `thresher.go:97-102`) — сегодня не
+  вызывается.
+- **Нет `Thresher.Shutdown`.** Перечисление `State` — `Invalid / NotStarted /
+  Started / Paused` (`thresher.go:58-95`) — **нет `Stopped`**. `Run(ctx)`
+  выставляет `Started`, синхронно вызывает `eventHub.Start(ctx)`, затем
+  поднимает `go eventHub.Run(ctx)` (`thresher.go:245-299`); `StartProcess`
+  проверяет `st != Started` (`thresher.go:623-647`). **Грациозной остановки
+  нет**: нет Thresher `Shutdown`/`Stop`.
+- **У EventHub нет shutdown и нет `WaitGroup`** (открытый пункт ADR-006 §2.5).
+  `EventHub` (`internal/eventproc/eventhub/eventhub.go:31-38`) держит `waiters
+  map[string]EventWaiter` + `m sync.RWMutex` + `started`; **нет `sync.WaitGroup`,
+  нет `Shutdown`/`Close`**. `Run(ctx)` просто блокируется на `<-ctx.Done()`
+  (`eventhub.go:86-96`). `Service(ctx)` каждого waiter'а поднимает фоновую
+  go-рутину (таймер: `waiters/timer.go:245-276`), а `Stop()` сигналит ей
+  (`timer.go:369-385`). Ничто **не ждёт** выхода этих го-рутин при остановке →
+  остановка оставляет живые го-рутины.
+- **Единоличное владение waiter'ами хабом уже на месте** (FIX-003): waiter
+  сообщает о терминальном срабатывании через `hub.WaiterFired(eDefID)` и **не
+  удаляет себя сам**; удаление принадлежит хабу (`eventhub.go:343` `WaiterFired`,
+  `:318` `RemoveWaiter`, `:214` `UnregisterEvent`). Дефекты double-close / TOCTOU /
+  double-removal (аудит 1.3/1.5/2.5-ownership) **исправлены**; от ADR-006 §2.5
+  остался **синхронизированный дренаж**.
+- **`UnregisterProcess` существует, но не учитывает живые экземпляры**
+  (`thresher.go:450-491`): удаляет записи `snapshots`/`starters` и снимает
+  регистрацию стартеров в хабе, **без проверки** работающих экземпляров этого
+  процесса. Карта `snapshots` освобождается только здесь (аудит 2.2). Карта
+  `instances` (`thresher.go:651` поиск `Instance(id)`) **никогда не чистится** —
+  завершённые экземпляры накапливаются.
+
+### 1.2 Проблема
+
+Хост может наблюдать работающий экземпляр (SRD-018), но не может **воздействовать**:
+нет отмены, нет грациозного завершения движка, нет способа освободить завершённый
+экземпляр, и EventHub утекает waiter-го-рутины при остановке (открыт ADR-006 §2.5).
+Этот SRD добавляет грубое, явное, опосредованное движком управление + жизненный
+цикл, решённые в ADR-013 §2.3/§2.5, и дренаж waiter'ов, нужный ADR-006 §2.5.
+
+## 2. Решение
+
+- **`InstanceHandle.Cancel(ctx)`** запрашивает завершение и блокируется
+  (ограничено ctx) до терминального состояния экземпляра. **Экземпляр получает
+  собственную отмену**: `Run` выводит `inst.ctx, inst.cancel = context.WithCancel(ctx)`
+  и предоставляет `Cancel()`; ручка вызывает его, затем ждёт на существующем
+  `Done()`/`loopDone`. Завершение по-прежнему исполняет проверенный каскад ADR-001
+  (Active→Terminating→Terminated). `Suspend`/`Resume` **объявлены, но
+  зарезервированы** (возвращают sentinel-ошибку) — им нужна отложенная подсистема
+  `Paused` (ADR-013 §2.3).
+- **`Thresher.Shutdown(ctx)`** грациозный, опосредованный движком: перевод в новое
+  терминальное состояние **`Stopped`** (так что `StartProcess`/`RegisterProcess`/`Run`
+  отвергают), отмена каждого работающего экземпляра и ожидание (ограничено ctx) их
+  оседания, затем дренаж EventHub.
+- **`EventHub.Shutdown(ctx)`** (реализует ADR-006 §2.5): остановить каждый waiter и
+  **дождаться выхода их го-рутин** через хабовую `sync.WaitGroup`, ограничено ctx;
+  удалить каждый waiter из реестра **даже если его `Stop()` вернул ошибку** (без
+  утечки); разблокировать `Run` хаба.
+- **Обнаружение + освобождение экземпляров.** Единая **`Instances(filter)`**
+  (`InstancesAll` / `InstancesRunning` / `InstancesCompleted`) перечисляет id
+  отслеживаемых экземпляров по живости (хост читает состояние каждого через
+  `Instance(id)`); **`Thresher.Forget(ids ...string)`** освобождает **терминальные**
+  экземпляры пакетно — всё-или-ничего (живой или неизвестный id — ошибка; при
+  ошибке ничего не удаляется) — явное освобождение для удерживаемых-ради-наблюдения
+  экземпляров. Поскольку у **event-start регистраций ещё нет экземпляра**, у них
+  своё перечисление — **`Starters() []StarterInfo`** — read-only проекция
+  зарегистрированных стартеров (процесс + триггер-событие + стартовый узел).
+  **`UnregisterProcess`** сохраняет текущее поведение (удалить определение +
+  стартеры; **живые экземпляры продолжают работать** на своём построенном снимке) —
+  теперь задокументировано, с примечанием, что завершённые экземпляры освобождаются
+  через `Forget`/`Shutdown`.
+
+Управление грубое и видимое (операторское действие через машину состояний движка),
+никогда не скрытый по-узловой listener (ADR-013 §4, ADR-011).
+
+## 3. Функциональные требования
+
+- **FR-1 — отмена экземпляра.** `InstanceHandle.Cancel(ctx context.Context)
+  (InstanceState, error)` запрашивает завершение и блокируется, пока экземпляр не
+  достигнет терминального состояния или `ctx` не завершится; возвращает терминальное
+  состояние (+ `ctx.Err()` при таймауте). Идемпотентно (второй `Cancel` или `Cancel`
+  уже-терминального экземпляра — no-op, возвращающий терминальное состояние).
+- **FR-2 — хук самоотмены экземпляра.** `internal/instance`: `Run` выводит внутренний
+  отменяемый контекст (`inst.cancel`); `Instance.Cancel()` отменяет его (идемпотентно),
+  запуская существующий каскад `ctx.Done()` цикла к `Terminating`→`Terminated`.
+  Родительский ctx Thresher'а (`instanceReg.stop`, ctx движка) по-прежнему каскадирует.
+- **FR-3 — зарезервированные suspend/resume.** `InstanceHandle.Suspend(ctx)` /
+  `Resume(ctx)` существуют и возвращают стабильный sentinel **`ErrNotImplemented`**
+  (зарезервированы под подсистему `Paused`; контракт зафиксирован уже сейчас,
+  ADR-013 §2.3).
+- **FR-4 — грациозное завершение движка.** `Thresher.Shutdown(ctx context.Context)
+  error`: (a) переход в `Stopped` (так что дальнейшие `StartProcess`/`RegisterProcess`/`Run`
+  отвергаются); (b) отмена каждого работающего экземпляра и ожидание (ограничено ctx) их
+  оседания; (c) вызов `EventHub.Shutdown(ctx)`; вернуть первую ошибку / `ctx.Err()` при
+  дедлайне. Идемпотентно.
+- **FR-5 — состояние `Stopped`.** Добавить `Stopped` в перечисление `State` Thresher'а;
+  `StartProcess` (`thresher.go:623`), `RegisterProcess` и `Run` отвергают при `Stopped`.
+- **FR-6 — синхронизированное завершение EventHub.** `EventHub.Shutdown(ctx context.Context)
+  error` останавливает каждый зарегистрированный waiter, **ждёт выхода их `Service`-го-рутин**
+  через хабовую `sync.WaitGroup`, ограничено `ctx`, и удаляет каждый waiter из реестра
+  **даже когда `Stop()` возвращает ошибку** (залогировано, никогда не утекает).
+  Разблокирует `Run` хаба и отвергает дальнейшую регистрацию. Го-рутина `Service`
+  waiter'а сигналит хабу о выходе (она уже держит ссылку `hub` и вызывает `WaiterFired`).
+- **FR-7 — забыть завершённые экземпляры (пакетно).** `Thresher.Forget(ids ...string)
+  error` удаляет перечисленные **терминальные** экземпляры из карты `instances`,
+  **всё-или-ничего**: сначала валидирует каждый id (известен **и** терминален) и не
+  удаляет ничего, если хоть один неизвестен или ещё живой, возвращая ошибку с именем
+  проблемного id. `Forget("x")` (одиночный) и `Forget(Instances(InstancesCompleted)...)`
+  (зачистка) оба работают.
+- **FR-7a — обнаружение экземпляров.** Единая `Thresher.Instances(filter InstanceFilter)
+  []string` перечисляет id отслеживаемых экземпляров по перечислению `InstanceFilter`:
+  `InstancesAll` (все отслеживаемые), `InstancesRunning` (нетерминальные — Created/Active/
+  Terminating), `InstancesCompleted` (терминальные — Completed/Terminated; список, питающий
+  пакетный `Forget`). Read-only, snapshot-консистентно под мьютексом движка.
+- **FR-7b — обнаружение стартеров.** `Thresher.Starters() []StarterInfo` перечисляет
+  зарегистрированные **event-start** регистрации (карта `starters`) — каждая это процесс,
+  ожидающий событие, у которого **ещё нет экземпляра**, так что они не могут появиться в
+  `Instances`. `StarterInfo` — read-only проекция внутреннего `instanceStarter`: процесс,
+  который он инстанцирует, стартовый узел, срабатывающий при совпадении, и сообщение,
+  которое он ждёт. Процесс с **ручным стартом** не регистрирует стартер, так что любой
+  перечисленный стартер — авто-старт (поле `Manual` не нужно).
+- **FR-8 — снятие регистрации при живых экземплярах.** `UnregisterProcess`
+  (`thresher.go:450`) удаляет определение + стартеры и **оставляет любые живые экземпляры
+  работающими** (текущее поведение, теперь задокументировано); per-process запись
+  `snapshots` освобождается.
+
+## 4. Нефункциональные требования
+
+- **NFR-1 — грубое, опосредованное движком управление.** Cancel/Shutdown действуют через
+  машины состояний экземпляра/движка (каскад ctx-cancel, `setState`), никогда не через
+  чёрный ход; нет мутирующего по-узлового listener'а (ADR-013 §4).
+- **NFR-2 — нет утечки го-рутин при завершении.** После возврата `EventHub.Shutdown`
+  (в пределах `ctx`) ни одна `Service`-го-рутина waiter'а не переживает хаб; неудачный
+  `Stop()` всё равно удаляет waiter (NFR реализует ADR-006 §2.5).
+- **NFR-3 — ограниченность + идемпотентность.** `Cancel`/`Shutdown` уважают дедлайны
+  `ctx` и идемпотентны (безопасно вызывать дважды / после терминала); сообщают об
+  отставших, а не виснут.
+- **NFR-4 — безопасность по конкурентности.** Мутации карт (`instances`/`snapshots`/`waiters`)
+  остаются под их существующими мьютексами; каскад отмены остаётся моделью
+  единоличного владения циклом (ADR-001); нет новой блокировки на горячем пути
+  наблюдения/исполнения.
+- **NFR-5 — покрытие.** Затронутые файлы финишируют ≥80% (цель 100%) diff-coverage;
+  `make ci` зелёный (особенно `-race` — завершение конкурентно-нагружено).
+
+## 5. Анализ путей (альтернативы)
+
+- **Cancel через самоотмену экземпляра (выбрано) vs ручка держит `instanceReg.stop`.**
+  Выбрано: экземпляр владеет своей отменой (`inst.cancel`, выведено в `Run`), `Cancel()`
+  её триггерит. Ручка (которая держит `*instance.Instance`) вызывает `inst.Cancel()` —
+  без обращения к thresher'у, завершение локально для ручки, и родительский каскад ctx
+  движка не тронут. Отклонено «ручка держит thresher-отмену»: связывает ручку с
+  внутренностями thresher'а и требует поиска.
+- **`Cancel(ctx)` запрос-и-ожидание (выбрано) vs fire-and-forget.** Выбрано: запрос +
+  ограниченное ctx ожидание терминала с возвратом состояния — симметрично с
+  `WaitCompletion`, даёт вызывающему подтверждение. Fire-and-forget вынудил бы
+  отдельный `WaitCompletion`.
+- **Дренаж EventHub через хабовую `WaitGroup` + сигнал выхода го-рутины waiter'а
+  (выбрано) vs синхронный `Stop()` (блокировать до выхода го-рутины).** Выбрано: хаб
+  делает `Add` при старте waiter'а, а го-рутина waiter'а делает `Done` при выходе
+  (зеркалит существующий колбэк waiter→hub `WaiterFired`); `Shutdown` делает `Stop`
+  всем, затем `Wait`, ограничено ctx. Отклонён синхронный-`Stop`: меняет семантику
+  `Stop()` каждого waiter'а и сериализует дренаж.
+- **Удержание экземпляров: keep + `Forget` (выбрано) vs авто-вытеснение при завершении
+  vs хранить вечно.** Выбрано (продуктовое решение): завершённые экземпляры остаются
+  доступными для поиска (`Instance(id)`/`Observe`/`State` работают после завершения —
+  живая in-memory модель ADR-013), с явным `Forget(id)` + `Shutdown` для освобождения.
+  Отклонено авто-вытеснение: теряет наблюдение после завершения; отклонено хранить-вечно:
+  неограниченно без освобождения.
+- **`Stopped` как новое терминальное состояние (выбрано) vs переиспользовать `NotStarted`.**
+  Выбрано: отдельное терминальное `Stopped`, чтобы остановленный движок не приняли за
+  перезапускаемый свежий.
+- **Обнаружение: одна `Instances(filter)` (выбрано) vs три метода
+  (`Instances`/`RunningInstances`/`CompletedInstances`).** Выбрано: единая функция с
+  именованным перечислением `InstanceFilter` (`InstancesAll`/`InstancesRunning`/
+  `InstancesCompleted`) — 3-путевой фильтр, не булев, так что одна функция читается чище
+  трёх и расширяется, если категории живости вырастут. Стартеры перечисляются
+  **отдельно** через `Starters() []StarterInfo`, а не как четвёртое значение
+  `InstanceFilter`, потому что стартер — **не экземпляр** (нет id экземпляра, нет
+  состояния жизненного цикла); вложить его в `Instances()` означало бы возвращать id,
+  которые не резолвятся через `Instance(id)`.
+- **`Forget(ids ...string)` пакетно, всё-или-ничего (выбрано) vs одиночный-id / частично.**
+  Выбрано: вариативный пакет (одиночный id тоже работает) с validate-all-then-remove, так
+  что плохой id в зачистке оставляет карту нетронутой, а ошибка действенна.
+- **`UnregisterProcess` допускает живые экземпляры (выбрано) vs отвергать / отменять их.**
+  Выбрано (продуктовое решение): удалить определение + стартеры, оставить живые экземпляры
+  работающими на построенном снимке; проще всего, без связывания unregister с завершением.
+  Хост использует `Shutdown`/`Cancel`/`Forget` для жизненного цикла экземпляра.
+
+## 6. API (публичная поверхность, `pkg/thresher`)
+
+```go
+// On the existing read-only handle (SRD-018), control is added:
+func (h *InstanceHandle) Cancel(ctx context.Context) (InstanceState, error)
+func (h *InstanceHandle) Suspend(ctx context.Context) error // reserved -> ErrNotImplemented
+func (h *InstanceHandle) Resume(ctx context.Context) error  // reserved -> ErrNotImplemented
+
+// Engine lifecycle:
+func (t *Thresher) Shutdown(ctx context.Context) error
+
+// Instance discovery + release:
+type InstanceFilter uint8
+const (
+	InstancesAll       InstanceFilter = iota // every tracked instance
+	InstancesRunning                          // non-terminal (Created/Active/Terminating)
+	InstancesCompleted                        // terminal (Completed/Terminated)
+)
+func (t *Thresher) Instances(filter InstanceFilter) []string
+func (t *Thresher) Forget(ids ...string) error // batch, terminal-only, all-or-nothing
+
+// Event-start registrations (no instance yet). A manual-start process registers
+// no starter, so a listed starter is always auto-start (hence no Manual field).
+type StarterInfo struct {
+	ProcessID string // the process a matching event instantiates
+	StartNode string // the start node fired on a match
+	Trigger   string // the message the starter waits on
+}
+func (t *Thresher) Starters() []StarterInfo
+
+// New thresher state (terminal):
+const Stopped State = /* iota after Paused */
+
+// Reserved-feature sentinel:
+var ErrNotImplemented = errs.New(/* "feature reserved, not yet implemented" */)
+```
+
+Внутренняя поддержка: `internal/instance` — `Run` выводит `inst.cancel`;
+`Instance.Cancel()` (идемпотентно). `internal/eventproc/eventhub` —
+`EventHub.Shutdown(ctx) error` + хабовая `sync.WaitGroup`; waiter'ы сигналят
+о выходе `Service`-го-рутины хабу (например, колбэк `hub.waiterDone()` в паре с
+`wg.Add(1)` на `w.Service(eh.ctx)` в `registerWaiter`).
+
+## 7. План тестирования
+
+- **`TestInstanceHandleCancel`** — `Cancel(ctx)` на припаркованном/долгоиграющем
+  экземпляре доводит его до `Terminated`; второй `Cancel` и `Cancel` завершённого
+  экземпляра — no-op'ы, возвращающие терминальное состояние (FR-1, FR-2).
+- **`TestCancelCtxBounded`** — `Cancel` с коротким ctx против экземпляра, который не
+  осядет, возвращает `ctx.Err()` и нетерминальное состояние (FR-1).
+- **`TestSuspendResumeReserved`** — оба возвращают `ErrNotImplemented` (FR-3).
+- **`TestThresherShutdown`** — `Shutdown(ctx)` отменяет работающие экземпляры,
+  переводит в `Stopped` и закрывает хаб; `StartProcess`/`RegisterProcess`/`Run` затем
+  отвергают; идемпотентно при втором вызове (FR-4, FR-5).
+- **`TestShutdownDrainsWaiters`** (`-race`) — с зарегистрированным таймер-waiter'ом
+  `EventHub.Shutdown` возвращается только после выхода го-рутины waiter'а (без утечки);
+  waiter, чей `Stop()` ошибается, всё равно удаляется (FR-6, NFR-2).
+- **`TestForget`** — `Forget(ids...)` удаляет завершённые экземпляры пакетно
+  (последующий `Instance(id)` → false); работает по принципу **всё-или-ничего** — пакет,
+  содержащий живой или неизвестный id, не удаляет ничего и ошибается с его именем (FR-7).
+- **`TestInstancesFilter`** — `Instances(InstancesAll/InstancesRunning/InstancesCompleted)`
+  возвращает правильные наборы id по ходу прогона (припаркованный экземпляр под Running,
+  завершённый под Completed, оба под All);
+  `Forget(Instances(InstancesCompleted)...)` зачищает завершённые (FR-7a).
+- **`TestStarters`** — процесс, зарегистрированный с message-start событием, появляется в
+  `Starters()` со своим id процесса + триггером; режим ручного старта отражён; процесс без
+  event-start не имеет записи стартера (FR-7b).
+- **`TestUnregisterProcessWithLiveInstance`** — `UnregisterProcess` успешен при живом
+  работающем экземпляре; определение исчезло, но экземпляр завершается (FR-8).
+- Внутренние юниты `internal/eventproc/eventhub` + `internal/instance` для
+  `EventHub.Shutdown` / `Instance.Cancel` (атрибуция межпакетного покрытия).
+
+## 8. Кросс-документная консистентность
+
+- **Реализует** [ADR-013 v.1](../design/ADR-013-instance-observability.ru.md) §2.3
+  (грубое управление), §2.5 (жизненный цикл движка: `Shutdown`/`UnregisterProcess`).
+- **Реализует** [ADR-006 v.1 §2.5](../design/ADR-006-events-and-subscriptions.ru.md) —
+  синхронизированную через `WaitGroup` остановку waiter'ов + no-leak-on-`Stop` (половина
+  с единоличным владением уже приземлена через FIX-003).
+- [ADR-001 v.5](../design/ADR-001-execution-model.ru.md) — общий каскад ctx-отмены, который
+  триггерит `Cancel` (Active→Terminating→Terminated).
+- [ADR-002 v.2](../design/ADR-002-extension-architecture.ru.md) — поверхность публичного API
+  §4.7, к которой присоединяются эти методы.
+- [SRD-018 v.1](SRD-018-instance-observe-handle.ru.md) — срез наблюдения, на который этот
+  строит поверхность управления (близнец).
+- Ссылки вверх/вбок, с пином версии; нет ссылок вниз (ADR-013/ADR-006 не цитируют SRD-019).
+
+## 9. Definition of Done
+
+- FR-1…FR-8 подключены и проверены тестами §7 (включая `-race` тест дренажа waiter'ов).
+- `InstanceHandle.Cancel`/`Suspend`/`Resume`, `Thresher.Shutdown`/`Forget`, состояние
+  `Stopped` + охранники, и `EventHub.Shutdown` + хабовая `WaitGroup` — все присутствуют.
+- Ни одна го-рутина waiter'а не переживает `EventHub.Shutdown` (NFR-2) — доказано под `-race`.
+- `make ci` зелёный (tidy, lint incl. fieldalignment, build, `-race`, diff-coverage ≥95,
+  govulncheck); затронутые файлы ≥80% (цель 100%).
+- Все 9 примеров smoke-run выходят с 0 (управление/завершение не сломали happy path).
+- §10 заполнена; статус → Принято; добавлен RU-близнец; связанные доки синхронизированы.
+
+## 10. Сводка реализации
+
+Приземлено на `feat/instance-control-lifecycle` (от `master`): четыре вехи, каждая —
+один коммит, плюс смежное улучшение примера.
+
+### 10.1 Вехи (коммиты)
+
+| M | Коммит | Объём | Тесты |
+|---|---|---|---|
+| M1 | `a35012a` | Отмена экземпляра: `inst.cancel` выведен в `Run`, `Instance.Cancel()`; `InstanceHandle.Cancel(ctx)` (запрос + ограниченное ctx ожидание, идемпотентно); зарезервированные `Suspend`/`Resume` → `ErrNotImplemented` | `TestInstanceHandleCancel`, `TestCancelCtxBounded`, `TestSuspendResumeReserved`, `TestInstanceCancel` (внутренний) |
+| M2 | `0c1ffab` | Дренаж waiter'ов `EventHub.Shutdown(ctx)`: `EventWaiter.Done()` + `Shutdown` хаба; таймер/message waiter'ы закрывают канал `done` при выходе го-рутины; `started bool` заменён перечислением `hubState` | `TestEventHubShutdownDrainsWaiters` (-race), `TestShutdownRemovesOnStopError`, `TestShutdownCtxBounded`; проверки `Done()` waiter'а в тестах таймера/message |
+| M3 | `75dcde6` | `Thresher.Shutdown(ctx)` + терминальное состояние `Stopped`; `Run` выводит `t.engineCancel` (главный рубильник каскада); охранники в `Run`/`StartProcess`/`RegisterProcess` | `TestThresherShutdown`, `TestThresherShutdownCtxBounded` |
+| M4 | `f3ee4a3` | Обнаружение + освобождение: `Instances(filter)`+`InstanceFilter`, `Forget(ids...)` (пакетно всё-или-ничего), `Starters()`+`StarterInfo`; примечание к `UnregisterProcess` | `TestInstancesFilter`, `TestForget`, `TestStarters`, `TestUnregisterProcessWithLiveInstance` |
+
+Плюс `ba32f4e` — базовый пример читает property + `RUNTIME/STARTED_AT` через
+`DataReader` gofunc'а (разбит по правилу >80 строк для примеров); смежно к этому
+SRD, в фазе примеров этой ветки.
+
+### 10.2 Ключевые файлы
+
+- `pkg/thresher/handle.go` — `Cancel`/`Suspend`/`Resume` + `ErrNotImplemented`.
+- `pkg/thresher/thresher.go` — состояние `Stopped`, `engineCancel`, `Shutdown`, охранники.
+- `pkg/thresher/discovery.go` (новый) — `InstanceFilter`, `Instances`, `Forget`, `StarterInfo`, `Starters`.
+- `internal/instance/instance.go` — `inst.cancel` + `Instance.Cancel()`.
+- `internal/eventproc/eventproc.go` — `EventWaiter.Done()` + `EventHub.Shutdown` на интерфейсах.
+- `internal/eventproc/eventhub/eventhub.go` — перечисление `hubState`, `EventHub.Shutdown`, охранник регистрации.
+- `internal/eventproc/eventhub/waiters/{timer,message}.go` — канал `done` + `Done()`.
+
+### 10.3 Верификация
+
+- `make ci` зелёный: tidy, lint (incl. fieldalignment), build, `-race`,
+  **diff-coverage 96.8% из 189 изменённых строк (≥95)**, govulncheck.
+- Покрытие затронутых функций всё ≥80% (большинство 100%; `Shutdown` 96%, `Run` 87%,
+  `RegisterProcess` 96%).
+- Все 9 примеров smoke-run выходят с 0.
+- NFR-2 (ни одна го-рутина waiter'а не переживает хаб) доказано под `-race`.
+
+### 10.4 Дельты против черновика
+
+- **Поля `StarterInfo`.** Черновик сначала набросал `{ProcessID, Trigger, Manual}`;
+  отгружено как `{ProcessID, StartNode, Trigger}` — процесс с **ручным стартом не
+  регистрирует стартер**, так что перечисленный стартер всегда авто-старт (поля `Manual`
+  нет). §6/FR-7b согласованы в `f3ee4a3`.
+- **Имена тестов дренажа waiter'ов.** Единственный `TestShutdownDrainsWaiters` из §7
+  приземлился как `TestEventHubShutdownDrainsWaiters` (дренаж реального таймера под
+  `-race`) + `TestShutdownRemovesOnStopError` (половина «Stop ошибся → всё равно удалён») +
+  `TestShutdownCtxBounded`; то же покрытие, разбито для ясности.
+- **Жизненный цикл EventHub.** M2 заменил `started bool` перечислением `hubState`
+  (`notStarted`/`started`/`stopped`), чтобы флаг завершения не мог образовать недопустимую
+  комбинацию «started-и-stopped» — небольшое уточнение сверх черновика.
+
+## История документа
+
+| Версия | Дата | Автор | Изменение |
+|---|---|---|---|
+| v.1 | 2026-06-18 | Руслан Габитов | Принято. Приземляет срез управления + жизненного цикла движка из ADR-013 v.1 (§2.3/§2.5) и реализует открытую часть ADR-006 v.1 §2.5: `InstanceHandle.Cancel(ctx)` (самоотмена экземпляра через выведенный в `Run` `inst.cancel`, запрос + ограниченное ctx ожидание, идемпотентно) + зарезервированные `Suspend`/`Resume`; `Thresher.Shutdown(ctx)` (новое терминальное состояние `Stopped`, отмена + оседание работающих экземпляров, дренаж хаба); `EventHub.Shutdown(ctx)` (хабовая `sync.WaitGroup` над `Service`-го-рутинами waiter'ов, ограниченное ctx ожидание, remove-even-on-`Stop`-error); `Thresher.Forget(ids ...string)` (пакетное, всё-или-ничего освобождение терминальных экземпляров) + обнаружение `Instances(filter)` (одна функция, `InstancesAll`/`InstancesRunning`/`InstancesCompleted`) + `Starters() []StarterInfo` (event-start регистрации, у которых ещё нет экземпляра) + `UnregisterProcess` задокументирован (живые экземпляры продолжают работать). Обосновано по коду `pkg/thresher`, `internal/instance`, `internal/eventproc/eventhub`. Близнец SRD-018 v.1 (наблюдение). Реализует ADR-013 v.1; реализует ADR-006 v.1 §2.5; ссылается на ADR-001 v.5, ADR-002 v.2. |

--- a/examples/basic-process/main.go
+++ b/examples/basic-process/main.go
@@ -2,11 +2,13 @@
 // Start → ServiceTask → End process where the ServiceTask runs YOUR Go code.
 //
 // The ServiceTask's work is a `gooper` functor — an ordinary Go function
-// wrapped as the operation's implementation. This is how you embed arbitrary
-// Go logic inside a BPMN process without messages or data mapping: the
-// operation carries nil in/out messages and the functor just runs.
+// wrapped as the operation's implementation. Here it reads a process property
+// and a runtime variable through its read-only DataReader, showing how a gofunc
+// reaches process data without any message ceremony.
 //
 //	start ─> work (runs a Go functor) ─> end
+//
+// The process build lives in process.go; this file is the engine wiring + run.
 package main
 
 import (
@@ -15,13 +17,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/dr-dobermann/gobpm/pkg/model/activities"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
-	"github.com/dr-dobermann/gobpm/pkg/model/events"
-	"github.com/dr-dobermann/gobpm/pkg/model/flow"
-	"github.com/dr-dobermann/gobpm/pkg/model/process"
-	"github.com/dr-dobermann/gobpm/pkg/model/service"
-	"github.com/dr-dobermann/gobpm/pkg/model/service/gooper"
 	"github.com/dr-dobermann/gobpm/pkg/thresher"
 )
 
@@ -32,57 +28,19 @@ func main() {
 }
 
 func run() error {
+	// Process properties instantiate with the standard data states.
+	if err := data.CreateDefaultStates(); err != nil {
+		return fmt.Errorf("init data states: %w", err)
+	}
+
 	engine, err := thresher.New("basic-process-engine")
 	if err != nil {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	proc, err := process.New("basic-process")
+	proc, err := buildProcess()
 	if err != nil {
-		return fmt.Errorf("create process: %w", err)
-	}
-
-	start, err := events.NewStartEvent("start")
-	if err != nil {
-		return fmt.Errorf("create start: %w", err)
-	}
-
-	// The ServiceTask runs a Go functor: an operation with no in/out messages
-	// (nil, nil) whose implementation is plain Go code. This is the simplest
-	// way to put your logic inside a process.
-	op, err := gooper.New(
-		"hello",
-		func(_ context.Context, _ service.DataReader, _ *data.ItemDefinition) (*data.ItemDefinition, error) {
-			fmt.Println("  ▶ hello from inside the process (Go code in a ServiceTask)")
-
-			return nil, nil
-		})
-	if err != nil {
-		return fmt.Errorf("create operation: %w", err)
-	}
-
-	task, err := activities.NewServiceTask("work", op, activities.WithoutParams())
-	if err != nil {
-		return fmt.Errorf("create service task: %w", err)
-	}
-
-	end, err := events.NewEndEvent("end")
-	if err != nil {
-		return fmt.Errorf("create end: %w", err)
-	}
-
-	for _, e := range []flow.Element{start, task, end} {
-		if err := proc.Add(e); err != nil {
-			return fmt.Errorf("add element: %w", err)
-		}
-	}
-
-	if _, err := flow.Link(start, task); err != nil {
-		return fmt.Errorf("link start->task: %w", err)
-	}
-
-	if _, err := flow.Link(task, end); err != nil {
-		return fmt.Errorf("link task->end: %w", err)
+		return fmt.Errorf("build process: %w", err)
 	}
 
 	if err := engine.RegisterProcess(proc); err != nil {
@@ -109,7 +67,7 @@ func run() error {
 	}
 
 	fmt.Printf("✓ basic-process completed (%s): "+
-		"start → service task (ran Go code) → end\n", state)
+		"start → service task (read property + RUNTIME var) → end\n", state)
 
 	return nil
 }

--- a/examples/basic-process/process.go
+++ b/examples/basic-process/process.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/model/service/gooper"
+)
+
+// buildProcess assembles start → work(greet) → end, with a process-level
+// "user_name" property the ServiceTask reads at runtime.
+func buildProcess() (*process.Process, error) {
+	proc, err := process.New("basic-process",
+		data.WithProperties(
+			data.MustProperty("user_name",
+				data.MustItemDefinition(
+					values.NewVariable("dr.Dobermann"),
+					foundation.WithID("user_name")),
+				data.ReadyDataState)))
+	if err != nil {
+		return nil, fmt.Errorf("create process: %w", err)
+	}
+
+	start, err := events.NewStartEvent("start")
+	if err != nil {
+		return nil, fmt.Errorf("create start: %w", err)
+	}
+
+	op, err := greetOp()
+	if err != nil {
+		return nil, fmt.Errorf("create operation: %w", err)
+	}
+
+	task, err := activities.NewServiceTask("work", op, activities.WithoutParams())
+	if err != nil {
+		return nil, fmt.Errorf("create service task: %w", err)
+	}
+
+	end, err := events.NewEndEvent("end")
+	if err != nil {
+		return nil, fmt.Errorf("create end: %w", err)
+	}
+
+	for _, e := range []flow.Element{start, task, end} {
+		if err := proc.Add(e); err != nil {
+			return nil, fmt.Errorf("add element: %w", err)
+		}
+	}
+
+	if _, err := flow.Link(start, task); err != nil {
+		return nil, fmt.Errorf("link start->task: %w", err)
+	}
+
+	if _, err := flow.Link(task, end); err != nil {
+		return nil, fmt.Errorf("link task->end: %w", err)
+	}
+
+	return proc, nil
+}
+
+// greetOp is the ServiceTask's Go functor. It reads the process "user_name"
+// property AND the engine's RUNTIME/STARTED_AT variable through its read-only
+// DataReader, then greets the user — showing how a gofunc reaches process data
+// and runtime variables without any message ceremony.
+func greetOp() (service.Operation, error) {
+	return gooper.New("greet",
+		func(ctx context.Context, r service.DataReader,
+			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			user, err := r.GetData("user_name")
+			if err != nil {
+				return nil, fmt.Errorf("read user_name: %w", err)
+			}
+
+			started, err := r.GetData("RUNTIME/STARTED_AT")
+			if err != nil {
+				return nil, fmt.Errorf("read RUNTIME/STARTED_AT: %w", err)
+			}
+
+			fmt.Printf("  ▶ hello, %v (instance started at %v)\n",
+				user.Value().Get(ctx), started.Value().Get(ctx))
+
+			return nil, nil
+		})
+}

--- a/internal/eventproc/eventhub/eventhub.go
+++ b/internal/eventproc/eventhub/eventhub.go
@@ -23,6 +23,20 @@ import (
 
 const errorClass = "EVENT_HUB_ERRORS"
 
+// hubState is the EventHub lifecycle, a single source of truth (one field can't
+// hold the invalid started-and-stopped combination two booleans allowed).
+type hubState uint8
+
+const (
+	// hubNotStarted is a freshly created hub, before Start.
+	hubNotStarted hubState = iota
+	// hubStarted is a started hub accepting registration and propagation.
+	hubStarted
+	// hubStopped is a shut-down hub: it drained its waiters and rejects further
+	// registration (terminal).
+	hubStopped
+)
+
 type (
 	// EventHub processes all registration requests from EventProcessors
 	// for specific eventDefinition.
@@ -34,7 +48,7 @@ type (
 		waiters map[string]eventproc.EventWaiter
 		events  []flow.EventDefinition
 		m       sync.RWMutex
-		started bool
+		state   hubState
 	}
 )
 
@@ -62,17 +76,17 @@ func New(rt renv.EngineRuntime) (*EventHub, error) {
 //
 // Start MUST be called exactly once before Run. Returning from Start
 // establishes a happens-before edge — any caller that observes the
-// successful return is guaranteed to see eh.started == true and the
+// successful return is guaranteed to see the hub in the started state and the
 // stored ctx, without needing additional synchronization. This is the
 // motivation for splitting Start from Run; see FIX-001.
 func (eh *EventHub) Start(ctx context.Context) error {
-	if eh.started {
+	if eh.state != hubNotStarted {
 		return errs.New(
-			errs.M("eventHub is already started"),
+			errs.M("eventHub is already started or stopped"),
 			errs.C(errorClass, errs.InvalidState))
 	}
 
-	eh.started = true
+	eh.state = hubStarted
 	eh.ctx = ctx
 
 	return nil
@@ -84,7 +98,7 @@ func (eh *EventHub) Start(ctx context.Context) error {
 //
 // Run blocks until its context is canceled and then returns ctx.Err().
 func (eh *EventHub) Run(ctx context.Context) error {
-	if !eh.started {
+	if eh.state != hubStarted {
 		return errs.New(
 			errs.M("eventHub isn't started"),
 			errs.C(errorClass, errs.InvalidState))
@@ -102,7 +116,7 @@ func (eh *EventHub) RegisterEvent(
 	ep eventproc.EventProcessor,
 	eDef flow.EventDefinition,
 ) error {
-	if !eh.started {
+	if eh.state != hubStarted {
 		return errs.New(
 			errs.M("eventHub isn't started"),
 			errs.C(errorClass, errs.InvalidState))
@@ -126,7 +140,7 @@ func (eh *EventHub) RegisterPersistentEvent(
 	ep eventproc.EventProcessor,
 	eDef flow.EventDefinition,
 ) error {
-	if !eh.started {
+	if eh.state != hubStarted {
 		return errs.New(
 			errs.M("eventHub isn't started"),
 			errs.C(errorClass, errs.InvalidState))
@@ -170,6 +184,13 @@ func (eh *EventHub) registerWaiter(
 	eh.m.Lock()
 	defer eh.m.Unlock()
 
+	if eh.state == hubStopped {
+		return errs.New(
+			errs.M("event hub is shut down; registration rejected"),
+			errs.C(errorClass, errs.InvalidState),
+			errs.D("event_definition_id", eDef.ID()))
+	}
+
 	if w, ok := eh.waiters[eDef.ID()]; ok {
 		if err := w.AddEventProcessor(ep); err != nil {
 			return errs.New(
@@ -209,13 +230,78 @@ func (eh *EventHub) registerWaiter(
 	return nil
 }
 
+// Shutdown stops every registered waiter and waits — bounded by ctx — for their
+// service goroutines to exit, so none outlives the hub (ADR-006 v.1 §2.5,
+// SRD-019). It marks the hub stopped (further registration is rejected) and
+// removes every waiter from the registry even if its Stop returns an error, so a
+// failed Stop never leaks the registry entry. Idempotent.
+func (eh *EventHub) Shutdown(ctx context.Context) error {
+	eh.m.Lock()
+	if eh.state == hubStopped {
+		eh.m.Unlock()
+
+		return nil
+	}
+
+	eh.state = hubStopped
+
+	ws := make([]eventproc.EventWaiter, 0, len(eh.waiters))
+	for _, w := range eh.waiters {
+		ws = append(ws, w)
+	}
+	// Remove all up front: the registry is clean regardless of any Stop error.
+	eh.waiters = map[string]eventproc.EventWaiter{}
+	eh.m.Unlock()
+
+	// Stop each waiter (logging — never aborting on — a failed Stop) and wait for
+	// its service goroutine to exit via its Done channel, off the lock.
+	var wg sync.WaitGroup
+
+	for _, w := range ws {
+		if err := w.Stop(); err != nil {
+			eh.rt.Logger().Warn("event waiter Stop failed during shutdown",
+				"waiter_id", w.ID(), "error", err.Error())
+		}
+
+		done := w.Done()
+		if done == nil {
+			continue // never serviced — no goroutine to drain
+		}
+
+		wg.Add(1)
+
+		go func(d <-chan struct{}) {
+			defer wg.Done()
+			<-d
+		}(done)
+	}
+
+	drained := make(chan struct{})
+
+	go func() {
+		wg.Wait()
+		close(drained)
+	}()
+
+	select {
+	case <-drained:
+		return nil
+
+	case <-ctx.Done():
+		return errs.New(
+			errs.M("event hub shutdown timed out before all waiters drained"),
+			errs.C(errorClass, errs.OperationFailed),
+			errs.E(ctx.Err()))
+	}
+}
+
 // UnregisterEvent removes the registered eventDefintions for single
 // EventProcessor.
 func (eh *EventHub) UnregisterEvent(
 	ep eventproc.EventProcessor,
 	eDefID string,
 ) error {
-	if !eh.started {
+	if eh.state != hubStarted {
 		return errs.New(
 			errs.M("eventHub isn't started"),
 			errs.C(errorClass, errs.InvalidState))
@@ -280,7 +366,7 @@ func (eh *EventHub) PropagateEvent(
 	_ context.Context,
 	eDef flow.EventDefinition,
 ) error {
-	if !eh.started {
+	if eh.state != hubStarted {
 		return errs.New(
 			errs.M("eventHub isn't started"),
 			errs.C(errorClass, errs.InvalidState))

--- a/internal/eventproc/eventhub/eventhub_shutdown_internal_test.go
+++ b/internal/eventproc/eventhub/eventhub_shutdown_internal_test.go
@@ -1,0 +1,63 @@
+package eventhub
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/internal/enginert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShutdownRemovesOnStopError verifies a waiter whose Stop errors is still
+// removed from the registry — a failed Stop never leaks the entry (FR-6, NFR-2).
+func TestShutdownRemovesOnStopError(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+
+	dc := make(chan struct{})
+	close(dc) // its service goroutine has already exited
+
+	w := mockeventproc.NewMockEventWaiter(t)
+	w.EXPECT().ID().Return("x").Maybe()
+	w.EXPECT().Stop().Return(errors.New("stop failed"))
+	w.EXPECT().Done().Return((<-chan struct{})(dc))
+
+	hub.m.Lock()
+	hub.waiters["x"] = w
+	hub.m.Unlock()
+
+	require.NoError(t, hub.Shutdown(context.Background()))
+
+	hub.m.RLock()
+	_, ok := hub.waiters["x"]
+	hub.m.RUnlock()
+	require.False(t, ok, "waiter must be removed even though its Stop errored")
+}
+
+// TestShutdownCtxBounded verifies Shutdown honours its ctx deadline when a
+// waiter's service goroutine does not exit (its Done never closes) — it returns
+// an error rather than hanging (FR-6, NFR-3).
+func TestShutdownCtxBounded(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+
+	dc := make(chan struct{}) // never closed — the goroutine "won't exit"
+	defer close(dc)
+
+	w := mockeventproc.NewMockEventWaiter(t)
+	w.EXPECT().ID().Return("y").Maybe()
+	w.EXPECT().Stop().Return(nil)
+	w.EXPECT().Done().Return((<-chan struct{})(dc))
+
+	hub.m.Lock()
+	hub.waiters["y"] = w
+	hub.m.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	require.Error(t, hub.Shutdown(ctx))
+}

--- a/internal/eventproc/eventhub/eventhub_shutdown_test.go
+++ b/internal/eventproc/eventhub/eventhub_shutdown_test.go
@@ -1,0 +1,44 @@
+package eventhub_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/internal/enginert"
+	"github.com/dr-dobermann/gobpm/internal/eventproc/eventhub"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/stretchr/testify/require"
+)
+
+// TestEventHubShutdownDrainsWaiters registers a real timer waiter (a running
+// service goroutine) and verifies Shutdown drains it — returns only after the
+// goroutine exits (no leak; meaningful under -race) — then rejects further
+// registration and is idempotent (SRD-019 FR-6, ADR-006 §2.5).
+func TestEventHubShutdownDrainsWaiters(t *testing.T) {
+	hub, err := eventhub.New(enginert.Default())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, hub.Start(ctx))
+
+	mp := mockeventproc.NewMockEventProcessor(t)
+	mp.EXPECT().ID().Return("ep").Maybe()
+
+	// A 5s timer — it will not fire during the test; Shutdown's Stop unblocks the
+	// service goroutine well before that.
+	cycleExpr, durationExpr := createTimerExpressions(t)
+	timerEvent, err := events.NewTimerEventDefinition(nil, cycleExpr, durationExpr)
+	require.NoError(t, err)
+	require.NoError(t, hub.RegisterEvent(mp, timerEvent))
+
+	sctx, scancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer scancel()
+	require.NoError(t, hub.Shutdown(sctx))
+
+	// Stopped: further registration is rejected; Shutdown is idempotent.
+	require.Error(t, hub.RegisterEvent(mp, timerEvent))
+	require.NoError(t, hub.Shutdown(sctx))
+}

--- a/internal/eventproc/eventhub/waiters/message.go
+++ b/internal/eventproc/eventhub/waiters/message.go
@@ -35,6 +35,7 @@ type messageWaiter struct {
 	rt         renv.EngineRuntime
 	eDef       *events.MessageEventDefinition
 	stopCh     chan struct{}
+	done       chan struct{}
 	sub        messaging.Subscription
 	name       string
 	id         string
@@ -230,6 +231,7 @@ func (mw *messageWaiter) Service(ctx context.Context) error {
 	mw.sub = sub
 	mw.state = eventproc.WSRunned
 	mw.stopCh = make(chan struct{})
+	mw.done = make(chan struct{})
 
 	go mw.runMessageService(ctx, sub.C())
 
@@ -244,6 +246,8 @@ func (mw *messageWaiter) runMessageService(
 	ctx context.Context,
 	ch <-chan messaging.Envelope,
 ) {
+	defer close(mw.done) // signal goroutine exit for EventHub.Shutdown drain
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -383,6 +387,13 @@ func (mw *messageWaiter) setState(s eventproc.EventWaiterState) {
 	mw.m.Lock()
 	mw.state = s
 	mw.m.Unlock()
+}
+
+// Done returns a channel closed when the service goroutine has exited; nil until
+// Service starts it (a registered waiter is always serviced first). EventHub.
+// Shutdown waits on it to drain goroutines (ADR-006 v.1 §2.5).
+func (mw *messageWaiter) Done() <-chan struct{} {
+	return mw.done
 }
 
 var _ eventproc.EventWaiter = (*messageWaiter)(nil)

--- a/internal/eventproc/eventhub/waiters/message_test.go
+++ b/internal/eventproc/eventhub/waiters/message_test.go
@@ -164,6 +164,14 @@ func TestMessageWaiterDelivery(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return w.State() == eventproc.WSEnded
 	}, time.Second, 10*time.Millisecond)
+
+	// The single-shot service goroutine exits after firing; Done reflects it
+	// (SRD-019: EventHub.Shutdown drains waiters via this channel).
+	select {
+	case <-w.Done():
+	case <-time.After(time.Second):
+		t.Fatal("message waiter Done did not close after the single-shot fire")
+	}
 }
 
 // keyedProc is an EventProcessor that declares correlation keys for its

--- a/internal/eventproc/eventhub/waiters/timer.go
+++ b/internal/eventproc/eventhub/waiters/timer.go
@@ -31,6 +31,7 @@ type timeWaiter struct {
 	hub        eventproc.EventHub
 	rt         renv.EngineRuntime
 	stopCh     chan struct{}
+	done       chan struct{}
 	id         string
 	processors []eventproc.EventProcessor
 	state      eventproc.EventWaiterState
@@ -269,6 +270,7 @@ func (tw *timeWaiter) Service(ctx context.Context) error {
 	}
 
 	tw.stopCh = make(chan struct{})
+	tw.done = make(chan struct{})
 
 	go tw.runTimerService(ctx)
 
@@ -283,6 +285,8 @@ func (tw *timeWaiter) Service(ctx context.Context) error {
 // so the close would signal nothing while racing Stop()'s close
 // (panic: close of closed channel — audit 1.3 / FIX-003 A).
 func (tw *timeWaiter) runTimerService(ctx context.Context) {
+	defer close(tw.done) // signal goroutine exit for EventHub.Shutdown drain
+
 	tckr := time.NewTicker(tw.duration)
 
 	for {
@@ -395,6 +399,13 @@ func (tw *timeWaiter) State() eventproc.EventWaiterState {
 	defer tw.m.Unlock()
 
 	return tw.state
+}
+
+// Done returns a channel closed when the service goroutine has exited; nil until
+// Service starts it (a registered waiter is always serviced first). EventHub.
+// Shutdown waits on it to drain goroutines (ADR-006 v.1 §2.5).
+func (tw *timeWaiter) Done() <-chan struct{} {
+	return tw.done
 }
 
 var _ eventproc.EventWaiter = (*timeWaiter)(nil)

--- a/internal/eventproc/eventhub/waiters/timer_test.go
+++ b/internal/eventproc/eventhub/waiters/timer_test.go
@@ -190,6 +190,14 @@ func TestTimeWaiter(t *testing.T) {
 			time.Sleep(3 * time.Second)
 			require.NoError(t, ws.Stop())
 			require.Equal(t, eventproc.WSStopped, ws.State())
+
+			// Done closes once the service goroutine has exited (SRD-019:
+			// EventHub.Shutdown drains waiters via this channel).
+			select {
+			case <-ws.Done():
+			case <-time.After(time.Second):
+				t.Fatal("timer waiter Done did not close after Stop")
+			}
 		})
 
 	t.Run("normal",

--- a/internal/eventproc/eventproc.go
+++ b/internal/eventproc/eventproc.go
@@ -87,6 +87,12 @@ type EventHub interface {
 	// after the first fire like the single-shot in-instance receiver
 	// RegisterEvent builds. Only message triggers are accepted.
 	RegisterPersistentEvent(ep EventProcessor, eDef flow.EventDefinition) error
+
+	// Shutdown stops every registered waiter and waits — bounded by ctx — for
+	// their service goroutines to exit, removing each from the registry even if
+	// its Stop returns an error, so no waiter goroutine outlives the hub
+	// (ADR-006 v.1 §2.5). After Shutdown the hub rejects further registration.
+	Shutdown(ctx context.Context) error
 }
 
 // EventWaiter represents an event waiter interface.
@@ -131,6 +137,11 @@ type EventWaiter interface {
 
 	// State returns current state of the EventWaiter.
 	State() EventWaiterState
+
+	// Done returns a channel that is closed when the waiter's service goroutine
+	// has exited (by Stop, ctx cancel, or a terminal fire). EventHub.Shutdown
+	// waits on it to drain waiter goroutines without a leak (ADR-006 v.1 §2.5).
+	Done() <-chan struct{}
 }
 
 // EventWaiterState represents the state of an event waiter.

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -82,6 +82,7 @@ func (s State) String() string {
 type Instance struct {
 	startTime time.Time
 	ctx       context.Context
+	cancel    context.CancelFunc
 	engrenv.EngineRuntime
 	rr                  interactor.Registrator
 	parentEventProducer eventproc.EventProducer
@@ -571,7 +572,10 @@ func (inst *Instance) Run(
 			errs.D("current_state", inst.State()))
 	}
 
-	inst.ctx = ctx
+	// Derive the instance's own cancellable context so Cancel() can terminate it
+	// (SRD-019). The parent ctx (the engine's, via the Thresher) still cascades —
+	// canceling either drives the loop's ctx.Done() termination path.
+	inst.ctx, inst.cancel = context.WithCancel(ctx)
 	inst.startTime = inst.now()
 	inst.setState(Active)
 
@@ -579,9 +583,20 @@ func (inst *Instance) Run(
 	// loop, which becomes the sole owner of lifecycle state from here on.
 	initial := maps.Values(inst.tracks)
 
-	go inst.loop(ctx, initial)
+	go inst.loop(inst.ctx, initial)
 
 	return nil
+}
+
+// Cancel requests termination of the instance: it cancels the instance context,
+// which the loop observes (ctx.Done()) and walks Active → Terminating →
+// Terminated, withdrawing its tracks. Idempotent and non-blocking — a host that
+// wants to await the terminal state uses the InstanceHandle's Cancel/
+// WaitCompletion. Safe before Run (no-op until the context exists).
+func (inst *Instance) Cancel() {
+	if inst.cancel != nil {
+		inst.cancel()
+	}
 }
 
 // emit delivers a track event to the loop. It never blocks forever: once the

--- a/internal/instance/instance_test.go
+++ b/internal/instance/instance_test.go
@@ -125,6 +125,42 @@ func TestObserveAccessors(t *testing.T) {
 	require.Equal(t, instance.Completed, inst.State())
 }
 
+// TestInstanceCancel covers Instance.Cancel within the instance package — the
+// no-op-before-Run guard and the after-Run cancel — since the public path is
+// only exercised cross-package via the thresher handle (SRD-019).
+func TestInstanceCancel(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	s, err := getSnapshot("cancel")
+	require.NoError(t, err)
+
+	ep := mockeventproc.NewMockEventProducer(t)
+
+	inst, err := instance.New(s, scope.EmptyDataPath, enginert.Default(), ep, nil)
+	require.NoError(t, err)
+
+	// Cancel before Run is a no-op (no context yet).
+	inst.Cancel()
+
+	ctx, cc := context.WithCancel(context.Background())
+	defer cc()
+	require.NoError(t, inst.Run(ctx))
+
+	inst.Cancel()
+
+	select {
+	case <-inst.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("Cancel did not terminate the instance")
+	}
+
+	// A terminal state either way (a fast process may complete before Cancel
+	// lands); the point is Cancel is wired and the instance settles.
+	require.Contains(t,
+		[]instance.State{instance.Completed, instance.Terminated},
+		inst.State())
+}
+
 // getSnapshot creates a simple process with user_name property
 // StartEvent -> ServiceTask(print hello user_name) -> EndEvent
 // and retruns its Snapshot.

--- a/pkg/thresher/control_test.go
+++ b/pkg/thresher/control_test.go
@@ -114,3 +114,53 @@ func TestSuspendResumeReserved(t *testing.T) {
 	require.ErrorIs(t, h.Suspend(context.Background()), thresher.ErrNotImplemented)
 	require.ErrorIs(t, h.Resume(context.Background()), thresher.ErrNotImplemented)
 }
+
+// TestThresherShutdown verifies graceful shutdown cancels running instances,
+// flips to Stopped, drains the hub, then rejects further lifecycle ops, and is
+// idempotent (FR-4, FR-5, FR-6).
+func TestThresherShutdown(t *testing.T) {
+	proc := blockingProcess(t, "sd-graceful")
+	th, cancel := runEngine(t, proc)
+	defer cancel()
+
+	h, err := th.StartProcess(proc.ID())
+	require.NoError(t, err)
+
+	time.Sleep(150 * time.Millisecond) // reach the blocking op
+
+	sctx, sc := context.WithTimeout(context.Background(), 3*time.Second)
+	defer sc()
+	require.NoError(t, th.Shutdown(sctx))
+
+	require.Equal(t, thresher.Stopped, th.State())
+	require.Equal(t, thresher.StateTerminated, h.State())
+
+	// A stopped engine rejects further lifecycle operations.
+	_, err = th.StartProcess(proc.ID())
+	require.Error(t, err)
+	require.Error(t, th.RegisterProcess(blockingProcess(t, "sd-after")))
+	require.Error(t, th.Run(context.Background()))
+
+	// Idempotent.
+	require.NoError(t, th.Shutdown(sctx))
+}
+
+// TestThresherShutdownCtxBounded verifies Shutdown honours its ctx deadline when
+// an instance will not settle promptly (a ctx-ignoring sleep), returning an
+// error while still having flipped to Stopped (FR-4, NFR-3).
+func TestThresherShutdownCtxBounded(t *testing.T) {
+	proc := linearProcess(t, "sd-bound", 2*time.Second) // op ignores ctx
+	th, cancel := runEngine(t, proc)
+	defer cancel()
+
+	_, err := th.StartProcess(proc.ID())
+	require.NoError(t, err)
+
+	time.Sleep(150 * time.Millisecond)
+
+	sctx, sc := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer sc()
+
+	require.Error(t, th.Shutdown(sctx))
+	require.Equal(t, thresher.Stopped, th.State())
+}

--- a/pkg/thresher/control_test.go
+++ b/pkg/thresher/control_test.go
@@ -1,0 +1,116 @@
+package thresher_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/model/service/gooper"
+	"github.com/dr-dobermann/gobpm/pkg/thresher"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingProcess builds start -> work(blocks until its ctx is cancelled) -> end,
+// so the instance stays Active until cancelled — and then terminates promptly
+// (the op respects ctx).
+func blockingProcess(t *testing.T, id string) *process.Process {
+	t.Helper()
+
+	op, err := gooper.New("block-op",
+		func(ctx context.Context, _ service.DataReader,
+			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			<-ctx.Done()
+
+			return nil, nil
+		})
+	require.NoError(t, err)
+
+	proc, err := process.New(id)
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	work, err := activities.NewServiceTask("work", op, activities.WithoutParams())
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{start, work, end} {
+		require.NoError(t, proc.Add(e))
+	}
+
+	link(t, start, work)
+	link(t, work, end)
+
+	return proc
+}
+
+// TestInstanceHandleCancel verifies Cancel drives a running instance to a
+// terminal state and is idempotent (FR-1, FR-2).
+func TestInstanceHandleCancel(t *testing.T) {
+	proc := blockingProcess(t, "ctl-cancel")
+	th, cancel := runEngine(t, proc)
+	defer cancel()
+
+	h, err := th.StartProcess(proc.ID())
+	require.NoError(t, err)
+
+	time.Sleep(150 * time.Millisecond) // let the track reach the blocking op
+
+	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cc()
+
+	state, err := h.Cancel(ctx)
+	require.NoError(t, err)
+	require.Equal(t, thresher.StateTerminated, state)
+
+	// Idempotent: a second Cancel (and Cancel of an already-terminal instance)
+	// returns the terminal state at once.
+	state2, err := h.Cancel(ctx)
+	require.NoError(t, err)
+	require.Equal(t, thresher.StateTerminated, state2)
+}
+
+// TestCancelCtxBounded verifies Cancel honours its ctx deadline when the instance
+// won't settle promptly (here a ctx-ignoring sleep keeps it from terminating),
+// returning ctx.Err() and a non-terminal state (FR-1).
+func TestCancelCtxBounded(t *testing.T) {
+	proc := linearProcess(t, "ctl-cancel-bound", 2*time.Second) // op ignores ctx
+	th, cancel := runEngine(t, proc)
+	defer cancel()
+
+	h, err := th.StartProcess(proc.ID())
+	require.NoError(t, err)
+
+	time.Sleep(150 * time.Millisecond)
+
+	ctx, cc := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cc()
+
+	state, err := h.Cancel(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NotEqual(t, thresher.StateTerminated, state)
+	require.NotEqual(t, thresher.StateCompleted, state)
+}
+
+// TestSuspendResumeReserved verifies the reserved control ops return the stable
+// ErrNotImplemented sentinel (FR-3).
+func TestSuspendResumeReserved(t *testing.T) {
+	proc := blockingProcess(t, "ctl-reserved")
+	th, cancel := runEngine(t, proc)
+	defer cancel()
+
+	h, err := th.StartProcess(proc.ID())
+	require.NoError(t, err)
+
+	require.ErrorIs(t, h.Suspend(context.Background()), thresher.ErrNotImplemented)
+	require.ErrorIs(t, h.Resume(context.Background()), thresher.ErrNotImplemented)
+}

--- a/pkg/thresher/discovery.go
+++ b/pkg/thresher/discovery.go
@@ -1,0 +1,118 @@
+package thresher
+
+import (
+	"github.com/dr-dobermann/gobpm/internal/instance"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+)
+
+// InstanceFilter selects which tracked instances Instances returns (SRD-019).
+type InstanceFilter uint8
+
+const (
+	// InstancesAll returns every tracked instance.
+	InstancesAll InstanceFilter = iota
+	// InstancesRunning returns the non-terminal instances (Created/Active/
+	// Terminating).
+	InstancesRunning
+	// InstancesCompleted returns the terminal instances (Completed/Terminated) —
+	// the ones Forget can release.
+	InstancesCompleted
+)
+
+// instanceTerminal reports whether an instance lifecycle state is terminal.
+func instanceTerminal(s instance.State) bool {
+	return s == instance.Completed || s == instance.Terminated
+}
+
+// Instances returns the ids of tracked instances matching filter (SRD-019).
+// The host reads each one's state/tokens/data via Instance(id). Snapshot-
+// consistent under the engine lock; order is unspecified.
+func (t *Thresher) Instances(filter InstanceFilter) []string {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	out := make([]string, 0, len(t.instances))
+
+	for id, reg := range t.instances {
+		terminal := instanceTerminal(reg.inst.State())
+
+		switch filter {
+		case InstancesRunning:
+			if terminal {
+				continue
+			}
+
+		case InstancesCompleted:
+			if !terminal {
+				continue
+			}
+		}
+
+		out = append(out, id)
+	}
+
+	return out
+}
+
+// Forget releases the listed terminal instances from the engine's tracking
+// (SRD-019), so a long-running engine doesn't accumulate finished instances.
+// All-or-nothing: every id is validated first (known AND terminal); on any
+// unknown or still-live id none are removed and an error naming it is returned.
+// Forget(Instances(InstancesCompleted)...) sweeps all finished instances.
+func (t *Thresher) Forget(ids ...string) error {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	for _, id := range ids {
+		reg, ok := t.instances[id]
+		if !ok {
+			return errs.New(
+				errs.M("unknown instance %q", id),
+				errs.C(errorClass, errs.ObjectNotFound))
+		}
+
+		if st := reg.inst.State(); !instanceTerminal(st) {
+			return errs.New(
+				errs.M("instance %q is still live (%s); cancel it before forgetting",
+					id, st.String()),
+				errs.C(errorClass, errs.InvalidState))
+		}
+	}
+
+	for _, id := range ids {
+		delete(t.instances, id)
+	}
+
+	return nil
+}
+
+// StarterInfo describes one event-start registration (SRD-019): a process
+// awaiting an event to instantiate — there is no instance yet, so it cannot
+// appear under Instances. A manual-start process registers no starter, so every
+// listed starter is auto-start.
+type StarterInfo struct {
+	ProcessID string // the process a matching event instantiates
+	StartNode string // the start node fired on a match
+	Trigger   string // the message the starter waits on
+}
+
+// Starters lists the registered event-start registrations (SRD-019).
+// Snapshot-consistent under the engine lock; order is unspecified.
+func (t *Thresher) Starters() []StarterInfo {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	out := make([]StarterInfo, 0, len(t.starters))
+
+	for procID, sts := range t.starters {
+		for _, s := range sts {
+			out = append(out, StarterInfo{
+				ProcessID: procID,
+				StartNode: s.startNode.Name(),
+				Trigger:   s.eDef.Message().Name(),
+			})
+		}
+	}
+
+	return out
+}

--- a/pkg/thresher/discovery_test.go
+++ b/pkg/thresher/discovery_test.go
@@ -1,0 +1,125 @@
+package thresher_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/thresher"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInstancesFilter verifies the InstanceFilter views and the Forget sweep
+// over the completed set (FR-7a, FR-7).
+func TestInstancesFilter(t *testing.T) {
+	bp := blockingProcess(t, "disc-run") // stays Running until cancelled
+	lp := linearProcess(t, "disc-done", 0)
+
+	th, cancel := runEngine(t, bp)
+	defer cancel()
+	require.NoError(t, th.RegisterProcess(lp))
+
+	running, err := th.StartProcess(bp.ID())
+	require.NoError(t, err)
+	doneH, err := th.StartProcess(lp.ID())
+	require.NoError(t, err)
+
+	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cc()
+	st, err := doneH.WaitCompletion(ctx)
+	require.NoError(t, err)
+	require.Equal(t, thresher.StateCompleted, st)
+
+	time.Sleep(150 * time.Millisecond) // running one reaches its blocking op
+
+	require.ElementsMatch(t, []string{running.ID(), doneH.ID()},
+		th.Instances(thresher.InstancesAll))
+	require.Equal(t, []string{doneH.ID()}, th.Instances(thresher.InstancesCompleted))
+	require.Equal(t, []string{running.ID()}, th.Instances(thresher.InstancesRunning))
+
+	// Sweep the finished instances.
+	require.NoError(t, th.Forget(th.Instances(thresher.InstancesCompleted)...))
+	_, ok := th.Instance(doneH.ID())
+	require.False(t, ok)
+	require.Equal(t, []string{running.ID()}, th.Instances(thresher.InstancesAll))
+}
+
+// TestForget verifies batch all-or-nothing release: unknown or still-live ids
+// error and remove nothing; terminal ids are removed (FR-7).
+func TestForget(t *testing.T) {
+	bp := blockingProcess(t, "forget-run")
+	lp := linearProcess(t, "forget-done", 0)
+
+	th, cancel := runEngine(t, bp)
+	defer cancel()
+	require.NoError(t, th.RegisterProcess(lp))
+
+	running, err := th.StartProcess(bp.ID())
+	require.NoError(t, err)
+	doneH, err := th.StartProcess(lp.ID())
+	require.NoError(t, err)
+
+	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cc()
+	_, err = doneH.WaitCompletion(ctx)
+	require.NoError(t, err)
+	time.Sleep(150 * time.Millisecond)
+
+	// Unknown id: error, nothing removed.
+	require.Error(t, th.Forget("no-such"))
+	require.Len(t, th.Instances(thresher.InstancesAll), 2)
+
+	// Batch with a still-live id: all-or-nothing — none removed, even the
+	// completed one in the same call.
+	require.Error(t, th.Forget(doneH.ID(), running.ID()))
+	_, ok := th.Instance(doneH.ID())
+	require.True(t, ok, "all-or-nothing: the completed id must remain after a failed batch")
+
+	// Terminal id alone: removed.
+	require.NoError(t, th.Forget(doneH.ID()))
+	_, ok = th.Instance(doneH.ID())
+	require.False(t, ok)
+}
+
+// TestStarters verifies event-start registrations are listed (FR-7b); a
+// none-start process registers no starter.
+func TestStarters(t *testing.T) {
+	done := make(chan string, 1)
+	proc := orderConversationProcess(t, done) // message-start "order placed"
+
+	th, cancel := runEngine(t, proc)
+	defer cancel()
+
+	starters := th.Starters()
+	require.Len(t, starters, 1)
+	require.Equal(t, proc.ID(), starters[0].ProcessID)
+	require.Equal(t, "start", starters[0].StartNode)
+	require.Equal(t, "order placed", starters[0].Trigger)
+
+	// A none-start process adds no starter.
+	require.NoError(t, th.RegisterProcess(blockingProcess(t, "no-starter")))
+	require.Len(t, th.Starters(), 1)
+}
+
+// TestUnregisterProcessWithLiveInstance verifies UnregisterProcess succeeds with
+// a live instance, which keeps running (FR-8).
+func TestUnregisterProcessWithLiveInstance(t *testing.T) {
+	bp := blockingProcess(t, "unreg-live")
+	th, cancel := runEngine(t, bp)
+	defer cancel()
+
+	h, err := th.StartProcess(bp.ID())
+	require.NoError(t, err)
+	time.Sleep(150 * time.Millisecond)
+
+	require.NoError(t, th.UnregisterProcess(bp.ID()))
+
+	// The live instance is unaffected: still Active and looked-up-able.
+	require.Equal(t, thresher.StateActive, h.State())
+	_, ok := th.Instance(h.ID())
+	require.True(t, ok)
+
+	// The definition is gone — a new start is rejected.
+	_, err = th.StartProcess(bp.ID())
+	require.Error(t, err)
+}

--- a/pkg/thresher/handle.go
+++ b/pkg/thresher/handle.go
@@ -5,8 +5,16 @@ import (
 	"time"
 
 	"github.com/dr-dobermann/gobpm/internal/instance"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
 )
+
+// ErrNotImplemented marks a control operation that is part of the stable handle
+// contract but not yet implemented — Suspend/Resume await the Paused subsystem
+// (ADR-013 §2.3, SRD-019).
+var ErrNotImplemented = errs.New(
+	errs.M("operation reserved, not yet implemented"),
+	errs.C(errorClass, errs.OperationFailed))
 
 // InstanceHandle is a read-only window onto one running process instance
 // (SRD-018, ADR-013 §2.1). It is returned by StartProcess and found by
@@ -98,6 +106,31 @@ func (h *InstanceHandle) WaitCompletion(
 	case <-ctx.Done():
 		return h.State(), ctx.Err()
 	}
+}
+
+// Cancel requests termination of the instance and blocks until it reaches a
+// terminal state (Completed/Terminated) or ctx is done, returning the observed
+// state (+ ctx.Err() on timeout). Coarse, engine-mediated control (ADR-013 §2.3):
+// it drives the instance's ctx-cancel cascade, never a back door. Idempotent — a
+// second call, or Cancel of an already-terminal instance, returns the terminal
+// state at once.
+func (h *InstanceHandle) Cancel(ctx context.Context) (InstanceState, error) {
+	h.inst.Cancel()
+
+	return h.WaitCompletion(ctx)
+}
+
+// Suspend is reserved (ADR-013 §2.3): pausing token movement needs the deferred
+// Paused subsystem. The method exists so the control contract is stable; it
+// returns ErrNotImplemented until that subsystem lands.
+func (h *InstanceHandle) Suspend(_ context.Context) error {
+	return ErrNotImplemented
+}
+
+// Resume is reserved (ADR-013 §2.3) — the counterpart of Suspend; returns
+// ErrNotImplemented until the Paused subsystem lands.
+func (h *InstanceHandle) Resume(_ context.Context) error {
+	return ErrNotImplemented
 }
 
 // InstanceState is the standard-named, OPEN instance lifecycle vocabulary

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -67,11 +67,14 @@ const (
 	Started
 	// Paused represents a thresher that has been paused.
 	Paused
+	// Stopped represents a thresher that has been gracefully shut down. It is
+	// terminal: a Stopped thresher rejects RegisterProcess/StartProcess/Run.
+	Stopped
 )
 
 // Validate checks State to be valid.
 func (s State) Validate() error {
-	if s > Paused {
+	if s > Stopped {
 		return errs.New(
 			errs.M("invalid thresher state %d", uint8(s)))
 	}
@@ -91,6 +94,7 @@ func (s State) String() string {
 		"NotStarted ",
 		"Started",
 		"Paused",
+		"Stopped",
 	}[s]
 }
 
@@ -103,16 +107,17 @@ type instanceReg struct {
 
 // Thresher represents the main BPMN process execution engine.
 type Thresher struct {
-	ctx       context.Context
-	cfg       thresherConfig
-	eventHub  eventproc.EventHub
-	snapshots map[string]*snapshot.Snapshot
-	instances map[string]instanceReg
-	starters  map[string][]*instanceStarter
-	seenKeys  map[string]struct{}
-	id        string
-	m         sync.Mutex
-	state     State
+	ctx          context.Context
+	engineCancel context.CancelFunc
+	cfg          thresherConfig
+	eventHub     eventproc.EventHub
+	snapshots    map[string]*snapshot.Snapshot
+	instances    map[string]instanceReg
+	starters     map[string][]*instanceStarter
+	seenKeys     map[string]struct{}
+	id           string
+	m            sync.Mutex
+	state        State
 }
 
 // New creates a new empty Thresher in NotStarted state. Engine-level extensions
@@ -257,7 +262,11 @@ func (t *Thresher) Run(ctx context.Context) error {
 			errs.C(errorClass, errs.EmptyNotAllowed))
 	}
 
-	t.ctx = ctx
+	// Derive the engine's own cancellable context: Shutdown cancels it to
+	// cascade-terminate every instance (launched under t.ctx) and unblock the
+	// hub Run, without touching the caller's ctx (SRD-019). The caller canceling
+	// their ctx still propagates here.
+	t.ctx, t.engineCancel = context.WithCancel(ctx)
 
 	// Synchronously initialize the EventHub so that any subsequent
 	// RegisterEvent / UnregisterEvent / PropagateEvent call sees a fully
@@ -266,7 +275,7 @@ func (t *Thresher) Run(ctx context.Context) error {
 	// FIX-001 for the race this replaces (previously the hub was spun up
 	// in a goroutine guarded only by a 1ms sleep, which is not a memory
 	// barrier under the Go memory model).
-	if err := t.eventHub.Start(ctx); err != nil {
+	if err := t.eventHub.Start(t.ctx); err != nil {
 		return errs.New(
 			errs.M("couldn't start eventHub"),
 			errs.C(errorClass, errs.OperationFailed),
@@ -274,7 +283,7 @@ func (t *Thresher) Run(ctx context.Context) error {
 	}
 
 	go func() {
-		_ = t.eventHub.Run(ctx)
+		_ = t.eventHub.Run(t.ctx)
 	}()
 
 	err := t.UpdateState(Started)
@@ -296,6 +305,53 @@ func (t *Thresher) Run(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// Shutdown gracefully stops the engine (ADR-013 §2.5): it flips to the terminal
+// Stopped state (rejecting further RegisterProcess/StartProcess/Run), cancels
+// the engine context — which cascade-terminates every running instance and
+// unblocks the hub Run — waits (bounded by ctx) for each instance to reach a
+// terminal state, then drains the EventHub's waiters (EventHub.Shutdown,
+// realizing ADR-006 §2.5). Idempotent; returns ctx.Err() if the deadline hits
+// before all instances settle.
+func (t *Thresher) Shutdown(ctx context.Context) error {
+	t.m.Lock()
+	if t.state == Stopped {
+		t.m.Unlock()
+
+		return nil
+	}
+
+	t.state = Stopped
+
+	regs := make([]instanceReg, 0, len(t.instances))
+	for _, r := range t.instances {
+		regs = append(regs, r)
+	}
+
+	cancel := t.engineCancel
+	t.m.Unlock()
+
+	// Cancel the engine context: every instance (launched under t.ctx) observes
+	// it and walks to Terminated; the hub Run unblocks.
+	if cancel != nil {
+		cancel()
+	}
+
+	// Settle each running instance, bounded by ctx.
+	for _, r := range regs {
+		select {
+		case <-r.inst.Done():
+		case <-ctx.Done():
+			return errs.New(
+				errs.M("thresher shutdown timed out before instances settled"),
+				errs.C(errorClass, errs.OperationFailed),
+				errs.E(ctx.Err()))
+		}
+	}
+
+	// Drain the event machinery: stop waiters and wait for their goroutines.
+	return t.eventHub.Shutdown(ctx)
 }
 
 // ------------------ EventProducer interface ----------------------------------
@@ -391,6 +447,13 @@ func (t *Thresher) RegisterProcess(
 		return errs.New(
 			errs.M("empty process"),
 			errs.C(errorClass, errs.EmptyNotAllowed))
+	}
+
+	if st := t.State(); st == Stopped {
+		return errs.New(
+			errs.M("thresher is shut down; process registration rejected"),
+			errs.C(errorClass, errs.InvalidState),
+			errs.D("current_state", st.String()))
 	}
 
 	var rc registerConfig

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -509,7 +509,9 @@ func (t *Thresher) RegisterProcess(
 // UnregisterProcess removes a registered process: it tears down every
 // persistent instance-starter subscription registered for it and drops its
 // snapshot. It is the teardown counterpart of RegisterProcess (SRD-015 FR-2).
-// Running instances of the process are unaffected.
+// Running instances of the process are unaffected — they keep executing against
+// their already-built snapshot; release finished instances via Forget, or stop
+// everything via Shutdown (SRD-019 FR-8).
 func (t *Thresher) UnregisterProcess(processID string) error {
 	processID = strings.TrimSpace(processID)
 	if processID == "" {


### PR DESCRIPTION
Summary

Lands the control + engine-lifecycle slice of ADR-013 v.1 (§2.3/§2.5) and realizes the open part of ADR-006 v.1 §2.5 (the WaitGroup-synchronized EventHub waiter drain). Sibling of the
already-merged observe slice (SRD-018). Control is coarse, explicit, and engine-mediated — no hidden per-node listeners.

What's added

- InstanceHandle.Cancel(ctx) — requests termination and blocks (ctx-bounded) until terminal; idempotent. Backed by an instance self-cancel (Run derives inst.cancel; Instance.Cancel() drives the
proven ADR-001 Active→Terminating→Terminated cascade).
- Suspend/Resume — reserved, return a stable ErrNotImplemented (the Paused subsystem is deferred).
- Thresher.Shutdown(ctx) — graceful: flips to a new terminal Stopped state (rejecting Start/Register/Run), cancels the engine context (cascade-terminating instances + unblocking the hub Run),
settles each instance bounded by ctx, then drains the hub.
- EventHub.Shutdown(ctx) — stops every waiter and waits for their Service goroutines to exit via per-waiter Done() channels (local WaitGroup, ctx-bounded); removes every waiter even on a Stop()
error (no leak). Hub lifecycle is now a single hubState enum.
- Discovery + release — Instances(filter) (InstancesAll/Running/Completed), Forget(ids…) (batch, terminal-only, all-or-nothing), Starters() []StarterInfo; UnregisterProcess documented (live
instances keep running).
- Example — the quick-start gofunc now reads a process property + RUNTIME/STARTED_AT via its DataReader (split into main.go/process.go).

Verification

- make ci green: lint (incl. fieldalignment), build, -race, diff-coverage 96.8%/189 (≥95), govulncheck.
- No waiter goroutine outlives EventHub.Shutdown — proven under -race.
- All 9 examples smoke-run exit 0.

Docs

SRD-019 (EN + RU twin), Accepted. References upward-only, version-pinned.
