### PR TITLE
docs,test: correct snapshot persistence claim and anchor Clone's shar…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ GoBPM is a BPMN v2 compliant Business Process Management engine with an event-dr
 
 **Event-Driven Flow:** Processes execute through event publishing/consumption rather than direct method calls. Events flow through the EventHub to registered waiters.
 
-**Snapshot-Based State:** Process definitions are converted to snapshots for execution, allowing for state persistence and recovery.
+**Snapshot-Based State:** A process definition is converted once into an immutable snapshot — a validated launch template. Each instance `Clone`s that snapshot into its own node graph and mutates only its own copy; the immutable header (process id/name, properties, correlation keys) is shared by reference across clones. A snapshot is *not* a durable persistence/recovery mechanism — instance tracks, scopes, and history are not stored in it; durable persistence and rehydration remain future work (see ADR-009).
 
 **Interface-Heavy Design:** Heavy use of interfaces for extensibility, with comprehensive mock generation for testing.
 

--- a/internal/instance/snapshot/snapshot_test.go
+++ b/internal/instance/snapshot/snapshot_test.go
@@ -345,3 +345,46 @@ func TestSnapshotCorrelationKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, s.CorrelationKeys, clone.CorrelationKeys)
 }
+
+// TestSnapshotCloneSharesProperties anchors the invariant that Clone shares the
+// process Properties by reference rather than deep-copying them (snapshot.go:
+// clone.Properties = s.Properties). This is intentional and safe only because a
+// Property is immutable configuration that an instance never rewrites: the
+// snapshot is a launch template, not a per-instance mutable store (ADR-009). The
+// test locks the sharing so a future change that breaks it — a defensive copy,
+// or a Property that becomes mutable — is caught here rather than silently
+// doubling the per-instance footprint or diverging clones from the snapshot.
+func TestSnapshotCloneSharesProperties(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	p, err := process.New("p-props",
+		data.WithProperties(
+			data.MustProperty("greeting",
+				data.MustItemDefinition(nil), data.ReadyDataState)))
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	require.NoError(t, p.Add(start))
+	require.NoError(t, p.Add(end))
+
+	_, err = flow.Link(start, end)
+	require.NoError(t, err)
+
+	s, err := snapshot.New(p)
+	require.NoError(t, err)
+	require.Len(t, s.Properties, 1)
+
+	clone, err := s.Clone()
+	require.NoError(t, err)
+
+	// the same backing slice and the same Property pointers are shared, not
+	// copied — the immutable header travels by reference.
+	require.Len(t, clone.Properties, len(s.Properties))
+	require.Same(t, s.Properties[0], clone.Properties[0],
+		"Clone must share the immutable Property, not copy it")
+}


### PR DESCRIPTION
…ed-Properties invariant

CLAUDE.md's "Key Patterns" described snapshots as "converted to snapshots for execution, allowing for state persistence and recovery." That overstates what a snapshot is: it is an immutable launch template, not a durable store. An instance Clones the snapshot into its own node graph and mutates only that copy; tracks, scopes, and history are never written back into the snapshot. Durable persistence and rehydration remain future work (ADR-009). The wording is corrected to say so, so the doc no longer implies a recovery mechanism the engine does not have.

Clone shares the snapshot's immutable header — process id/name, properties, correlation keys — by reference (snapshot.go: clone.Properties = s.Properties). That sharing was documented on Clone and exercised for CorrelationKeys, but the Properties slice had no test pinning it: every Clone-source process in the suite had zero properties. TestSnapshotCloneSharesProperties closes that gap, asserting the Property pointers are shared, not copied. The invariant is safe only while a Property is immutable config; the test guards against a future change (a defensive copy, or a Property that becomes mutable) silently breaking it.

This is the §4-c item of the 2026-06-11 audit consolidation (snapshot doc-honesty). No production code changes.