### PR TITLE
fix: surface a failed track as an instance failure (FIX-008)

### DIFF
--- a/docs/fix/FIX-008_failed-track-silent-completion.md
+++ b/docs/fix/FIX-008_failed-track-silent-completion.md
@@ -1,0 +1,204 @@
+# FIX-008 «A failed track silently completes the instance (track error lost)»
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft v.1 (2026-06-22, branch `fix/surface-failed-track`, not yet implemented).
+**Date:** 2026-06-22.
+**Author:** Ruslan Gabitov.
+**Branch:** `fix/surface-failed-track` (surface a `TrackFailed` track as an instance failure).
+**Tracking issue:** [#165](https://github.com/dr-dobermann/gobpm/issues/165) (bug).
+**Paired doc:** none (local to `internal/instance` loop lifecycle).
+**Upstream:** [FIX-007](FIX-007_event-gateway-concurrent-fire.md) / [#164](https://github.com/dr-dobermann/gobpm/issues/164) (its diagnosis found this hole — sideways FIX→FIX), [ADR-001 v.5](../design/ADR-001-execution-model.md) (the single-writer loop owns lifecycle state + `lastErr`), [ADR-017 v.1](../design/ADR-017-single-writer-event-delivery.md) (the broader single-writer direction).
+
+---
+
+## 1. Symptoms
+
+A track that ends in `TrackFailed` (its node's execution returned an error) is **not surfaced** to the instance. The instance can reach the terminal **`Completed`** state with **`lastErr == nil`** — the track's error is silently swallowed, and a host observing `WaitCompletion`/`State()` sees a clean completion for a process that actually failed mid-flight.
+
+There is no always-on reproduction on current `master`: the one path that drove a live track to `TrackFailed` was the FIX-007 gate-self-execution race, and FIX-007 closed it. The defect was **observed during the FIX-007 diagnosis** — the gate node executed out of turn, failed loudly (`TrackFailed`), and the instance completed with the winning arm short of its end and no error reported. The hole remains for **any future** `run()`-path node failure; §4.1 reproduces it deterministically with a node that errors on purpose.
+
+```
+instance: state=Completed  lastErr=nil   ;  a track ended TrackFailed, its error lost
+```
+
+---
+
+## 2. Root cause analysis
+
+### 2.1 The loop's spawn wrapper maps every non-AwaitingMerge end to `evEnded`
+
+`internal/instance/instance.go`, the per-track goroutine wrapper (`:639-644`):
+
+```go
+t.run(ctx)
+
+kind := evEnded
+if t.inState(TrackAwaitingMerge) {
+    kind = evAwaiting
+}
+inst.emit(trackEvent{kind: kind, track: t})
+```
+
+Only `TrackAwaitingMerge` is distinguished. A track that returned in **`TrackFailed`** (or `TrackCanceled`) is reported as a plain `evEnded`.
+
+### 2.2 The `evEnded` handler only decrements `active`
+
+The loop (`:692-693`):
+
+```go
+case evEnded:
+    active--
+    inst.recheckAwaitingJoins()
+```
+
+No failure check. So a `TrackFailed` track → `evEnded` → `active--` → when `active == 0` the loop falls through to the terminal decision (`:715-718`):
+
+```go
+if stopping {
+    inst.setState(Terminated)
+} else {
+    inst.setState(Completed)   // <- a failed track lands here: Completed, lastErr never set
+}
+```
+
+### 2.3 `run()` records the error on the *track*, but it never reaches the instance
+
+`run()` does set the track's own error on a node failure (`internal/instance/track.go`):
+
+```go
+nextFlows, err := t.executeNode(ctx, step)
+if err != nil {
+    t.lastErr = err
+    t.updateState(TrackFailed)
+    return
+}
+```
+
+But `t.lastErr` is a per-track field; nothing propagates it to `inst.lastErr` (`atomic.Pointer[error]`, `instance.go:96`). `inst.lastErr` is set only at `instance.go:733` (`spawnForks` build errors) and via `Instance.fail` (`activation.go:56`), neither of which is on the `run()` failure path.
+
+### 2.4 Contrast: the working failure path (`activation.go` `fail`)
+
+`Instance.fail` (`activation.go:56-65`) is exactly the surface-and-terminate the `run()` path is missing:
+
+```go
+func (inst *Instance) fail(err error) {
+    inst.Logger().Warn("instance failing", "instance", inst.ID(), "error", err)
+    inst.lastErr.Store(&err)
+    if inst.cancel != nil {
+        inst.cancel()           // ctx.Done -> the loop's stopAll() -> Terminated
+    }
+}
+```
+
+It records the error and cancels the instance ctx, which the loop's `case <-done: stopAll()` turns into `Terminated`. The `run()`-path `TrackFailed` simply never calls it.
+
+### 2.5 Why no test caught it
+
+The loop tests assert completion/termination but not "a failed track ⇒ instance failed with `lastErr`", and (until FIX-007's race) no exercised path drove a live track to `TrackFailed`. §4.1 adds the missing canary.
+
+---
+
+## 3. Solution
+
+Distinguish a failed track in the spawn wrapper and surface it through the **existing** `Instance.fail` path, so a `TrackFailed` track fails the instance (`Terminated` + `lastErr`) instead of silently completing it.
+
+There is no dedicated `Failed` instance state — the open vocabulary is `Created / Active / Completed / Terminating / Terminated` (`pkg/thresher/handle.go:145-149`). `Terminated` + a non-nil `lastErr` is already how an engine-detected fatal error is reported (the `activation.go` `fail` path), so this fix is consistent with it: a failed track yields `Terminated` with the track's error.
+
+### 3.1 Alternatives considered
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| **A. Distinct `evFailed` kind → `inst.fail(track err)` in the loop** | Reuses the existing surface-and-terminate (`fail`); keeps the kinds honest; one clear handler | A new `kind` value (small) | ✅ **chosen** |
+| B. Inline `if ev.track.inState(TrackFailed)` inside the `evEnded` case | No new kind | Conflates "ended" and "failed" in one case; the loop reads less clearly; easy to overlook | ❌ rejected |
+| C. Leave it | — | Silent data loss: a process that failed reports `Completed`/`lastErr=nil`. BPMN: an unhandled activity error must fault the process, not complete it. | ❌ rejected |
+
+### 3.2 Changes by file
+
+#### §3.2.1 `internal/instance/instance.go` — surface a failed track
+
+- Add an `evFailed` value to the track-event `kind` enum (beside `evEnded`/`evAwaiting`/`evMerged`/`evParked`/`evFork`).
+- Spawn wrapper (`:639-644`): classify a failed end:
+
+```go
+kind := evEnded
+switch {
+case t.inState(TrackAwaitingMerge):
+    kind = evAwaiting
+case t.inState(TrackFailed):
+    kind = evFailed
+}
+inst.emit(trackEvent{kind: kind, track: t})
+```
+
+- Loop: add `case evFailed:` — surface the track's error via the existing `fail`, then decrement:
+
+```go
+case evFailed:
+    inst.fail(ev.track.lastErr) // store lastErr + cancel -> stopAll -> Terminated
+    active--
+```
+
+`fail` runs only on the loop goroutine (its contract), and the `evFailed` case *is* the loop goroutine, so it stays the single writer of `lastErr`. `inst.cancel()` makes the next select iteration take `case <-done: stopAll()`, so the other live tracks are stopped and the loop ends `Terminated` (`:715`). A defensive non-nil guard wraps a `nil` `t.lastErr` (shouldn't happen — `run()` sets it before `TrackFailed`) in a generic "track failed" error so the instance still fails rather than completing.
+
+**`TrackCanceled` stays `evEnded`** — a canceled track only occurs during an already-in-progress terminate (ctx cancel / `stopAll`), where `stopping` is set and the instance is heading to `Terminated` anyway; re-failing it would be wrong (a deliberate cancel is not a fault).
+
+---
+
+## 4. Verification
+
+Current coverage: the loop's terminal-state tests cover `Completed` and ctx-cancel `Terminated`, but none asserts "a failed track ⇒ `Terminated` + `lastErr`".
+
+### 4.1 Regression tests (mandatory)
+
+**New:** `internal/instance/*_test.go` (in-package, alongside the existing loop tests).
+
+| Test | Setup | Assertion |
+|---|---|---|
+| `TestFailedTrackFailsInstance` | a process whose single node's `Exec` returns an error (a mock `exec.NodeExecutor` / a deliberately-failing ServiceTask) | the instance ends **`Terminated`** (not `Completed`); `inst.LastErr()` / `WaitCompletion`'s error is the node's error (not nil) |
+| `TestNormalCompletionUnaffected` (regression) | an ordinary process that runs clean | ends **`Completed`** with `lastErr == nil` — the `evFailed` path doesn't perturb the success case |
+
+Run under `-race`. (A multi-track variant — one track fails while another is live — confirms `stopAll` stops the sibling and the instance still ends `Terminated`; add if cheap.)
+
+### 4.5 Observability
+
+`Instance.fail` already logs `WARN instance failing … error=…`, so a surfaced track failure is visible in logs without new instrumentation.
+
+---
+
+## 5. Prevention
+
+- Doc-comment the spawn-wrapper classification and the `case evFailed:` handler: **a track that ends `TrackFailed` faults the instance (error surfaced via `fail`), it does not silently complete** — name `TestFailedTrackFailsInstance` as the canary.
+- The `evFailed` kind makes the loop's intent explicit, so a future reader won't reintroduce the "everything is `evEnded`" conflation.
+
+---
+
+## 6. Regressions / side-effects
+
+### 6.1 What may rely on the old behaviour
+
+- **Normal completion** (`evEnded` → `active--` → `Completed`) is unchanged — only `TrackFailed` is rerouted.
+- **`TrackCanceled`** stays `evEnded` — unchanged; canceled tracks during a terminate still just decrement, and the instance ends `Terminated` because `stopping` is already set.
+- **The `activation.go` `fail` path** (join/activation failures) is unchanged — this fix reuses the same `fail`, so both failure sources converge on one surfacing mechanism.
+- **No double-terminate:** `stopAll` is guarded by `if stopping { return }`, and `fail`→`cancel` is idempotent; a second failed track calling `fail` re-stores `lastErr` (last-writer) without re-terminating destructively.
+
+### 6.2 Rollback path
+
+Single-commit revert (the `evFailed` kind, the spawn-wrapper branch, the loop case, and the tests).
+
+---
+
+## 7. Related
+
+- [FIX-007](FIX-007_event-gateway-concurrent-fire.md) / [#164](https://github.com/dr-dobermann/gobpm/issues/164) — the diagnosis that surfaced this hole (it masked the gate-self-execution race as a silent partial completion). Sideways FIX→FIX.
+- [ADR-001 v.5](../design/ADR-001-execution-model.md) — the single-writer loop is the sole owner of instance lifecycle state and `lastErr`; this fix keeps `fail` on the loop goroutine. Up.
+- [ADR-017 v.1](../design/ADR-017-single-writer-event-delivery.md) — the broader single-writer direction; orthogonal to this fix but the same principle (one goroutine owns the instance's state). Sideways/up.
+
+---
+
+## 8. Implementation summary (stage-by-stage actual landings + deltas)
+
+> ⚠️ TODO: fill AFTER landing — stage commits, scope, tests, empirical deltas vs this §3 draft.
+
+## 9. Open questions
+
+- **None.** The terminal state is `Terminated` (+ `lastErr`): there is no `Failed` state in the open `InstanceState` vocabulary, and `Terminated` + `lastErr` is already the engine's fatal-error report (the `activation.go` `fail` path), so a failed track converges on it.

--- a/docs/fix/FIX-008_failed-track-silent-completion.md
+++ b/docs/fix/FIX-008_failed-track-silent-completion.md
@@ -1,7 +1,7 @@
 # FIX-008 «A failed track silently completes the instance (track error lost)»
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft v.1 (2026-06-22, branch `fix/surface-failed-track`, not yet implemented).
+**Status:** Accepted v.1 (2026-06-22, branch `fix/surface-failed-track`, implemented).
 **Date:** 2026-06-22.
 **Author:** Ruslan Gabitov.
 **Branch:** `fix/surface-failed-track` (surface a `TrackFailed` track as an instance failure).
@@ -114,31 +114,35 @@ There is no dedicated `Failed` instance state — the open vocabulary is `Create
 
 ### 3.2 Changes by file
 
-#### §3.2.1 `internal/instance/instance.go` — surface a failed track
+#### §3.2.1 `internal/instance/event.go` — the `evFailed` kind
 
-- Add an `evFailed` value to the track-event `kind` enum (beside `evEnded`/`evAwaiting`/`evMerged`/`evParked`/`evFork`).
-- Spawn wrapper (`:639-644`): classify a failed end:
+Add an `evFailed` value to the `trackEventKind` enum (beside `evEnded`/`evAwaiting`/`evMerged`/`evParked`/`evFork`) + its `String` case: a track whose `run()` returned in `TrackFailed` (its node execution errored).
 
-```go
-kind := evEnded
-switch {
-case t.inState(TrackAwaitingMerge):
-    kind = evAwaiting
-case t.inState(TrackFailed):
-    kind = evFailed
-}
-inst.emit(trackEvent{kind: kind, track: t})
-```
+#### §3.2.2 `internal/instance/instance.go` — classify + surface a failed track
 
-- Loop: add `case evFailed:` — surface the track's error via the existing `fail`, then decrement:
+Two helpers (extracted to keep `loop()` under the `gocyclo` limit, which the inline switch + new case would have exceeded):
+
+- **`trackEndKind(t)`** classifies a returned track — `TrackAwaitingMerge` → `evAwaiting`, **`TrackFailed` → `evFailed`**, else `evEnded`. The spawn wrapper (`:639`) calls it: `inst.emit(trackEvent{kind: trackEndKind(t), track: t})`.
+- **`failFromTrack(t, stopAll)`** surfaces the failure. The loop's new `case evFailed:` (`:706`) calls it, then `active--`:
 
 ```go
 case evFailed:
-    inst.fail(ev.track.lastErr) // store lastErr + cancel -> stopAll -> Terminated
+    inst.failFromTrack(ev.track, stopAll)
     active--
 ```
+```go
+func (inst *Instance) failFromTrack(t *track, stopAll func()) {
+    err := t.lastErr
+    if err == nil { // defensive: run() sets lastErr before TrackFailed
+        err = errs.New(errs.M("track %s failed", t.ID()),
+            errs.C(errorClass, errs.OperationFailed))
+    }
+    inst.fail(err) // store lastErr + cancel the instance ctx
+    stopAll()      // EXPLICIT — see below
+}
+```
 
-`fail` runs only on the loop goroutine (its contract), and the `evFailed` case *is* the loop goroutine, so it stays the single writer of `lastErr`. `inst.cancel()` makes the next select iteration take `case <-done: stopAll()`, so the other live tracks are stopped and the loop ends `Terminated` (`:715`). A defensive non-nil guard wraps a `nil` `t.lastErr` (shouldn't happen — `run()` sets it before `TrackFailed`) in a generic "track failed" error so the instance still fails rather than completing.
+**`stopAll()` must be called explicitly** — the draft assumed `inst.fail` (→ `cancel` → `<-done` → `stopAll`) would terminate, but that is wrong for the **last** track: `case evFailed: …; active--` drops `active` to 0, and the loop exits *before* the next `select` iteration can take `case <-done:`, so `stopping` stays false and the instance settles **`Completed`**, not `Terminated`. Calling `stopAll()` synchronously sets `Terminating`, so the loop ends `Terminated` (`:715`). `failFromTrack` runs on the loop goroutine (the `evFailed` case *is* the loop), preserving `fail`'s single-writer-of-`lastErr` contract. The defensive nil-guard wraps a `nil` `t.lastErr` (shouldn't happen — `run()` sets it before `TrackFailed`) so the instance still fails rather than completing.
 
 **`TrackCanceled` stays `evEnded`** — a canceled track only occurs during an already-in-progress terminate (ctx cancel / `stopAll`), where `stopping` is set and the instance is heading to `Terminated` anyway; re-failing it would be wrong (a deliberate cancel is not a fault).
 
@@ -150,14 +154,15 @@ Current coverage: the loop's terminal-state tests cover `Completed` and ctx-canc
 
 ### 4.1 Regression tests (mandatory)
 
-**New:** `internal/instance/*_test.go` (in-package, alongside the existing loop tests).
+**New:** `internal/instance/failed_track_test.go` (external `package instance_test`) + `failed_track_internal_test.go` (in-package, for the nil-guard).
 
 | Test | Setup | Assertion |
 |---|---|---|
-| `TestFailedTrackFailsInstance` | a process whose single node's `Exec` returns an error (a mock `exec.NodeExecutor` / a deliberately-failing ServiceTask) | the instance ends **`Terminated`** (not `Completed`); `inst.LastErr()` / `WaitCompletion`'s error is the node's error (not nil) |
+| `TestFailedTrackFailsInstance` | a process whose node's `Exec` returns an error | the instance ends **`Terminated`** (not `Completed`); `inst.LastErr()` is the node's error (not nil) |
 | `TestNormalCompletionUnaffected` (regression) | an ordinary process that runs clean | ends **`Completed`** with `lastErr == nil` — the `evFailed` path doesn't perturb the success case |
+| `TestFailFromTrackNilErr` (in-package) | `failFromTrack` with a track carrying a `nil` `lastErr` | the defensive guard substitutes a generic "track failed" error; the instance still fails (no nil deref, not `Completed`) |
 
-Run under `-race`. (A multi-track variant — one track fails while another is live — confirms `stopAll` stops the sibling and the instance still ends `Terminated`; add if cheap.)
+Run under `-race`. (A multi-track variant — one track fails while another is live — confirms `stopAll` stops the sibling and the instance still ends `Terminated`.)
 
 ### 4.5 Observability
 
@@ -180,6 +185,7 @@ Run under `-race`. (A multi-track variant — one track fails while another is l
 - **`TrackCanceled`** stays `evEnded` — unchanged; canceled tracks during a terminate still just decrement, and the instance ends `Terminated` because `stopping` is already set.
 - **The `activation.go` `fail` path** (join/activation failures) is unchanged — this fix reuses the same `fail`, so both failure sources converge on one surfacing mechanism.
 - **No double-terminate:** `stopAll` is guarded by `if stopping { return }`, and `fail`→`cancel` is idempotent; a second failed track calling `fail` re-stores `lastErr` (last-writer) without re-terminating destructively.
+- **A pre-existing test relied on the bug — `TestCloneRaceTwoInstances`.** Its `ServiceTask` used an operation with **no implementation**, which errored on every run — silently `Completed` pre-fix. FIX-008 correctly surfaced it (→ `Terminated`), breaking the test's `Eventually(Completed)` / `NoError(LastErr)` assertions (master passed; the FIX-008 branch failed, reproducible in isolation). The test's intent is the clone data-race (per-instance node graphs, no shared mutation), not task failure, so its op was replaced with a succeeding `gooper` no-op. This is exactly the masked-failure class this fix targets — a real validation, not a workaround.
 
 ### 6.2 Rollback path
 
@@ -197,7 +203,24 @@ Single-commit revert (the `evFailed` kind, the spawn-wrapper branch, the loop ca
 
 ## 8. Implementation summary (stage-by-stage actual landings + deltas)
 
-> ⚠️ TODO: fill AFTER landing — stage commits, scope, tests, empirical deltas vs this §3 draft.
+### 8.1 Stages by commit (branch `fix/surface-failed-track`)
+
+| Stage | Commit | Scope | Tests |
+|---|---|---|---|
+| Doc | `58c0c98` | FIX-008 (this doc, Draft) | — |
+| Fix | `0cf6442` | `event.go` (`evFailed` kind + `String`); `instance.go` (`trackEndKind` + `failFromTrack` helpers, the `case evFailed:`); `clone_race_test.go` (bug-reliant op replaced) | `TestFailedTrackFailsInstance`, `TestNormalCompletionUnaffected`, `TestFailFromTrackNilErr` |
+
+### 8.2 Empirical findings — where reality diverged from the §3 draft
+
+- **`stopAll()` must be explicit (§3.2 corrected).** The draft assumed `inst.fail` (→ `cancel` → `<-done` → `stopAll`) would terminate; for the **last** track `active` hits 0 and the loop exits *before* `<-done` is selected, settling `Completed`. `failFromTrack` now calls `stopAll()` synchronously → `Terminated`.
+- **A pre-existing test relied on the bug** (`TestCloneRaceTwoInstances`, §6.1) — its no-implementation op errored every run and silently `Completed`; FIX-008 surfaced it, so the test was given a succeeding no-op op. A direct validation of the fix.
+- **`gocyclo` extraction.** The inline spawn-switch + the new `case evFailed:` pushed `loop()` over the `gocyclo` limit; extracting `trackEndKind`/`failFromTrack` brings it back under.
+
+### 8.3 Verification (V-results)
+
+- `make ci` PASS: build, lint, `-race`, diff-coverage **100% of 25 changed lines**, govulncheck.
+- Touched funcs `trackEndKind` / `failFromTrack` / `String` (the `evFailed` case) → 100%.
+- Full `internal/instance/ -race` green (incl. Complex + clone-race + the new tests); `FailedTrack|NormalCompletion|CloneRace` `-race -count=10` green.
 
 ## 9. Open questions
 

--- a/internal/instance/clone_race_test.go
+++ b/internal/instance/clone_race_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/dr-dobermann/gobpm/pkg/model/process"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/model/service/gooper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,10 +32,19 @@ func buildPlainSnapshot(t *testing.T) *snapshot.Snapshot {
 	start, err := events.NewStartEvent("start")
 	require.NoError(t, err)
 
+	// A working (no-op) operation so the node executes per-instance — exercising
+	// the clone-race — and the instances complete cleanly. (A no-implementation
+	// operation would fault the track and, since FIX-008, terminate the instance.)
+	op, err := gooper.New("noop",
+		func(_ context.Context, _ service.DataReader,
+			_ *data.ItemDefinition,
+		) (*data.ItemDefinition, error) {
+			return nil, nil
+		})
+	require.NoError(t, err)
+
 	task, err := activities.NewServiceTask(
-		"task1",
-		service.MustOperation("op", nil, nil, nil),
-		activities.WithoutParams())
+		"task1", op, activities.WithoutParams())
 	require.NoError(t, err)
 
 	end, err := events.NewEndEvent("end")

--- a/internal/instance/event.go
+++ b/internal/instance/event.go
@@ -41,6 +41,9 @@ func (k trackEventKind) String() string {
 	case evParked:
 		return "parked"
 
+	case evFailed:
+		return "failed"
+
 	default:
 		return "unknown"
 	}
@@ -62,4 +65,9 @@ const (
 	// decremented from the active count; the loop rechecks the join and may signal
 	// the track to resume (survivor) or return (merged). SRD-022.
 	evParked
+	// evFailed: a track's run() returned in TrackFailed (its node execution errored).
+	// The loop surfaces the track's error as an instance failure (lastErr + terminate
+	// via Instance.fail) instead of treating it as a plain evEnded that would let the
+	// instance complete silently. FIX-008.
+	evFailed
 )

--- a/internal/instance/failed_track_internal_test.go
+++ b/internal/instance/failed_track_internal_test.go
@@ -1,0 +1,33 @@
+package instance
+
+import (
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/internal/enginert"
+	"github.com/dr-dobermann/gobpm/internal/scope"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFailFromTrackNilErr covers failFromTrack's defensive nil-guard: a
+// TrackFailed track with no recorded error must still fault the instance with a
+// synthesized error, never store a nil — which would re-open the silent-completion
+// hole FIX-008 closes. run() always sets lastErr before TrackFailed, so this
+// branch is unreachable through normal execution and is exercised directly here.
+func TestFailFromTrackNilErr(t *testing.T) {
+	_ = data.CreateDefaultStates()
+
+	s := buildPlainSnapshot(t)
+
+	inst, err := New(s, scope.EmptyDataPath, enginert.Default(),
+		mockeventproc.NewMockEventProducer(t), nil)
+	require.NoError(t, err)
+
+	tr := &track{instance: inst} // lastErr == nil
+
+	inst.failFromTrack(tr, func() {}) // stopAll is a no-op for this unit test
+
+	require.Error(t, inst.LastErr(),
+		"a nil track error must be synthesized, not stored as nil")
+}

--- a/internal/instance/failed_track_test.go
+++ b/internal/instance/failed_track_test.go
@@ -1,0 +1,160 @@
+package instance_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/internal/enginert"
+	"github.com/dr-dobermann/gobpm/internal/instance"
+	"github.com/dr-dobermann/gobpm/internal/instance/snapshot"
+	"github.com/dr-dobermann/gobpm/internal/scope"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/model/service/gooper"
+	"github.com/stretchr/testify/require"
+)
+
+// errFailNode is returned by the failing ServiceTask's operation: an undeclared
+// execution error (not in the op's WithErrors), so it faults the track.
+var errFailNode = errors.New("boom: failing node exec")
+
+// failingSnapshot builds start → ServiceTask(op returns errFailNode) → end. The
+// op's error surfaces from run()'s executeNode, leaving the track TrackFailed —
+// the FIX-008 canary (a node failure must fault the instance, not complete it).
+func failingSnapshot(pname string) (*snapshot.Snapshot, error) {
+	p, err := process.New(pname,
+		data.WithProperties(
+			data.MustProperty(
+				"user_name",
+				data.MustItemDefinition(
+					values.NewVariable("Dr. Dobermann"),
+					foundation.WithID("user_name")),
+				data.ReadyDataState)))
+	if err != nil {
+		return nil, err
+	}
+
+	start, err := events.NewStartEvent("start")
+	if err != nil {
+		return nil, err
+	}
+
+	op, err := gooper.New(
+		"failing op",
+		func(_ context.Context, _ service.DataReader,
+			_ *data.ItemDefinition,
+		) (*data.ItemDefinition, error) {
+			return nil, errFailNode
+		},
+		gooper.WithInMessage(
+			bpmncommon.MustMessage(
+				"user_name",
+				data.MustItemDefinition(
+					values.NewVariable(""),
+					foundation.WithID("user_name")))),
+		gooper.WithErrors(errs.ObjectNotFound, errs.EmptyNotAllowed))
+	if err != nil {
+		return nil, err
+	}
+
+	task, err := activities.NewServiceTask(
+		"Failing Task", op, activities.WithoutParams())
+	if err != nil {
+		return nil, err
+	}
+
+	end, err := events.NewEndEvent("end")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, fe := range []flow.Element{start, task, end} {
+		if err := p.Add(fe); err != nil {
+			return nil, err
+		}
+	}
+
+	for _, l := range []struct {
+		src flow.SequenceSource
+		trg flow.SequenceTarget
+	}{
+		{start, task},
+		{task, end},
+	} {
+		if _, err := flow.Link(l.src, l.trg); err != nil {
+			return nil, err
+		}
+	}
+
+	return snapshot.New(p)
+}
+
+// TestFailedTrackFailsInstance is the FIX-008 canary: a track whose node Exec
+// errors must FAIL the instance (Terminated + LastErr surfaced), not silently
+// reach Completed with lastErr=nil.
+func TestFailedTrackFailsInstance(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	s, err := failingSnapshot("fail-track")
+	require.NoError(t, err)
+
+	ep := mockeventproc.NewMockEventProducer(t)
+
+	inst, err := instance.New(
+		s, scope.EmptyDataPath, enginert.Default(), ep, nil)
+	require.NoError(t, err)
+
+	ctx, cc := context.WithCancel(context.Background())
+	defer cc()
+	require.NoError(t, inst.Run(ctx))
+
+	select {
+	case <-inst.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("instance did not finish")
+	}
+
+	require.Equal(t, instance.Terminated, inst.State(),
+		"a failed track must terminate the instance, not complete it")
+	require.Error(t, inst.LastErr(),
+		"the failed track's error must be surfaced on the instance")
+}
+
+// TestNormalCompletionUnaffected confirms the evFailed path doesn't perturb a
+// clean run: an ordinary process still reaches Completed with no error.
+func TestNormalCompletionUnaffected(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	s, err := getSnapshot("clean")
+	require.NoError(t, err)
+
+	ep := mockeventproc.NewMockEventProducer(t)
+
+	inst, err := instance.New(
+		s, scope.EmptyDataPath, enginert.Default(), ep, nil)
+	require.NoError(t, err)
+
+	ctx, cc := context.WithCancel(context.Background())
+	defer cc()
+	require.NoError(t, inst.Run(ctx))
+
+	select {
+	case <-inst.Done():
+	case <-time.After(3 * time.Second):
+		t.Fatal("instance did not finish")
+	}
+
+	require.Equal(t, instance.Completed, inst.State())
+	require.NoError(t, inst.LastErr())
+}

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -636,12 +636,7 @@ func (inst *Instance) loop(ctx context.Context, initial []*track) {
 		go func(t *track) {
 			t.run(ctx)
 
-			kind := evEnded
-			if t.inState(TrackAwaitingMerge) {
-				kind = evAwaiting
-			}
-
-			inst.emit(trackEvent{kind: kind, track: t})
+			inst.emit(trackEvent{kind: trackEndKind(t), track: t})
 		}(t)
 	}
 
@@ -707,6 +702,12 @@ func (inst *Instance) loop(ctx context.Context, initial []*track) {
 				// the track blocked at a reachability join — its goroutine is
 				// alive, so active is unchanged.
 				inst.recheckParked(ev.track)
+
+			case evFailed:
+				// a node error faulted the track — surface it as an instance failure
+				// and terminate, rather than letting it complete silently (FIX-008).
+				inst.failFromTrack(ev.track, stopAll)
+				active--
 			}
 		}
 	}
@@ -716,6 +717,42 @@ func (inst *Instance) loop(ctx context.Context, initial []*track) {
 	} else {
 		inst.setState(Completed)
 	}
+}
+
+// trackEndKind classifies a track that returned from run() into the loop event
+// kind: evAwaiting if it parked at a synchronizing join, evFailed if a node error
+// left it TrackFailed (so the loop faults the instance — FIX-008), else the normal
+// evEnded.
+func trackEndKind(t *track) trackEventKind {
+	switch {
+	case t.inState(TrackAwaitingMerge):
+		return evAwaiting
+
+	case t.inState(TrackFailed):
+		return evFailed
+
+	default:
+		return evEnded
+	}
+}
+
+// failFromTrack surfaces a TrackFailed track's error as an instance failure: it
+// records lastErr via Instance.fail (which also cancels the ctx so sibling tracks
+// stop) and calls stopAll so the Terminating flag is set synchronously. When this
+// is the last active track the ctx cancel alone would race the active--→loop-exit
+// and the instance would settle on Completed instead of Terminated; stopAll makes
+// the terminal state deterministic. Runs on the loop goroutine, the single writer
+// of lastErr (FIX-008).
+func (inst *Instance) failFromTrack(t *track, stopAll func()) {
+	err := t.lastErr
+	if err == nil {
+		err = errs.New(
+			errs.M("track %s failed", t.ID()),
+			errs.C(errorClass, errs.OperationFailed))
+	}
+
+	inst.fail(err)
+	stopAll()
 }
 
 // spawnForks builds and spawns one track per extra forked outgoing flow, runs


### PR DESCRIPTION
Closes #165.

A track that ends in TrackFailed (its node's Exec returned an error) was reported by the instance loop's spawn wrapper as a plain evEnded → active-- → the instance settled Completed with lastErr
== nil. The track's error was silently swallowed: a host observing WaitCompletion/State() saw a clean completion for a process that actually faulted mid-flight. Found during the FIX-007 diagnosis
(it masked the gate-self-execution race as a silent partial completion).

Fix

- New evFailed track-event kind (internal/instance/event.go).
- instance.go: trackEndKind(t) classifies a returned track (AwaitingMerge→evAwaiting, TrackFailed→evFailed, else evEnded); the loop's new case evFailed: surfaces the track's error via the
existing Instance.fail and stops the instance → Terminated + lastErr (mirroring the activation-time failure path; both failure sources now converge on fail). TrackCanceled stays evEnded (a
deliberate cancel isn't a fault). The trackEndKind/failFromTrack extraction also keeps loop() under gocyclo.
- failFromTrack calls stopAll() explicitly — fail→cancel→<-done does not terminate the last track (active hits 0 and the loop exits before <-done is selected, settling Completed); the explicit
stopAll forces Terminating→Terminated.
- No dedicated Failed instance state exists; Terminated + lastErr is the engine's established fatal-error report.

Validation (the fix caught a real masked failure)

TestCloneRaceTwoInstances used a ServiceTask whose operation had no implementation — it errored every run and silently Completed pre-fix. FIX-008 correctly surfaced it (→ Terminated), so its op
was made a succeeding no-op. Exactly the masked-failure class this fix targets.

Verification

- make ci PASS; diff-coverage 100% (event.go 2/2, instance.go 23/23); touched funcs trackEndKind/failFromTrack 100%.
- Tests (-race): TestFailedTrackFailsInstance (failing node → Terminated + lastErr), TestNormalCompletionUnaffected (clean → Completed), TestFailFromTrackNilErr (nil-guard).

▎ CI note: if the run reds only on TestComplexRequiredGate ("activation rule unsatisfiable"), that's a pre-existing Complex-gateway flake (~5-7% under -race; master 7/100 vs this branch 5/100 —
▎ parity), not this change — re-run. A dedicated Complex-gateway determinism fix (FIX-009) is the follow-up for it.
