### PR TITLE
test: clear the sub-80% coverage backlog (model packages)

### DIFF
--- a/pkg/model/flow/element_test.go
+++ b/pkg/model/flow/element_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,4 +14,48 @@ func TestElementTypes(t *testing.T) {
 	require.Error(t, flow.ElementType("unknown_type").Validate())
 	require.NoError(t, flow.NodeElement.Validate())
 	require.Error(t, flow.ValidateNodeTypes(flow.ActivityNodeType, flow.EventNodeType, "unknown_typw"))
+}
+
+func TestBaseElementBindUnbind(t *testing.T) {
+	be, err := flow.NewBaseElement("be")
+	require.NoError(t, err)
+
+	procA, err := process.New("procA")
+	require.NoError(t, err)
+	procB, err := process.New("procB")
+	require.NoError(t, err)
+
+	// a nil container is rejected.
+	require.Error(t, be.BindTo(nil))
+	require.Nil(t, be.Container())
+
+	// binding succeeds and is reflected by Container().
+	require.NoError(t, be.BindTo(procA))
+	require.Equal(t, procA.ID(), be.Container().ID())
+
+	// re-binding to the same container is a no-op success.
+	require.NoError(t, be.BindTo(procA))
+
+	// binding to a different container is rejected.
+	require.Error(t, be.BindTo(procB))
+
+	// unbinding succeeds; a second unbind fails (no container left).
+	require.NoError(t, be.Unbind())
+	require.Nil(t, be.Container())
+	require.Error(t, be.Unbind())
+}
+
+func TestBaseElementETypePanics(t *testing.T) {
+	be, err := flow.NewBaseElement("be")
+	require.NoError(t, err)
+
+	// EType has no meaning on a generic BaseElement — each concrete element
+	// implements its own; the generic one panics.
+	require.Panics(t, func() { _ = be.EType() })
+}
+
+func TestNewBaseElementError(t *testing.T) {
+	// a failing base option (empty explicit id) is propagated.
+	_, err := flow.NewBaseElement("be", foundation.WithID("  "))
+	require.Error(t, err)
 }

--- a/pkg/model/flow/node_test.go
+++ b/pkg/model/flow/node_test.go
@@ -6,9 +6,32 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/events"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 	"github.com/dr-dobermann/gobpm/pkg/model/gateways"
 	"github.com/stretchr/testify/require"
 )
+
+func TestBaseNodeGenericPanics(t *testing.T) {
+	bn, err := flow.NewBaseNode("bn")
+	require.NoError(t, err)
+
+	// Node and NodeType are abstract on a generic BaseNode — each concrete node
+	// type implements its own; the generic ones panic.
+	require.Panics(t, func() { _ = bn.Node() })
+	require.Panics(t, func() { _ = bn.NodeType() })
+}
+
+func TestBaseNodeEType(t *testing.T) {
+	bn, err := flow.NewBaseNode("bn")
+	require.NoError(t, err)
+	require.Equal(t, flow.NodeElement, bn.EType())
+}
+
+func TestNewBaseNodeError(t *testing.T) {
+	// a failing base option (empty explicit id) is propagated.
+	_, err := flow.NewBaseNode("bn", foundation.WithID("  "))
+	require.Error(t, err)
+}
 
 // TestBaseNodeFlowOrder guards FIX-005: Incoming()/Outgoing() return flows in
 // declaration order (not the randomized map order they used to), so the gateway

--- a/pkg/model/flow/sequenceflow_options_internal_test.go
+++ b/pkg/model/flow/sequenceflow_options_internal_test.go
@@ -1,0 +1,27 @@
+package flow
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// foreignConfig is an options.Configurator that is not *sflowConfig, used to
+// drive sflowOption.Apply down its type-casting error branch.
+type foreignConfig struct{}
+
+func (foreignConfig) Validate() error { return nil }
+
+func TestSflowOptionApply(t *testing.T) {
+	var opt sflowOption = func(*sflowConfig) error { return nil }
+
+	// the matching configurator runs the closure.
+	require.NoError(t, opt.Apply(&sflowConfig{}))
+
+	// a foreign configurator is rejected with a type-casting error.
+	require.Error(t, opt.Apply(foreignConfig{}))
+}
+
+func TestSflowConfigValidate(t *testing.T) {
+	require.NoError(t, (&sflowConfig{}).Validate())
+}

--- a/pkg/model/flow/sequenceflow_test.go
+++ b/pkg/model/flow/sequenceflow_test.go
@@ -8,9 +8,42 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 	"github.com/dr-dobermann/gobpm/pkg/model/options"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSequenceFlowEType(t *testing.T) {
+	se, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+	ee, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	sf, err := flow.Link(se, ee)
+	require.NoError(t, err)
+	require.Equal(t, flow.SequenceBaseElement, sf.EType())
+}
+
+// TestSequenceFlowContainerMismatch drives connect → checkConnections →
+// SequenceFlow.Validate down its error branch: the source belongs to a process
+// while the target belongs to none, so the endpoints are not in the same (or a
+// uniformly nil) container. It also exercises getContainerID on both a non-nil
+// container (the source's) and a nil one (the target's).
+func TestSequenceFlowContainerMismatch(t *testing.T) {
+	se, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+	ee, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	proc, err := process.New("proc")
+	require.NoError(t, err)
+
+	// source bound to proc, target left unbound → container mismatch.
+	require.NoError(t, proc.Add(se))
+
+	_, err = flow.Link(se, ee)
+	require.Error(t, err)
+}
 
 func TestSequenceFlow(t *testing.T) {
 	se, err := events.NewStartEvent("start")
@@ -47,6 +80,10 @@ func TestSequenceFlow(t *testing.T) {
 			require.Error(t, err)
 
 			_, err = flow.Link(se, st1, activities.WithStartQuantity(1))
+			require.Error(t, err)
+
+			// a failing base option propagates out of the flow's BaseElement build.
+			_, err = flow.Link(se, st1, foundation.WithID("  "))
 			require.Error(t, err)
 		})
 

--- a/pkg/model/foundation/base_test.go
+++ b/pkg/model/foundation/base_test.go
@@ -40,3 +40,22 @@ func TestBaseElement(t *testing.T) {
 			require.Equal(t, "text/rtf", docs[1].Format())
 		})
 }
+
+// foreignConfig is an options.Configurator that is not *baseConfig, used to
+// drive BaseOption.Apply down its type-casting error branch.
+type foreignConfig struct{}
+
+func (foreignConfig) Validate() error { return nil }
+
+func TestMustBaseElementPanics(t *testing.T) {
+	// a failing option (blank explicit id) makes the Must form panic.
+	require.Panics(t, func() {
+		_ = foundation.MustBaseElement(foundation.WithID("  "))
+	})
+}
+
+func TestBaseOptionApplyForeignConfig(t *testing.T) {
+	bo, ok := foundation.WithID("x").(foundation.BaseOption)
+	require.True(t, ok)
+	require.Error(t, bo.Apply(foreignConfig{}))
+}

--- a/pkg/model/foundation/id_test.go
+++ b/pkg/model/foundation/id_test.go
@@ -1,0 +1,19 @@
+package foundation_test
+
+import (
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/stretchr/testify/require"
+)
+
+func TestID(t *testing.T) {
+	// NewID always yields a non-empty generated identifier.
+	require.NotEmpty(t, foundation.NewID().ID())
+
+	// NewIdentifyer keeps a provided identifier verbatim.
+	require.Equal(t, "given-id", foundation.NewIdentifyer("given-id").ID())
+
+	// NewIdentifyer generates one when the identifier is blank.
+	require.NotEmpty(t, foundation.NewIdentifyer("   ").ID())
+}

--- a/pkg/model/foundation/options_internal_test.go
+++ b/pkg/model/foundation/options_internal_test.go
@@ -1,0 +1,13 @@
+package foundation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBaseConfigValidate covers baseConfig.Validate, which is only reachable
+// from inside the package (the type is unexported).
+func TestBaseConfigValidate(t *testing.T) {
+	require.NoError(t, (&baseConfig{}).Validate())
+}

--- a/pkg/model/hinteraction/resources_test.go
+++ b/pkg/model/hinteraction/resources_test.go
@@ -1,0 +1,68 @@
+package hinteraction_test
+
+import (
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/hinteraction"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewResourceRole(t *testing.T) {
+	res, err := bpmncommon.NewResource("approvers",
+		bpmncommon.MustResourceParameter("level", "int", true))
+	require.NoError(t, err)
+
+	t.Run("empty name is rejected", func(t *testing.T) {
+		_, err := hinteraction.NewResourceRole("  ", res, nil, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("resource and assignment expression are mutually exclusive",
+		func(t *testing.T) {
+			ae := &hinteraction.ResourceAssignmentExpression{}
+			_, err := hinteraction.NewResourceRole("role", res, ae, nil)
+			require.Error(t, err)
+		})
+
+	t.Run("an invalid base option is propagated", func(t *testing.T) {
+		_, err := hinteraction.NewResourceRole("role", res, nil, nil,
+			foundation.WithID("  "))
+		require.Error(t, err)
+	})
+
+	t.Run("by resource reference", func(t *testing.T) {
+		rr, err := hinteraction.NewResourceRole("reviewer", res, nil, nil,
+			foundation.WithID("rr-1"))
+		require.NoError(t, err)
+		require.Equal(t, "reviewer", rr.Name())
+		require.Equal(t, "rr-1", rr.ID())
+	})
+
+	t.Run("by assignment expression", func(t *testing.T) {
+		ae := &hinteraction.ResourceAssignmentExpression{}
+		rr, err := hinteraction.NewResourceRole("owner", nil, ae,
+			[]hinteraction.ResourceParameterBinding{})
+		require.NoError(t, err)
+		require.Equal(t, "owner", rr.Name())
+	})
+}
+
+func TestMustResourceRole(t *testing.T) {
+	res, err := bpmncommon.NewResource("approvers",
+		bpmncommon.MustResourceParameter("level", "int", true))
+	require.NoError(t, err)
+
+	t.Run("returns the role on success", func(t *testing.T) {
+		rr := hinteraction.MustResourceRole("reviewer", res, nil, nil)
+		require.NotNil(t, rr)
+		require.Equal(t, "reviewer", rr.Name())
+	})
+
+	t.Run("panics on failure", func(t *testing.T) {
+		require.Panics(t, func() {
+			hinteraction.MustResourceRole("", res, nil, nil)
+		})
+	})
+}

--- a/pkg/model/process/process_options_internal_test.go
+++ b/pkg/model/process/process_options_internal_test.go
@@ -1,0 +1,22 @@
+package process
+
+import (
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	hi "github.com/dr-dobermann/gobpm/pkg/model/hinteraction"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProcessConfigAddNilRejected covers the nil guards of AddRole/AddProperty.
+// The public WithRoles/WithProperties options filter nils before calling them,
+// so the error branches are only reachable from inside the package.
+func TestProcessConfigAddNilRejected(t *testing.T) {
+	pc := &processConfig{
+		roles: map[string]*hi.ResourceRole{},
+		props: map[string]*data.Property{},
+	}
+
+	require.Error(t, pc.AddRole(nil))
+	require.Error(t, pc.AddProperty(nil))
+}

--- a/pkg/model/process/process_test.go
+++ b/pkg/model/process/process_test.go
@@ -303,3 +303,44 @@ func TestProcessValidateComplexGateway(t *testing.T) {
 	// threshold 5 > incoming 2 → rejected by the per-node hook.
 	require.Error(t, newProc(t, 5).Validate())
 }
+
+// TestProcessElementsNodesRemove covers Elements(), Remove() (nil, not-found,
+// node and flow removal) and the has() helper reached by Nodes() with a valid
+// type filter.
+func TestProcessElementsNodesRemove(t *testing.T) {
+	p, err := process.New("ops")
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	// link before binding the nodes, so the flow is not auto-added to the
+	// process; add the nodes and the flow explicitly afterwards.
+	f, err := flow.Link(start, end)
+	require.NoError(t, err)
+
+	require.NoError(t, p.Add(start))
+	require.NoError(t, p.Add(end))
+	require.NoError(t, p.Add(f))
+
+	// Nodes() with a valid type filter drives the has() helper.
+	require.Len(t, p.Nodes(flow.EventNodeType), 2)
+	require.Empty(t, p.Nodes(flow.GatewayNodeType))
+
+	// Elements() returns every node and flow.
+	require.Len(t, p.Elements(), 3)
+
+	// Remove(): a nil element and an element not in the process are rejected.
+	require.Error(t, p.Remove(nil))
+
+	other, err := events.NewStartEvent("other")
+	require.NoError(t, err)
+	require.Error(t, p.Remove(other))
+
+	// removing the flow and a node succeeds and unbinds them.
+	require.NoError(t, p.Remove(f))
+	require.NoError(t, p.Remove(start))
+	require.Len(t, p.Elements(), 1)
+}


### PR DESCRIPTION
Summary

Raises every package that was below the 80% coverage bar up over it — pure test additions, no production code touched. A fresh full-repo measurement (the prior backlog baseline was stale after
the ADR-017/boundary/terminate landings) found four packages under 80%; all four are now cleared, two at 100%.

┌────────────────────────┬────────┬────────┐
│        Package                                           │ Before         │ After            │
├────────────────────────┼────────┼────────┤
│ pkg/model/hinteraction                      │ 0.0%            │ 100.0%         │
├────────────────────────┼────────┼────────┤
│ pkg/model/flow                                    │ 72.3%           │ 95.0%          │
├────────────────────────┼────────┼────────┤
│ pkg/model/process                              │ 75.0%          │ 96.9%          │
├────────────────────────┼────────┼────────┤
│ pkg/model/foundation                        │ 77.4%          │ 100.0%        │
└────────────────────────┴────────┴────────┘

Approach

External _test packages for the bulk; a small internal (package <x>) test where an unexported type's method needed reaching (option Apply/Validate). New tests target the previously-uncovered
surface: accessor/EType methods, Must* panic paths, option type-cast guards, nil-argument rejections, and the flow container-mismatch path (connect → checkConnections → Validate →
getContainerID).

Verification

make ci green: tidy, golangci-lint (0 issues), build, -race, diff-coverage gate (PASS — 0 changed production lines), govulncheck (no vulnerabilities).

Known residual

pkg/model/flow keeps a small gap (the Support/AcceptIncomingFlow reject branches need a BoundaryEvent fixture) — noted in the commit, left for a follow-up. Packages still in the 80–90% band
(errs, data, bpmncommon, artifacts, events, data_objects, consinp) clear the bar; pushing them to 100% is aspirational, not blocking.
