### PR TITLE
Feat/signal events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ examples/message-send-receive/message-send-receive
 examples/message-intermediate-events/message-intermediate-events
 examples/inter-instance-correlation/inter-instance-correlation
 examples/conversation-routing/conversation-routing
+examples/signal-broadcast/signal-broadcast

--- a/docs/srd/SRD-020-signal-events.md
+++ b/docs/srd/SRD-020-signal-events.md
@@ -1,8 +1,8 @@
-# SRD-020 — Signal events: name-indexed broadcast catch & throw
+# SRD-020 — Signal events: name-matched broadcast catch & throw
 
 | Field | Value |
 |---|---|
-| Status | Draft |
+| Status | Accepted |
 | Version | v.1 |
 | Date | 2026-06-18 |
 | Owner | Ruslan Gabitov |
@@ -239,7 +239,7 @@ this SRD wires their **runtime**.
   a no-op (no error), and a later catch of the same name is **not** retro-delivered
   (FR-4, NFR-1; the §2.4 no-buffer contract).
 - **`TestSignalSingleShotConsume`** — after a catch fires, its processor is removed;
-  a second throw does not re-fire the consumed catch; the name waiter is gone once
+  a second throw does not re-fire the consumed catch; the waiter is gone once
   empty (FR-5).
 - **`TestPropagateNoWaiterIsNoop`** (internal `eventhub`) — `PropagateEvent` with an
   absent key returns `nil` and logs at debug, for both a signal and a non-signal
@@ -256,7 +256,7 @@ this SRD wires their **runtime**.
 - [ADR-001 v.5](../design/ADR-001-execution-model.md) — the track/loop model the
   delivery path runs against (single-mutator; signal reuses `track.ProcessEvent`).
 - [ADR-009 v.1](../design/ADR-009-per-instance-node-graph.md) — per-instance clones;
-  each instance's catch is a distinct processor on the shared name waiter.
+  each instance's catch is a distinct processor on the shared waiter.
 - [ADR-013 v.1](../design/ADR-013-instance-observability.md) §2.5 / [SRD-019 v.1](SRD-019-instance-control-lifecycle.md)
   — the `EventHub.Shutdown` waiter drain the passive signal waiter obeys (closed
   `Done()`).
@@ -268,8 +268,8 @@ this SRD wires their **runtime**.
 ## 9. Definition of Done
 
 - FR-1…FR-7 wired and exercised by the §7 tests (incl. the `-race` broadcast canary).
-- `signalWaiter` + `CreateWaiter` signal case + name keying + §2.4 no-op present;
-  signal catch/throw/end run end-to-end.
+- `signalWaiter` + `CreateWaiter` signal case + `broadcastSignal` name-scan + §2.4
+  no-op present; signal catch/throw/end run end-to-end.
 - §2.4 closed: `PropagateEvent` no-waiter is a logged no-op (the old `ObjectNotFound`
   path is gone), proven by `TestPropagateNoWaiterIsNoop`.
 - `make ci` green (tidy, lint incl. fieldalignment, build, `-race`, diff-coverage
@@ -281,10 +281,48 @@ this SRD wires their **runtime**.
 
 ## 10. Implementation summary
 
-> ⚠️ TODO: fill AFTER landing — commits, key files, V-results, deltas vs this draft.
+Landed on `feat/signal-events` (off `master`): two code milestones + a
+prerequisite fix + a runnable example.
+
+### 10.1 Commits
+
+| # | Commit | Scope | Tests |
+|---|---|---|---|
+| doc | `24a451c` | SRD-020 draft | — |
+| fix | `30c8437` | Pre-existing SRD-019 race: `EventHub.state` made `atomic.Uint32` (Run/PropagateEvent read it lock-free while Start/Shutdown write it). Surfaced by M1's timing shift. | `TestThresherShutdown -race` |
+| M1 | `d4460a7` | §2.4 no-waiter no-op: `PropagateEvent` to an absent key → debug-logged `nil` (was `ObjectNotFound`). | `TestPropagateNoWaiterIsNoop` |
+| M2 | `ed43854` | Signal runtime: passive `signalWaiter`, `CreateWaiter` signal case, `broadcastSignal` name-scan in `PropagateEvent`. | `TestSignalWaiter*`, `TestBroadcastSignalFanOut`, `TestSignalCatchThrow`, `TestSignalBroadcast -race`, `TestSignalThrownIntoVoid`, `TestSignalSingleShotConsume` |
+| M3 | `ce0bc96` | `examples/signal-broadcast` (one throw → two watcher instances). | smoke |
+
+### 10.2 Key files
+
+- `internal/eventproc/eventhub/waiters/signal.go` (new) — the passive `signalWaiter`.
+- `internal/eventproc/eventhub/waiters/waiters.go` — `CreateWaiter` `TriggerSignal` case + per-trigger-identity NOTE.
+- `internal/eventproc/eventhub/eventhub.go` — `broadcastSignal`/`signalName`, the `PropagateEvent` signal branch + §2.4 no-op, and the `atomic.Uint32` state (race fix).
+- `examples/signal-broadcast/` (new) — `process.go` (catcher/thrower builders) + `main.go`.
+
+### 10.3 Verification
+
+- `make ci` green: tidy, lint, build, `-race`, **diff-coverage 97.2% of 212
+  changed lines (≥95)**, govulncheck. Touched funcs ≥80% (signal.go +
+  `broadcastSignal` 100%).
+- All **10** examples smoke-run exit 0 (incl. `signal-broadcast`).
+
+### 10.4 Deltas vs the draft
+
+- **Matching mechanism corrected (FR-2/§2/§5).** The draft first sketched a
+  name-keyed registry (`waiterKey`); implementation revealed the simpler truth:
+  catchers across instances already share one waiter (signal eDefs aren't
+  cloned), and throw→catch matches by **name-scan** in `PropagateEvent`
+  (`broadcastSignal`) — no keying change, no `UnregisterEvent` signature churn.
+  The doc was corrected in M2. A future `SubscriptionKey()` generalization
+  (when Link events land) is captured as a follow-up, not built here.
+- **Prerequisite race fix.** M1's `-race` run exposed a pre-existing SRD-019
+  `EventHub.state` data race; fixed as its own `30c8437` commit before M1, not
+  folded in silently.
 
 ## Document History
 
 | Version | Date | Author | Change |
 |---|---|---|---|
-| v.1 | 2026-06-18 | Ruslan Gabitov | Draft. First runtime slice of the ADR-006 v.1 events workstream: signal events (intermediate catch + intermediate/end throw) via a name-keyed passive `signalWaiter` that reuses the hub's find-or-add-processor + fan-out + §2.5-ownership machinery to broadcast (one throw of name `X` → every catcher of `X` across instances in reach, §2.1/§10.5.1); no `CloneForInstance` (sharing the name waiter *is* the broadcast); and closes the §2.4 no-waiter gap (`PropagateEvent` absent-key → logged no-op, replacing `ObjectNotFound`). Signal **start** (instantiating) and **boundary** events deferred. Code-grounded against `pkg/model/events` (signal.go, intermediate_catch.go), `internal/eventproc/eventhub` (eventhub.go, waiters/), `internal/instance` (track.go ProcessEvent/checkNodeType). Implements ADR-006 v.1 §2.1/§2.4; refs ADR-001 v.5, ADR-009 v.1, ADR-013 v.1, ADR-014 v.1, SRD-019 v.1. |
+| v.1 | 2026-06-18 | Ruslan Gabitov | Accepted. First runtime slice of the ADR-006 v.1 events workstream: signal events (intermediate catch + intermediate/end throw) via a passive `signalWaiter` (no broker, no goroutine; `Process` fans out to all catchers, no correlation; closed `Done()` for §2.5 drain). Broadcast is matched by **name-scan** in `PropagateEvent` (`broadcastSignal`) — throw and catch are distinct nodes with distinct ids — while catchers across instances share one waiter because signal eDefs aren't cloned (`cloneDefsForInstance` shares by reference; the deliberate inverse of FIX-004's point-to-point clone). Also closes the §2.4 no-waiter gap (`PropagateEvent` absent-key → logged no-op, replacing `ObjectNotFound`; landed in M1) and fixed a pre-existing SRD-019 `EventHub.state` data race (atomic). Drafted with a name-keyed registry; corrected to shared-id + name-scan during implementation (no `waiterKey`/`UnregisterEvent` churn). Signal **start** (instantiating) and **boundary** events deferred; a polymorphic `SubscriptionKey()` matching generalization deferred to the Link-events workstream. Code-grounded against `pkg/model/events`, `internal/eventproc/eventhub`, `internal/instance`. Implements ADR-006 v.1 §2.1/§2.4; refs ADR-001 v.5, ADR-009 v.1, ADR-013 v.1, ADR-014 v.1, SRD-019 v.1. |

--- a/docs/srd/SRD-020-signal-events.md
+++ b/docs/srd/SRD-020-signal-events.md
@@ -1,0 +1,266 @@
+# SRD-020 — Signal events: name-indexed broadcast catch & throw
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-06-18 |
+| Owner | Ruslan Gabitov |
+| Implements | [ADR-006 v.1 Events & Subscriptions](../design/ADR-006-events-and-subscriptions.md) §2.1, §2.4 |
+
+This SRD lands the first runtime slice of the **events workstream** opened by
+[ADR-006 v.1](../design/ADR-006-events-and-subscriptions.md): **signal events** —
+the *publication / broadcast* trigger (§2.1) — for **intermediate catch** and
+**throw** (intermediate-throw + signal end event). It also closes the dormant
+**§2.4 no-waiter gap** (propagating to no listener becomes a logged no-op, not an
+error) that has been waiting for signals. Signal **start** (instantiating) and
+signal **boundary** events are deferred to the instantiation and boundary
+workstreams respectively.
+
+## 1. Background & motivation
+
+### 1.1 Current state (verified against the code)
+
+- **Signals are modelled but not executable.** `SignalEventDefinition`
+  (`pkg/model/events/signal.go:59-112`) exists with `Type() → flow.TriggerSignal`
+  (`:110-112`) and a `Signal()` accessor over a named `Signal`
+  (`signal.go:14-51`, `Name()` at `:49`); the intermediate-catch trigger
+  whitelist **already admits** signals
+  (`pkg/model/events/intermediate_catch.go:18-23`, `flow.TriggerSignal` at `:21`).
+  But there is **no signal waiter**: the waiter-builder switch
+  (`internal/eventproc/eventhub/waiters/waiters.go:53-70`) has cases only for
+  `TriggerTimer` and `TriggerMessage`; a signal falls through to the `default`
+  error ("couldn't find builder for event definition of type …", `:64-70`). So a
+  process with a signal catch/throw fails at registration today.
+- **The hub is point-to-point, keyed by `eDef.ID()`.** The registry is
+  `waiters map[string]eventproc.EventWaiter` (`eventhub.go:48`); `registerWaiter`
+  keys by `eDef.ID()` — *find-or-build*, and if a waiter already exists for the
+  key it **adds the processor to it** (`eventhub.go:194-228`). A waiter fans out
+  to **all** its registered `EventProcessor`s when it fires (the message waiter
+  loops them — `waiters/message.go:307-322`). `PropagateEvent` looks up **one**
+  waiter by `eDef.ID()` (`eventhub.go:376`) and delivers to it.
+- **Propagating to no waiter is an ERROR (the §2.4 gap).** `PropagateEvent`
+  returns `ObjectNotFound` when `eDef.ID()` is absent from the registry
+  (`eventhub.go:379-385`). For a **signal broadcast with no live catcher** this is
+  *wrong* — a signal thrown into the void is simply not caught (§10.5.1), a normal
+  condition, not a failure (ADR-006 §2.4).
+- **Delivery runs on the waiter goroutine, track-synchronized.** A fired event
+  reaches the waiting track via `track.ProcessEvent`
+  (`internal/instance/track.go:723-778`), which runs **on the waiter goroutine**
+  (comment `:743`), guards `TrackWaitForEvent` (`:730`), delivers to the node, then
+  `unregisterEvent` + `TrackReady` (`:769-775`). Registration is `track.checkNodeType`
+  → `RegisterEvent(t, d)` per definition when the token reaches the node
+  (`track.go:301-340`, register at `:328`). The throw side: a throw event's
+  `Execute` propagates via the instance's `EventProducer.PropagateEvent`
+  (`internal/instance/instance.go:987-1002`) → `Thresher.PropagateEvent`
+  (`thresher.go:400-419`) → `EventHub.PropagateEvent`. This is the proven path
+  message/timer already use; **signals reuse it** (ADR-006 §2.1's single-loop
+  inbound edge stays conception, as it is for message/timer today).
+
+### 1.2 Problem
+
+The signal trigger — BPMN's broadcast publication strategy (§10.5.1) — has a model
+but no runtime. A process cannot throw or catch a signal, and the hub's
+point-to-point, error-on-no-waiter behaviour is the wrong shape for broadcast. This
+SRD makes signals executable and turns the §2.4 contract into reality.
+
+## 2. Decision
+
+- **Signal waiters are keyed by signal NAME, not `eDef.ID()`.** A single hub
+  waiter represents one signal name; every track catching that name registers as a
+  **processor** on it. The existing find-or-add-processor `registerWaiter` then
+  gives **broadcast for free**: a throw of name `X` fires every processor on the
+  `X` waiter — i.e. every catching track across every instance in reach
+  (ADR-006 §2.1 broadcast; §10.5.1). No `CloneForInstance` for signals (unlike
+  message/timer, *sharing one waiter is exactly the desired broadcast*, because the
+  waiter holds one processor per catching track).
+- **A passive `signalWaiter`.** Unlike message (broker subscription) / timer
+  (ticker), a signal has **no external source** — it is fired only by an in-process
+  throw via `PropagateEvent`. So the signal waiter spawns **no service goroutine**;
+  its `Service` is a no-op that marks it running and its `Done()` is already closed.
+  It obeys §2.5 ownership (the hub creates/removes it; it never self-removes) and
+  fans `Process` out to all its processors with **no correlation filter** (signals
+  have no correlation, §10.5.1).
+- **No-waiter ⇒ logged no-op (closes §2.4).** `PropagateEvent` to an absent key is
+  a debug-logged no-op, not an error — correct for a signal broadcast with no live
+  catcher, harmless for any other kind.
+- **Catch is single-shot; the name waiter persists until empty.** An intermediate
+  catch consumes the signal once: on fire the track `unregisterEvent`s (removes its
+  processor); when the last processor leaves, the hub removes the name waiter (the
+  existing empty-waiter cleanup, `eventhub.go:397-398`). A later throw of the same
+  name with no current catcher is a no-op.
+- **Throw broadcasts by name.** Intermediate-throw and signal **end** events
+  propagate their `SignalEventDefinition`; the hub keys by name and fans out. Reach
+  is **engine-wide** (every instance registered in the `Thresher`), **including the
+  throwing instance's own catchers** — the single-process in-memory conformance
+  target (§2.4).
+
+```mermaid
+flowchart LR
+  TA[instance A: catch signal X] -->|register processor| W[(hub waiter key=signal:X)]
+  TB[instance B: catch signal X] -->|register processor| W
+  THR[instance C: throw signal X] -->|PropagateEvent| W
+  W -->|fan out, no correlation| TA
+  W -->|fan out| TB
+  W -.->|no processors -> logged no-op| VOID[thrown into the void]
+```
+
+## 3. Functional requirements
+
+- **FR-1 — signal catch waiter.** A `signalWaiter` (`eventproc.EventWaiter`) is
+  built for a `SignalEventDefinition`; `waiters.CreateWaiter` gains a
+  `flow.TriggerSignal` case. It is **passive** (no service goroutine): `Service`
+  marks it `WSRunned` and leaves `Done()` closed; `Stop` marks it stopped; it never
+  removes itself (§2.5).
+- **FR-2 — name keying.** Signal waiters register and propagate under a
+  **name-derived key** (the signal name), not `eDef.ID()`. A hub helper resolves
+  the registry key per event kind (signal → name; others → `eDef.ID()`), used
+  consistently by `registerWaiter`, `PropagateEvent`, and removal. Two instances
+  catching the same signal name share one waiter as two processors.
+- **FR-3 — broadcast fan-out.** `signalWaiter.Process(eDef)` delivers to **every**
+  registered `EventProcessor` (each catching track), with no correlation filter; a
+  per-processor delivery error is logged and does not abort the rest of the
+  broadcast. Each delivered track resumes via the existing `track.ProcessEvent`
+  path.
+- **FR-4 — no-waiter no-op (closes §2.4).** `EventHub.PropagateEvent` with no
+  registered waiter for the (name/ID) key is a **debug-logged no-op returning
+  `nil`**, replacing the current `ObjectNotFound` error (`eventhub.go:379-385`).
+- **FR-5 — single-shot catch.** An intermediate signal catch is consumed once: on
+  fire the track unregisters its processor (existing `track.ProcessEvent`
+  `unregisterEvent`); the name waiter is removed when its last processor leaves
+  (existing empty-waiter cleanup).
+- **FR-6 — signal throw.** Intermediate-throw and **signal end** events propagate a
+  `SignalEventDefinition` through the existing throw path
+  (`instance.PropagateEvent` → `Thresher.PropagateEvent` → `EventHub`); no new throw
+  plumbing — the hub's name keying does the broadcast.
+- **FR-7 — deferrals (documented, not built).** Signal **start** events
+  (instantiating — extends ADR-015) and signal **boundary** events (boundary
+  workstream) are out of scope; the catch path here is the intermediate **in-flow**
+  waiter only (ADR-006 §2.3 row 1).
+
+## 4. Non-functional requirements
+
+- **NFR-1 — BPMN broadcast semantics.** One throw of name `X` reaches **all**
+  current catchers of `X` in reach (§10.5.1); zero catchers is a no-op, never an
+  error or a buffered late-delivery (§2.4 — the hub is not a store).
+- **NFR-2 — §2.5 ownership.** The signal waiter is hub-owned: created on first
+  catch, removed when empty or on `Shutdown`; it never self-removes; it drains
+  cleanly (its `Done()` is closed, so `EventHub.Shutdown`'s wait is immediate).
+- **NFR-3 — no new locks / single-mutator preserved.** Registration/propagation
+  stay under the hub's existing `m sync.RWMutex`; delivery reuses the track's
+  existing `t.m`/state synchronization (ADR-001). No change to the instance loop.
+- **NFR-4 — coverage.** Touched files finish ≥80% (target 100%) diff-coverage;
+  `make ci` green (incl. `-race` — broadcast crosses instances/goroutines).
+
+## 5. Path analysis (alternatives)
+
+- **Name-keyed shared waiter (chosen) vs a parallel `map[name][]subscriber`
+  index.** Chosen: key signal waiters by name in the **existing** registry, so the
+  find-or-add-processor + fan-out + §2.5 ownership + empty-cleanup machinery is
+  reused unchanged — broadcast falls out of the multi-processor waiter that already
+  exists. Rejected the parallel index: it duplicates ownership/shutdown logic the
+  hub already has, and splits propagation into two code paths.
+- **Passive waiter (chosen) vs a service goroutine that waits on a channel.**
+  Chosen: a signal has no external source (it is fired by an in-process throw), so a
+  goroutine would block on nothing and only complicate the §2.5 drain. A passive
+  waiter (closed `Done()`) is the honest shape. Rejected the goroutine: needless
+  concurrency + a drain edge with no benefit.
+- **No `CloneForInstance` for signals (chosen) vs per-instance clone like
+  message/timer.** Chosen: message/timer clone to a fresh per-instance ID so
+  concurrent instances do **not** share a waiter (point-to-point — sharing was the
+  FIX-004 broadcast bug). For signals the opposite is correct: catchers across
+  instances **should** all fire on one throw, so they **should** share the
+  name-keyed waiter as distinct processors. Rejected cloning: it would fragment the
+  broadcast into per-instance waiters a single throw can't reach.
+- **No-waiter no-op (chosen) vs keep the error / buffer the signal.** Chosen:
+  logged no-op (ADR-006 §2.4) — a signal with no catcher is normal BPMN. Rejected
+  the error (wrong for broadcast) and buffering (the hub is not a store; signals are
+  not replayed — §2.4).
+- **Reach = engine-wide incl. self-instance (chosen) vs per-instance only.**
+  Chosen: a thrown signal reaches every catcher in the engine, including the
+  thrower's own instance (§10.5.1 "within and across Processes"). The single-process
+  in-memory model is the conformance target (§2.4). Cross-engine reach is the
+  persistence/distribution ADR's, not here.
+
+## 6. API & key shapes
+
+```go
+// internal/eventproc/eventhub/waiters — new passive waiter:
+//   NewSignalWaiter(eh, ep, eDef, rt) (eventproc.EventWaiter, error)
+//   keyed by the signal name; Process fans out to all EventProcessors (no
+//   correlation); Service is a no-op (no goroutine); Done() is closed.
+// waiters.CreateWaiter gains:
+//   case flow.TriggerSignal: w, err = NewSignalWaiter(eh, ep, eDef, rt)
+
+// internal/eventproc/eventhub/eventhub.go — name-vs-id keying + §2.4 no-op:
+//   func waiterKey(eDef flow.EventDefinition) string // signal -> name; else eDef.ID()
+//   registerWaiter / PropagateEvent / removal use waiterKey(eDef).
+//   PropagateEvent: absent key -> debug log + return nil (was ObjectNotFound).
+```
+
+No new public `pkg/` surface: signals are authored with the existing
+`events.NewSignalEventDefinition` + intermediate catch/throw + end-event builders;
+this SRD wires their **runtime**.
+
+## 7. Test plan
+
+- **`TestSignalCatchThrow`** — one instance: a track waits on an intermediate
+  signal catch; another track (or a second flow) throws the same signal name; the
+  catch fires and the process completes (FR-1, FR-3, FR-6).
+- **`TestSignalBroadcast`** (`-race`) — two concurrent instances each catch signal
+  `X`; a throw of `X` (from a third) fires **both** — both reach their downstream
+  node (FR-2, FR-3, NFR-1). This is the broadcast canary (the inverse of FIX-004's
+  no-cross-instance rule, which holds for message/timer).
+- **`TestSignalThrownIntoVoid`** — throwing a signal with no registered catcher is
+  a no-op (no error), and a later catch of the same name is **not** retro-delivered
+  (FR-4, NFR-1; the §2.4 no-buffer contract).
+- **`TestSignalSingleShotConsume`** — after a catch fires, its processor is removed;
+  a second throw does not re-fire the consumed catch; the name waiter is gone once
+  empty (FR-5).
+- **`TestPropagateNoWaiterIsNoop`** (internal `eventhub`) — `PropagateEvent` with an
+  absent key returns `nil` and logs at debug, for both a signal and a non-signal
+  eDef (FR-4) — the direct §2.4 regression test against `eventhub.go:379-385`.
+- Internal `internal/eventproc/eventhub/waiters` unit for `signalWaiter`
+  (passive `Service`/closed `Done`, fan-out `Process`, `Stop`) for cross-package
+  coverage attribution.
+
+## 8. Cross-document consistency
+
+- **Implements** [ADR-006 v.1](../design/ADR-006-events-and-subscriptions.md) §2.1
+  (publication/broadcast reach, per-instance subscription identity), §2.4 (no-waiter
+  no-op, non-durable, no buffering — signals are not the broker's job).
+- [ADR-001 v.5](../design/ADR-001-execution-model.md) — the track/loop model the
+  delivery path runs against (single-mutator; signal reuses `track.ProcessEvent`).
+- [ADR-009 v.1](../design/ADR-009-per-instance-node-graph.md) — per-instance clones;
+  each instance's catch is a distinct processor on the shared name waiter.
+- [ADR-013 v.1](../design/ADR-013-instance-observability.md) §2.5 / [SRD-019 v.1](SRD-019-instance-control-lifecycle.md)
+  — the `EventHub.Shutdown` waiter drain the passive signal waiter obeys (closed
+  `Done()`).
+- [ADR-014 v.1](../design/ADR-014-message-handling.md) — the message waiter this
+  mirrors (and deliberately diverges from on correlation/broadcast).
+- References up/sideways, version-pinned; no downward refs (ADR-006 does not cite
+  SRD-020).
+
+## 9. Definition of Done
+
+- FR-1…FR-7 wired and exercised by the §7 tests (incl. the `-race` broadcast canary).
+- `signalWaiter` + `CreateWaiter` signal case + name keying + §2.4 no-op present;
+  signal catch/throw/end run end-to-end.
+- §2.4 closed: `PropagateEvent` no-waiter is a logged no-op (the old `ObjectNotFound`
+  path is gone), proven by `TestPropagateNoWaiterIsNoop`.
+- `make ci` green (tidy, lint incl. fieldalignment, build, `-race`, diff-coverage
+  ≥95, govulncheck); touched files ≥80% (target 100%).
+- A runnable `examples/signal-broadcast` (or extension of an existing example)
+  smoke-runs exit 0, plus the existing 9 examples still exit 0.
+- §10 filled; status → Accepted; RU twin added; linked docs synced; GitHub
+  sub-issue under epic #90 closed by the PR.
+
+## 10. Implementation summary
+
+> ⚠️ TODO: fill AFTER landing — commits, key files, V-results, deltas vs this draft.
+
+## Document History
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v.1 | 2026-06-18 | Ruslan Gabitov | Draft. First runtime slice of the ADR-006 v.1 events workstream: signal events (intermediate catch + intermediate/end throw) via a name-keyed passive `signalWaiter` that reuses the hub's find-or-add-processor + fan-out + §2.5-ownership machinery to broadcast (one throw of name `X` → every catcher of `X` across instances in reach, §2.1/§10.5.1); no `CloneForInstance` (sharing the name waiter *is* the broadcast); and closes the §2.4 no-waiter gap (`PropagateEvent` absent-key → logged no-op, replacing `ObjectNotFound`). Signal **start** (instantiating) and **boundary** events deferred. Code-grounded against `pkg/model/events` (signal.go, intermediate_catch.go), `internal/eventproc/eventhub` (eventhub.go, waiters/), `internal/instance` (track.go ProcessEvent/checkNodeType). Implements ADR-006 v.1 §2.1/§2.4; refs ADR-001 v.5, ADR-009 v.1, ADR-013 v.1, ADR-014 v.1, SRD-019 v.1. |

--- a/docs/srd/SRD-020-signal-events.md
+++ b/docs/srd/SRD-020-signal-events.md
@@ -66,14 +66,19 @@ SRD makes signals executable and turns the §2.4 contract into reality.
 
 ## 2. Decision
 
-- **Signal waiters are keyed by signal NAME, not `eDef.ID()`.** A single hub
-  waiter represents one signal name; every track catching that name registers as a
-  **processor** on it. The existing find-or-add-processor `registerWaiter` then
-  gives **broadcast for free**: a throw of name `X` fires every processor on the
-  `X` waiter — i.e. every catching track across every instance in reach
-  (ADR-006 §2.1 broadcast; §10.5.1). No `CloneForInstance` for signals (unlike
-  message/timer, *sharing one waiter is exactly the desired broadcast*, because the
-  waiter holds one processor per catching track).
+- **Broadcast falls out of shared eDef identity (no name index needed).** Signal
+  `EventDefinition`s have **no `CloneForInstance`**, so `Event.clone()`
+  (`events/event.go:161-167`) shares them **by reference** across per-instance
+  node-graph clones (ADR-009) via `cloneDefsForInstance` (`event.go:175-191`,
+  "definitions without the capability are shared by reference"). Every instance
+  catching the same modelled signal node therefore holds the **same `eDef.ID()`**,
+  so the existing find-or-add-processor `registerWaiter` lands all catchers on
+  **one** ID-keyed waiter as distinct processors, and a throw (`PropagateEvent` by
+  that id) fans `Process` out to all of them — **broadcast via the existing
+  registry**, no name index, no keying change. The clone-vs-share asymmetry in
+  `cloneDefsForInstance` already encodes it: message/timer clone → point-to-point
+  (the FIX-004 no-share rule); **signal shares → broadcast** (the deliberate
+  inverse). Signal therefore deliberately does **not** add `CloneForInstance`.
 - **A passive `signalWaiter`.** Unlike message (broker subscription) / timer
   (ticker), a signal has **no external source** — it is fired only by an in-process
   throw via `PropagateEvent`. So the signal waiter spawns **no service goroutine**;
@@ -84,20 +89,25 @@ SRD makes signals executable and turns the §2.4 contract into reality.
 - **No-waiter ⇒ logged no-op (closes §2.4).** `PropagateEvent` to an absent key is
   a debug-logged no-op, not an error — correct for a signal broadcast with no live
   catcher, harmless for any other kind.
-- **Catch is single-shot; the name waiter persists until empty.** An intermediate
-  catch consumes the signal once: on fire the track `unregisterEvent`s (removes its
-  processor); when the last processor leaves, the hub removes the name waiter (the
-  existing empty-waiter cleanup, `eventhub.go:397-398`). A later throw of the same
-  name with no current catcher is a no-op.
-- **Throw broadcasts by name.** Intermediate-throw and signal **end** events
-  propagate their `SignalEventDefinition`; the hub keys by name and fans out. Reach
+- **Catch is single-shot; the waiter persists until empty.** An intermediate catch
+  consumes the signal once: on fire the track `unregisterEvent`s (removes its
+  processor); when the last processor leaves, the hub removes the waiter. Because
+  the broadcast fan-out drives each catcher to self-unregister **during**
+  `Process`, the last unregister removes the now-empty waiter, so `PropagateEvent`'s
+  own post-`Process` empty-cleanup (`eventhub.go:397-398`) must **tolerate an
+  already-removed waiter** (a lock-check-delete, not a hard `RemoveWaiter` that
+  errors `ObjectNotFound`). This path is currently dead for message (its `Process`
+  errors) and timer (fires via `WaiterFired`), so signal is the first to exercise
+  it.
+- **Throw broadcasts.** Intermediate-throw and signal **end** events propagate
+  their `SignalEventDefinition`; the hub finds the shared-id waiter and fans out. Reach
   is **engine-wide** (every instance registered in the `Thresher`), **including the
   throwing instance's own catchers** — the single-process in-memory conformance
   target (§2.4).
 
 ```mermaid
 flowchart LR
-  TA[instance A: catch signal X] -->|register processor| W[(hub waiter key=signal:X)]
+  TA[instance A: catch signal X] -->|register processor| W[(one waiter: shared eDef id of X)]
   TB[instance B: catch signal X] -->|register processor| W
   THR[instance C: throw signal X] -->|PropagateEvent| W
   W -->|fan out, no correlation| TA
@@ -112,27 +122,33 @@ flowchart LR
   `flow.TriggerSignal` case. It is **passive** (no service goroutine): `Service`
   marks it `WSRunned` and leaves `Done()` closed; `Stop` marks it stopped; it never
   removes itself (§2.5).
-- **FR-2 — name keying.** Signal waiters register and propagate under a
-  **name-derived key** (the signal name), not `eDef.ID()`. A hub helper resolves
-  the registry key per event kind (signal → name; others → `eDef.ID()`), used
-  consistently by `registerWaiter`, `PropagateEvent`, and removal. Two instances
-  catching the same signal name share one waiter as two processors.
+- **FR-2 — shared-eDef-id broadcast (no keying change).** Signal
+  `EventDefinition`s deliberately have **no `CloneForInstance`**, so all instances
+  catching the same modelled signal node share one `eDef.ID()` (`Event.clone` →
+  `cloneDefsForInstance`, shared by reference). The existing `eDef.ID()`-keyed
+  `registerWaiter` find-or-add-processor then lands every catcher on one waiter as a
+  distinct processor — broadcast, with **no `waiterKey` and no change to
+  `registerWaiter`/`PropagateEvent`/`UnregisterEvent` keying**.
 - **FR-3 — broadcast fan-out.** `signalWaiter.Process(eDef)` delivers to **every**
   registered `EventProcessor` (each catching track), with no correlation filter; a
   per-processor delivery error is logged and does not abort the rest of the
   broadcast. Each delivered track resumes via the existing `track.ProcessEvent`
   path.
 - **FR-4 — no-waiter no-op (closes §2.4).** `EventHub.PropagateEvent` with no
-  registered waiter for the (name/ID) key is a **debug-logged no-op returning
-  `nil`**, replacing the current `ObjectNotFound` error (`eventhub.go:379-385`).
-- **FR-5 — single-shot catch.** An intermediate signal catch is consumed once: on
-  fire the track unregisters its processor (existing `track.ProcessEvent`
-  `unregisterEvent`); the name waiter is removed when its last processor leaves
-  (existing empty-waiter cleanup).
+  registered waiter for `eDef.ID()` is a **debug-logged no-op returning `nil`**,
+  replacing the current `ObjectNotFound` error (`eventhub.go:379-385`). **Landed in
+  M1.**
+- **FR-5 — single-shot catch + cleanup tolerance.** An intermediate signal catch is
+  consumed once: on fire the track unregisters its processor (existing
+  `track.ProcessEvent` `unregisterEvent`); the waiter is removed when its last
+  processor leaves. Since the broadcast fan-out makes catchers self-unregister
+  **during** `Process`, `PropagateEvent`'s post-`Process` empty-cleanup must
+  tolerate the waiter being **already removed** (lock-check-delete, not a hard
+  `RemoveWaiter`).
 - **FR-6 — signal throw.** Intermediate-throw and **signal end** events propagate a
   `SignalEventDefinition` through the existing throw path
   (`instance.PropagateEvent` → `Thresher.PropagateEvent` → `EventHub`); no new throw
-  plumbing — the hub's name keying does the broadcast.
+  plumbing — the shared-id waiter fans out.
 - **FR-7 — deferrals (documented, not built).** Signal **start** events
   (instantiating — extends ADR-015) and signal **boundary** events (boundary
   workstream) are out of scope; the catch path here is the intermediate **in-flow**
@@ -154,12 +170,16 @@ flowchart LR
 
 ## 5. Path analysis (alternatives)
 
-- **Name-keyed shared waiter (chosen) vs a parallel `map[name][]subscriber`
-  index.** Chosen: key signal waiters by name in the **existing** registry, so the
-  find-or-add-processor + fan-out + §2.5 ownership + empty-cleanup machinery is
-  reused unchanged — broadcast falls out of the multi-processor waiter that already
-  exists. Rejected the parallel index: it duplicates ownership/shutdown logic the
-  hub already has, and splits propagation into two code paths.
+- **Shared-eDef-id via the existing registry (chosen) vs name-keying vs a parallel
+  `map[name][]subscriber` index.** Chosen: rely on signal eDefs being shared by
+  reference across instance clones (no `CloneForInstance`), so all catchers share
+  one `eDef.ID()` and the existing `eDef.ID()`-keyed find-or-add-processor +
+  fan-out + §2.5 ownership + empty-cleanup machinery gives broadcast **with no
+  keying change at all**. Rejected name-keying (`waiterKey`): it would force
+  `registerWaiter`/`PropagateEvent`/`UnregisterEvent` (which takes `eDef.ID()`) onto
+  a name-derived key — extra threading for an asymmetry `cloneDefsForInstance`
+  already encodes. Rejected a parallel index: duplicates ownership/shutdown and
+  splits propagation into two paths.
 - **Passive waiter (chosen) vs a service goroutine that waits on a channel.**
   Chosen: a signal has no external source (it is fired by an in-process throw), so a
   goroutine would block on nothing and only complicate the §2.5 drain. A passive
@@ -169,9 +189,10 @@ flowchart LR
   message/timer.** Chosen: message/timer clone to a fresh per-instance ID so
   concurrent instances do **not** share a waiter (point-to-point — sharing was the
   FIX-004 broadcast bug). For signals the opposite is correct: catchers across
-  instances **should** all fire on one throw, so they **should** share the
-  name-keyed waiter as distinct processors. Rejected cloning: it would fragment the
-  broadcast into per-instance waiters a single throw can't reach.
+  instances **should** all fire on one throw, so they **should** share one waiter
+  as distinct processors — achieved precisely by *not* adding `CloneForInstance`
+  (`cloneDefsForInstance` then shares the eDef by reference). Rejected cloning: it
+  would fragment the broadcast into per-instance waiters a single throw can't reach.
 - **No-waiter no-op (chosen) vs keep the error / buffer the signal.** Chosen:
   logged no-op (ADR-006 §2.4) — a signal with no catcher is normal BPMN. Rejected
   the error (wrong for broadcast) and buffering (the hub is not a store; signals are
@@ -187,15 +208,18 @@ flowchart LR
 ```go
 // internal/eventproc/eventhub/waiters — new passive waiter:
 //   NewSignalWaiter(eh, ep, eDef, rt) (eventproc.EventWaiter, error)
-//   keyed by the signal name; Process fans out to all EventProcessors (no
-//   correlation); Service is a no-op (no goroutine); Done() is closed.
+//   Process fans out to all EventProcessors (no correlation); Service is a
+//   no-op (no goroutine); Done() is closed; never self-removes (§2.5).
 // waiters.CreateWaiter gains:
 //   case flow.TriggerSignal: w, err = NewSignalWaiter(eh, ep, eDef, rt)
 
-// internal/eventproc/eventhub/eventhub.go — name-vs-id keying + §2.4 no-op:
-//   func waiterKey(eDef flow.EventDefinition) string // signal -> name; else eDef.ID()
-//   registerWaiter / PropagateEvent / removal use waiterKey(eDef).
-//   PropagateEvent: absent key -> debug log + return nil (was ObjectNotFound).
+// internal/eventproc/eventhub/eventhub.go:
+//   PropagateEvent post-Process empty-cleanup tolerates an already-removed
+//   waiter (the broadcast fan-out self-unregisters its catchers). The §2.4
+//   no-waiter no-op landed in M1.
+// No keying change: signal eDefs share one eDef.ID() across instances
+// (cloneDefsForInstance shares by reference), so the existing eDef.ID()-keyed
+// registry broadcasts via find-or-add-processor.
 ```
 
 No new public `pkg/` surface: signals are authored with the existing

--- a/docs/srd/SRD-020-signal-events.ru.md
+++ b/docs/srd/SRD-020-signal-events.ru.md
@@ -1,0 +1,334 @@
+# SRD-020 — Сигнальные события: широковещательные catch и throw с сопоставлением по имени
+
+| Поле | Значение |
+|---|---|
+| Статус | Принято |
+| Версия | v.1 |
+| Дата | 2026-06-18 |
+| Владелец | Руслан Габитов |
+| Реализует | [ADR-006 v.1 Events & Subscriptions](../design/ADR-006-events-and-subscriptions.ru.md) §2.1, §2.4 |
+
+Этот SRD приземляет первый рантайм-срез **events-workstream**, открытого
+[ADR-006 v.1](../design/ADR-006-events-and-subscriptions.ru.md): **сигнальные
+события** — триггер *публикации / широковещания* (§2.1) — для **промежуточного
+catch** и **throw** (intermediate-throw + сигнальное end-событие). Также закрывает
+дремлющую **§2.4 no-waiter gap** (распространение события без слушателя становится
+залогированным no-op, а не ошибкой), которая ждала сигналов. Сигнальные **start**
+(инстанцирующие) и **boundary** события отложены в workstream'ы инстанцирования и
+boundary соответственно.
+
+## 1. Контекст и мотивация
+
+### 1.1 Текущее состояние (проверено по коду)
+
+- **Сигналы смоделированы, но не исполнимы.** `SignalEventDefinition`
+  (`pkg/model/events/signal.go:59-112`) существует с `Type() → flow.TriggerSignal`
+  (`:110-112`) и аксессором `Signal()` над именованным `Signal` (`signal.go:14-51`,
+  `Name()` на `:49`); whitelist триггеров промежуточного catch **уже допускает**
+  сигналы (`pkg/model/events/intermediate_catch.go:18-23`, `flow.TriggerSignal` на
+  `:21`). Но **нет signal waiter**: switch builder'а waiter'ов
+  (`internal/eventproc/eventhub/waiters/waiters.go:53-70`) имеет ветки только для
+  `TriggerTimer` и `TriggerMessage`; сигнал проваливается в `default`-ошибку
+  ("couldn't find builder for event definition of type …", `:64-70`). Так что
+  процесс с сигнальным catch/throw сегодня падает на регистрации.
+- **Хаб — точка-в-точку, ключ `eDef.ID()`.** Реестр —
+  `waiters map[string]eventproc.EventWaiter` (`eventhub.go:48`); `registerWaiter`
+  ключует по `eDef.ID()` — *find-or-build*, и если waiter для ключа уже существует,
+  он **добавляет в него processor** (`eventhub.go:194-228`). Waiter веером
+  раздаёт **всем** своим зарегистрированным `EventProcessor`'ам при срабатывании
+  (message waiter перебирает их — `waiters/message.go:307-322`). `PropagateEvent`
+  ищет **один** waiter по `eDef.ID()` (`eventhub.go:376`) и доставляет ему.
+- **Распространение без waiter'а — ОШИБКА (§2.4 gap).** `PropagateEvent` возвращает
+  `ObjectNotFound`, когда `eDef.ID()` отсутствует в реестре (`eventhub.go:379-385`).
+  Для **широковещательного сигнала без живого catcher'а** это *неверно* — сигнал,
+  брошенный в пустоту, просто не пойман (§10.5.1), нормальное состояние, не сбой
+  (ADR-006 §2.4).
+- **Доставка идёт на waiter-горутине, синхронизирована треком.** Сработавшее событие
+  достигает ждущего трека через `track.ProcessEvent`
+  (`internal/instance/track.go:723-778`), который исполняется **на waiter-горутине**
+  (комментарий `:743`), охраняет `TrackWaitForEvent` (`:730`), доставляет узлу, затем
+  `unregisterEvent` + `TrackReady` (`:769-775`). Регистрация — `track.checkNodeType`
+  → `RegisterEvent(t, d)` на определение, когда токен достигает узла
+  (`track.go:301-340`, регистрация на `:328`). Сторона throw: `Execute` throw-события
+  распространяет через `EventProducer.PropagateEvent` экземпляра
+  (`internal/instance/instance.go:987-1002`) → `Thresher.PropagateEvent`
+  (`thresher.go:400-419`) → `EventHub.PropagateEvent`. Это проверенный путь, который
+  message/timer уже используют; **сигналы переиспользуют его** (single-loop inbound
+  edge из ADR-006 §2.1 остаётся концепцией, как и для message/timer сегодня).
+
+### 1.2 Проблема
+
+Сигнальный триггер — широковещательная стратегия публикации BPMN (§10.5.1) — имеет
+модель, но не рантайм. Процесс не может бросить или поймать сигнал, а
+точка-в-точку поведение хаба с ошибкой-на-нет-waiter'а — неправильная форма для
+широковещания. Этот SRD делает сигналы исполнимыми и превращает §2.4-контракт в
+реальность.
+
+## 2. Решение
+
+- **Широковещание вытекает из разделяемой идентичности eDef (индекс по имени не
+  нужен).** У сигнальных `EventDefinition` **нет `CloneForInstance`**, поэтому
+  `Event.clone()` (`events/event.go:161-167`) разделяет их **по ссылке** между
+  per-instance клонами node-graph (ADR-009) через `cloneDefsForInstance`
+  (`event.go:175-191`, "definitions without the capability are shared by reference").
+  Каждый экземпляр, ловящий один и тот же смоделированный сигнальный узел,
+  держит **тот же `eDef.ID()`**, так что существующий find-or-add-processor
+  `registerWaiter` приземляет всех catcher'ов на **один** waiter с ключом-id как
+  отдельные processor'ы, а throw (`PropagateEvent` по этому id) веером раздаёт
+  `Process` всем — **широковещание через существующий реестр**, без индекса по
+  имени, без смены ключевания. Асимметрия clone-vs-share в `cloneDefsForInstance`
+  уже это кодирует: message/timer клонируются → точка-в-точку (правило no-share из
+  FIX-004); **сигнал разделяется → широковещание** (умышленная инверсия). Поэтому
+  сигнал умышленно **не** добавляет `CloneForInstance`.
+- **Пассивный `signalWaiter`.** В отличие от message (подписка брокера) / timer
+  (тикер), у сигнала **нет внешнего источника** — он срабатывает только от
+  in-process throw через `PropagateEvent`. Поэтому signal waiter **не поднимает
+  service-горутину**; его `Service` — no-op, помечающий running, а `Done()` уже
+  закрыт. Он подчиняется §2.5-владению (хаб создаёт/удаляет; сам себя никогда не
+  удаляет) и веером раздаёт `Process` всем processor'ам **без correlation-фильтра**
+  (у сигналов нет корреляции, §10.5.1).
+- **Нет waiter'а ⇒ залогированный no-op (закрывает §2.4).** `PropagateEvent` к
+  отсутствующему ключу — залогированный no-op, не ошибка — верно для
+  широковещательного сигнала без живого catcher'а, безвредно для любого другого.
+- **Catch одноразовый; waiter живёт до опустошения.** Промежуточный catch потребляет
+  сигнал один раз: при срабатывании трек делает `unregisterEvent` (убирает свой
+  processor); когда уходит последний processor, хаб удаляет waiter. Поскольку
+  широковещательный fan-out заставляет каждого catcher'а само-разрегистрироваться
+  **во время** `Process`, последняя разрегистрация удаляет уже-пустой waiter, так что
+  собственная post-`Process` empty-cleanup в `PropagateEvent` (`eventhub.go:397-398`)
+  должна **толерировать уже-удалённый waiter** (lock-check-delete, а не жёсткий
+  `RemoveWaiter`, который ошибается `ObjectNotFound`). Этот путь сейчас мёртв для
+  message (его `Process` ошибается) и timer (срабатывает через `WaiterFired`), так
+  что сигнал — первый, кто его задействует.
+- **Throw широковещает.** Intermediate-throw и сигнальные **end**-события
+  распространяют свой `SignalEventDefinition`; хаб находит waiter с разделяемым id и
+  веером раздаёт. Охват — **движок-широкий** (каждый экземпляр, зарегистрированный в
+  `Thresher`), **включая catcher'ов самого бросающего экземпляра** — цель
+  конформности single-process in-memory (§2.4).
+
+```mermaid
+flowchart LR
+  TA[instance A: catch signal X] -->|register processor| W[(one waiter: shared eDef id of X)]
+  TB[instance B: catch signal X] -->|register processor| W
+  THR[instance C: throw signal X] -->|PropagateEvent| W
+  W -->|fan out, no correlation| TA
+  W -->|fan out| TB
+  W -.->|no processors -> logged no-op| VOID[thrown into the void]
+```
+
+## 3. Функциональные требования
+
+- **FR-1 — signal catch waiter.** `signalWaiter` (`eventproc.EventWaiter`) строится
+  для `SignalEventDefinition`; `waiters.CreateWaiter` получает ветку
+  `flow.TriggerSignal`. Он **пассивен** (нет service-горутины): `Service` помечает
+  его `WSRunned` и оставляет `Done()` закрытым; `Stop` помечает stopped; сам себя
+  никогда не удаляет (§2.5).
+- **FR-2 — широковещание через разделяемый eDef-id (без смены ключевания).** У
+  сигнальных `EventDefinition` умышленно **нет `CloneForInstance`**, поэтому все
+  экземпляры, ловящие один смоделированный сигнальный узел, разделяют один
+  `eDef.ID()` (`Event.clone` → `cloneDefsForInstance`, разделение по ссылке).
+  Существующий find-or-add-processor `registerWaiter` с ключом `eDef.ID()` приземляет
+  каждого catcher'а на один waiter как отдельный processor — широковещание, **без
+  `waiterKey` и без изменения ключевания
+  `registerWaiter`/`PropagateEvent`/`UnregisterEvent`**.
+- **FR-3 — fan-out широковещания.** `signalWaiter.Process(eDef)` доставляет
+  **каждому** зарегистрированному `EventProcessor` (каждому ловящему треку), без
+  correlation-фильтра; ошибка доставки одному processor'у логируется и не прерывает
+  остальное широковещание. Каждый доставленный трек возобновляется через существующий
+  путь `track.ProcessEvent`.
+- **FR-4 — no-waiter no-op (закрывает §2.4).** `EventHub.PropagateEvent` без
+  зарегистрированного waiter'а для `eDef.ID()` — **залогированный no-op, возвращающий
+  `nil`**, заменяющий текущую `ObjectNotFound`-ошибку (`eventhub.go:379-385`).
+  **Приземлено в M1.**
+- **FR-5 — одноразовый catch + толерантность cleanup.** Промежуточный сигнальный
+  catch потребляется один раз: при срабатывании трек разрегистрирует свой processor
+  (существующий `track.ProcessEvent` `unregisterEvent`); waiter удаляется, когда
+  уходит его последний processor. Поскольку широковещательный fan-out заставляет
+  catcher'ов само-разрегистрироваться **во время** `Process`, post-`Process`
+  empty-cleanup в `PropagateEvent` должен толерировать **уже-удалённый** waiter
+  (lock-check-delete, а не жёсткий `RemoveWaiter`).
+- **FR-6 — signal throw.** Intermediate-throw и **сигнальные end**-события
+  распространяют `SignalEventDefinition` через существующий throw-путь
+  (`instance.PropagateEvent` → `Thresher.PropagateEvent` → `EventHub`); никакого
+  нового throw-обвеса — waiter с разделяемым id веером раздаёт.
+- **FR-7 — отложенное (задокументировано, не построено).** Сигнальные **start**
+  события (инстанцирующие — расширяют ADR-015) и сигнальные **boundary** события
+  (boundary-workstream) — вне scope; путь catch здесь — только промежуточный
+  **in-flow** waiter (ADR-006 §2.3 строка 1).
+
+## 4. Нефункциональные требования
+
+- **NFR-1 — семантика широковещания BPMN.** Один throw имени `X` достигает **всех**
+  текущих catcher'ов `X` в охвате (§10.5.1); ноль catcher'ов — no-op, никогда не
+  ошибка и не буферизованная поздняя доставка (§2.4 — хаб не хранилище).
+- **NFR-2 — §2.5-владение.** Signal waiter принадлежит хабу: создаётся на первый
+  catch, удаляется при опустошении или на `Shutdown`; сам себя никогда не удаляет;
+  дренируется чисто (его `Done()` закрыт, так что ожидание `EventHub.Shutdown`
+  мгновенно).
+- **NFR-3 — нет новых блокировок / single-mutator сохранён.** Регистрация/распространение
+  остаются под существующим `m sync.RWMutex` хаба; доставка переиспользует
+  существующую `t.m`/state-синхронизацию трека (ADR-001). Цикл экземпляра не меняется.
+- **NFR-4 — покрытие.** Затронутые файлы финишируют ≥80% (цель 100%) diff-coverage;
+  `make ci` зелёный (incl. `-race` — широковещание пересекает экземпляры/горутины).
+
+## 5. Анализ путей (альтернативы)
+
+- **Разделяемый eDef-id через существующий реестр (выбрано) vs ключевание по имени
+  vs параллельный индекс `map[name][]subscriber`.** Выбрано: полагаться на то, что
+  сигнальные eDef разделяются по ссылке между клонами экземпляров (нет
+  `CloneForInstance`), так что все catcher'ы разделяют один `eDef.ID()`, и существующая
+  машинерия find-or-add-processor + fan-out + §2.5-владение + empty-cleanup с ключом
+  `eDef.ID()` даёт широковещание **вообще без смены ключевания**. Отклонено
+  ключевание по имени (`waiterKey`): оно вынудило бы
+  `registerWaiter`/`PropagateEvent`/`UnregisterEvent` (который берёт `eDef.ID()`) на
+  ключ от имени — лишнее протягивание ради асимметрии, которую `cloneDefsForInstance`
+  уже кодирует. Отклонён параллельный индекс: дублирует владение/shutdown и расщепляет
+  распространение на два пути.
+- **Пассивный waiter (выбрано) vs service-горутина, ждущая на канале.** Выбрано: у
+  сигнала нет внешнего источника (он срабатывает от in-process throw), так что
+  горутина блокировалась бы ни на чём и только усложняла §2.5-дренаж. Пассивный waiter
+  (закрытый `Done()`) — честная форма. Отклонена горутина: лишняя конкурентность +
+  грань дренажа без пользы.
+- **Нет `CloneForInstance` для сигналов (выбрано) vs per-instance клон как
+  message/timer.** Выбрано: message/timer клонируются на свежий per-instance ID, чтобы
+  конкурентные экземпляры **не** разделяли waiter (точка-в-точку — разделение было
+  багом широковещания FIX-004). Для сигналов верно обратное: catcher'ы между
+  экземплярами **должны** все сработать на один throw, так что **должны** разделять
+  один waiter как отдельные processor'ы — достигается именно *не*-добавлением
+  `CloneForInstance` (`cloneDefsForInstance` тогда разделяет eDef по ссылке). Отклонено
+  клонирование: оно фрагментировало бы широковещание на per-instance waiter'ы, которых
+  один throw не достанет.
+- **No-waiter no-op (выбрано) vs оставить ошибку / буферизовать сигнал.** Выбрано:
+  залогированный no-op (ADR-006 §2.4) — сигнал без catcher'а нормален для BPMN.
+  Отклонены ошибка (неверно для широковещания) и буферизация (хаб не хранилище;
+  сигналы не переигрываются — §2.4).
+- **Охват = движок-широкий incl. self-instance (выбрано) vs только per-instance.**
+  Выбрано: брошенный сигнал достигает каждого catcher'а в движке, включая собственный
+  экземпляр бросающего (§10.5.1 "within and across Processes"). Single-process
+  in-memory модель — цель конформности (§2.4). Cross-engine охват — дело
+  persistence/distribution ADR, не здесь.
+
+## 6. API и ключевые формы
+
+```go
+// internal/eventproc/eventhub/waiters — new passive waiter:
+//   NewSignalWaiter(eh, ep, eDef, rt) (eventproc.EventWaiter, error)
+//   Process fans out to all EventProcessors (no correlation); Service is a
+//   no-op (no goroutine); Done() is closed; never self-removes (§2.5).
+// waiters.CreateWaiter gains:
+//   case flow.TriggerSignal: w, err = NewSignalWaiter(eh, ep, eDef, rt)
+
+// internal/eventproc/eventhub/eventhub.go:
+//   PropagateEvent post-Process empty-cleanup tolerates an already-removed
+//   waiter (the broadcast fan-out self-unregisters its catchers). The §2.4
+//   no-waiter no-op landed in M1.
+// No keying change: signal eDefs share one eDef.ID() across instances
+// (cloneDefsForInstance shares by reference), so the existing eDef.ID()-keyed
+// registry broadcasts via find-or-add-processor.
+```
+
+Никакой новой публичной `pkg/`-поверхности: сигналы авторятся существующими
+`events.NewSignalEventDefinition` + промежуточными catch/throw + end-event
+builder'ами; этот SRD подключает их **рантайм**.
+
+## 7. План тестирования
+
+- **`TestSignalCatchThrow`** — один экземпляр: трек ждёт на промежуточном сигнальном
+  catch; другой трек (или второй поток) бросает то же имя сигнала; catch срабатывает,
+  процесс завершается (FR-1, FR-3, FR-6).
+- **`TestSignalBroadcast`** (`-race`) — два конкурентных экземпляра ловят сигнал `X`;
+  throw `X` (от третьего) срабатывает **обоим** — оба достигают своего downstream-узла
+  (FR-2, FR-3, NFR-1). Это канарейка широковещания (инверсия no-cross-instance правила
+  FIX-004, которое держится для message/timer).
+- **`TestSignalThrownIntoVoid`** — бросок сигнала без зарегистрированного catcher'а —
+  no-op (без ошибки), и поздний catch того же имени **не** доставляется ретроспективно
+  (FR-4, NFR-1; §2.4 no-buffer контракт).
+- **`TestSignalSingleShotConsume`** — после срабатывания catch его processor удалён;
+  второй throw не пересрабатывает потреблённый catch; waiter исчезает по опустошении
+  (FR-5).
+- **`TestPropagateNoWaiterIsNoop`** (внутренний `eventhub`) — `PropagateEvent` с
+  отсутствующим ключом возвращает `nil` и логирует на debug, для сигнального и
+  не-сигнального eDef (FR-4) — прямой §2.4 regression-тест против
+  `eventhub.go:379-385`.
+- Внутренний юнит `internal/eventproc/eventhub/waiters` для `signalWaiter` (пассивный
+  `Service`/закрытый `Done`, fan-out `Process`, `Stop`) для атрибуции межпакетного
+  покрытия.
+
+## 8. Кросс-документная консистентность
+
+- **Реализует** [ADR-006 v.1](../design/ADR-006-events-and-subscriptions.ru.md) §2.1
+  (охват публикации/широковещания, per-instance идентичность подписки), §2.4 (no-waiter
+  no-op, недолговечно, без буферизации — сигналы не дело брокера).
+- [ADR-001 v.5](../design/ADR-001-execution-model.ru.md) — модель track/loop, против
+  которой работает путь доставки (single-mutator; сигнал переиспользует
+  `track.ProcessEvent`).
+- [ADR-009 v.1](../design/ADR-009-per-instance-node-graph.ru.md) — per-instance клоны;
+  catch каждого экземпляра — отдельный processor на разделяемом waiter'е.
+- [ADR-013 v.1](../design/ADR-013-instance-observability.ru.md) §2.5 / [SRD-019 v.1](SRD-019-instance-control-lifecycle.ru.md)
+  — дренаж waiter'ов `EventHub.Shutdown`, которому подчиняется пассивный signal waiter
+  (закрытый `Done()`).
+- [ADR-014 v.1](../design/ADR-014-message-handling.ru.md) — message waiter, который
+  этот зеркалит (и умышленно расходится по корреляции/широковещанию).
+- Ссылки вверх/вбок, с пином версии; нет ссылок вниз (ADR-006 не цитирует SRD-020).
+
+## 9. Definition of Done
+
+- FR-1…FR-7 подключены и проверены тестами §7 (включая `-race` канарейку широковещания).
+- `signalWaiter` + ветка signal в `CreateWaiter` + name-scan `broadcastSignal` + §2.4
+  no-op присутствуют; сигнальные catch/throw/end работают end-to-end.
+- §2.4 закрыта: no-waiter в `PropagateEvent` — залогированный no-op (старый путь
+  `ObjectNotFound` исчез), доказано `TestPropagateNoWaiterIsNoop`.
+- `make ci` зелёный (tidy, lint incl. fieldalignment, build, `-race`, diff-coverage
+  ≥95, govulncheck); затронутые файлы ≥80% (цель 100%).
+- Запускаемый `examples/signal-broadcast` smoke-run выходит с 0, плюс существующие 9
+  примеров всё ещё выходят с 0.
+- §10 заполнена; статус → Принято; добавлен RU-близнец; связанные доки синхронизированы;
+  GitHub sub-issue под epic #90 закрыт PR'ом.
+
+## 10. Сводка реализации
+
+Приземлено на `feat/signal-events` (от `master`): две кодовые вехи + предварительный
+fix + запускаемый пример.
+
+### 10.1 Коммиты
+
+| # | Коммит | Объём | Тесты |
+|---|---|---|---|
+| doc | `24a451c` | Черновик SRD-020 | — |
+| fix | `30c8437` | Пред-существующая гонка SRD-019: `EventHub.state` сделан `atomic.Uint32` (Run/PropagateEvent читают lock-free, пока Start/Shutdown пишут). Вскрыта сдвигом тайминга M1. | `TestThresherShutdown -race` |
+| M1 | `d4460a7` | §2.4 no-waiter no-op: `PropagateEvent` к отсутствующему ключу → залогированный `nil` (было `ObjectNotFound`). | `TestPropagateNoWaiterIsNoop` |
+| M2 | `ed43854` | Рантайм сигналов: пассивный `signalWaiter`, ветка signal в `CreateWaiter`, name-scan `broadcastSignal` в `PropagateEvent`. | `TestSignalWaiter*`, `TestBroadcastSignalFanOut`, `TestSignalCatchThrow`, `TestSignalBroadcast -race`, `TestSignalThrownIntoVoid`, `TestSignalSingleShotConsume` |
+| M3 | `ce0bc96` | `examples/signal-broadcast` (один throw → два watcher-экземпляра). | smoke |
+
+### 10.2 Ключевые файлы
+
+- `internal/eventproc/eventhub/waiters/signal.go` (новый) — пассивный `signalWaiter`.
+- `internal/eventproc/eventhub/waiters/waiters.go` — ветка `TriggerSignal` в `CreateWaiter` + NOTE про per-trigger-идентичность.
+- `internal/eventproc/eventhub/eventhub.go` — `broadcastSignal`/`signalName`, ветка signal в `PropagateEvent` + §2.4 no-op, и `atomic.Uint32` state (race fix).
+- `examples/signal-broadcast/` (новый) — `process.go` (builder'ы catcher/thrower) + `main.go`.
+
+### 10.3 Верификация
+
+- `make ci` зелёный: tidy, lint, build, `-race`, **diff-coverage 97.2% из 212
+  изменённых строк (≥95)**, govulncheck. Затронутые функции ≥80% (signal.go +
+  `broadcastSignal` 100%).
+- Все **10** примеров smoke-run выходят с 0 (incl. `signal-broadcast`).
+
+### 10.4 Дельты против черновика
+
+- **Механизм сопоставления исправлен (FR-2/§2/§5).** Черновик сначала набросал
+  реестр с ключом по имени (`waiterKey`); реализация вскрыла более простую истину:
+  catcher'ы между экземплярами уже разделяют один waiter (сигнальные eDef не
+  клонируются), а throw→catch сопоставляется **name-scan'ом** в `PropagateEvent`
+  (`broadcastSignal`) — без смены ключевания, без churn'а сигнатуры `UnregisterEvent`.
+  Док исправлен в M2. Будущая генерализация `SubscriptionKey()` (когда придут Link
+  события) зафиксирована как follow-up, здесь не строится.
+- **Предварительный race fix.** `-race`-прогон M1 вскрыл пред-существующую гонку
+  `EventHub.state` из SRD-019; исправлено отдельным коммитом `30c8437` до M1, не
+  свёрнуто молча.
+
+## История документа
+
+| Версия | Дата | Автор | Изменение |
+|---|---|---|---|
+| v.1 | 2026-06-18 | Руслан Габитов | Принято. Первый рантайм-срез events-workstream ADR-006 v.1: сигнальные события (промежуточный catch + intermediate/end throw) через пассивный `signalWaiter` (без брокера, без горутины; `Process` веером раздаёт всем catcher'ам, без корреляции; закрытый `Done()` для §2.5-дренажа). Широковещание сопоставляется **name-scan'ом** в `PropagateEvent` (`broadcastSignal`) — throw и catch это разные узлы с разными id — при этом catcher'ы между экземплярами разделяют один waiter, потому что сигнальные eDef не клонируются (`cloneDefsForInstance` разделяет по ссылке; умышленная инверсия точка-в-точку клона FIX-004). Также закрывает §2.4 no-waiter gap (`PropagateEvent` отсутствующий-ключ → залогированный no-op, заменяя `ObjectNotFound`; приземлено в M1) и исправлена пред-существующая гонка данных `EventHub.state` из SRD-019 (atomic). Черновик с реестром по имени; исправлено на shared-id + name-scan в ходе реализации (без churn'а `waiterKey`/`UnregisterEvent`). Сигнальные **start** (инстанцирующие) и **boundary** события отложены; полиморфная генерализация сопоставления `SubscriptionKey()` отложена в Link-events workstream. Обосновано по коду `pkg/model/events`, `internal/eventproc/eventhub`, `internal/instance`. Реализует ADR-006 v.1 §2.1/§2.4; ссылается на ADR-001 v.5, ADR-009 v.1, ADR-013 v.1, ADR-014 v.1, SRD-019 v.1. |

--- a/examples/signal-broadcast/go.mod
+++ b/examples/signal-broadcast/go.mod
@@ -1,0 +1,11 @@
+module signal-broadcast
+
+go 1.25
+
+toolchain go1.25.11
+
+replace github.com/dr-dobermann/gobpm => ../..
+
+require github.com/dr-dobermann/gobpm v0.0.0-00010101000000-000000000000
+
+require golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d // indirect

--- a/examples/signal-broadcast/go.sum
+++ b/examples/signal-broadcast/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d h1:N0hmiNbwsSNwHBAvR3QB5w25pUwH4tK0Y/RltD1j1h4=
+golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/signal-broadcast/main.go
+++ b/examples/signal-broadcast/main.go
@@ -1,0 +1,90 @@
+// Command signal-broadcast demonstrates BPMN signal broadcast: one thrown
+// signal is caught by EVERY waiting catcher, across independent instances.
+//
+// Two instances of a "watcher" process each park on an intermediate catch of
+// the signal "order-cancelled"; a single "canceller" instance throws it once,
+// and BOTH watchers resume — a signal has no correlation, it broadcasts to all
+// catchers in reach (ADR-006 §2.1).
+//
+// The process build lives in process.go; this file is the engine wiring + run.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/thresher"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	const signal = "order-cancelled"
+
+	engine, err := thresher.New("signal-broadcast-engine")
+	if err != nil {
+		return fmt.Errorf("create engine: %w", err)
+	}
+
+	catcher, err := catcherProcess("watcher", signal)
+	if err != nil {
+		return fmt.Errorf("build catcher: %w", err)
+	}
+
+	thrower, err := throwerProcess("canceller", signal)
+	if err != nil {
+		return fmt.Errorf("build thrower: %w", err)
+	}
+
+	if err := engine.RegisterProcess(catcher); err != nil {
+		return fmt.Errorf("register catcher: %w", err)
+	}
+
+	if err := engine.RegisterProcess(thrower); err != nil {
+		return fmt.Errorf("register thrower: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := engine.Run(ctx); err != nil {
+		return fmt.Errorf("run engine: %w", err)
+	}
+
+	// Two independent watcher instances, both waiting on the one signal.
+	h1, err := engine.StartProcess(catcher.ID())
+	if err != nil {
+		return fmt.Errorf("start watcher 1: %w", err)
+	}
+
+	h2, err := engine.StartProcess(catcher.ID())
+	if err != nil {
+		return fmt.Errorf("start watcher 2: %w", err)
+	}
+
+	time.Sleep(200 * time.Millisecond) // both reach and park on the catch
+	fmt.Println("  ▶ two watcher instances are waiting on \"order-cancelled\"")
+
+	if _, err := engine.StartProcess(thrower.ID()); err != nil { // one broadcast
+		return fmt.Errorf("start canceller: %w", err)
+	}
+	fmt.Println("  ▶ one canceller threw the signal once")
+
+	for i, h := range []*thresher.InstanceHandle{h1, h2} {
+		st, err := h.WaitCompletion(ctx)
+		if err != nil {
+			return fmt.Errorf("watcher %d completion: %w", i+1, err)
+		}
+		fmt.Printf("  ✓ watcher %d completed (%s) — caught the broadcast\n", i+1, st)
+	}
+
+	fmt.Println("✓ one throw → every waiting instance caught it (broadcast)")
+
+	return nil
+}

--- a/examples/signal-broadcast/process.go
+++ b/examples/signal-broadcast/process.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+)
+
+// signalDef builds a payload-less signal event definition for the given name.
+// Catcher and thrower each get their own definition (distinct nodes) — they
+// meet by signal NAME, which is how a signal broadcast is matched.
+func signalDef(name string) (*events.SignalEventDefinition, error) {
+	sig, err := events.NewSignal(name, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create signal: %w", err)
+	}
+
+	return events.NewSignalEventDefinition(sig)
+}
+
+// catcherProcess builds start -> catch(signal) -> end: an instance that parks on
+// the intermediate catch until the signal is broadcast.
+func catcherProcess(id, signal string) (*process.Process, error) {
+	def, err := signalDef(signal)
+	if err != nil {
+		return nil, err
+	}
+
+	catch, err := events.NewIntermediateCatchEvent("await-"+signal, def)
+	if err != nil {
+		return nil, fmt.Errorf("create catch: %w", err)
+	}
+
+	return wire(id, catch)
+}
+
+// throwerProcess builds start -> throw(signal) -> end: an instance that
+// broadcasts the signal to every catcher in reach.
+func throwerProcess(id, signal string) (*process.Process, error) {
+	def, err := signalDef(signal)
+	if err != nil {
+		return nil, err
+	}
+
+	throw, err := events.NewIntermediateThrowEvent("raise-"+signal, def)
+	if err != nil {
+		return nil, fmt.Errorf("create throw: %w", err)
+	}
+
+	return wire(id, throw)
+}
+
+// wire assembles start -> mid -> end into a process.
+func wire(id string, mid flow.Element) (*process.Process, error) {
+	start, err := events.NewStartEvent("start")
+	if err != nil {
+		return nil, fmt.Errorf("create start: %w", err)
+	}
+
+	end, err := events.NewEndEvent("end")
+	if err != nil {
+		return nil, fmt.Errorf("create end: %w", err)
+	}
+
+	proc, err := process.New(id)
+	if err != nil {
+		return nil, fmt.Errorf("create process: %w", err)
+	}
+
+	for _, e := range []flow.Element{start, mid, end} {
+		if err := proc.Add(e); err != nil {
+			return nil, fmt.Errorf("add element: %w", err)
+		}
+	}
+
+	if _, err := flow.Link(start, mid.(flow.SequenceTarget)); err != nil {
+		return nil, fmt.Errorf("link start->mid: %w", err)
+	}
+
+	if _, err := flow.Link(mid.(flow.SequenceSource), end); err != nil {
+		return nil, fmt.Errorf("link mid->end: %w", err)
+	}
+
+	return proc, nil
+}

--- a/internal/eventproc/eventhub/eventhub.go
+++ b/internal/eventproc/eventhub/eventhub.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/dr-dobermann/gobpm/internal/eventproc"
 	"github.com/dr-dobermann/gobpm/internal/eventproc/eventhub/waiters"
@@ -48,7 +49,11 @@ type (
 		waiters map[string]eventproc.EventWaiter
 		events  []flow.EventDefinition
 		m       sync.RWMutex
-		state   hubState
+		// state is read lock-free by Run/PropagateEvent and written by
+		// Start/Shutdown, so it lives in an atomic to stay race-free across those
+		// unsynchronized readers (registration/shutdown still serialize the map
+		// under m; the atomic just removes the state data race).
+		state atomic.Uint32
 	}
 )
 
@@ -70,6 +75,19 @@ func New(rt renv.EngineRuntime) (*EventHub, error) {
 		nil
 }
 
+// getState reads the lock-free hub lifecycle state.
+func (eh *EventHub) getState() hubState {
+	// hubState is a 0..2 enum stored in the atomic; the narrowing never
+	// overflows.
+	//nolint:gosec // bounded enum, no overflow
+	return hubState(eh.state.Load())
+}
+
+// setState writes the lock-free hub lifecycle state.
+func (eh *EventHub) setState(s hubState) {
+	eh.state.Store(uint32(s))
+}
+
 // Start performs synchronous initialization of the EventHub: records the
 // context that subsequent Run / RegisterEvent / UnregisterEvent /
 // PropagateEvent calls will observe, and flips the started flag.
@@ -80,13 +98,13 @@ func New(rt renv.EngineRuntime) (*EventHub, error) {
 // stored ctx, without needing additional synchronization. This is the
 // motivation for splitting Start from Run; see FIX-001.
 func (eh *EventHub) Start(ctx context.Context) error {
-	if eh.state != hubNotStarted {
+	if eh.getState() != hubNotStarted {
 		return errs.New(
 			errs.M("eventHub is already started or stopped"),
 			errs.C(errorClass, errs.InvalidState))
 	}
 
-	eh.state = hubStarted
+	eh.setState(hubStarted)
 	eh.ctx = ctx
 
 	return nil
@@ -98,7 +116,7 @@ func (eh *EventHub) Start(ctx context.Context) error {
 //
 // Run blocks until its context is canceled and then returns ctx.Err().
 func (eh *EventHub) Run(ctx context.Context) error {
-	if eh.state != hubStarted {
+	if eh.getState() != hubStarted {
 		return errs.New(
 			errs.M("eventHub isn't started"),
 			errs.C(errorClass, errs.InvalidState))
@@ -116,7 +134,7 @@ func (eh *EventHub) RegisterEvent(
 	ep eventproc.EventProcessor,
 	eDef flow.EventDefinition,
 ) error {
-	if eh.state != hubStarted {
+	if eh.getState() != hubStarted {
 		return errs.New(
 			errs.M("eventHub isn't started"),
 			errs.C(errorClass, errs.InvalidState))
@@ -140,7 +158,7 @@ func (eh *EventHub) RegisterPersistentEvent(
 	ep eventproc.EventProcessor,
 	eDef flow.EventDefinition,
 ) error {
-	if eh.state != hubStarted {
+	if eh.getState() != hubStarted {
 		return errs.New(
 			errs.M("eventHub isn't started"),
 			errs.C(errorClass, errs.InvalidState))
@@ -184,7 +202,7 @@ func (eh *EventHub) registerWaiter(
 	eh.m.Lock()
 	defer eh.m.Unlock()
 
-	if eh.state == hubStopped {
+	if eh.getState() == hubStopped {
 		return errs.New(
 			errs.M("event hub is shut down; registration rejected"),
 			errs.C(errorClass, errs.InvalidState),
@@ -237,13 +255,13 @@ func (eh *EventHub) registerWaiter(
 // failed Stop never leaks the registry entry. Idempotent.
 func (eh *EventHub) Shutdown(ctx context.Context) error {
 	eh.m.Lock()
-	if eh.state == hubStopped {
+	if eh.getState() == hubStopped {
 		eh.m.Unlock()
 
 		return nil
 	}
 
-	eh.state = hubStopped
+	eh.setState(hubStopped)
 
 	ws := make([]eventproc.EventWaiter, 0, len(eh.waiters))
 	for _, w := range eh.waiters {
@@ -301,7 +319,7 @@ func (eh *EventHub) UnregisterEvent(
 	ep eventproc.EventProcessor,
 	eDefID string,
 ) error {
-	if eh.state != hubStarted {
+	if eh.getState() != hubStarted {
 		return errs.New(
 			errs.M("eventHub isn't started"),
 			errs.C(errorClass, errs.InvalidState))
@@ -366,7 +384,7 @@ func (eh *EventHub) PropagateEvent(
 	_ context.Context,
 	eDef flow.EventDefinition,
 ) error {
-	if eh.state != hubStarted {
+	if eh.getState() != hubStarted {
 		return errs.New(
 			errs.M("eventHub isn't started"),
 			errs.C(errorClass, errs.InvalidState))

--- a/internal/eventproc/eventhub/eventhub.go
+++ b/internal/eventproc/eventhub/eventhub.go
@@ -395,11 +395,16 @@ func (eh *EventHub) PropagateEvent(
 	eh.m.RUnlock()
 
 	if !ok {
-		return errs.New(
-			errs.M("couldn't find waiter for EventDefinition"),
-			errs.C(errorClass, errs.ObjectNotFound),
-			errs.D("event_definition_id", eDef.ID()),
-			errs.D("event_definition_type", eDef.Type()))
+		// ADR-006 §2.4: propagating to no registered waiter is a logged no-op,
+		// not an error. A signal thrown with no live catcher is simply not
+		// caught (BPMN §10.5.1); the hub is a live dispatcher, not a store, so
+		// there is nothing to buffer and nothing to fail.
+		eh.rt.Logger().Debug(
+			"event propagated with no registered waiter; ignored (no-op)",
+			"event_definition_id", eDef.ID(),
+			"event_definition_type", string(eDef.Type()))
+
+		return nil
 	}
 
 	if err := w.Process(eDef); err != nil {

--- a/internal/eventproc/eventhub/eventhub.go
+++ b/internal/eventproc/eventhub/eventhub.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dr-dobermann/gobpm/internal/eventproc"
 	"github.com/dr-dobermann/gobpm/internal/eventproc/eventhub/waiters"
 	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/dr-dobermann/gobpm/pkg/renv"
 )
@@ -390,6 +391,13 @@ func (eh *EventHub) PropagateEvent(
 			errs.C(errorClass, errs.InvalidState))
 	}
 
+	// A signal is a broadcast publication matched by NAME, not by the throw's
+	// eDef.ID() (throw and catch are distinct nodes — ADR-006 v.1 §2.1, SRD-020):
+	// fan out to every catcher of the same signal name.
+	if eDef.Type() == flow.TriggerSignal {
+		return eh.broadcastSignal(eDef)
+	}
+
 	eh.m.RLock()
 	w, ok := eh.waiters[eDef.ID()]
 	eh.m.RUnlock()
@@ -422,6 +430,61 @@ func (eh *EventHub) PropagateEvent(
 	}
 
 	return nil
+}
+
+// broadcastSignal delivers a thrown signal to every registered catcher of the
+// same signal name — the BPMN broadcast publication strategy (ADR-006 v.1 §2.1,
+// §10.5.1). It matches by name (not eDef.ID(): throw and catch are distinct
+// nodes), scanning the waiter registry. No catcher in reach is a logged no-op,
+// not an error (§2.4). Each fired catcher self-unregisters as it resumes
+// (track.ProcessEvent), so the hub removes the emptied waiters. The linear scan
+// is the simple name index; an O(1) name→subscribers map is the deferred §5
+// optimization.
+func (eh *EventHub) broadcastSignal(eDef flow.EventDefinition) error {
+	name, ok := signalName(eDef)
+	if !ok {
+		return errs.New(
+			errs.M("not a signal event definition"),
+			errs.C(errorClass, errs.TypeCastingError),
+			errs.D("event_definition_id", eDef.ID()))
+	}
+
+	eh.m.RLock()
+	targets := make([]eventproc.EventWaiter, 0, len(eh.waiters))
+	for _, w := range eh.waiters {
+		if n, isSig := signalName(w.EventDefinition()); isSig && n == name {
+			targets = append(targets, w)
+		}
+	}
+	eh.m.RUnlock()
+
+	if len(targets) == 0 {
+		eh.rt.Logger().Debug(
+			"signal thrown with no catcher in reach; ignored (no-op)",
+			"signal", name)
+
+		return nil
+	}
+
+	// Fan out off the lock: each delivery resumes a catcher's track, which
+	// self-unregisters (track.ProcessEvent) — that removal needs eh.m. Process
+	// is best-effort and never returns a delivery error (it logs per catcher).
+	for _, w := range targets {
+		_ = w.Process(eDef)
+	}
+
+	return nil
+}
+
+// signalName returns the signal name of a SignalEventDefinition, or ("", false)
+// for any other event definition.
+func signalName(eDef flow.EventDefinition) (string, bool) {
+	sig, ok := eDef.(*events.SignalEventDefinition)
+	if !ok || sig.Signal() == nil {
+		return "", false
+	}
+
+	return sig.Signal().Name(), true
 }
 
 // RemoveWaiter removes the waiter registered for eDefID from the

--- a/internal/eventproc/eventhub/eventhub_base_test.go
+++ b/internal/eventproc/eventhub/eventhub_base_test.go
@@ -172,7 +172,7 @@ func TestPropagateEvent_BaseErrors(t *testing.T) {
 		require.Contains(t, err.Error(), "eventHub isn't started")
 	})
 
-	t.Run("no waiters found error", func(t *testing.T) {
+	t.Run("no waiters found is a no-op (ADR-006 §2.4)", func(t *testing.T) {
 		hub, err := eventhub.New(enginert.Default())
 		require.NoError(t, err)
 
@@ -184,8 +184,33 @@ func TestPropagateEvent_BaseErrors(t *testing.T) {
 		mockEventDef.EXPECT().ID().Return("test-event-id").Maybe()
 		mockEventDef.EXPECT().Type().Return(flow.EventTrigger("TestType")).Maybe()
 
+		// Propagating to no registered waiter is a logged no-op, not an error.
 		err = hub.PropagateEvent(context.Background(), mockEventDef)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "couldn't find waiter for EventDefinition")
+		require.NoError(t, err)
 	})
+}
+
+// TestPropagateNoWaiterIsNoop is the ADR-006 §2.4 regression (SRD-020):
+// PropagateEvent to an absent key is a no-op returning nil for both a signal
+// and a non-signal trigger — correct for a signal thrown into the void
+// (BPMN §10.5.1), harmless for any other kind.
+func TestPropagateNoWaiterIsNoop(t *testing.T) {
+	for _, trig := range []flow.EventTrigger{
+		flow.TriggerSignal, flow.TriggerMessage,
+	} {
+		t.Run(string(trig), func(t *testing.T) {
+			hub, err := eventhub.New(enginert.Default())
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			require.NoError(t, hub.Start(ctx))
+
+			eDef := mockflow.NewMockEventDefinition(t)
+			eDef.EXPECT().ID().Return("absent-" + string(trig)).Maybe()
+			eDef.EXPECT().Type().Return(trig).Maybe()
+
+			require.NoError(t, hub.PropagateEvent(ctx, eDef))
+		})
+	}
 }

--- a/internal/eventproc/eventhub/eventhub_base_test.go
+++ b/internal/eventproc/eventhub/eventhub_base_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
 	"github.com/dr-dobermann/gobpm/generated/mockflow"
 	"github.com/dr-dobermann/gobpm/internal/eventproc/eventhub"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/stretchr/testify/require"
 )
@@ -191,26 +192,44 @@ func TestPropagateEvent_BaseErrors(t *testing.T) {
 }
 
 // TestPropagateNoWaiterIsNoop is the ADR-006 §2.4 regression (SRD-020):
-// PropagateEvent to an absent key is a no-op returning nil for both a signal
-// and a non-signal trigger — correct for a signal thrown into the void
-// (BPMN §10.5.1), harmless for any other kind.
+// PropagateEvent with no catcher is a no-op returning nil — for a signal thrown
+// into the void (broadcast with zero subscribers, BPMN §10.5.1) and for a
+// non-signal trigger with no registered waiter.
 func TestPropagateNoWaiterIsNoop(t *testing.T) {
-	for _, trig := range []flow.EventTrigger{
-		flow.TriggerSignal, flow.TriggerMessage,
-	} {
-		t.Run(string(trig), func(t *testing.T) {
-			hub, err := eventhub.New(enginert.Default())
-			require.NoError(t, err)
+	startedHub := func(t *testing.T) *eventhub.EventHub {
+		t.Helper()
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			require.NoError(t, hub.Start(ctx))
+		hub, err := eventhub.New(enginert.Default())
+		require.NoError(t, err)
+		require.NoError(t, hub.Start(context.Background()))
 
-			eDef := mockflow.NewMockEventDefinition(t)
-			eDef.EXPECT().ID().Return("absent-" + string(trig)).Maybe()
-			eDef.EXPECT().Type().Return(trig).Maybe()
-
-			require.NoError(t, hub.PropagateEvent(ctx, eDef))
-		})
+		return hub
 	}
+
+	t.Run("signal broadcast with no catcher", func(t *testing.T) {
+		sig, err := events.NewSignal("GO", nil)
+		require.NoError(t, err)
+		def, err := events.NewSignalEventDefinition(sig)
+		require.NoError(t, err)
+
+		require.NoError(t, startedHub(t).PropagateEvent(context.Background(), def))
+	})
+
+	t.Run("non-signal with no waiter", func(t *testing.T) {
+		eDef := mockflow.NewMockEventDefinition(t)
+		eDef.EXPECT().ID().Return("absent").Maybe()
+		eDef.EXPECT().Type().Return(flow.TriggerMessage).Maybe()
+
+		require.NoError(t, startedHub(t).PropagateEvent(context.Background(), eDef))
+	})
+
+	// A TriggerSignal eDef that isn't a *events.SignalEventDefinition trips
+	// broadcastSignal's defensive type guard (real signals always are).
+	t.Run("signal-typed non-signal errors", func(t *testing.T) {
+		eDef := mockflow.NewMockEventDefinition(t)
+		eDef.EXPECT().ID().Return("bogus").Maybe()
+		eDef.EXPECT().Type().Return(flow.TriggerSignal).Maybe()
+
+		require.Error(t, startedHub(t).PropagateEvent(context.Background(), eDef))
+	})
 }

--- a/internal/eventproc/eventhub/eventhub_signal_test.go
+++ b/internal/eventproc/eventhub/eventhub_signal_test.go
@@ -1,0 +1,44 @@
+package eventhub_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/internal/enginert"
+	"github.com/dr-dobermann/gobpm/internal/eventproc/eventhub"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func signalDef(t *testing.T, name string) *events.SignalEventDefinition {
+	t.Helper()
+
+	sig, err := events.NewSignal(name, nil)
+	require.NoError(t, err)
+	def, err := events.NewSignalEventDefinition(sig)
+	require.NoError(t, err)
+
+	return def
+}
+
+// TestBroadcastSignalFanOut verifies a thrown signal is matched to catchers by
+// NAME, not eDef.ID(): a throw with a DIFFERENT signal definition of the same
+// name reaches the registered catcher (ADR-006 §2.1, SRD-020).
+func TestBroadcastSignalFanOut(t *testing.T) {
+	hub, err := eventhub.New(enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().ID().Return("catcher").Maybe()
+	ep.EXPECT().ProcessEvent(mock.Anything, mock.Anything).Return(nil).Once()
+
+	// Register a catcher of signal "GO".
+	require.NoError(t, hub.RegisterEvent(ep, signalDef(t, "GO")))
+
+	// Throw a DIFFERENT signal definition of the same name — it must still reach
+	// the catcher (matched by name, not by the throw's eDef.ID()).
+	require.NoError(t, hub.PropagateEvent(context.Background(), signalDef(t, "GO")))
+}

--- a/internal/eventproc/eventhub/eventhub_timer_test.go
+++ b/internal/eventproc/eventhub/eventhub_timer_test.go
@@ -138,10 +138,10 @@ func TestTimerEvents(t *testing.T) {
 		timerEvent, err := events.NewTimerEventDefinition(nil, cycleExpr, durationExpr)
 		require.NoError(t, err)
 
-		// Try to propagate event when no processors are registered
+		// Propagating with no registered waiter is a logged no-op, not an
+		// error (ADR-006 §2.4, SRD-020).
 		err = hub.PropagateEvent(context.Background(), timerEvent)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "couldn't find waiter for EventDefinition")
+		require.NoError(t, err)
 	})
 }
 

--- a/internal/eventproc/eventhub/waiters/signal.go
+++ b/internal/eventproc/eventhub/waiters/signal.go
@@ -1,0 +1,236 @@
+package waiters
+
+import (
+	"context"
+	"reflect"
+	"slices"
+	"strings"
+	"sync"
+
+	"github.com/dr-dobermann/gobpm/internal/eventproc"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/renv"
+)
+
+// SignalWaiterError classifies signalWaiter failures.
+const SignalWaiterError = "SIGNAL_WAITER_ERROR"
+
+// signalWaiter catches a BPMN signal (ADR-006 v.1 §2.1, SRD-020). A signal is a
+// broadcast publication with no correlation: a throw of signal name X fires
+// EVERY catcher of X. The waiter is **passive** — unlike the message (broker)
+// and timer (ticker) waiters it has no external source, so it spawns no service
+// goroutine; it is fired only by an in-process throw through EventHub.Process.
+// Broadcast across instances falls out of identity sharing: signal event
+// definitions have no CloneForInstance, so every instance catching the same
+// modeled node shares one eDef.ID() and so one waiter, with one processor per
+// catching track. It never removes itself — the hub is the sole owner
+// (ADR-006 v.1 §2.5).
+type signalWaiter struct {
+	hub        eventproc.EventHub
+	rt         renv.EngineRuntime
+	eDef       *events.SignalEventDefinition
+	ctx        context.Context
+	done       chan struct{}
+	name       string
+	id         string
+	processors []eventproc.EventProcessor
+	state      eventproc.EventWaiterState
+	m          sync.Mutex
+}
+
+// NewSignalWaiter builds a signalWaiter for a SignalEventDefinition. It rejects
+// empty dependencies and a non-signal definition.
+func NewSignalWaiter(
+	eh eventproc.EventHub,
+	ep eventproc.EventProcessor,
+	eDefI flow.EventDefinition,
+	id string,
+	rt renv.EngineRuntime,
+) (eventproc.EventWaiter, error) {
+	if ep == nil || eDefI == nil || eh == nil || rt == nil {
+		return nil,
+			errs.New(
+				errs.M("couldn't create a Waiter with empty EventProcessor, "+
+					"EventDefinition, EventHub or EngineRuntime"),
+				errs.C(SignalWaiterError,
+					errs.InvalidParameter, errs.EmptyNotAllowed))
+	}
+
+	eDef, ok := eDefI.(*events.SignalEventDefinition)
+	if !ok {
+		return nil,
+			errs.New(
+				errs.M("not a SignalEventDefinition"),
+				errs.C(SignalWaiterError, errs.TypeCastingError),
+				errs.D("event_definition_type", reflect.TypeOf(eDefI)))
+	}
+
+	sig := eDef.Signal()
+	if sig == nil {
+		return nil,
+			errs.New(
+				errs.M("SignalEventDefinition has no signal"),
+				errs.C(SignalWaiterError, errs.EmptyNotAllowed),
+				errs.D("event_definition_id", eDef.ID()))
+	}
+
+	id = strings.TrimSpace(id)
+	if id == "" {
+		id = foundation.GenerateID()
+	}
+
+	// done is closed at construction: a passive waiter has no goroutine to wait
+	// for, so EventHub.Shutdown's drain on Done() returns immediately.
+	done := make(chan struct{})
+	close(done)
+
+	return &signalWaiter{
+		id:         id,
+		name:       sig.Name(),
+		eDef:       eDef,
+		hub:        eh,
+		rt:         rt,
+		done:       done,
+		processors: []eventproc.EventProcessor{ep},
+		state:      eventproc.WSReady,
+	}, nil
+}
+
+// ID returns the waiter id.
+func (sw *signalWaiter) ID() string {
+	return sw.id
+}
+
+// EventDefinition returns the signal event definition the waiter waits for.
+func (sw *signalWaiter) EventDefinition() flow.EventDefinition {
+	return sw.eDef
+}
+
+// AddEventProcessor adds ep to the waiter's processor list (idempotent). A
+// second instance catching the same shared-id signal lands here, joining the
+// broadcast set.
+func (sw *signalWaiter) AddEventProcessor(ep eventproc.EventProcessor) error {
+	if ep == nil {
+		return errs.New(
+			errs.M("empty EventProcessor isn't allowed"),
+			errs.C(SignalWaiterError, errs.EmptyNotAllowed))
+	}
+
+	sw.m.Lock()
+	defer sw.m.Unlock()
+
+	if idx := slices.Index(sw.processors, ep); idx == -1 {
+		sw.processors = append(sw.processors, ep)
+	}
+
+	return nil
+}
+
+// RemoveEventProcessor removes ep from the waiter's processor list (a catcher
+// that fired and consumed the signal, or a canceled track).
+func (sw *signalWaiter) RemoveEventProcessor(ep eventproc.EventProcessor) error {
+	if ep == nil {
+		return errs.New(
+			errs.M("empty EventProcessor isn't allowed"),
+			errs.C(SignalWaiterError, errs.EmptyNotAllowed))
+	}
+
+	sw.m.Lock()
+	defer sw.m.Unlock()
+
+	idx := slices.Index(sw.processors, ep)
+	if idx == -1 {
+		return errs.New(
+			errs.M("event processor isn't registered with the waiter"),
+			errs.C(SignalWaiterError, errs.ObjectNotFound),
+			errs.D("waiter_id", sw.id),
+			errs.D("event_processor_id", ep.ID()))
+	}
+
+	sw.processors = slices.Delete(sw.processors, idx, idx+1)
+
+	return nil
+}
+
+// EventProcessors returns the waiter's registered processors.
+func (sw *signalWaiter) EventProcessors() []eventproc.EventProcessor {
+	sw.m.Lock()
+	defer sw.m.Unlock()
+
+	return sw.processors
+}
+
+// Service records the engine context the catchers resume under and marks the
+// waiter running. It spawns NO goroutine: a signal has no external source.
+func (sw *signalWaiter) Service(ctx context.Context) error {
+	sw.m.Lock()
+	defer sw.m.Unlock()
+
+	if sw.state != eventproc.WSReady {
+		return errs.New(
+			errs.M("waiter isn't ready to start"),
+			errs.C(SignalWaiterError, errs.InvalidState),
+			errs.D("current_state", sw.state))
+	}
+
+	sw.ctx = ctx
+	sw.state = eventproc.WSRunned
+
+	return nil
+}
+
+// Process delivers a thrown signal to EVERY registered catcher — the broadcast
+// (ADR-006 v.1 §2.1, BPMN §10.5.1). It has no correlation filter. Delivery is
+// best-effort: one catcher's failure is logged and does not stop the signal
+// reaching the others. Each catching track self-unregisters as it resumes
+// (track.ProcessEvent), so the hub removes the emptied waiter afterwards.
+func (sw *signalWaiter) Process(eDef flow.EventDefinition) error {
+	sw.m.Lock()
+	ctx := sw.ctx
+	// Iterate a copy: each delivery makes its track self-unregister, mutating
+	// sw.processors under sw.m while we fan out.
+	processors := append([]eventproc.EventProcessor(nil), sw.processors...)
+	sw.m.Unlock()
+
+	for _, ep := range processors {
+		if err := ep.ProcessEvent(ctx, eDef); err != nil {
+			sw.rt.Logger().Warn("signal delivery to a catcher failed",
+				"waiter_id", sw.id,
+				"signal", sw.name,
+				"event_processor_id", ep.ID(),
+				"error", err.Error())
+		}
+	}
+
+	return nil
+}
+
+// Stop marks the waiter stopped. There is no goroutine to signal — the passive
+// waiter has none.
+func (sw *signalWaiter) Stop() error {
+	sw.m.Lock()
+	defer sw.m.Unlock()
+
+	sw.state = eventproc.WSStopped
+
+	return nil
+}
+
+// State returns the current waiter state.
+func (sw *signalWaiter) State() eventproc.EventWaiterState {
+	sw.m.Lock()
+	defer sw.m.Unlock()
+
+	return sw.state
+}
+
+// Done returns an already-closed channel: a passive waiter has no service
+// goroutine, so EventHub.Shutdown's drain completes immediately (ADR-006 §2.5).
+func (sw *signalWaiter) Done() <-chan struct{} {
+	return sw.done
+}
+
+var _ eventproc.EventWaiter = (*signalWaiter)(nil)

--- a/internal/eventproc/eventhub/waiters/signal_test.go
+++ b/internal/eventproc/eventhub/waiters/signal_test.go
@@ -1,0 +1,127 @@
+package waiters_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/internal/enginert"
+	"github.com/dr-dobermann/gobpm/internal/eventproc"
+	"github.com/dr-dobermann/gobpm/internal/eventproc/eventhub/waiters"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func signalEDef(t *testing.T, name string) *events.SignalEventDefinition {
+	t.Helper()
+
+	sig, err := events.NewSignal(name, nil)
+	require.NoError(t, err)
+
+	def, err := events.NewSignalEventDefinition(sig)
+	require.NoError(t, err)
+
+	return def
+}
+
+func TestNewSignalWaiterErrors(t *testing.T) {
+	hub := mockeventproc.NewMockEventHub(t)
+	ep := mockeventproc.NewMockEventProcessor(t)
+
+	// empty dependencies
+	_, err := waiters.NewSignalWaiter(nil, nil, nil, "", nil)
+	require.Error(t, err)
+
+	// a non-signal definition is rejected
+	_, err = waiters.NewSignalWaiter(hub, ep, msgEventDef(t), "", enginert.Default())
+	require.Error(t, err)
+}
+
+func TestSignalWaiterPassive(t *testing.T) {
+	hub := mockeventproc.NewMockEventHub(t)
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().ID().Return("ep-1").Maybe()
+
+	def := signalEDef(t, "GO")
+	w, err := waiters.NewSignalWaiter(hub, ep, def, "", enginert.Default())
+	require.NoError(t, err)
+
+	require.NotEmpty(t, w.ID())
+	require.Equal(t, def, w.EventDefinition())
+
+	require.NoError(t, w.Service(context.Background()))
+	require.Equal(t, eventproc.WSRunned, w.State())
+
+	// A passive waiter has no service goroutine: Done is closed at once.
+	select {
+	case <-w.Done():
+	case <-time.After(time.Second):
+		t.Fatal("signal waiter Done is not closed for a passive waiter")
+	}
+
+	require.NoError(t, w.Stop())
+	require.Equal(t, eventproc.WSStopped, w.State())
+}
+
+func TestSignalWaiterBroadcastFanOut(t *testing.T) {
+	hub := mockeventproc.NewMockEventHub(t)
+	def := signalEDef(t, "GO")
+
+	ep1 := mockeventproc.NewMockEventProcessor(t)
+	ep1.EXPECT().ID().Return("ep-1").Maybe()
+	ep1.EXPECT().ProcessEvent(context.Background(), def).Return(nil).Once()
+
+	ep2 := mockeventproc.NewMockEventProcessor(t)
+	ep2.EXPECT().ID().Return("ep-2").Maybe()
+	ep2.EXPECT().ProcessEvent(context.Background(), def).Return(nil).Once()
+
+	w, err := waiters.NewSignalWaiter(hub, ep1, def, "", enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, w.Service(context.Background()))
+	require.NoError(t, w.AddEventProcessor(ep2))
+	require.Len(t, w.EventProcessors(), 2)
+
+	// Process fans the signal out to every registered catcher (broadcast).
+	require.NoError(t, w.Process(def))
+
+	// RemoveEventProcessor drops a catcher (a consumed/cancelled track).
+	require.NoError(t, w.RemoveEventProcessor(ep1))
+	require.Len(t, w.EventProcessors(), 1)
+}
+
+func TestSignalWaiterEdgeCases(t *testing.T) {
+	hub := mockeventproc.NewMockEventHub(t)
+	def := signalEDef(t, "GO")
+
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().ID().Return("ep-1").Maybe()
+
+	w, err := waiters.NewSignalWaiter(hub, ep, def, "", enginert.Default())
+	require.NoError(t, err)
+
+	// nil add/remove and removing an unregistered processor are errors.
+	require.Error(t, w.AddEventProcessor(nil))
+	require.Error(t, w.RemoveEventProcessor(nil))
+
+	other := mockeventproc.NewMockEventProcessor(t)
+	other.EXPECT().ID().Return("other").Maybe()
+	require.Error(t, w.RemoveEventProcessor(other))
+
+	// Service twice → not ready.
+	require.NoError(t, w.Service(context.Background()))
+	require.Error(t, w.Service(context.Background()))
+
+	// Process tolerates a failing catcher: it logs and still returns nil so the
+	// broadcast reaches the others (FR-3).
+	failEP := mockeventproc.NewMockEventProcessor(t)
+	failEP.EXPECT().ID().Return("fail").Maybe()
+	failEP.EXPECT().ProcessEvent(mock.Anything, def).
+		Return(errors.New("boom")).Once()
+	require.NoError(t, w.AddEventProcessor(failEP))
+
+	ep.EXPECT().ProcessEvent(mock.Anything, def).Return(nil).Once()
+	require.NoError(t, w.Process(def))
+}

--- a/internal/eventproc/eventhub/waiters/waiters.go
+++ b/internal/eventproc/eventhub/waiters/waiters.go
@@ -44,12 +44,13 @@ func CreateWaiter(
 		err error
 	)
 
-	// NOTE: timer and message are the only catchable triggers with a waiter
-	// builder. Any future case added here (signal, conditional, …) MUST also
-	// give its EventDefinition a CloneForInstance method (see
-	// MessageEventDefinition / TimerEventDefinition), or concurrent instances
-	// waiting on it will share one waiter and a single occurrence will resume
-	// them all (the FIX-004 / SRD-017 per-instance-identity rule).
+	// NOTE: per-instance identity is by trigger semantics, not a blanket rule.
+	// A POINT-TO-POINT trigger (message, timer) MUST give its EventDefinition a
+	// CloneForInstance method so concurrent instances get distinct per-id waiters
+	// — else one occurrence resumes them all (the FIX-004 / SRD-017 rule). A
+	// BROADCAST trigger (signal) MUST NOT: catchers across instances share one
+	// eDef.ID() (no CloneForInstance) so a single throw fans out to all of them
+	// (ADR-006 §2.1, SRD-020). Choose by reach when adding a trigger.
 	switch eDef.Type() {
 	case flow.TriggerTimer:
 		w, err = NewTimeWaiter(eh, ep, eDef, "", rt)
@@ -59,6 +60,12 @@ func CreateWaiter(
 		// removes them after one fire). The persistent instance-starter waiter
 		// (SRD-015) is built on a dedicated path: CreatePersistentWaiter.
 		w, err = NewMessageWaiter(eh, ep, eDef, "", rt, true)
+
+	case flow.TriggerSignal:
+		// Signal: a passive broadcast waiter, fired by an in-process throw via
+		// EventHub.Process (no broker, no goroutine). Catchers share one waiter
+		// by shared eDef.ID() (SRD-020).
+		w, err = NewSignalWaiter(eh, ep, eDef, "", rt)
 
 	default:
 		err = errs.New(

--- a/internal/eventproc/eventhub/waiters/waiters_test.go
+++ b/internal/eventproc/eventhub/waiters/waiters_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/generated/mockflow"
 	"github.com/dr-dobermann/gobpm/internal/enginert"
 	"github.com/dr-dobermann/gobpm/internal/eventproc/eventhub/waiters"
 	"github.com/dr-dobermann/gobpm/pkg/errs"
@@ -14,6 +15,7 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
 	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
 	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 	"github.com/stretchr/testify/require"
 )
@@ -61,7 +63,16 @@ func TestNewWaiter(t *testing.T) {
 	_, err = waiters.CreateWaiter(mockHub, ep, nil, enginert.Default())
 	requireClass(err, errs.EmptyNotAllowed)
 
-	// unknown trigger type (signal has no builder yet).
-	_, err = waiters.CreateWaiter(mockHub, ep, signalEDef, enginert.Default())
+	// signal is now supported (SRD-020): CreateWaiter builds a passive
+	// signalWaiter.
+	w, err := waiters.CreateWaiter(mockHub, ep, signalEDef, enginert.Default())
+	require.NoError(t, err)
+	require.NotNil(t, w)
+
+	// an unsupported trigger (conditional) still hits the default branch.
+	condEDef := mockflow.NewMockEventDefinition(t)
+	condEDef.EXPECT().Type().Return(flow.TriggerConditional).Maybe()
+	condEDef.EXPECT().ID().Return("cond-1").Maybe()
+	_, err = waiters.CreateWaiter(mockHub, ep, condEDef, enginert.Default())
 	requireClass(err, errs.ObjectNotFound)
 }

--- a/pkg/thresher/signal_test.go
+++ b/pkg/thresher/signal_test.go
@@ -1,0 +1,176 @@
+package thresher_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/dr-dobermann/gobpm/pkg/thresher"
+	"github.com/stretchr/testify/require"
+)
+
+// signalCatchProcess builds start -> catch(signal name) -> end.
+func signalCatchProcess(t *testing.T, procID, name string) *process.Process {
+	t.Helper()
+
+	sig, err := events.NewSignal(name, nil)
+	require.NoError(t, err)
+	def, err := events.NewSignalEventDefinition(sig)
+	require.NoError(t, err)
+
+	catch, err := events.NewIntermediateCatchEvent("catch-"+name, def)
+	require.NoError(t, err)
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	proc, err := process.New(procID)
+	require.NoError(t, err)
+	for _, e := range []flow.Element{start, catch, end} {
+		require.NoError(t, proc.Add(e))
+	}
+	link(t, start, catch)
+	link(t, catch, end)
+
+	return proc
+}
+
+// signalThrowProcess builds start -> throw(signal name) -> end.
+func signalThrowProcess(t *testing.T, procID, name string) *process.Process {
+	t.Helper()
+
+	sig, err := events.NewSignal(name, nil)
+	require.NoError(t, err)
+	def, err := events.NewSignalEventDefinition(sig)
+	require.NoError(t, err)
+
+	throw, err := events.NewIntermediateThrowEvent("throw-"+name, def)
+	require.NoError(t, err)
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	proc, err := process.New(procID)
+	require.NoError(t, err)
+	for _, e := range []flow.Element{start, throw, end} {
+		require.NoError(t, proc.Add(e))
+	}
+	link(t, start, throw)
+	link(t, throw, end)
+
+	return proc
+}
+
+// TestSignalCatchThrow verifies a thrown signal resumes a waiting catcher in
+// another instance (FR-1, FR-3, FR-6).
+func TestSignalCatchThrow(t *testing.T) {
+	catcher := signalCatchProcess(t, "sc-catch", "GO")
+	thrower := signalThrowProcess(t, "sc-throw", "GO")
+
+	th, cancel := runEngine(t, catcher)
+	defer cancel()
+	require.NoError(t, th.RegisterProcess(thrower))
+
+	ch, err := th.StartProcess(catcher.ID())
+	require.NoError(t, err)
+
+	time.Sleep(150 * time.Millisecond) // catcher reaches and parks on the catch
+
+	_, err = th.StartProcess(thrower.ID()) // throws GO
+	require.NoError(t, err)
+
+	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cc()
+	st, err := ch.WaitCompletion(ctx)
+	require.NoError(t, err)
+	require.Equal(t, thresher.StateCompleted, st)
+}
+
+// TestSignalBroadcast verifies one throw fires EVERY catcher of the signal name
+// across instances (FR-2, FR-3, NFR-1) — the broadcast canary.
+func TestSignalBroadcast(t *testing.T) {
+	catcher := signalCatchProcess(t, "sb-catch", "GO")
+	thrower := signalThrowProcess(t, "sb-throw", "GO")
+
+	th, cancel := runEngine(t, catcher)
+	defer cancel()
+	require.NoError(t, th.RegisterProcess(thrower))
+
+	c1, err := th.StartProcess(catcher.ID())
+	require.NoError(t, err)
+	c2, err := th.StartProcess(catcher.ID())
+	require.NoError(t, err)
+
+	time.Sleep(150 * time.Millisecond) // both catchers park on the catch
+
+	_, err = th.StartProcess(thrower.ID()) // one throw of GO
+	require.NoError(t, err)
+
+	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cc()
+	st1, err := c1.WaitCompletion(ctx)
+	require.NoError(t, err)
+	require.Equal(t, thresher.StateCompleted, st1)
+	st2, err := c2.WaitCompletion(ctx)
+	require.NoError(t, err)
+	require.Equal(t, thresher.StateCompleted, st2)
+}
+
+// TestSignalThrownIntoVoid verifies a signal with no catcher is a no-op and is
+// NOT buffered for a later catcher (FR-4, NFR-1 — the §2.4 no-store contract).
+func TestSignalThrownIntoVoid(t *testing.T) {
+	catcher := signalCatchProcess(t, "sv-catch", "GO")
+	thrower := signalThrowProcess(t, "sv-throw", "GO")
+
+	th, cancel := runEngine(t, thrower)
+	defer cancel()
+	require.NoError(t, th.RegisterProcess(catcher))
+
+	_, err := th.StartProcess(thrower.ID()) // throw GO with no catcher → no-op
+	require.NoError(t, err)
+
+	time.Sleep(150 * time.Millisecond)
+
+	ch, err := th.StartProcess(catcher.ID()) // starts AFTER the throw
+	require.NoError(t, err)
+
+	// The earlier signal is not retro-delivered: the catcher stays parked.
+	ctx, cc := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cc()
+	_, err = ch.WaitCompletion(ctx)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// TestSignalSingleShotConsume verifies an intermediate catch consumes the signal
+// once, and a later throw with no catcher is a clean no-op (FR-5).
+func TestSignalSingleShotConsume(t *testing.T) {
+	catcher := signalCatchProcess(t, "ss-catch", "GO")
+	thrower := signalThrowProcess(t, "ss-throw", "GO")
+
+	th, cancel := runEngine(t, catcher)
+	defer cancel()
+	require.NoError(t, th.RegisterProcess(thrower))
+
+	ch, err := th.StartProcess(catcher.ID())
+	require.NoError(t, err)
+
+	time.Sleep(150 * time.Millisecond)
+
+	_, err = th.StartProcess(thrower.ID()) // throw 1 → catcher fires
+	require.NoError(t, err)
+
+	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cc()
+	st, err := ch.WaitCompletion(ctx)
+	require.NoError(t, err)
+	require.Equal(t, thresher.StateCompleted, st)
+
+	// The catch is consumed; a second throw finds no catcher → clean no-op.
+	_, err = th.StartProcess(thrower.ID())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
First runtime slice of the ADR-006 events workstream (epic #90): **BPMN signal events** — the broadcast publication trigger. One thrown signal reaches **every** catcher of that name, across
instances. Also **closes ADR-006 §2.4** (propagating to no listener is now a logged no-op, not an error) and fixes a **pre-existing SRD-019 data race** the work surfaced.

## What's added
- **`signalWaiter`** (`waiters/signal.go`) — a *passive* waiter: no broker, no goroutine (a signal has no external source); `Process` fans out to all catchers with no correlation; closed `Done()`
so `EventHub.Shutdown` drains it instantly; never self-removes (§2.5).
- **`PropagateEvent` signal branch** — `broadcastSignal` matches catchers **by name** (throw/catch are distinct nodes), fanning out; broadcast across instances falls out of signal eDefs not being
cloned (the deliberate inverse of FIX-004's point-to-point rule). No registry/keying change.
- **§2.4 no-waiter no-op** — `PropagateEvent` to an absent key is a debug-logged no-op (was `ObjectNotFound`).
- **Race fix** — `EventHub.state` → `atomic.Uint32` (Run/PropagateEvent read it lock-free while Start/Shutdown write it; SRD-019's CI passed only by timing luck).
- **`examples/signal-broadcast`** — one throw → two watcher instances both resume.

## Verification
- `make ci` green: lint, build, `-race`, **diff-coverage 97.2%/212 (≥95)**, govulncheck.
- All 10 examples smoke-run exit 0.
- Broadcast canary (`TestSignalBroadcast`, `-race`) + no-buffering (`TestSignalThrownIntoVoid`) + single-shot consume.

## Docs
SRD-020 (EN + RU twin), Accepted. References upward-only, version-pinned.

## Follow-up (not in this PR)
Signal *start*/*boundary* events deferred to their workstreams; a polymorphic `SubscriptionKey()` matching generalization deferred to **Link events**.

Closes #149.
