### PR TITLE
fix: Event-Based gateway concurrent-fire races (FIX-007) + ADR-017

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/dr-dobermann/gobpm)
 [![codecov](https://codecov.io/github/dr-dobermann/gobpm/graph/badge.svg?token=ENKOTEL4VN)](https://codecov.io/github/dr-dobermann/gobpm)
 [![Go Report Card](https://goreportcard.com/badge/github.com/dr-dobermann/gobpm)](https://goreportcard.com/report/github.com/dr-dobermann/gobpm)
+[![Go Reference](https://pkg.go.dev/badge/github.com/dr-dobermann/gobpm.svg)](https://pkg.go.dev/github.com/dr-dobermann/gobpm)
 
 **GoBPM** is a native Go BPMN 2.0 engine. It is designed to embed directly into a Go application as a minimal, dependency-light **library** — and to scale up to a standalone process **server** through additive runtime components, without forcing library users to ship what they don't need.
 

--- a/docs/design/ADR-017-single-writer-event-delivery.md
+++ b/docs/design/ADR-017-single-writer-event-delivery.md
@@ -1,0 +1,144 @@
+# ADR-017 — Single-writer event delivery
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-06-21 |
+| Owner | Ruslan Gabitov |
+| Refines | [ADR-001 v.5 Execution Model](ADR-001-execution-model.md) |
+
+> **Draft (conception; implementation deferred).** Decides that a fired event must be
+> **delivered through the per-instance single writer** (the instance loop), not applied to a
+> track directly on the EventHub waiter's goroutine. This extends ADR-001 v.5's single-writer
+> principle to event delivery and eliminates — by construction — the class of races where a
+> track is mutated by a goroutine other than its owner. The queue/response mechanics are
+> deferred to the implementing SRD; this ADR fixes the **model and direction**.
+
+---
+
+## 1. Context & problem
+
+ADR-001 v.5 makes the per-instance **loop** the single owner of an instance's lifecycle
+state: tracks never mutate that state directly — they **emit** events to the loop, which
+applies them in order on one goroutine, so no lock guards lifecycle state. That single-writer
+discipline is what makes the engine's concurrency tractable.
+
+**Event delivery currently breaks that discipline.** When a waited event fires, the EventHub
+delivers it **synchronously on the waiter's own goroutine**: the waiter calls into the target
+track and mutates it (advancing it past its wait, transitioning its state, appending its next
+step) — *while the track's own goroutine is concurrently reading and executing it*. A track is
+thus mutated by a **foreign goroutine**, in violation of the single-writer model.
+
+This is not one bug but a **class** of races — any place where the waiter-goroutine mutation
+and the track's own run loop interleave. Two concrete instances have already been observed at
+the **Event-Based gateway** (the BPMN deferred choice, where one gate subscription stands in
+for several arms, and where a **signal broadcast** — unscoped, name-matched, fanning out to
+every catcher in reach — can deliver to two arms near-simultaneously):
+
+- **Two events race the deferred-choice transition** — both pass the "still waiting?" guard
+  before either commits the winner, so both arms advance ("exactly one arm wins" is violated).
+- **The run loop executes a stale position** — the waiter flips the track's state and appends
+  the winning arm mid-iteration, so the run loop proceeds with the position it captured a
+  moment earlier (the gate itself, which must never execute).
+
+These have been patched **site by site** (a per-track event mutex; re-reading the position
+after the wait-guard). Each patch is correct, but the *class* persists: every future
+event-delivery site must independently get the interleaving right, and a missed site is a
+latent, rare, hard-to-reproduce race. The root cause is structural — **delivery runs on the
+wrong goroutine** — and is best removed structurally.
+
+## 2. Decision
+
+**Extend the single-writer principle to event delivery.** A fired event is **handed to the
+instance's loop**, not applied to the track on the waiter's goroutine:
+
+- The EventHub waiter, on a fired event, **enqueues** it for the target instance — onto a
+  per-instance event queue drained by the loop, or the loop's existing event channel — and
+  returns. It does **not** call into the track.
+- The **loop dequeues and applies** the event to the track, serially, in the same single
+  goroutine that already applies track lifecycle events (ADR-001 v.5).
+
+A track is then mutated **only by its owner** (the loop, or the track's own run path acting
+under the loop's coordination). The entire foreign-goroutine race class is eliminated **by
+construction**, not site by site: per-site event mutexes and defensive re-reads become
+unnecessary, because no two goroutines ever touch a track's state concurrently.
+
+This is the same move ADR-001 v.5 already made for lifecycle state ("tracks emit, the loop
+applies"), now applied to the one path that still bypassed it.
+
+## 3. Consequences
+
+- **Delivery becomes asynchronous — the principal cost.** Today a caller of "propagate event"
+  gets the **outcome inline**: a broadcast with no live catcher is a no-op (ADR-006 v.1 §2.4);
+  a correlation mismatch is reported back so the broker keeps or drops the message; an
+  Event-Based gateway routes the winning arm immediately and the caller observes it. A queue
+  **decouples delivery from outcome**, so the contract needs an explicit **response/ack
+  mechanism** (a per-event completion signal the waiter can wait on) — or a deliberate
+  fire-and-forget model where outcomes are observed via the instance's state/observers rather
+  than the call return. Reconciling this with the existing synchronous expectations is the
+  main design work the implementing SRD must do.
+- **Per-instance queue policy.** Event **ordering** (FIFO per instance) and **backpressure**
+  (a bounded queue, and what happens when full — block the waiter, drop, or grow) must be
+  decided. The queue shares the instance's lifetime and must be drained on **shutdown** so no
+  fired event is silently lost.
+- **BPMN delivery semantics must be preserved** across the async boundary: a signal broadcast
+  still reaches every in-reach catcher; a no-catcher broadcast is still a benign no-op
+  (ADR-006 v.1); correlation rejection still leaves a receiver waiting. The async path must
+  not change *what* is delivered, only *which goroutine* applies it.
+- **Net simplification once landed.** The site-by-site concurrency guards added to event
+  delivery can be removed; the engine gains one place to reason about event ordering and
+  delivery, consistent with the rest of the single-writer model.
+
+## 4. Alternatives considered
+
+- **Per-site locks / careful re-reads (the status quo + patches).** Guard each delivery site
+  individually (a per-track event mutex; re-read positions after a guard). *Rejected as the
+  end state:* correct per site but does not generalize — lock proliferation, and every new
+  delivery site must re-derive the correct interleaving; a missed site is a silent race. Useful
+  as an interim safety measure, not as the model.
+- **Synchronous waiter-goroutine delivery (today's model).** *Rejected:* it is precisely the
+  model that admits the race class; no amount of local guarding makes "a foreign goroutine
+  mutates the track" structurally safe.
+- **One coarse instance-wide lock around all delivery and run.** Serialize event delivery and
+  the run loop under a single instance lock. *Rejected:* serializes far more than necessary
+  (kills track concurrency), and holding a lock across node execution invites deadlock — the
+  same reasons ADR-001 v.5 chose the emit-to-loop model over a big lock in the first place.
+
+## 5. Enterprise-readiness recommendations
+
+- **Queue observability:** expose the per-instance event-queue depth and any drop/backpressure
+  events as metrics, so operators can see delivery saturation before it becomes latency.
+- **Foundation for durability/replay:** routing every fired event through one ordered,
+  per-instance ingress point is the natural seam for **durable, replayable** event delivery
+  later (persist the queue; replay on hydration) — a prerequisite for the deferred persistence
+  workstream. The ADR does not require durability now, but the model should not preclude it.
+- **Delivery contract documentation:** the implementing SRD should specify the new async
+  contract (ack vs fire-and-forget, ordering, backpressure) as a first-class public behaviour,
+  since it changes how hosts and the broker observe delivery outcomes.
+
+## 6. References
+
+- [ADR-001 v.5 Execution Model](ADR-001-execution-model.md) — the single-writer principle
+  (the loop owns lifecycle state; tracks emit, the loop applies) that this ADR extends to event
+  delivery.
+- [ADR-006 v.1 Events & subscriptions](ADR-006-events-and-subscriptions.md) — the event
+  delivery contract (broadcast, no-catcher no-op, waiter lifecycle) whose *semantics* must be
+  preserved across the new async boundary.
+- BPMN 2.0 — signal publication is unscoped within reach and carries no correlation
+  (`docs/bpmn-spec/semantics/event-handling.md`); the async path must keep this broadcast
+  semantic intact.
+
+## 7. Open questions
+
+- **None at the model level** — single-writer event delivery is the decision. The shape of the
+  **async delivery contract** (a per-event response/ack the waiter awaits, vs. fire-and-forget
+  with outcomes observed via the instance) and the **queue backpressure policy** are deferred
+  to the implementing SRD, where they will be decided against the concrete waiter→loop→track
+  flow rather than assumed here.
+
+## Document History
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v.1 (Draft) | 2026-06-21 | Ruslan Gabitov | Draft conception: deliver fired events through the per-instance single writer (the loop) instead of mutating a track on the EventHub waiter's goroutine, eliminating the foreign-goroutine event-delivery race class by construction. Refines ADR-001 v.5; preserves ADR-006 v.1 delivery semantics. Implementation (queue + async contract + backpressure) deferred to a follow-up SRD. |

--- a/docs/fix/FIX-007_event-gateway-concurrent-fire.md
+++ b/docs/fix/FIX-007_event-gateway-concurrent-fire.md
@@ -1,0 +1,197 @@
+# FIX-007 «Event-Based gateway double-win under concurrent fires»
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft v.1 (2026-06-21, branch `fix/event-gate-concurrent-fire`, not yet implemented).
+**Date:** 2026-06-21.
+**Author:** Ruslan Gabitov.
+**Branch:** `fix/event-gate-concurrent-fire` (the defect is a concurrent-fire race in the Event-Based gateway's deferred choice).
+**Tracking issue:** [#164](https://github.com/dr-dobermann/gobpm/issues/164) (bug).
+**Paired doc:** none (local to `internal/instance` track event delivery).
+**Upstream:** [SRD-024 v.1](../srd/SRD-024-event-based-gateway.md) (the gate this fixes), [SRD-026 v.1](../srd/SRD-026-signal-events.md) (signals — concurrent broadcast delivery makes the race reachable), [ADR-001 v.5](../design/ADR-001-execution-model.md) (the single-writer execution model the follow-up ADR in §7 would extend).
+
+---
+
+## 1. Symptoms
+
+The Event-Based gateway's deferred-choice invariant — **exactly one arm wins** — can be violated under **concurrent** event delivery: two arms both win (a double-win). It surfaced as a CI flake.
+
+```
+--- FAIL: TestEventGatewayConcurrentFires (0.01s)
+    event_gateway_internal_test.go:238:
+        Error: Should be true
+        Test:  TestEventGatewayConcurrentFires
+        Messages: exactly one arm wins
+```
+
+Rare: the test passes ~60×/60× locally under `-race`; CI hit the failure once. The test (`internal/instance/event_gateway_internal_test.go:209`) builds a gate with two signal arms (`GO_A`, `GO_B`), fires both **concurrently** via two goroutines each calling `eh.PropagateEvent`, waits for the instance to complete, then asserts (`:238`):
+
+```go
+require.True(t, ranA != ranB, "exactly one arm wins")
+```
+
+`ranA != ranB` is an XOR — exactly one arm's path (arm + end) ran. A failure means **both** ran (the double-win) — or, far less likely, neither.
+
+---
+
+## 2. Root cause analysis
+
+### 2.1 A TOCTOU in `track.ProcessEvent` (`internal/instance/track.go`)
+
+`ProcessEvent` guards on the track state, then much later transitions it — with no lock held across the two:
+
+```go
+func (t *track) ProcessEvent(ctx context.Context, eDef flow.EventDefinition) error {
+	if !t.inState(TrackWaitForEvent) {          // :816  — lock-free guard (check)
+		return errs.New(errs.M("...doesn't expect any event"), ...)
+	}
+	...
+	if t.instance.validateAndAssociate(ctx, eDef) { // :847 — correlation reject (keeps waiting)
+		return eventproc.ErrRejected
+	}
+	if err := ep.ProcessEvent(ctx, eDef); err != nil { // :851 — bind + (gate) resolve the arm
+		return err
+	}
+	...
+	if er, ok := n.(eventRouter); ok {
+		t.advanceToArm(n, er, eDef)             // :868 — append the winning arm's step
+	}
+	t.updateState(TrackReady)                   // :871 — state finally leaves WaitForEvent (act)
+	return nil
+}
+```
+
+The check is at `:816`; the state only changes at `:871`, **after** `advanceToArm`. The window `:816 → :871` is unprotected.
+
+### 2.2 Why two arms win
+
+An Event-Based gateway subscribes the hub on behalf of **all** its arms through a single gate track (SRD-024 v.1 §4.1) — the gate track is the one `EventProcessor` for every arm's definition. So two concurrent `eh.PropagateEvent` calls (here `GO_A` and `GO_B`) become **two waiter goroutines** both invoking `ProcessEvent` on the **same** gate track:
+
+```
+goroutine A (GO_A)              goroutine B (GO_B)
+:816 inState(WaitForEvent)=true
+                                :816 inState(WaitForEvent)=true   ← both pass
+:868 advanceToArm(armA)
+                                :868 advanceToArm(armB)           ← both arms appended
+:871 updateState(Ready)
+                                :871 updateState(Ready)
+```
+
+Both append an arm step → both arms run → `ranA && ranB` → the invariant breaks. The narrow window (state changes only at `:871`) is why it is rare.
+
+Signals make this reachable in real use, not just in a stress test: a signal broadcast (`broadcastSignal`, SRD-026) fans out to every catcher by name and can deliver to two arms of the same gate near-simultaneously.
+
+### 2.3 Why the test didn't catch it earlier
+
+`TestEventGatewayConcurrentFires` exists but fires the two events exactly once per run — it exercises the race but only **non-deterministically** wins it, so it passed nearly always and did not reliably guard the invariant (§4.1 hardens it).
+
+---
+
+## 3. Solution
+
+Serialize event delivery to a track with a **dedicated per-track mutex** held across `ProcessEvent`'s critical section, so the first fire runs to completion (transitioning the state) before any second fire is evaluated. The loser then fails the `:816` guard (state is no longer `TrackWaitForEvent`) and is dropped.
+
+The correlation-reject path needs **no special handling**: `validateAndAssociate` (`:847`) returning `ErrRejected` does not transition the state, so a wrong-conversation message naturally leaves the track in `TrackWaitForEvent` — the next event still finds it waiting.
+
+### 3.1 Alternatives considered
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| **A. Dedicated `eventMu` held across `ProcessEvent`** | Minimal; serializes the check+act; the reject path is correct for free (state untouched ⇒ still waiting) | A losing fire blocks briefly (µs) before being dropped | ✅ **chosen** |
+| B. Claimed-flag (`bool` guard + claim/release) | Loser fails fast (no block) | Needs an **explicit un-claim** on the `validateAndAssociate` reject path, or a rejected message wedges the waiter — extra state, easy to get wrong | ❌ rejected: more error-prone for no real gain |
+| C. Async event-consumer queue (route `ProcessEvent` through the instance loop / a per-instance event queue — single-writer, ADR-001-aligned) | Eliminates the **whole** waiter-goroutine race class, not just this site | Changes `PropagateEvent`'s **synchronous contract** — callers get the processing error / no-catcher no-op / `ErrRejected` inline today; a queue decouples that — a design change touching the waiter→track→loop flow | ❌ rejected for now: too big for a one-shot FIX → recorded as a follow-up ADR (§7) |
+
+**Critical implementation detail:** it MUST be a **new** mutex, **not** the existing `t.m`. `t.m` (a `sync.RWMutex`, `track` field at `:178`) is taken **inside** the method — the steps `RLock` at `:831` and again inside `advanceToArm`. Go mutexes are not reentrant, so holding `t.m` across the body would deadlock; reusing it would force gutting the inner locking. A separate `eventMu` is the surgical change.
+
+### 3.2 Changes by file
+
+#### §3.2.1 `internal/instance/track.go` — `eventMu` field + held critical section
+
+New field on `track` (placed next to the existing `m sync.RWMutex`):
+
+```go
+// eventMu serializes ProcessEvent on this track: one event is processed to
+// completion (guard → state transition) before the next is evaluated, so
+// concurrent fires at an Event-Based gateway can't both advance an arm
+// (FIX-007). Distinct from m (the steps lock, taken inside) — Go mutexes
+// aren't reentrant.
+eventMu sync.Mutex
+```
+
+`ProcessEvent` takes `eventMu` for the whole body:
+
+```go
+func (t *track) ProcessEvent(ctx context.Context, eDef flow.EventDefinition) error {
+	t.eventMu.Lock()
+	defer t.eventMu.Unlock()
+
+	if !t.inState(TrackWaitForEvent) {   // loser (2nd concurrent fire) lands here → dropped
+		return errs.New(errs.M("...doesn't expect any event"), ...)
+	}
+	// ... unchanged: steps read, validateAndAssociate, ep.ProcessEvent, advanceToArm, updateState ...
+}
+```
+
+No other production change. `validateAndAssociate`, `advanceToArm`, the gate, and the catch/receive paths are untouched.
+
+---
+
+## 4. Verification
+
+Current coverage: `TestEventGatewayConcurrentFires` (`event_gateway_internal_test.go:209`) exercises the race but wins it non-deterministically — it is not a reliable canary.
+
+### 4.1 Regression test (mandatory)
+
+Harden the canary so it reproduces the double-win **pre-fix** and is green **post-fix**.
+
+| Test | Setup | Assertion |
+|---|---|---|
+| `TestEventGatewayConcurrentFires` (or a new `TestEventGatewayConcurrentFiresStress`) | the same two-arm gate; fire both arms concurrently, **looped 200–1000 iterations** (a fresh instance per iteration) under `-race` | every iteration: exactly one arm wins (`ranA != ranB`); never a double-win |
+
+Run pre-fix (expect a failure within the loop) and post-fix (`go test ./internal/instance/ -run ConcurrentFires -race -count=1` green; also `-count=20`).
+
+### 4.5 Observability
+
+None needed — the loser already returns the existing "doesn't expect any event" error, which `broadcastSignal` ignores (best-effort delivery).
+
+---
+
+## 5. Prevention
+
+- Doc-comment on `ProcessEvent` stating the serialization invariant: **one event is processed to completion per track**, guarded by `eventMu`; concurrent fires at an Event-Based gateway are serialized so exactly one arm wins.
+- The §4.1 stress test is the named canary — if it falls, the serialization regressed.
+
+---
+
+## 6. Regressions / side-effects
+
+### 6.1 What may rely on the old behaviour
+
+`ProcessEvent` is the delivery path for **every** waited event — message/timer/signal intermediate catch, Receive Task, and the Event-Based gateway. Audit before landing:
+
+- **Deadlock:** confirm `eventMu` never nests with `t.m` or the instance loop in a cycle. `eventMu` is held across the body; `t.m` is taken *inside* (steps / `advanceToArm`) — strictly nested (eventMu ⊃ t.m), never the reverse, so no lock-order cycle. The loop never takes `eventMu`.
+- **Normal single-event paths** (catch, receive, gate first-fire) still work — `eventMu` is uncontended there.
+- **Correlation reject** (`validateAndAssociate` → `ErrRejected`) still leaves the track waiting (state untouched under the held lock).
+- The loser's "doesn't expect any event" error is already swallowed by `broadcastSignal` (best-effort) — no new error surfaces to callers.
+
+### 6.2 Rollback path
+
+Single-commit revert (the `eventMu` field + the lock placement + the test).
+
+---
+
+## 7. Related
+
+- **Promote-to-ADR candidate (follow-up):** Option C — an **async event-consumer / single-writer event delivery** model (route `ProcessEvent` through the instance loop or a per-instance event queue). It would eliminate the whole class of waiter-goroutine races and align event delivery with ADR-001 v.5's single-writer principle, at the cost of redesigning `PropagateEvent`'s synchronous contract (inline error / no-catcher no-op / `ErrRejected`). To be drafted as an ADR after this fix lands.
+- [SRD-024 v.1](../srd/SRD-024-event-based-gateway.md) — the Event-Based gateway whose deferred-choice invariant this protects.
+- [SRD-026 v.1](../srd/SRD-026-signal-events.md) — signals; concurrent broadcast delivery is what makes the race reachable in real use.
+- [ADR-001 v.5](../design/ADR-001-execution-model.md) — the single-writer execution model the §7 follow-up ADR would extend.
+
+---
+
+## 8. Implementation summary (stage-by-stage actual landings + deltas)
+
+> ⚠️ TODO: fill AFTER landing — stage commits, scope, tests, empirical deltas vs this §3 draft.
+
+## 9. Open questions
+
+- **None.**

--- a/docs/fix/FIX-007_event-gateway-concurrent-fire.md
+++ b/docs/fix/FIX-007_event-gateway-concurrent-fire.md
@@ -158,10 +158,11 @@ None needed — the deferred-choice loser-drop is now a Debug no-op (`signal del
 - **Correlation reject** (`validateAndAssociate` → `ErrRejected`) still leaves the track waiting (state untouched under the held lock).
 - The loser-drop now returns `eventproc.ErrRejected` (was an InvalidState error); the signal + message waiters treat it as a benign no-op, so no failure surfaces to callers.
 - **Timer-waiter note (follow-up, not in this FIX):** the timer waiter still treats *any* delivery error as a waiter failure (`WSFailed`), so a timer-arm loser-drop would mark the waiter failed. Pre-existing and rare — timer arms don't fire concurrently the way signals broadcast — so it's left unchanged to keep FIX-007 focused; aligning the timer waiter with the signal/message benign-`ErrRejected` handling is a small follow-up.
+- **Busy-wait yield (race-2 side-effect, fixed here):** the race-2 re-fetch moved `step := t.currentStep()` out of the `TrackWaitForEvent` busy-wait, removing the per-spin `t.m.RLock` that implicitly yielded — tightening the hot spin enough to starve the per-instance loop under `-race`, which **amplified a pre-existing ~1/100 `TestComplexAbortInstance` flake** (master flakes too, same rate) to ~7/100. A `runtime.Gosched()` in the spin's `continue` path restores master parity (~1/100) with no added latency. The residual ~1/100 is the poll-based `TrackWaitForEvent` wait anti-pattern itself — its proper cure is single-writer event delivery (ADR-017), not this FIX. The yield is correct regardless (a hot busy-wait should not starve the scheduler).
 
 ### 6.2 Rollback path
 
-Single-commit revert (the `eventMu` field + the lock placement + the test).
+Single-commit revert (the `eventMu` field, the `run()` re-fetch + `runtime.Gosched()` yield, the guard→`ErrRejected`, and the test).
 
 ---
 

--- a/docs/fix/FIX-007_event-gateway-concurrent-fire.md
+++ b/docs/fix/FIX-007_event-gateway-concurrent-fire.md
@@ -1,7 +1,7 @@
-# FIX-007 «Event-Based gateway double-win under concurrent fires»
+# FIX-007 «Event-Based gateway concurrent-fire races (double-win + gate self-execution)»
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft v.1 (2026-06-21, branch `fix/event-gate-concurrent-fire`, not yet implemented).
+**Status:** Accepted v.1 (2026-06-21, branch `fix/event-gate-concurrent-fire`, implemented).
 **Date:** 2026-06-21.
 **Author:** Ruslan Gabitov.
 **Branch:** `fix/event-gate-concurrent-fire` (the defect is a concurrent-fire race in the Event-Based gateway's deferred choice).
@@ -35,130 +35,115 @@ require.True(t, ranA != ranB, "exactly one arm wins")
 
 ## 2. Root cause analysis
 
-### 2.1 A TOCTOU in `track.ProcessEvent` (`internal/instance/track.go`)
+The flake is **two distinct concurrent-fire races** on the gate track, not one — the second was found during implementation (`eventMu` fixed the double-win but the canary still failed). Both stem from the gate track being mutated by a **waiter goroutine** (`ProcessEvent`) racing another goroutine: a second waiter (race 1), then the track's own `run()` (race 2).
 
-`ProcessEvent` guards on the track state, then much later transitions it — with no lock held across the two:
+### 2.1 Race 1 — double-win (waiter-vs-waiter): a TOCTOU in `track.ProcessEvent`
+
+An Event-Based gateway subscribes the hub on behalf of **all** its arms through a single gate track (SRD-024 v.1 §4.1) — the gate track is the one `EventProcessor` for every arm's definition. So two concurrent `eh.PropagateEvent` calls (`GO_A`, `GO_B`) become **two waiter goroutines** both invoking `ProcessEvent` on the **same** track. The method guards on the track state, then transitions it much later, with no lock across (`internal/instance/track.go`):
 
 ```go
-func (t *track) ProcessEvent(ctx context.Context, eDef flow.EventDefinition) error {
-	if !t.inState(TrackWaitForEvent) {          // :816  — lock-free guard (check)
-		return errs.New(errs.M("...doesn't expect any event"), ...)
-	}
-	...
-	if t.instance.validateAndAssociate(ctx, eDef) { // :847 — correlation reject (keeps waiting)
-		return eventproc.ErrRejected
-	}
-	if err := ep.ProcessEvent(ctx, eDef); err != nil { // :851 — bind + (gate) resolve the arm
-		return err
-	}
-	...
-	if er, ok := n.(eventRouter); ok {
-		t.advanceToArm(n, er, eDef)             // :868 — append the winning arm's step
-	}
-	t.updateState(TrackReady)                   // :871 — state finally leaves WaitForEvent (act)
-	return nil
+func (t *track) ProcessEvent(...) error {
+	if !t.inState(TrackWaitForEvent) { ... }     // :838 — guard (check)
+	... ep.ProcessEvent(...) ...                  // bind + (gate) resolve the arm
+	t.advanceToArm(n, er, eDef)                   // :889 — append the winning arm's step
+	t.updateState(TrackReady)                     // :892 — state leaves WaitForEvent (act)
 }
 ```
 
-The check is at `:816`; the state only changes at `:871`, **after** `advanceToArm`. The window `:816 → :871` is unprotected.
-
-### 2.2 Why two arms win
-
-An Event-Based gateway subscribes the hub on behalf of **all** its arms through a single gate track (SRD-024 v.1 §4.1) — the gate track is the one `EventProcessor` for every arm's definition. So two concurrent `eh.PropagateEvent` calls (here `GO_A` and `GO_B`) become **two waiter goroutines** both invoking `ProcessEvent` on the **same** gate track:
-
 ```
 goroutine A (GO_A)              goroutine B (GO_B)
-:816 inState(WaitForEvent)=true
-                                :816 inState(WaitForEvent)=true   ← both pass
-:868 advanceToArm(armA)
-                                :868 advanceToArm(armB)           ← both arms appended
-:871 updateState(Ready)
-                                :871 updateState(Ready)
+:838 inState(WaitForEvent)=true
+                                :838 inState(WaitForEvent)=true   ← both pass
+:889 advanceToArm(armA)
+                                :889 advanceToArm(armB)           ← both arms appended
 ```
 
-Both append an arm step → both arms run → `ranA && ranB` → the invariant breaks. The narrow window (state changes only at `:871`) is why it is rare.
+Both append an arm step → both arms run → `ranA && ranB`. The narrow window (state changes only at `:892`) is why it is rare. Signals make it reachable in real use: a broadcast (`broadcastSignal`, SRD-026) fans out by name and can deliver to two arms near-simultaneously.
 
-Signals make this reachable in real use, not just in a stress test: a signal broadcast (`broadcastSignal`, SRD-026) fans out to every catcher by name and can deliver to two arms of the same gate near-simultaneously.
+### 2.2 Race 2 — gate self-execution (waiter-vs-`run()`)
+
+Serializing `ProcessEvent` (race 1) was **necessary but not sufficient** — the stress canary still failed, now with the instance `Completed` but the winning arm short of its end (`arm=true, end=false`). A *different* goroutine pair: the waiter (`ProcessEvent`) vs the track's own `run()` loop, which captured the step **before** the wait-guard:
+
+```go
+for {
+	step := t.currentStep()                 // captured here — the GATE step
+	... if t.inState(TrackWaitForEvent) { continue } ...   // :443 — wait-guard
+	... executeNode(ctx, step) ...          // ran the stale captured step
+}
+```
+
+When `ProcessEvent` (waiter goroutine) flipped the state out of `WaitForEvent` and appended the arm step **mid-iteration**, `run()` fell through the `:443` guard but executed the **stale GATE step** — the gate node's `Exec` fails loudly ("the gate must not be executed", SRD-024) → `TrackFailed`, and the instance then silently completed with the arm short of its end. (That silent completion of a `TrackFailed` track is a *separate* latent bug — see §7 / FIX-008 / #165.)
 
 ### 2.3 Why the test didn't catch it earlier
 
-`TestEventGatewayConcurrentFires` exists but fires the two events exactly once per run — it exercises the race but only **non-deterministically** wins it, so it passed nearly always and did not reliably guard the invariant (§4.1 hardens it).
+`TestEventGatewayConcurrentFires` fired the two events exactly once per run — it exercised the races but only **non-deterministically** triggered them, so it passed nearly always and did not reliably guard the invariant. §4.1 adds a looped stress canary that reproduces both.
 
 ---
 
 ## 3. Solution
 
-Serialize event delivery to a track with a **dedicated per-track mutex** held across `ProcessEvent`'s critical section, so the first fire runs to completion (transitioning the state) before any second fire is evaluated. The loser then fails the `:816` guard (state is no longer `TrackWaitForEvent`) and is dropped.
+A two-part serialization fix plus a benign-drop tidy:
 
-The correlation-reject path needs **no special handling**: `validateAndAssociate` (`:847`) returning `ErrRejected` does not transition the state, so a wrong-conversation message naturally leaves the track in `TrackWaitForEvent` — the next event still finds it waiting.
+1. **`eventMu`** (race 1): a dedicated per-track mutex held across `ProcessEvent`'s critical section, so the first fire completes (transitioning the state) before any second fire is evaluated; the loser then fails the guard.
+2. **Re-fetch-after-guard** (race 2): `run()` reads the current step **after** the wait-guard, not before — once the track is no longer `WaitForEvent`, `advanceToArm` has appended the arm step, so `run()` runs the arm, never the stale gate step. `eventMu` alone did not fix this (a different goroutine pair); the re-fetch is the surgical fix for the waiter-vs-`run()` race.
+3. **Benign loser-drop**: the guard returns `eventproc.ErrRejected` (not an InvalidState error), and the signal waiter treats `ErrRejected` as a Debug no-op (mirroring the message waiter), so the normal deferred-choice drop no longer logs a misleading "delivery failed" WARN.
+
+The correlation-reject path (`validateAndAssociate` → `ErrRejected`) needs **no special handling**: it doesn't transition the state, so a wrong-conversation message naturally stays waiting.
 
 ### 3.1 Alternatives considered
 
 | Alternative | Pros | Cons | Decision |
 |---|---|---|---|
-| **A. Dedicated `eventMu` held across `ProcessEvent`** | Minimal; serializes the check+act; the reject path is correct for free (state untouched ⇒ still waiting) | A losing fire blocks briefly (µs) before being dropped | ✅ **chosen** |
-| B. Claimed-flag (`bool` guard + claim/release) | Loser fails fast (no block) | Needs an **explicit un-claim** on the `validateAndAssociate` reject path, or a rejected message wedges the waiter — extra state, easy to get wrong | ❌ rejected: more error-prone for no real gain |
-| C. Async event-consumer queue (route `ProcessEvent` through the instance loop / a per-instance event queue — single-writer, ADR-001-aligned) | Eliminates the **whole** waiter-goroutine race class, not just this site | Changes `PropagateEvent`'s **synchronous contract** — callers get the processing error / no-catcher no-op / `ErrRejected` inline today; a queue decouples that — a design change touching the waiter→track→loop flow | ❌ rejected for now: too big for a one-shot FIX → recorded as a follow-up ADR (§7) |
+| **A. `eventMu` + re-fetch-after-guard** | Surgical; serializes waiter-vs-waiter (`eventMu`) **and** fixes waiter-vs-`run()` (re-fetch); the reject path is correct for free | a losing fire blocks briefly (µs) | ✅ **chosen** |
+| B. Claimed-flag (`bool` guard + claim/release) | loser fails fast (no block) | needs an explicit un-claim on the reject path or the waiter wedges — extra state, error-prone | ❌ rejected |
+| C. Async event-consumer / single-writer event delivery (route `ProcessEvent` through the instance loop) | eliminates the **whole** waiter-goroutine race class (both races + future ones) | changes `PropagateEvent`'s **synchronous contract** (inline error / no-catcher no-op / `ErrRejected`) — a design change touching the waiter→track→loop flow | ❌ for now → ADR-017 (§7) |
 
-**Critical implementation detail:** it MUST be a **new** mutex, **not** the existing `t.m`. `t.m` (a `sync.RWMutex`, `track` field at `:178`) is taken **inside** the method — the steps `RLock` at `:831` and again inside `advanceToArm`. Go mutexes are not reentrant, so holding `t.m` across the body would deadlock; reusing it would force gutting the inner locking. A separate `eventMu` is the surgical change.
+`eventMu` **alone** (a per-site lock for race 1) was insufficient — race 2 (waiter-vs-`run()`) needed the re-fetch. Per-site fixes patch each site; the race *class* is what ADR-017 would close.
+
+**Critical detail:** `eventMu` MUST be a **new** mutex, not `t.m`. `t.m` (a `sync.RWMutex`) is taken **inside** `ProcessEvent` (the steps read; `advanceToArm`) — Go mutexes aren't reentrant, so holding `t.m` across the body would deadlock.
 
 ### 3.2 Changes by file
 
-#### §3.2.1 `internal/instance/track.go` — `eventMu` field + held critical section
+#### §3.2.1 `internal/instance/track.go`
 
-New field on `track` (placed next to the existing `m sync.RWMutex`):
+- **`eventMu sync.Mutex`** field on `track` (beside `m sync.RWMutex`), held as the first statement of `ProcessEvent` (`:835`). The guard's not-`WaitForEvent` case (`:838`) now returns `eventproc.ErrRejected` (benign drop) instead of an InvalidState error.
+- **`run()` re-fetch** (`:454`): `step := t.currentStep()` moved to **after** the wait-guard (`:443`), so it observes the advanced arm step rather than the stale gate step.
 
-```go
-// eventMu serializes ProcessEvent on this track: one event is processed to
-// completion (guard → state transition) before the next is evaluated, so
-// concurrent fires at an Event-Based gateway can't both advance an arm
-// (FIX-007). Distinct from m (the steps lock, taken inside) — Go mutexes
-// aren't reentrant.
-eventMu sync.Mutex
-```
+#### §3.2.2 `internal/eventproc/eventhub/waiters/signal.go`
 
-`ProcessEvent` takes `eventMu` for the whole body:
+The delivery loop treats `errors.Is(err, eventproc.ErrRejected)` (`:212`) as a Debug no-op ("signal delivery skipped: catcher not waiting", `:216`) and continues; other errors keep the existing `Warn` (`:223`). Mirrors the message waiter.
 
-```go
-func (t *track) ProcessEvent(ctx context.Context, eDef flow.EventDefinition) error {
-	t.eventMu.Lock()
-	defer t.eventMu.Unlock()
+#### §3.2.3 `internal/eventproc/eventhub/waiters/signal_test.go`
 
-	if !t.inState(TrackWaitForEvent) {   // loser (2nd concurrent fire) lands here → dropped
-		return errs.New(errs.M("...doesn't expect any event"), ...)
-	}
-	// ... unchanged: steps read, validateAndAssociate, ep.ProcessEvent, advanceToArm, updateState ...
-}
-```
+`TestSignalWaiterEdgeCases` extended with an `ErrRejected`-returning catcher (covers the benign branch).
 
-No other production change. `validateAndAssociate`, `advanceToArm`, the gate, and the catch/receive paths are untouched.
+(The timer waiter was **not** changed — see §6.)
 
 ---
 
 ## 4. Verification
 
-Current coverage: `TestEventGatewayConcurrentFires` (`event_gateway_internal_test.go:209`) exercises the race but wins it non-deterministically — it is not a reliable canary.
+`TestEventGatewayConcurrentFires` (`event_gateway_internal_test.go:210`) exercised the races non-deterministically — not a reliable canary.
 
-### 4.1 Regression test (mandatory)
+### 4.1 Regression tests
 
-Harden the canary so it reproduces the double-win **pre-fix** and is green **post-fix**.
+`TestEventGatewayConcurrentFiresStress` (`event_gateway_internal_test.go:247`): the two-arm gate, both arms fired concurrently, **looped 500× (a fresh instance per iteration)** under `-race`, asserting exactly one arm wins every iteration. It reproduces **both** races pre-fix (the double-win, then the gate-self-execution at iter ~354) and is green post-fix.
 
-| Test | Setup | Assertion |
-|---|---|---|
-| `TestEventGatewayConcurrentFires` (or a new `TestEventGatewayConcurrentFiresStress`) | the same two-arm gate; fire both arms concurrently, **looped 200–1000 iterations** (a fresh instance per iteration) under `-race` | every iteration: exactly one arm wins (`ranA != ranB`); never a double-win |
+`TestSignalWaiterEdgeCases` (`waiters/signal_test.go:95`) is extended with an `ErrRejected`-returning catcher — covers the benign-drop branch.
 
-Run pre-fix (expect a failure within the loop) and post-fix (`go test ./internal/instance/ -run ConcurrentFires -race -count=1` green; also `-count=20`).
+Post-fix: `go test ./internal/instance/ -run ConcurrentFires -race -count=8` green; `make ci` green.
 
 ### 4.5 Observability
 
-None needed — the loser already returns the existing "doesn't expect any event" error, which `broadcastSignal` ignores (best-effort delivery).
+None needed — the deferred-choice loser-drop is now a Debug no-op (`signal delivery skipped: catcher not waiting`), not a WARN.
 
 ---
 
 ## 5. Prevention
 
 - Doc-comment on `ProcessEvent` stating the serialization invariant: **one event is processed to completion per track**, guarded by `eventMu`; concurrent fires at an Event-Based gateway are serialized so exactly one arm wins.
-- The §4.1 stress test is the named canary — if it falls, the serialization regressed.
+- Doc-comment on the `run()` re-fetch: the step is read **after** the wait-guard so a gate advance landing mid-iteration is observed (never the stale gate step).
+- The §4.1 stress test is the named canary — if it falls, either the serialization or the re-fetch regressed.
 
 ---
 
@@ -171,7 +156,8 @@ None needed — the loser already returns the existing "doesn't expect any event
 - **Deadlock:** confirm `eventMu` never nests with `t.m` or the instance loop in a cycle. `eventMu` is held across the body; `t.m` is taken *inside* (steps / `advanceToArm`) — strictly nested (eventMu ⊃ t.m), never the reverse, so no lock-order cycle. The loop never takes `eventMu`.
 - **Normal single-event paths** (catch, receive, gate first-fire) still work — `eventMu` is uncontended there.
 - **Correlation reject** (`validateAndAssociate` → `ErrRejected`) still leaves the track waiting (state untouched under the held lock).
-- The loser's "doesn't expect any event" error is already swallowed by `broadcastSignal` (best-effort) — no new error surfaces to callers.
+- The loser-drop now returns `eventproc.ErrRejected` (was an InvalidState error); the signal + message waiters treat it as a benign no-op, so no failure surfaces to callers.
+- **Timer-waiter note (follow-up, not in this FIX):** the timer waiter still treats *any* delivery error as a waiter failure (`WSFailed`), so a timer-arm loser-drop would mark the waiter failed. Pre-existing and rare — timer arms don't fire concurrently the way signals broadcast — so it's left unchanged to keep FIX-007 focused; aligning the timer waiter with the signal/message benign-`ErrRejected` handling is a small follow-up.
 
 ### 6.2 Rollback path
 
@@ -181,7 +167,8 @@ Single-commit revert (the `eventMu` field + the lock placement + the test).
 
 ## 7. Related
 
-- **Promote-to-ADR candidate (follow-up):** Option C — an **async event-consumer / single-writer event delivery** model (route `ProcessEvent` through the instance loop or a per-instance event queue). It would eliminate the whole class of waiter-goroutine races and align event delivery with ADR-001 v.5's single-writer principle, at the cost of redesigning `PropagateEvent`'s synchronous contract (inline error / no-catcher no-op / `ErrRejected`). To be drafted as an ADR after this fix lands.
+- **Follow-up ADR — ADR-017 (single-writer event delivery):** route `ProcessEvent` through the instance loop / a per-instance event queue so a track is mutated only by its owner — eliminates the whole waiter-goroutine race class (both races here + future ones) and aligns with ADR-001 v.5's single-writer principle, at the cost of redesigning `PropagateEvent`'s synchronous contract (inline error / no-catcher no-op / `ErrRejected`). Drafted as a deferred conception after this fix lands.
+- **Sibling bug — FIX-008 / [#165](https://github.com/dr-dobermann/gobpm/issues/165):** a `TrackFailed` track silently completes the instance (`evEnded` → `active--` → `Completed`, `lastErr` lost) — found during this diagnosis (it masked race 2's failure as a silent partial completion). Latent in general; an independent surgical fix.
 - [SRD-024 v.1](../srd/SRD-024-event-based-gateway.md) — the Event-Based gateway whose deferred-choice invariant this protects.
 - [SRD-026 v.1](../srd/SRD-026-signal-events.md) — signals; concurrent broadcast delivery is what makes the race reachable in real use.
 - [ADR-001 v.5](../design/ADR-001-execution-model.md) — the single-writer execution model the §7 follow-up ADR would extend.
@@ -190,7 +177,27 @@ Single-commit revert (the `eventMu` field + the lock placement + the test).
 
 ## 8. Implementation summary (stage-by-stage actual landings + deltas)
 
-> ⚠️ TODO: fill AFTER landing — stage commits, scope, tests, empirical deltas vs this §3 draft.
+### 8.1 Stages by commit (branch `fix/event-gate-concurrent-fire`)
+
+| Stage | Commit | Scope | Tests |
+|---|---|---|---|
+| Doc | `8e44513` | FIX-007 (this doc, Draft) | — |
+| Fix | `97db6c4` | `track.go` (`eventMu` + `run()` re-fetch + guard→`ErrRejected`); `signal.go` (`ErrRejected`-benign delivery); `signal_test.go` (ErrRejected catcher); the stress canary | `TestEventGatewayConcurrentFiresStress`, `TestSignalWaiterEdgeCases` |
+
+The fix commit was amended once: an initial version also touched the timer waiter and had a per-package coverage gap; the timer change was reverted and the signal `ErrRejected` test added before landing.
+
+### 8.2 Empirical findings — where reality diverged from the §3 draft
+
+- **The RCA was incomplete: one race → two.** The draft (and #164) saw only the double-win (waiter-vs-waiter). `eventMu` fixed that, but the stress canary still failed — a second race (gate self-execution, waiter-vs-`run()`) surfaced, fixed by the `run()` re-fetch-after-guard. §2 now documents both.
+- **`eventMu` necessary-but-not-sufficient.** A per-site lock closes only its site; race 2 was a different goroutine pair — the evidence motivating ADR-017 (the race *class*).
+- **The feared "needs single-writer" turned out surgical.** Diagnosis suggested race 2 might only be cleanly fixable via the async event-consumer (ADR-017); the re-fetch fixed it surgically. ADR-017 remains architectural prevention, not a prerequisite.
+- **Timer-waiter consistency reverted.** An interim version also made the timer waiter treat `ErrRejected` benignly; it dragged in the timer waiter's untested `Process` path and wasn't the reported symptom, so it was reverted (the timer-arm benign-drop is a §6 follow-up).
+- **A sibling latent bug found.** The `TrackFailed`-silently-completes hole (§7, FIX-008 / #165) was discovered while diagnosing race 2 — it had masked race 2's failure as a silent partial completion.
+
+### 8.3 Verification (V-results)
+
+- `make ci` PASS: build, lint, `-race`, **diff-coverage 100% of 30 changed lines** (`track.go` 15/15, `signal.go` 15/15), govulncheck.
+- `TestEventGatewayConcurrentFiresStress` green under `-race -count=8` (4000 concurrent-fire iterations); reproduced both races pre-fix.
 
 ## 9. Open questions
 

--- a/internal/eventproc/eventhub/waiters/signal.go
+++ b/internal/eventproc/eventhub/waiters/signal.go
@@ -2,6 +2,7 @@ package waiters
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"slices"
 	"strings"
@@ -203,13 +204,27 @@ func (sw *signalWaiter) Process(eDef flow.EventDefinition) error {
 		"processors", len(processors))
 
 	for _, ep := range processors {
-		if err := ep.ProcessEvent(ctx, eDef); err != nil {
-			sw.rt.Logger().Warn("signal delivery to a catcher failed",
-				"waiter_id", sw.id,
-				"signal", sw.name,
-				"event_processor_id", ep.ID(),
-				"error", err.Error())
+		err := ep.ProcessEvent(ctx, eDef)
+		if err == nil {
+			continue
 		}
+
+		if errors.Is(err, eventproc.ErrRejected) {
+			// the catcher is no longer waiting (an already-fired / deferred-choice
+			// loser, or a correlation mismatch): a benign drop, not a delivery
+			// failure — broadcast reaches every catcher in range (FIX-007).
+			sw.rt.Logger().Debug("signal delivery skipped: catcher not waiting",
+				"waiter_id", sw.id, "signal", sw.name,
+				"event_processor_id", ep.ID())
+
+			continue
+		}
+
+		sw.rt.Logger().Warn("signal delivery to a catcher failed",
+			"waiter_id", sw.id,
+			"signal", sw.name,
+			"event_processor_id", ep.ID(),
+			"error", err.Error())
 	}
 
 	return nil

--- a/internal/eventproc/eventhub/waiters/signal_test.go
+++ b/internal/eventproc/eventhub/waiters/signal_test.go
@@ -122,6 +122,15 @@ func TestSignalWaiterEdgeCases(t *testing.T) {
 		Return(errors.New("boom")).Once()
 	require.NoError(t, w.AddEventProcessor(failEP))
 
+	// A catcher that rejects the broadcast (ErrRejected — already fired / not
+	// waiting, FIX-007) is a benign Debug no-op: Process skips it without a WARN
+	// and still delivers to the rest.
+	rejEP := mockeventproc.NewMockEventProcessor(t)
+	rejEP.EXPECT().ID().Return("rej").Maybe()
+	rejEP.EXPECT().ProcessEvent(mock.Anything, def).
+		Return(eventproc.ErrRejected).Once()
+	require.NoError(t, w.AddEventProcessor(rejEP))
+
 	ep.EXPECT().ProcessEvent(mock.Anything, def).Return(nil).Once()
 	require.NoError(t, w.Process(def))
 }

--- a/internal/instance/event_gateway_internal_test.go
+++ b/internal/instance/event_gateway_internal_test.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -236,4 +237,56 @@ func TestEventGatewayConcurrentFires(t *testing.T) {
 	ranA := v[armA.ID()] && v[endA.ID()]
 	ranB := v[armB.ID()] && v[endB.ID()]
 	require.True(t, ranA != ranB, "exactly one arm wins")
+}
+
+// TestEventGatewayConcurrentFiresStress is the FIX-007 canary: it loops the concurrent
+// two-arm fire many times so the deferred-choice "exactly one arm wins" invariant is
+// reliably exercised under -race. Pre-fix (the TOCTOU between the ProcessEvent state
+// guard and the state transition) it reproduces the double-win within the loop; post-fix
+// (the per-track eventMu serialization) every iteration wins exactly one arm.
+func TestEventGatewayConcurrentFiresStress(t *testing.T) {
+	_ = data.CreateDefaultStates()
+
+	const iterations = 500
+
+	for i := 0; i < iterations; i++ {
+		func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			p, nodes, defA, defB := ebGateProcess(
+				t, fmt.Sprintf("eb-stress-%d", i), "GO_A", "GO_B")
+			armA, endA, armB, endB := nodes[0], nodes[1], nodes[2], nodes[3]
+
+			inst, eh := startEventGate(t, ctx, p)
+
+			var wg sync.WaitGroup
+
+			wg.Add(2)
+
+			for _, d := range []flow.EventDefinition{defA, defB} {
+				go func(def flow.EventDefinition) {
+					defer wg.Done()
+
+					_ = eh.PropagateEvent(ctx, def)
+				}(d)
+			}
+
+			wg.Wait()
+			requireCompleted(t, inst)
+
+			// Exactly one arm's full path (arm + end) ran. Polled, so a history
+			// publish that lags the Completed flip settles rather than flaking; a
+			// genuine double-win (both paths) or stuck token (neither) never
+			// satisfies the XOR and times out.
+			require.Eventuallyf(t, func() bool {
+				v := visited(inst)
+				ranA := v[armA.ID()] && v[endA.ID()]
+				ranB := v[armB.ID()] && v[endB.ID()]
+
+				return ranA != ranB
+			}, 2*time.Second, 5*time.Millisecond,
+				"iteration %d: exactly one arm must win", i)
+		}()
+	}
 }

--- a/internal/instance/track.go
+++ b/internal/instance/track.go
@@ -174,10 +174,18 @@ type track struct {
 	// track's fate (survivor → proceed, merged → return). Buffered(1) so the
 	// loop never blocks on the signal. SRD-022.
 	parkCh chan struct{}
-	steps  []*stepInfo
-	m      sync.RWMutex
-	state  trackState
-	stopIt atomic.Bool
+	steps []*stepInfo
+	m     sync.RWMutex
+	// eventMu serializes ProcessEvent on this track: one event is processed to
+	// completion — the state guard through the WaitForEvent→Ready transition —
+	// before the next is evaluated, so concurrent fires at an Event-Based gateway
+	// (its single gate track is the EventProcessor for every arm) can't both pass
+	// the guard and both advance an arm (FIX-007). Distinct from m (taken inside
+	// ProcessEvent, via the steps read and advanceToArm) — Go mutexes aren't
+	// reentrant, so reusing m would deadlock.
+	eventMu sync.Mutex
+	state   trackState
+	stopIt  atomic.Bool
 }
 
 // record appends a track-state transition to the history, copy-on-write, and
@@ -418,8 +426,6 @@ func (t *track) run(
 	t.ctx = ctx
 
 	for {
-		step := t.currentStep()
-
 		select {
 		case <-ctx.Done():
 			t.updateState(TrackCanceled)
@@ -438,6 +444,14 @@ func (t *track) run(
 				continue
 			}
 		}
+
+		// Read the current step AFTER the wait-guard, not before it. An Event-Based
+		// gateway's ProcessEvent (on the waiter goroutine) appends the winning arm's
+		// step and then flips the state out of TrackWaitForEvent; capturing the step
+		// before the guard could execute the stale gate step (which fails loudly,
+		// SRD-024) when the flip lands mid-iteration. Reading here — once the track is
+		// no longer WaitForEvent — observes the advanced arm step (FIX-007).
+		step := t.currentStep()
 
 		// run while there is a step to take
 		if step.state != StepCreated {
@@ -813,13 +827,20 @@ func (t *track) ProcessEvent(
 	ctx context.Context,
 	eDef flow.EventDefinition,
 ) error {
+	// Serialize event delivery to this track (FIX-007): the first fire runs to
+	// completion — the WaitForEvent guard below through the WaitForEvent→Ready
+	// transition — before any concurrent second fire is evaluated, so two events
+	// reaching an Event-Based gateway's single gate track can't both advance an arm.
+	// The loser then fails the guard (state is no longer WaitForEvent) and is dropped.
+	t.eventMu.Lock()
+	defer t.eventMu.Unlock()
+
 	if !t.inState(TrackWaitForEvent) {
-		return errs.New(
-			errs.M("track #%s of instance #%s doesn't expect any event",
-				t.ID(), t.instance.ID()),
-			errs.C(errorClass, errs.InvalidState),
-			errs.D("event_trigger", string(eDef.Type())),
-			errs.D("event_definition_id", eDef.ID()))
+		// An event reaching a track that isn't waiting — the Event-Based gateway's
+		// deferred-choice loser (a second concurrent fire after the winner already
+		// advanced), or any stray late delivery — is a benign drop, not a failure.
+		// Return ErrRejected so the waiters treat it as a no-op (no WARN); FIX-007.
+		return eventproc.ErrRejected
 	}
 
 	if ctx == nil {

--- a/internal/instance/track.go
+++ b/internal/instance/track.go
@@ -39,6 +39,7 @@ package instance
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -441,6 +442,16 @@ func (t *track) run(
 			}
 
 			if t.inState(TrackWaitForEvent) {
+				// Yield: a track parked on the WaitForEvent busy-wait must not
+				// starve the per-instance loop (which drives reachability-join
+				// re-evaluation, abort, completion). Before FIX-007 the
+				// per-iteration currentStep() read (an RLock) implicitly yielded
+				// here; the re-fetch below moved it out of the spin, so yield
+				// explicitly. (The poll-based wait is a pre-existing anti-pattern
+				// — TestComplexAbortInstance flakes on master too — whose proper
+				// cure is the event-driven, single-writer delivery of ADR-017.)
+				runtime.Gosched()
+
 				continue
 			}
 		}


### PR DESCRIPTION
  Closes #164.

  Two concurrent-fire races violated the Event-Based gateway's deferred-choice "exactly one arm wins" invariant (surfaced as a CI flake):
  1. Double-win (waiter-vs-waiter) — both fires pass the wait-guard before either transitions → both arms advance. Fix: a per-track eventMu serializes ProcessEvent.
  2. Gate self-execution (waiter-vs-run(), found during implementation) — run() captured the step before the wait-guard, so it executed the stale gate node mid-transition → TrackFailed. Fix:
  re-read the step after the wait-guard.

  Plus the deferred-choice loser-drop is now benign (ErrRejected → the signal waiter Debug-skips it, no misleading WARN).

  Canary: TestEventGatewayConcurrentFiresStress (500× concurrent fire, -race) reproduces both pre-fix, green post-fix. diff-coverage 100%.

  Also lands ADR-017 (Draft) — single-writer event delivery: the architectural follow-up that would eliminate this whole foreign-goroutine race class by construction (the loop applies events;
  eventMu/re-fetch become unnecessary). Concept-first; implementation deferred to a future SRD.

  Follow-ups: #165 (FIX-008 — a latent TrackFailed-silently-completes bug, found during diagnosis); the ADR-017 implementing SRD.

  That closes out the chain: the signal-events slice exposed the gateway race → FIX-007 fixes it → ADR-017 records the principled cure. After you merge, the open threads are #165 (FIX-008) and the
  ADR-017 SRD whenever you want to pick them up.
