### PR TITLE
Feat/adr 019 definition versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING — process registration and start API (ADR-019, SRD-031.A).**
+  `Thresher.RegisterProcess` now returns a `(*ProcessRegistration, error)`
+  registration handle instead of a bare `error`, and re-registering the same
+  process id mints a new integer version instead of silently no-op'ing.
+  `StartProcess` now takes that handle (was: the process id). Two new methods
+  address by process id: `StartLatest(key)` (newest version) and
+  `StartVersion(key, n)` (a specific version). The latest registered version
+  owns auto-start — registering a newer version supersedes the previous one's
+  starters, and unregistering the latest promotes the now-newest remaining
+  version.
+
+  Migration: `engine.RegisterProcess(p)` → `reg, _ := engine.RegisterProcess(p)`;
+  `engine.StartProcess(p.ID())` → `engine.StartProcess(reg)` or
+  `engine.StartLatest(p.ID())`.
+
+### Fixed
+
+- **membroker: message subscriptions are torn down on waiter stop.** A stopped
+  message waiter previously left its subscription registered, so a later publish
+  on the same message name could be swallowed into the dead (buffered) channel
+  before a live waiter received it. `messaging.Subscription` gains
+  `Unsubscribe()`; the message waiter now unsubscribes on every exit path.
+
 ## [v0.7.0] - 2026-06-28
 
 **Version-line correction — no functional change from v0.1.1.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `StartVersion(key, n)` (a specific version). The latest registered version
   owns auto-start — registering a newer version supersedes the previous one's
   starters, and unregistering the latest promotes the now-newest remaining
-  version.
+  version. Removal is split by scope: `UnregisterProcess(reg)` is renamed
+  `UnregisterVersion(reg)` (removes one version), and `UnregisterProcess(key)`
+  now removes the whole process (every version of the key). Version numbers are
+  monotonic per key and never reused, so removing a non-latest version leaves a
+  gap; `Registrations(key)` enumerates a key's versions.
 
   Migration: `engine.RegisterProcess(p)` → `reg, _ := engine.RegisterProcess(p)`;
   `engine.StartProcess(p.ID())` → `engine.StartProcess(reg)` or
-  `engine.StartLatest(p.ID())`.
+  `engine.StartLatest(p.ID())`; `engine.UnregisterProcess(reg)` →
+  `engine.UnregisterVersion(reg)` (or `engine.UnregisterProcess(p.ID())` to drop
+  all versions).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -97,11 +97,15 @@ _ = proc.Add(end)
 _, _ = flow.Link(start, task)
 _, _ = flow.Link(task, end)
 
-_ = engine.RegisterProcess(proc)
+// RegisterProcess returns a registration handle naming the (key, version);
+// re-registering the same process id mints a new version.
+reg, _ := engine.RegisterProcess(proc)
 _ = engine.Run(context.Background())
 
-// StartProcess returns a read-only handle onto the running instance.
-inst, _ := engine.StartProcess(proc.ID())
+// Start the exact registered version by its handle. StartLatest(key) and
+// StartVersion(key, n) address by process id instead. Each returns a read-only
+// handle onto the running instance.
+inst, _ := engine.StartProcess(reg)
 
 // Block until the instance finishes — the guaranteed completion signal.
 state, _ := inst.WaitCompletion(context.Background())

--- a/README.ru.md
+++ b/README.ru.md
@@ -99,11 +99,15 @@ _ = proc.Add(end)
 _, _ = flow.Link(start, task)
 _, _ = flow.Link(task, end)
 
-_ = engine.RegisterProcess(proc)
+// RegisterProcess возвращает дескриптор регистрации с (key, version);
+// повторная регистрация того же id процесса создаёт новую версию.
+reg, _ := engine.RegisterProcess(proc)
 _ = engine.Run(context.Background())
 
-// StartProcess returns a read-only handle onto the running instance.
-inst, _ := engine.StartProcess(proc.ID())
+// Запуск конкретной зарегистрированной версии по её дескриптору. StartLatest(key)
+// и StartVersion(key, n) адресуют по id процесса. Каждый возвращает read-only
+// дескриптор выполняющегося инстанса.
+inst, _ := engine.StartProcess(reg)
 
 // Block until the instance finishes — the guaranteed completion signal.
 state, _ := inst.WaitCompletion(context.Background())

--- a/docs/design/ADR-019-definition-versioning.md
+++ b/docs/design/ADR-019-definition-versioning.md
@@ -1,0 +1,379 @@
+# ADR-019 — Definition versioning and the registration handle
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-06-28 |
+| Owner | Ruslan Gabitov |
+| Refines | [SAD-001 v.1 Vision & Architecture](SAD-001-vision-and-architecture.md) |
+
+> **Draft** — to be landed by its implementing SRDs.
+> Decides **definition versioning**: registering a process produces an immutable,
+> **versioned** snapshot addressed by a **registration handle**, rather than a
+> single mutable-by-accident registration keyed on the process id. Re-registering
+> the same process id yields a *new version*; older versions keep running their
+> already-started instances; the **latest** version owns auto-start. The process
+> model stays **mutable** after registration (no freeze) — the engine is isolated
+> from it by a snapshot taken at registration time. The concrete model-editing API
+> (`Unlink`, `Remove`, `Clear`, …) is the sibling **rich-editing ADR**; the
+> Thresher registry's concurrency discipline (audit §2.6) is owned by the
+> implementing SRD.
+
+## 1. Context & problem
+
+[SAD-001 v.1](SAD-001-vision-and-architecture.md) states the engine's input
+contract plainly: the **Snapshot** is an *"immutable, validated representation of
+a Process definition. Engine accepts a Snapshot, not a mutable model."* Today the
+engine honours the *immutable* half only by convention, and the *identity* of a
+registration is ambiguous. Three gaps follow.
+
+### 1.1 Registration identity is ambiguous and silently single
+
+`Thresher.RegisterProcess` takes a `*process.Process`, builds a snapshot, and
+stores it keyed by the process **id**. `Thresher.StartProcess` then takes that
+**id** (a `string`) and starts whatever snapshot is stored under it. Two problems
+compound:
+
+1. **Re-registration is a silent no-op.** Registering a process whose id is
+   already present keeps the first registration and discards the second ("first
+   registration wins"). A user who edits a process and re-registers it expecting
+   the engine to run the new shape gets the *old* one, with no error and no
+   signal. The mismatch surfaces only as wrong runtime behaviour.
+
+2. **The start key is the process's own id, not a registration receipt.** The
+   caller addresses a registration by reaching back into the model object for its
+   id. There is no first-class token that says *"this exact registered
+   definition."* When more than one shape of a process could legitimately be
+   registered over time, "start the process with id X" cannot say *which* X.
+
+### 1.2 The snapshot is not actually isolated from the model — a silent leak
+
+A process model is **mutable after registration**. Its public surface lets a
+caller keep adding and rewiring elements once the snapshot has been taken, and
+nothing rejects or even notices it. Worse, the snapshot does **not** take its own
+copy of the definition's node graph at registration: it shares the model's node
+objects by reference and only clones them later, once per running instance. The
+consequence is a class of silent, shape-dependent corruption:
+
+- **Structural edits are invisible.** A node or sequence flow added to the model
+  after registration never enters the already-taken snapshot, so the started
+  instance runs a definition the caller can no longer see in their own object.
+- **In-place edits leak backward.** Rewiring or mutating an *existing* shared node
+  reaches into the snapshot through the shared pointer, so the next instance born
+  from that snapshot silently picks the change up — and does so racing any
+  instance already cloning the snapshot, with no lock on that path.
+
+This is the architecture audit's finding **§3.3** ("validation and mutability of
+the process model"): the model can be mutated after the snapshot is taken and
+during execution. The audit's proposed remedy was to *freeze* the model after the
+first snapshot. This ADR reaches the same safety by the opposite, more composable
+route — see §2.3 and §4.1.
+
+### 1.3 Prior art — Camunda definition versioning
+
+Camunda (a mature BPMN engine) resolves exactly this ambiguity with **definition
+versioning**, and its model is widely understood by BPMN practitioners:
+
+- Redeploying a changed definition under the same **key** creates a *new version*;
+  versions increment as integers. *"If you redeploy a changed process definition,
+  you get a new version in the database."*
+- **Running instances are unaffected:** *"Running process instances will continue
+  to run in the version they were started in. New process instances will run in
+  the new version — unless specified explicitly."*
+- **Starting picks a version deterministically:** by **key** starts *"an instance
+  of the latest deployed version"*; by a specific **id** starts that exact
+  version.
+- **Auto-start subscriptions move to the latest version:** *"Upon deployment of a
+  new version of a process definition, the signal subscriptions of the previous
+  version are canceled"* — so only the latest version starts new instances from a
+  message/signal start trigger; older versions merely finish their in-flight work.
+
+This ADR adopts that model, mapped onto gobpm's snapshot/instance-starter
+vocabulary. (SAD-001 already lists platform **versioning** as a tracked epic;
+this is the in-memory registration foundation for it, not the durable
+deployment/migration story, which stays deferred — §2.8.)
+
+## 2. Decision
+
+### 2.1 Registration is versioned by the process id (the BPMN key)
+
+The **versioning key** is the process **id** — BPMN's stable element identity. A
+caller fixes it explicitly (the BPMN `id` attribute; in gobpm, the process-id
+option). Two registrations carrying the same id are two **versions** of one
+logical definition; versions increment as integers (v1, v2, …) per key in
+registration order.
+
+A process registered **without** an explicit id keeps gobpm's default — a
+generated unique id — and is therefore its own singleton key at version 1. That
+is the correct outcome: an anonymous definition has no shared identity to form a
+version lineage with, and silently merging two unrelated anonymous processes
+would be worse than treating each as distinct.
+
+The id is chosen over the process **name** deliberately. BPMN cross-references
+elements **by `id`** — every `(ref)` in the model is an id reference to another
+element — whereas `name` is a plain optional attribute with no referential role.
+The `id` is therefore the element's identity and `name` is display text; keying
+versions on a display name would collide two genuinely different processes that
+happen to share a label into one lineage. (See §4.2 for the name-keyed
+alternative and why it is rejected.)
+
+### 2.2 `RegisterProcess` returns a registration handle
+
+`RegisterProcess` **returns a value** — a **registration handle** — instead of
+only an error. The handle is the first-class receipt for *this exact registered
+version*. It carries (conceptually) the **key** (process id), the integer
+**version**, and an opaque **registration id**, and it is what the caller passes
+to start or unregister that version.
+
+```
+reg, err := th.RegisterProcess(p)   // reg names a specific (key, version)
+inst, err := th.StartProcess(reg)   // starts THAT version, unambiguously
+err = th.Unregister(reg)            // removes THAT version
+```
+
+This removes the §1.1 ambiguity at the root: the caller no longer reaches into
+the model for an id and hopes the engine still holds the shape they mean — they
+hold a receipt for the precise version they registered.
+
+### 2.3 A version is frozen at registration — snapshot isolation
+
+Taking the snapshot at registration **deep-copies the definition's node graph**,
+so the snapshot owns its own nodes and flows, fully independent of the model
+object. From that instant the version is genuinely immutable: later edits to the
+model — structural or in-place — touch nothing the engine holds, and a started
+instance always runs the shape that existed at *its* registration.
+
+This is the mechanism that lets the model stay mutable **without** the audit's
+freeze. Isolation, not prohibition, is what makes "the engine accepts an
+immutable Snapshot" (SAD-001) actually true, and it closes the §1.2 / audit §3.3
+leak and its attendant data race by construction: there is no longer any shared
+mutable object between the caller's editing goroutine and the engine's cloning
+path. (Immutable per-definition configuration that an instance never rewrites —
+e.g. declared properties — may still be shared by reference; only the mutable
+graph must be copied. The per-instance clone that an running instance mutates is
+unchanged and still taken from the frozen snapshot.)
+
+### 2.4 Starting — three addressing modes
+
+A caller can name the version to start in three ways, ordered from most to least
+specific:
+
+- **By handle** — `StartProcess(reg)` starts the exact version the handle names.
+  The canonical, unambiguous path, and the only one that needs no lookup.
+- **By key + version** — `StartVersion(key, version)` starts that specific
+  integer version of the key, or errors if the key or version is unknown. This
+  addresses a particular historical version *without* holding its handle (the
+  human-friendly `(key, version)` rather than the opaque registration id) — e.g.
+  re-running v2 after v3 is live.
+- **By key (latest)** — `StartLatest(key)` starts the **latest** registered
+  version of the key, or errors if the key is unknown. This mirrors Camunda's
+  common "just run the current one" case, so the everyday call need not thread a
+  handle or track a version number.
+
+All three return the per-instance observation handle that `StartProcess` returns
+today (unchanged — distinct from the registration handle of §2.2). The exact
+method names/signatures are finalized in the implementing SRD; conceptually the
+engine exposes handle-addressed, `(key, version)`-addressed, and latest-of-key
+starts.
+
+### 2.5 Auto-start follows latest-supersedes
+
+For a process registered in auto-instantiation mode (a message/signal start
+trigger spawns instances — [ADR-015 v.1](ADR-015-event-triggered-instantiation.md)),
+registering a **newer version of the same key** transfers auto-start to it: the
+previous version's instance-starters are torn down from the engine event bus and
+the new version's are registered in their place. Only the **latest** version
+spawns new instances from a trigger; instances already running under older
+versions continue to completion on their own frozen snapshots.
+
+This is the direct analogue of Camunda's *"the signal subscriptions of the
+previous version are canceled"* (§1.3), and it resolves the otherwise-sharp edge
+of "do all registered versions react to the same incoming message?" — they do
+not; the latest version owns the trigger. Manual-start versions register no
+starters, so there is nothing to supersede.
+
+Correlation/dedup of an in-flight conversation ([ADR-016
+v.1](ADR-016-message-correlation.md)) remains keyed within the spawning version's
+lineage; because only the latest version auto-starts, create-or-join stays
+coherent. Cross-version correlation (a conversation begun under v1 routed into a
+v2 instance) is **not** a goal here — §2.8.
+
+### 2.6 The model stays mutable — editing is a sibling decision
+
+The process model is **not** frozen by registration. A caller may keep building or
+revising it and re-register to mint the next version. This ADR commits to that
+*principle*; it deliberately does **not** specify the editing operations
+themselves. The first-class model-editing surface — un-linking flows, removing
+nodes, clearing a process, and the validation/ordering rules those imply — is a
+distinct decision with its own object-model reasoning and is owned by the sibling
+**rich process-model editing ADR**. Snapshot isolation (§2.3) is the precondition
+that makes such editing safe to land independently: once registration copies the
+graph, post-registration editing cannot disturb any taken version.
+
+### 2.7 Concurrency discipline of the versioned registry — owned by the SRD
+
+Introducing versions reshapes the engine registry from "one snapshot per id" to
+"an ordered set of versions per key, with the latest distinguished," and it
+rewrites the very registration/start/unregister methods whose lock discipline the
+architecture audit flagged as **fragile** (audit §2.6: correctness resting on a
+comment, *"release before launch … re-acquire"*, a refactor-hostile invariant).
+Because the implementing work touches exactly those methods, the clean
+concurrency discipline the audit asks for — engine state as an atomic value, and
+an explicit, documented split between lock-held and lock-free sections — is
+adopted **as part of landing this ADR**, recorded as an implementation decision in
+its **dedicated concurrency SRD**, separate from the versioning SRD. This ADR
+fixes the *what* (versions, handle, isolation, latest-supersedes); the SRD owns
+the *how* of the registry's internals and retires audit §2.6 there.
+
+### 2.8 Non-goals and out of scope (each with a named home)
+
+- **Durable / persistent versioning and migration.** Versions here live in the
+  running engine's memory only. Persisting deployments, rehydrating instances onto
+  a stored version, and migrating live instances across versions remain the
+  deferred platform epics (SAD-001) — a future Persistence & State decision.
+- **The model-editing API.** `Unlink` / `Remove` / `Clear` and their semantics —
+  the sibling rich-editing ADR (§2.6).
+- **The registry concurrency rewrite's mechanics.** The dedicated concurrency SRD
+  (§2.7); this ADR carries no file/line.
+- **Cross-version correlation and version-pinned message routing.** A conversation
+  spanning versions (§2.5) — out of scope; revisit with the durable story.
+- **Version tags / semantic version labels.** Camunda's `versionTag` is *"only for
+  tagging and will neither influence the start … behaviour."* Integer version
+  ordering is sufficient here; named tags are a later ergonomic add if asked.
+
+## 3. Consequences
+
+**Positive.**
+
+- The §1.1 ambiguity disappears: a handle names exactly one version; "start what I
+  just registered" is unambiguous, and re-registration is a meaningful operation
+  (a new version) instead of a silent no-op.
+- The §1.2 / audit §3.3 leak and its race are closed *by construction* via
+  isolation (§2.3), without restricting the user — honouring the project's
+  "compose, don't restrict" principle.
+- Behaviour matches a model BPMN practitioners already know (Camunda), lowering
+  the learning curve.
+- Multiple shapes of a definition can coexist safely: long-running v1 instances
+  finish while v2 takes new starts.
+
+**Negative / costs.**
+
+- **A contract change.** `RegisterProcess` gains a return value; `StartProcess` /
+  `UnregisterProcess` take a handle, with `StartVersion(key, version)` and
+  `StartLatest(key)` as the lookup-based paths. Pre-versioning call sites must
+  adopt the handle. This is acceptable pre-1.0 and is the point of the change.
+- **Registration is no longer idempotent.** Re-registering now *adds a version*.
+  Callers that re-registered defensively must stop, or accept version growth.
+- **Per-registration copy cost.** Deep-copying the graph at registration adds work
+  and memory per version (bounded by definition size, paid once per registration,
+  not per instance).
+- **Unbounded version accumulation** if a caller re-registers in a loop without
+  unregistering. Mitigations (retention/pruning) are noted under §5; the engine
+  does not impose a cap in this ADR.
+
+## 4. Alternatives considered
+
+### 4.1 Freeze the model after the first snapshot (the audit's proposal)
+
+Mark the process immutable on registration; reject later edits with an error.
+**Rejected** as the primary mechanism: it restricts the user to solve an engine
+isolation bug, and it conflicts with the rich-editing direction (§2.6) and the
+project's "compose, don't restrict" principle. Snapshot isolation (§2.3) achieves
+the same safety while *keeping* the model editable, which is strictly more
+composable. (A freeze could still be offered later as an opt-in assertion for
+callers who *want* a sealed builder, but it is not the default and not required
+for safety.)
+
+### 4.2 Key versions by process name
+
+Use the model's display **name** as the versioning key (the most "Camunda-feel"
+ergonomically, since a name is always present). **Rejected:** in BPMN the name is
+non-identifying display text; keying on it collides two unrelated processes that
+share a label into one version lineage, and silently. The id is the standard's
+identity and is the safe key (§2.1). Ergonomics are recovered by letting the
+caller set a short, stable id.
+
+### 4.3 Snapshot isolation without a handle (deep-copy only)
+
+Fix only §1.2 — make the snapshot copy the graph — but keep the single-keyed,
+id-addressed, idempotent registration. **Rejected as insufficient:** it removes
+the leak and the race, but a post-registration edit is then *silently ignored*
+(the snapshot is frozen and re-registration is still a no-op), which is the §1.1
+confusion the user raised. Isolation is necessary but not sufficient; the handle +
+versioning is what makes the user's intent expressible.
+
+### 4.4 Opaque registration id without key grouping
+
+Return an opaque id per registration with **no** notion of a shared key/version
+lineage (every registration is an island). **Rejected:** it disambiguates
+starting, but loses "latest version of this definition," cannot express auto-start
+supersession (§2.5), and discards the well-understood Camunda mental model for no
+gain.
+
+## 5. Enterprise-readiness recommendations
+
+- **Version retention policy.** Provide (in the implementing SRD or a follow-up) a
+  way to enumerate a key's versions and prune superseded ones once their instances
+  drain, so a long-lived engine that re-registers frequently does not accumulate
+  dead snapshots. Surface counts via the existing observability surface.
+- **Observability of versioning.** Log at registration the assigned `(key,
+  version)` and, on auto-start supersession, the from→to version and the
+  starter-subscription move, so operators can see which version is live and why a
+  trigger spawned the version it did.
+- **Explicit-id guidance.** Document that durable, intentional versioning requires
+  a stable process id; an anonymous (auto-id) process is always a singleton v1.
+  Consider a debug-level warning when two registrations share a *name* but differ
+  in id (a likely "I meant to version this" mistake).
+- **Deprecation path to durability.** Keep the in-memory model's vocabulary
+  (key/version/handle) aligned with the future durable deployment story so the
+  persistence ADR can adopt it without renaming the public surface.
+
+## 6. References
+
+- [SAD-001 v.1 Vision & Architecture](SAD-001-vision-and-architecture.md) — the
+  parent: the **Snapshot** as the engine's immutable input contract ("Engine
+  accepts a Snapshot, not a mutable model"), and the tracked **versioning**
+  platform epic this lays the in-memory foundation for.
+- [ADR-009 v.1 Per-instance node graph](ADR-009-per-instance-node-graph.md) — the
+  snapshot→per-instance clone model this extends; §2.3's registration-time graph
+  copy is the missing first hop of that same isolation story.
+- [ADR-015 v.1 Event-triggered instantiation](ADR-015-event-triggered-instantiation.md)
+  — the definition-level **instance-starters** whose latest-supersedes transfer
+  (§2.5) is decided here; the manual-start mode that registers none.
+- [ADR-016 v.1 Message correlation](ADR-016-message-correlation.md) — the
+  create-or-join resolution that stays coherent under versioning because only the
+  latest version auto-starts (§2.5).
+- [ADR-001 v.6 Execution model](ADR-001-execution-model.md) — instances, tracks,
+  and the per-instance lifecycle that older versions keep running after they are
+  superseded.
+- [ADR-013 v.1 Instance observability](ADR-013-instance-observability.md) — the
+  read-only handle/discovery surface the versioning observability (§5) extends.
+- Architecture audit 2026-06-11 — **§3.3** (model mutability after snapshot; this
+  ADR resolves it via isolation rather than freeze) and **§2.6** (fragile Thresher
+  mutex discipline; retired by this ADR's concurrency SRD, §2.7).
+- BPMN 2.0 — the `BaseElement` **`id`** is the attribute other elements reference
+  (`docs/bpmn-spec/elements/foundation.md`; the spec's cross-references are `(ref)`
+  id-references), whereas **`name`** is a plain optional attribute with no
+  referential role — the basis for §2.1's key choice.
+- Camunda 7 manual — *Process Versioning* (version on redeploy-by-key; running
+  instances stay; start-by-key = latest; `versionTag` is non-behavioural) and
+  *Signal Events* (*"the signal subscriptions of the previous version are
+  canceled"*) — the prior-art model adopted in §1.3 / §2.5.
+
+## 7. Open questions
+
+None. Scope: **in-memory definition versioning** — versioned registration keyed on
+the process id, a registration handle, snapshot isolation at registration time,
+start by handle / by key+version / by latest-of-key, and latest-supersedes
+auto-start. The
+**model-editing API** is the sibling rich-editing ADR; the **registry concurrency
+rewrite** (audit §2.6) is this ADR's dedicated concurrency SRD; **durable
+versioning, migration, cross-version correlation, and version tags** are named
+deferrals (§2.8).
+
+## Document History
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v.1 | 2026-06-28 | Ruslan Gabitov | Draft. **Definition versioning**: `RegisterProcess` returns a **registration handle** naming a `(key, version)`; the versioning **key is the process id** (BPMN identity, not the display name), anonymous processes are singleton v1; the snapshot **deep-copies the graph at registration** so each version is frozen and the model stays **mutable** without a freeze (closing audit §3.3's leak/race by isolation); start **by handle** (exact), **by key+version** (specific), or **by key** (latest); **latest-supersedes** auto-start transfers instance-starters to the newest version (Camunda-grounded). Refines SAD-001 v.1; siblings ADR-009 v.1, ADR-015 v.1, ADR-016 v.1, ADR-001 v.6, ADR-013 v.1. The **model-editing API** is carved out to a sibling rich-editing ADR; the **registry concurrency discipline** (audit §2.6) to a dedicated SRD; durable versioning/migration/cross-version correlation/version tags deferred. |

--- a/docs/design/ADR-019-definition-versioning.md
+++ b/docs/design/ADR-019-definition-versioning.md
@@ -13,7 +13,9 @@
 > **versioned** snapshot addressed by a **registration handle**, rather than a
 > single mutable-by-accident registration keyed on the process id. Re-registering
 > the same process id yields a *new version*; older versions keep running their
-> already-started instances; the **latest** version owns auto-start. The process
+> already-started instances. The **latest** version always owns auto-start —
+> registering a newer version supersedes the prior one's starters, and
+> unregistering the latest promotes the now-newest version back to live. The process
 > model stays **mutable** after registration (no freeze) — the engine is isolated
 > from it by a snapshot taken at registration time. The concrete model-editing API
 > (`Unlink`, `Remove`, `Clear`, …) is the sibling **rich-editing ADR**; the
@@ -177,7 +179,7 @@ method names/signatures are finalized in the implementing SRD; conceptually the
 engine exposes handle-addressed, `(key, version)`-addressed, and latest-of-key
 starts.
 
-### 2.5 Auto-start follows latest-supersedes
+### 2.5 Auto-start follows the latest version — supersede on register, promote on remove
 
 For a process registered in auto-instantiation mode (a message/signal start
 trigger spawns instances — [ADR-015 v.1](ADR-015-event-triggered-instantiation.md)),
@@ -387,4 +389,4 @@ deferrals (§2.8).
 
 | Version | Date | Author | Change |
 |---|---|---|---|
-| v.1 | 2026-06-28 | Ruslan Gabitov | Draft. **Definition versioning**: `RegisterProcess` returns a **registration handle** naming a `(key, version)`; the versioning **key is the process id** (BPMN identity, not the display name), anonymous processes are singleton v1; the snapshot **deep-copies the graph at registration** so each version is frozen and the model stays **mutable** without a freeze (closing audit §3.3's leak/race by isolation); start **by handle** (exact), **by key+version** (specific), or **by key** (latest); **latest-supersedes** auto-start transfers instance-starters to the newest version (Camunda-grounded). Refines SAD-001 v.1; siblings ADR-009 v.1, ADR-015 v.1, ADR-016 v.1, ADR-001 v.6, ADR-013 v.1. The **model-editing API** is carved out to a sibling rich-editing ADR; the **registry concurrency discipline** (audit §2.6) to a dedicated SRD; durable versioning/migration/cross-version correlation/version tags deferred. |
+| v.1 | 2026-06-28 | Ruslan Gabitov | Draft. **Definition versioning**: `RegisterProcess` returns a **registration handle** naming a `(key, version)`; the versioning **key is the process id** (BPMN identity, not the display name), anonymous processes are singleton v1; the snapshot **deep-copies the graph at registration** so each version is frozen and the model stays **mutable** without a freeze (closing audit §3.3's leak/race by isolation); start **by handle** (exact), **by key+version** (specific), or **by key** (latest); **latest-supersedes** auto-start keeps the latest version as the sole live auto-starter — registering a newer version transfers the instance-starters to it, and unregistering the latest promotes the now-newest remaining version back to live (Camunda-grounded, symmetric in both directions). Refines SAD-001 v.1; siblings ADR-009 v.1, ADR-015 v.1, ADR-016 v.1, ADR-001 v.6, ADR-013 v.1. The **model-editing API** is carved out to a sibling rich-editing ADR; the **registry concurrency discipline** (audit §2.6) to a dedicated SRD; durable versioning/migration/cross-version correlation/version tags deferred. |

--- a/docs/design/ADR-019-definition-versioning.md
+++ b/docs/design/ADR-019-definition-versioning.md
@@ -193,6 +193,17 @@ of "do all registered versions react to the same incoming message?" — they do
 not; the latest version owns the trigger. Manual-start versions register no
 starters, so there is nothing to supersede.
 
+The supersession is symmetric on removal: **un**registering the latest version
+**promotes** the now-newest remaining version — its starters are registered in
+turn, so it becomes the live auto-start version. The invariant *the latest
+registered version is the live auto-start version* therefore holds at all times,
+in both directions. This mirrors Camunda's delete-deployment behaviour (the
+previous version's start-event subscriptions re-activate) and gives users a
+direct lever to re-activate an earlier version's auto-start: remove the later
+versions until the wanted one is latest again. A previous (non-latest) version
+remains startable, but **only manually** via `StartVersion(key, n)` — it holds
+no hub subscriptions while a newer version exists.
+
 Correlation/dedup of an in-flight conversation ([ADR-016
 v.1](ADR-016-message-correlation.md)) remains keyed within the spawning version's
 lineage; because only the latest version auto-starts, create-or-join stays

--- a/docs/design/ADR-019-definition-versioning.md
+++ b/docs/design/ADR-019-definition-versioning.md
@@ -104,7 +104,11 @@ The **versioning key** is the process **id** — BPMN's stable element identity.
 caller fixes it explicitly (the BPMN `id` attribute; in gobpm, the process-id
 option). Two registrations carrying the same id are two **versions** of one
 logical definition; versions increment as integers (v1, v2, …) per key in
-registration order.
+registration order. A version number is **monotonic and never reused** for the
+lifetime of the key: removing a version (§2.5) leaves its number retired, so the
+sequence may carry gaps (v1, v3, …) and a later registration always takes a fresh
+higher number rather than refilling a hole. A version number therefore names one
+definition unambiguously for as long as the key lives.
 
 A process registered **without** an explicit id keeps gobpm's default — a
 generated unique id — and is therefore its own singleton key at version 1. That
@@ -164,10 +168,12 @@ specific:
 - **By handle** — `StartProcess(reg)` starts the exact version the handle names.
   The canonical, unambiguous path, and the only one that needs no lookup.
 - **By key + version** — `StartVersion(key, version)` starts that specific
-  integer version of the key, or errors if the key or version is unknown. This
-  addresses a particular historical version *without* holding its handle (the
-  human-friendly `(key, version)` rather than the opaque registration id) — e.g.
-  re-running v2 after v3 is live.
+  integer version of the key, or errors if the key or version is unknown. It
+  addresses by the version **number**, not a slice position, so it stays correct
+  across the gaps a removal can leave (§2.5) — re-running v3 after v2 was pruned
+  resolves v3, and the retired v2 errors. This addresses a particular historical
+  version *without* holding its handle (the human-friendly `(key, version)` rather
+  than the opaque registration id).
 - **By key (latest)** — `StartLatest(key)` starts the **latest** registered
   version of the key, or errors if the key is unknown. This mirrors Camunda's
   common "just run the current one" case, so the everyday call need not thread a
@@ -178,6 +184,12 @@ today (unchanged — distinct from the registration handle of §2.2). The exact
 method names/signatures are finalized in the implementing SRD; conceptually the
 engine exposes handle-addressed, `(key, version)`-addressed, and latest-of-key
 starts.
+
+Because removals can leave gaps in a key's version sequence (§2.5), the engine
+also exposes a **discovery** path: enumerating a key's registered versions
+(returning their handles) so a caller can see which versions exist — and pick one
+to start or unregister — rather than guessing a number. Enumeration is read-only
+discovery, the registration-side analogue of the SRD-019 instance/starter views.
 
 ### 2.5 Auto-start follows the latest version — supersede on register, promote on remove
 
@@ -205,6 +217,15 @@ direct lever to re-activate an earlier version's auto-start: remove the later
 versions until the wanted one is latest again. A previous (non-latest) version
 remains startable, but **only manually** via `StartVersion(key, n)` — it holds
 no hub subscriptions while a newer version exists.
+
+Removal comes in two granularities, named for their scope: removing **one
+version** (by handle) versus removing the **whole process** — every version of a
+key — in one operation. A *process* is the whole keyed definition; a *version* is
+one snapshot of it, so the bulk operation carries the `Process` name and the
+single-version one is explicitly a *version* removal. Both leave running instances
+untouched (they own their snapshots); only the live latest's starters are ever
+torn down. Whole-process removal also retires the key's version counter, so a
+later registration of that id restarts at v1.
 
 Correlation/dedup of an in-flight conversation ([ADR-016
 v.1](ADR-016-message-correlation.md)) remains keyed within the spawning version's
@@ -272,10 +293,11 @@ the *how* of the registry's internals and retires audit §2.6 there.
 
 **Negative / costs.**
 
-- **A contract change.** `RegisterProcess` gains a return value; `StartProcess` /
-  `UnregisterProcess` take a handle, with `StartVersion(key, version)` and
-  `StartLatest(key)` as the lookup-based paths. Pre-versioning call sites must
-  adopt the handle. This is acceptable pre-1.0 and is the point of the change.
+- **A contract change.** `RegisterProcess` gains a return value; `StartProcess` and
+  the single-version `UnregisterVersion` take a handle, with `StartVersion(key,
+  version)` / `StartLatest(key)` / `UnregisterProcess(key)` (whole-process removal)
+  as the key-addressed paths. Pre-versioning call sites must adopt the handle. This
+  is acceptable pre-1.0 and is the point of the change.
 - **Registration is no longer idempotent.** Re-registering now *adds a version*.
   Callers that re-registered defensively must stop, or accept version growth.
 - **Per-registration copy cost.** Deep-copying the graph at registration adds work

--- a/docs/srd/SRD-031.A-definition-versioning.md
+++ b/docs/srd/SRD-031.A-definition-versioning.md
@@ -336,8 +336,8 @@ their parameters/returns change, plus the two new `StartVersion`/`StartLatest`.
 | T-7 | `StartVersion(key, n)` starts version n; unknown key/version → ObjectNotFound; version<1 → error | FR-5, NFR-1 | `thresher/versioning_test.go` |
 | T-8 | `StartLatest(key)` starts the newest version; unknown/empty key → error | FR-6, NFR-1 | `thresher/versioning_test.go` |
 | T-9 | Registering v2 (auto, message-start) moves the start subscription: a trigger spawns a v2 instance, not v1; a running v1 instance is unaffected | FR-7 | `thresher/versioning_internal_test.go` |
-| T-10 | `UnregisterProcess(reg)` removes that version; a running instance of it survives; foreign/nil handle → error | FR-8, NFR-1 | `thresher/versioning_internal_test.go` |
-| T-11 | Unregistering the latest auto version stops auto-start for the key (no promotion of the prior version) | FR-8 | `thresher/versioning_internal_test.go` |
+| T-10 | `UnregisterProcess(reg)` removes that version; a running instance of it survives; foreign/nil handle → error | FR-8, NFR-1 | `thresher/discovery_test.go` (survives+removal) + `thresher/instance_starter_internal_test.go` (nil/foreign) |
+| T-11 | Unregistering the latest auto version promotes the now-newest remaining version to live auto-start — it owns the trigger again (a publish spawns its instance) | FR-8 | `thresher/versioning_internal_test.go` |
 | T-12 | `go test -race ./pkg/thresher/...` green under concurrent register/start | NFR-2 | existing + new |
 
 ## 7. Milestones
@@ -351,7 +351,10 @@ their parameters/returns change, plus the two new `StartVersion`/`StartLatest`.
 - **A3 — Start addressing.** `StartProcess(reg)`, `StartVersion`, `StartLatest`,
   with validation; T-6/T-7/T-8.
 - **A4 — Latest-supersedes + unregister.** Supersession on register;
-  `UnregisterProcess(reg)`; no auto-promotion; T-9/T-10/T-11.
+  `UnregisterProcess(reg)` with promote-on-removal; plus the membroker
+  subscription-teardown fix it depends on (a stopped waiter now unsubscribes,
+  else a superseding version's publish is swallowed by the dead subscription);
+  T-9/T-10/T-11.
 - **A5 — Migration.** All examples, `pkg/thresher/*_test.go`, `README*.md`,
   `examples/README.md`; examples build+run; `CHANGELOG` migration note (NFR-5).
 - **A6 — Verify & land.** `/check-style`, `/check-srd`, `make ci`, fill §10, flip
@@ -392,7 +395,43 @@ their parameters/returns change, plus the two new `StartVersion`/`StartLatest`.
 
 ## 10. Implementation summary
 
-_(filled at landing: files/lines, T-results, milestone SHAs.)_
+Landed on `feat/adr-019-definition-versioning` (off `master`).
+
+**Milestones & commits**
+- **A1** — snapshot isolation (single-pass `New` clone + shared `wireClonedGraph`):
+  `2a67914`.
+- **A2** — handle + versioned registry (`ProcessRegistration`, `registrations`
+  map, `RegisterProcess` returns the handle): `14583dc`.
+- **A3** — start addressing (`StartProcess(reg)`, `StartVersion`, `StartLatest`):
+  `ffaa668`.
+- **A4** — latest-supersedes + `UnregisterProcess` promote-on-removal: `8f1d4d9`;
+  the membroker subscription-teardown fix it depends on: `d9a16c7`; coverage
+  completion: `56e2263`.
+- **A5** — caller/doc migration (examples were already on the new API; the
+  `README.md` / `README.ru.md` / `examples/README.md` snippets; the `CHANGELOG`
+  migration note; this §10): the A5 docs commit on this branch.
+
+**Key files**
+- `internal/instance/snapshot/snapshot.go` — `New` clones nodes in its validation
+  pass; shared `wireClonedGraph` (relink/remap/rebind) used by both `New` and
+  `Clone`.
+- `pkg/thresher/registration.go` (new) — `ProcessRegistration` read-only handle
+  (`Key`/`Version`/`ID`).
+- `pkg/thresher/thresher.go` — `registrations map[string][]*ProcessRegistration`;
+  `RegisterProcess` (append version + supersession), `StartProcess` /
+  `StartVersion` / `StartLatest`, `UnregisterProcess` (promote-on-removal),
+  latest-only `registerAllStarters`.
+- `pkg/thresher/discovery.go` — `Starters()` latest-only.
+- `pkg/messaging/messagebroker.go` + `pkg/messaging/membroker/membroker.go` —
+  `Subscription.Unsubscribe()`.
+- `internal/eventproc/eventhub/waiters/message.go` — waiter unsubscribes on stop
+  (synchronously) and on the goroutine exit paths.
+
+**Verification (V-results)**
+- T-1..T-12 implemented and green (file map in §6).
+- `make ci` green: golangci-lint **0 issues**, `-race` across all modules,
+  **diff-coverage 99.2%** of changed lines (min 95% — NFR-4), govulncheck clean.
+- All 18 `examples/*` run green (`go run -C <dir> .`, exit 0).
 
 ## Open questions
 

--- a/docs/srd/SRD-031.A-definition-versioning.md
+++ b/docs/srd/SRD-031.A-definition-versioning.md
@@ -116,14 +116,21 @@ they keep running their own per-instance clone.
 - **FR-2 — Registration handle.** `RegisterProcess` returns a
   `*ProcessRegistration` exposing `Key() string`, `Version() int`, `ID() string`.
 - **FR-3 — Versioning.** Registering a process whose key already has
-  registrations appends a new version with `Version()` = previous + 1 (first =
-  1). The silent idempotent no-op (§1.1) is removed. A process with no explicit
-  id (auto-generated UUID) is its own singleton key at version 1.
+  registrations appends a new version. Version numbers come from a **per-key
+  monotonic counter**, not the slice length: a number is **never reused** while
+  the key has at least one live version, so removing a non-latest version (FR-8)
+  cannot make the next registration collide with a still-registered version. The
+  counter resets only when the key is fully unregistered (a later registration of
+  that key is v1 again). The silent idempotent no-op (§1.1) is removed. A process
+  with no explicit id (auto-generated UUID) is its own singleton key at version 1.
 - **FR-4 — Start by handle.** `StartProcess(reg *ProcessRegistration)` starts the
   exact version the handle names and returns its `*InstanceHandle`.
 - **FR-5 — Start by `(key, version)`.** `StartVersion(key string, version int)`
   starts that specific version, or errors (`ObjectNotFound`) if the key or
-  version is unknown.
+  version is unknown. It addresses by the version **number**, not slice position,
+  so it stays correct across gaps left by non-latest removals (FR-8) — e.g. after
+  v2 is removed, `StartVersion(key, 3)` still starts v3 and `StartVersion(key, 2)`
+  errors.
 - **FR-6 — Start latest.** `StartLatest(key string)` starts the latest registered
   version of the key, or errors (`ObjectNotFound`) if the key is unknown.
 - **FR-7 — Latest-supersedes auto-start.** Registering a newer version of a key in
@@ -131,19 +138,37 @@ they keep running their own per-instance clone.
   and registers the new version's, so only the latest version spawns new
   instances from a trigger. Instances already running under older versions
   continue to completion. Manual-start versions register no starters.
-- **FR-8 — Unregister by handle, promote-on-removal.** `UnregisterProcess(reg
-  *ProcessRegistration)` removes that version (its snapshot and, if it was the
-  live latest, its starters). Running instances survive. Removing the **latest**
-  auto version **promotes** the now-newest remaining version: its starters are
-  registered so it becomes the live auto-start version — the invariant *latest
-  registration == live starter set* holds at all times. (This is how a user
-  re-activates a previous version's auto-start: remove the later versions until
-  it is latest again; a previous version is otherwise manual-only via
-  `StartVersion`.) Removing the last version of a key drops the key entirely.
-  Removing a non-latest version touches no hub subscriptions.
+- **FR-8 — Unregister one version by handle, promote-on-removal.**
+  `UnregisterVersion(reg *ProcessRegistration)` removes the single version that
+  handle names (its snapshot and, if it was the live latest, its starters).
+  Running instances survive. Removing the **latest** auto version **promotes** the
+  now-newest remaining version: its starters are registered so it becomes the live
+  auto-start version — the invariant *latest registration == live starter set*
+  holds at all times. (This is how a user re-activates a previous version's
+  auto-start: remove the later versions until it is latest again; a previous
+  version is otherwise manual-only via `StartVersion`.) Removing the last version
+  of a key drops the key entirely. Removing a non-latest version touches no hub
+  subscriptions and **leaves a gap** in the key's version sequence (v1, v3, …) —
+  the surviving versions keep their numbers, addressable by `StartVersion` (FR-5)
+  and enumerable by `Registrations` (FR-10); `StartLatest` still resolves to the
+  highest surviving version.
 - **FR-9 — Migration.** Every in-repo caller of the changed methods adopts the new
   API: all `examples/*`, all `pkg/thresher/*_test.go`, `README.md`,
   `README.ru.md`, `examples/README.md`. Examples build **and run** green.
+- **FR-10 — List registered versions.** `Registrations(key string)
+  []*ProcessRegistration` returns the key's registered versions ascending by
+  version (empty for an unknown key). Each element is a **live handle** — read its
+  `Version()` / `ID()`, or pass it straight to `StartProcess` / `UnregisterVersion`
+  — so a caller can discover which versions exist (including gaps from FR-8) before
+  addressing one by `StartVersion`.
+- **FR-11 — Unregister the whole process by key.** `UnregisterProcess(key string)`
+  removes **every** registered version of the key in one call, drops the key, and
+  resets its version counter (a later registration of the key is v1 again). It is
+  the bulk counterpart of `UnregisterVersion`; the name matches its scope — a
+  *process* is the whole keyed definition, a *version* is one snapshot of it. Only
+  the latest version's starters are live, so only those are torn down; running
+  instances of any version survive. Errors `EmptyNotAllowed` on an empty key,
+  `ObjectNotFound` on an unknown key.
 
 ### Non-functional
 
@@ -173,7 +198,7 @@ A read-only receipt wrapping the engine's internal per-version state, mirroring
 ```go
 // ProcessRegistration is the receipt for one registered version of a process
 // definition. It names a (key, version) and is the token passed to StartProcess
-// and UnregisterProcess. Read-only: it exposes identity, never the snapshot or
+// and UnregisterVersion. Read-only: it exposes identity, never the snapshot or
 // the engine internals it wraps.
 type ProcessRegistration struct {
 	key      string                 // the versioning key = process id
@@ -260,11 +285,21 @@ over the definition; (b) inline the full relink/remap/rebind in `New` as well as
 `Clone` — single-pass, but duplicates ~40 lines of tricky graph-wiring in two
 places that must stay correct in lockstep.
 
-### 4.2 Version assignment and the latest pointer (decided)
+### 4.2 Version assignment is a per-key monotonic counter, not the slice index (decided)
 
-A version is its 1-based index in `registrations[key]`; the latest is the last
-element. This keeps assignment, lookup-by-version (FR-5), and latest (FR-6) all
-O(1)/O(len) with no separate counter to keep consistent. Registration appends
+The version is **not** the slice position. An earlier draft assigned `version =
+len(registrations[key]) + 1` and looked up `regs[version-1]`, coupling the number
+to the position — which breaks the moment a **non-latest** version is removed
+(FR-8): the slice `[v1, v2, v3]` becomes `[v1, v3]`, so `regs[version-1]` returns
+the wrong snapshot for `StartVersion(key, 2)`/`(key, 3)`, and the next
+registration reuses number 3. So version assignment uses a **per-key monotonic
+counter** (`nextVersion map[string]int`): each registration increments it and
+takes the new value, so a number is never reused while the key lives. The counter
+is dropped with the key on full unregistration (a fresh key restarts at v1). The
+slice stays append-ordered and removals preserve order, so it is always ascending
+by version — hence the **latest** (FR-6) is still `regs[len-1]` (O(1)), while
+**lookup-by-version** (FR-5) scans for the matching `version` (O(len), gap-safe)
+and **enumeration** (FR-10) returns a copy of the slice. Registration appends
 under `t.m`; the supersession hub calls run **outside** `t.m` (§4.4).
 
 ### 4.3 Latest-supersedes composes existing primitives (decided)
@@ -272,7 +307,7 @@ under `t.m`; the supersession hub calls run **outside** `t.m` (§4.4).
 FR-7 is the existing teardown + register sequence applied across versions: on
 registering a new auto version when the engine is `Started`, unregister the prior
 latest's starters (`eventHub.UnregisterEvent(st, st.eDef.ID())`, as
-`UnregisterProcess` already does, `thresher.go:544`) and register the new
+`UnregisterVersion` already does, `thresher.go:545`) and register the new
 version's (`registerStarters`, `thresher.go:561`). No new hub mechanism. This is
 the direct analogue of Camunda's "subscriptions of the previous version are
 canceled" (ADR-019 §2.5). Before `Run` (engine not yet `Started`) nothing is on
@@ -297,11 +332,13 @@ non-goal; `seenKeys` semantics are unchanged here.
 
 ### 4.6 The handle is engine-scoped (decided)
 
-`StartProcess`/`UnregisterProcess` validate the handle is non-nil (NFR-1);
-`UnregisterProcess` additionally verifies the handle is a member of this engine's
+`StartProcess`/`UnregisterVersion` validate the handle is non-nil (NFR-1);
+`UnregisterVersion` additionally verifies the handle is a member of this engine's
 `registrations` (else `ObjectNotFound`), since removal is bookkeeping on this
 registry. `StartProcess` launches `reg.snapshot` directly. Passing a foreign
 handle is a programming error surfaced by the membership check on unregister.
+(`UnregisterProcess` is key-addressed, not handle-addressed, so it has no
+membership check — it errors `ObjectNotFound` when the key has no versions.)
 
 ## 5. Public API surface
 
@@ -311,15 +348,20 @@ func (t *Thresher) RegisterProcess(p *process.Process, opts ...RegisterOption) (
 func (t *Thresher) StartProcess(reg *ProcessRegistration) (*InstanceHandle, error)
 func (t *Thresher) StartVersion(key string, version int) (*InstanceHandle, error)
 func (t *Thresher) StartLatest(key string) (*InstanceHandle, error)
-func (t *Thresher) UnregisterProcess(reg *ProcessRegistration) error
+func (t *Thresher) UnregisterVersion(reg *ProcessRegistration) error
+func (t *Thresher) UnregisterProcess(key string) error
+func (t *Thresher) Registrations(key string) []*ProcessRegistration
 
 func (r *ProcessRegistration) Key() string
 func (r *ProcessRegistration) Version() int
 func (r *ProcessRegistration) ID() string
 ```
 
-Method names are kept (`RegisterProcess`/`StartProcess`/`UnregisterProcess`); only
-their parameters/returns change, plus the two new `StartVersion`/`StartLatest`.
+`RegisterProcess`/`StartProcess` keep their names (parameters/returns change). The
+single-version teardown is renamed `UnregisterProcess(id)` → `UnregisterVersion(reg)`,
+and `UnregisterProcess(key)` is repurposed to remove the **whole** process (every
+version) — so the name now matches its scope. New: `StartVersion`/`StartLatest`/
+`Registrations`/`UnregisterProcess(key)`.
 `snapshot.New`'s signature is unchanged (its behavior — deep copy — changes).
 `Thresher.Instance(id)` and the SRD-019 discovery surface are unaffected.
 
@@ -336,9 +378,11 @@ their parameters/returns change, plus the two new `StartVersion`/`StartLatest`.
 | T-7 | `StartVersion(key, n)` starts version n; unknown key/version → ObjectNotFound; version<1 → error | FR-5, NFR-1 | `thresher/versioning_test.go` |
 | T-8 | `StartLatest(key)` starts the newest version; unknown/empty key → error | FR-6, NFR-1 | `thresher/versioning_test.go` |
 | T-9 | Registering v2 (auto, message-start) moves the start subscription: a trigger spawns a v2 instance, not v1; a running v1 instance is unaffected | FR-7 | `thresher/versioning_internal_test.go` |
-| T-10 | `UnregisterProcess(reg)` removes that version; a running instance of it survives; foreign/nil handle → error | FR-8, NFR-1 | `thresher/discovery_test.go` (survives+removal) + `thresher/instance_starter_internal_test.go` (nil/foreign) |
+| T-10 | `UnregisterVersion(reg)` removes that version; a running instance of it survives; foreign/nil handle → error | FR-8, NFR-1 | `thresher/discovery_test.go` (survives+removal) + `thresher/instance_starter_internal_test.go` (nil/foreign) |
 | T-11 | Unregistering the latest auto version promotes the now-newest remaining version to live auto-start — it owns the trigger again (a publish spawns its instance) | FR-8 | `thresher/versioning_internal_test.go` |
 | T-12 | `go test -race ./pkg/thresher/...` green under concurrent register/start | NFR-2 | existing + new |
+| T-13 | Removing a non-latest version leaves a gap: `StartVersion(key,3)` still starts v3 and `(key,2)` errors; re-register yields v4 (no reuse); `StartLatest`→v3; `Registrations(key)` reports `[1,3]`→`[1,3,4]`; full removal via `UnregisterVersion` resets to v1 | FR-3, FR-5, FR-8, FR-10 | `thresher/versioning_test.go` |
+| T-14 | `UnregisterProcess(key)` removes every version at once (`Registrations` empty, `StartLatest` errors); empty/unknown key → error; the counter resets so a later registration is v1 | FR-11, NFR-1 | `thresher/versioning_test.go` |
 
 ## 7. Milestones
 
@@ -357,7 +401,14 @@ their parameters/returns change, plus the two new `StartVersion`/`StartLatest`.
   T-9/T-10/T-11.
 - **A5 — Migration.** All examples, `pkg/thresher/*_test.go`, `README*.md`,
   `examples/README.md`; examples build+run; `CHANGELOG` migration note (NFR-5).
-- **A6 — Verify & land.** `/check-style`, `/check-srd`, `make ci`, fill §10, flip
+- **A6 — Gapped versions + unregister granularity.** Decouple the version number
+  from the slice index: a per-key monotonic `nextVersion` counter (never reused;
+  reset on full removal), `StartVersion` scans by number, and `Registrations(key)`
+  enumerates the versions (FR-10). Split removal by scope: rename the single-version
+  teardown `UnregisterProcess(reg)` → `UnregisterVersion(reg)`, and repurpose
+  `UnregisterProcess(key)` to drop the whole process (FR-11). Hardens
+  FR-3/FR-5/FR-8 against non-latest removal; T-13/T-14.
+- **A7 — Verify & land.** `/check-style`, `/check-srd`, `make ci`, fill §10, flip
   status. (T-12 throughout.)
 
 ## 8. Cross-doc
@@ -380,7 +431,7 @@ their parameters/returns change, plus the two new `StartVersion`/`StartLatest`.
 
 ## 9. Definition of Done
 
-- [ ] FR-1..FR-9 wired and covered by T-1..T-12.
+- [ ] FR-1..FR-11 wired and covered by T-1..T-14.
 - [ ] All examples build **and run** (`go run`) green; `examples/README` + both
   `README*.md` migrated.
 - [ ] `pkg/thresher/*_test.go` migrated; no reference to the removed `StartProcess(id)`
@@ -409,7 +460,13 @@ Landed on `feat/adr-019-definition-versioning` (off `master`).
   completion: `56e2263`.
 - **A5** — caller/doc migration (examples were already on the new API; the
   `README.md` / `README.ru.md` / `examples/README.md` snippets; the `CHANGELOG`
-  migration note; this §10): the A5 docs commit on this branch.
+  migration note; this §10): `47b5340`.
+- **A6** — gapped versions + unregister granularity: per-key monotonic
+  `nextVersion` counter (never reused; reset on full removal), `StartVersion`
+  scans by version number, new `Registrations(key)` (FR-10); rename
+  `UnregisterProcess(reg)` → `UnregisterVersion(reg)` and repurpose
+  `UnregisterProcess(key)` for whole-process removal (FR-11); T-13/T-14: the A6
+  commit on this branch.
 
 **Key files**
 - `internal/instance/snapshot/snapshot.go` — `New` clones nodes in its validation
@@ -417,11 +474,14 @@ Landed on `feat/adr-019-definition-versioning` (off `master`).
   `Clone`.
 - `pkg/thresher/registration.go` (new) — `ProcessRegistration` read-only handle
   (`Key`/`Version`/`ID`).
-- `pkg/thresher/thresher.go` — `registrations map[string][]*ProcessRegistration`;
-  `RegisterProcess` (append version + supersession), `StartProcess` /
-  `StartVersion` / `StartLatest`, `UnregisterProcess` (promote-on-removal),
-  latest-only `registerAllStarters`.
-- `pkg/thresher/discovery.go` — `Starters()` latest-only.
+- `pkg/thresher/thresher.go` — `registrations map[string][]*ProcessRegistration`
+  + per-key `nextVersion map[string]int`; `RegisterProcess` (monotonic version +
+  supersession), `StartProcess` / `StartVersion` (scan-by-number) / `StartLatest`,
+  `UnregisterVersion` (single version, promote-on-removal; drops the counter on
+  full removal) + `UnregisterProcess(key)` (whole-process removal), latest-only
+  `registerAllStarters`.
+- `pkg/thresher/discovery.go` — `Starters()` latest-only; `Registrations(key)`
+  enumerates a key's versions (FR-10).
 - `pkg/messaging/messagebroker.go` + `pkg/messaging/membroker/membroker.go` —
   `Subscription.Unsubscribe()`.
 - `internal/eventproc/eventhub/waiters/message.go` — waiter unsubscribes on stop

--- a/docs/srd/SRD-031.A-definition-versioning.md
+++ b/docs/srd/SRD-031.A-definition-versioning.md
@@ -131,11 +131,16 @@ they keep running their own per-instance clone.
   and registers the new version's, so only the latest version spawns new
   instances from a trigger. Instances already running under older versions
   continue to completion. Manual-start versions register no starters.
-- **FR-8 — Unregister by handle.** `UnregisterProcess(reg *ProcessRegistration)`
-  removes that version (its snapshot and, if live, its starters). Running
-  instances survive. Unregistering the latest auto version does **not** promote a
-  prior version's starters back to live (no auto-promotion); auto-start for the
-  key ceases until a new version is registered.
+- **FR-8 — Unregister by handle, promote-on-removal.** `UnregisterProcess(reg
+  *ProcessRegistration)` removes that version (its snapshot and, if it was the
+  live latest, its starters). Running instances survive. Removing the **latest**
+  auto version **promotes** the now-newest remaining version: its starters are
+  registered so it becomes the live auto-start version — the invariant *latest
+  registration == live starter set* holds at all times. (This is how a user
+  re-activates a previous version's auto-start: remove the later versions until
+  it is latest again; a previous version is otherwise manual-only via
+  `StartVersion`.) Removing the last version of a key drops the key entirely.
+  Removing a non-latest version touches no hub subscriptions.
 - **FR-9 — Migration.** Every in-repo caller of the changed methods adopts the new
   API: all `examples/*`, all `pkg/thresher/*_test.go`, `README.md`,
   `README.ru.md`, `examples/README.md`. Examples build **and run** green.

--- a/docs/srd/SRD-031.A-definition-versioning.md
+++ b/docs/srd/SRD-031.A-definition-versioning.md
@@ -1,0 +1,399 @@
+# SRD-031.A — Definition versioning and the registration handle
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-06-28 |
+| Owner | Ruslan Gabitov |
+| Implements | [ADR-019 v.1 Definition versioning](../design/ADR-019-definition-versioning.md) |
+
+This SRD lands the **versioning half** of [ADR-019
+v.1](../design/ADR-019-definition-versioning.md): `RegisterProcess` returns a
+**registration handle** naming a `(key, version)`; the engine snapshot is
+**isolated** from the model at registration time (closing the architecture audit
+§3.3 mutation leak/race by construction); instances start **by handle**, **by
+`(key, version)`**, or **by latest-of-key**; and registering a newer version
+**supersedes** the previous version's auto-start. The Thresher registry's
+concurrency-discipline rework (audit §2.6) is the **sibling SRD-031.B**, landed
+on the same branch after this one. The first-class model-editing API is a
+separate ADR, not in scope here.
+
+---
+
+## 1. Background & current state (verified against the code)
+
+### 1.1 Registration identity is ambiguous, and re-registration is a silent no-op
+
+`Thresher.RegisterProcess` returns only an `error` and stores the snapshot keyed
+on the process id; a second registration of the same id is silently discarded
+(`pkg/thresher/thresher.go:485-491`):
+
+```go
+t.m.Lock()
+if _, ok := t.snapshots[s.ProcessID]; ok {
+	// Already registered — idempotent, keep the first registration.
+	t.m.Unlock()
+	return nil
+}
+```
+
+`StartProcess` then takes that **id string** and starts whatever is stored under
+it (`pkg/thresher/thresher.go:702,716`):
+
+```go
+func (t *Thresher) StartProcess(processID string) (*InstanceHandle, error) {
+	...
+	s, ok := t.snapshots[processID]
+```
+
+A caller who edits a process and re-registers it expecting the new shape gets the
+*old* snapshot, with no error — and addresses the registration by reaching back
+into the model object for its id, with no way to say *which* registered shape is
+meant.
+
+### 1.2 The snapshot shares the model's node graph — the audit §3.3 leak
+
+`snapshot.New` does **not** copy the definition's nodes/flows; it stores the model
+objects by reference (`internal/instance/snapshot/snapshot.go:58,68,113`):
+
+```go
+Properties:  p.Properties(),
+...
+for _, n := range p.Nodes() {
+	s.Nodes[n.ID()] = n        // shares the model node by pointer
+}
+...
+	s.Flows[f.ID()] = f        // shares the model flow by pointer
+```
+
+The deep copy happens only later, **once per running instance**, in `Clone`
+(`snapshot.go:149-237`): clone every node, relink flows, remap default flows,
+rebind boundary events. The process model stays mutable after registration via
+its public `Add`/`Remove` (`pkg/model/process/process.go:168,272`), so:
+
+- a node/flow **added** after registration never enters the already-taken
+  snapshot (invisible), and
+- an **in-place** edit to an existing shared node reaches the snapshot through the
+  shared pointer and is picked up by the next `Clone`, racing any instance
+  already cloning it (no lock on that path).
+
+This is architecture-audit **§3.3** ("validation and mutability of the process
+model"). ADR-019 §2.3 resolves it by **isolation** (copy at registration) rather
+than the audit's freeze.
+
+### 1.3 The registry today
+
+The Thresher holds four maps under one mutex (`pkg/thresher/thresher.go:109-121`):
+
+```go
+snapshots    map[string]*snapshot.Snapshot      // key = ProcessID
+instances    map[string]instanceReg             // key = instance id
+starters     map[string][]*instanceStarter      // key = ProcessID
+seenKeys     map[string]struct{}                // correlation dedup
+m            sync.Mutex
+state        State
+```
+
+Auto-start starters are built per process by `scanInstantiatingStarts`
+(`instance_starter.go:109`) and registered/torn down on the EventHub via
+`registerStarters` (`thresher.go:561`, `RegisterPersistentEvent`) and
+`eventHub.UnregisterEvent(st, st.eDef.ID())` (`thresher.go:544`). Running
+instances are tracked independently in `instances` and are **unaffected** by
+unregistering a process (`UnregisterProcess` comment, `thresher.go:512-514`) —
+they keep running their own per-instance clone.
+
+## 2. Requirements
+
+### Functional
+
+- **FR-1 — Snapshot isolation.** `snapshot.New` deep-copies the definition's node
+  graph (nodes, flows, default-flow and boundary wiring) so the snapshot owns an
+  independent graph. After `RegisterProcess` returns, no edit to the source
+  `*process.Process` — structural or in-place — changes the taken snapshot or any
+  instance later born from it. Immutable per-definition config (properties,
+  correlation keys) may remain shared by reference.
+- **FR-2 — Registration handle.** `RegisterProcess` returns a
+  `*ProcessRegistration` exposing `Key() string`, `Version() int`, `ID() string`.
+- **FR-3 — Versioning.** Registering a process whose key already has
+  registrations appends a new version with `Version()` = previous + 1 (first =
+  1). The silent idempotent no-op (§1.1) is removed. A process with no explicit
+  id (auto-generated UUID) is its own singleton key at version 1.
+- **FR-4 — Start by handle.** `StartProcess(reg *ProcessRegistration)` starts the
+  exact version the handle names and returns its `*InstanceHandle`.
+- **FR-5 — Start by `(key, version)`.** `StartVersion(key string, version int)`
+  starts that specific version, or errors (`ObjectNotFound`) if the key or
+  version is unknown.
+- **FR-6 — Start latest.** `StartLatest(key string)` starts the latest registered
+  version of the key, or errors (`ObjectNotFound`) if the key is unknown.
+- **FR-7 — Latest-supersedes auto-start.** Registering a newer version of a key in
+  auto mode tears down the previous version's instance-starters from the EventHub
+  and registers the new version's, so only the latest version spawns new
+  instances from a trigger. Instances already running under older versions
+  continue to completion. Manual-start versions register no starters.
+- **FR-8 — Unregister by handle.** `UnregisterProcess(reg *ProcessRegistration)`
+  removes that version (its snapshot and, if live, its starters). Running
+  instances survive. Unregistering the latest auto version does **not** promote a
+  prior version's starters back to live (no auto-promotion); auto-start for the
+  key ceases until a new version is registered.
+- **FR-9 — Migration.** Every in-repo caller of the changed methods adopts the new
+  API: all `examples/*`, all `pkg/thresher/*_test.go`, `README.md`,
+  `README.ru.md`, `examples/README.md`. Examples build **and run** green.
+
+### Non-functional
+
+- **NFR-1 — Parameter validation.** Every new/changed public method rejects bad
+  input with a self-identifying error (nil handle, empty key, version < 1) — per
+  the project's public-API validation rule — never a silent default or panic.
+- **NFR-2 — No new races.** The change introduces no data race under concurrent
+  register/start/unregister (`go test -race`). This SRD preserves the existing
+  lock discipline; the explicit atomic-state/lock-boundary hardening (audit §2.6)
+  is **SRD-031.B**.
+- **NFR-3 — Bounded cost.** Isolation adds one graph clone per registration (paid
+  once, bounded by definition size); no per-instance runtime regression (the
+  per-instance `Clone` is unchanged, now cloning from the isolated snapshot).
+- **NFR-4 — Coverage.** Diff-coverage ≥ project standard (95%, aim 100%) on every
+  touched file; `make ci` green.
+- **NFR-5 — Documented breaking change.** The API break is recorded in
+  `CHANGELOG.md` with a migration note (old `StartProcess(id)` →
+  `StartProcess(reg)` / `StartLatest(key)`).
+
+## 3. Models
+
+### 3.1 `ProcessRegistration` — the registration handle (`pkg/thresher/registration.go`, new)
+
+A read-only receipt wrapping the engine's internal per-version state, mirroring
+`InstanceHandle`'s wrap-by-reference pattern (`handle.go:24`):
+
+```go
+// ProcessRegistration is the receipt for one registered version of a process
+// definition. It names a (key, version) and is the token passed to StartProcess
+// and UnregisterProcess. Read-only: it exposes identity, never the snapshot or
+// the engine internals it wraps.
+type ProcessRegistration struct {
+	key      string                 // the versioning key = process id
+	version  int                    // 1-based, increments per key
+	id       string                 // opaque registration id (foundation id)
+	snapshot *snapshot.Snapshot     // the frozen version (engine-internal)
+	starters []*instanceStarter     // auto-start starters of this version (nil in manual mode)
+	manual   bool                   // registered WithManualStart
+}
+
+func (r *ProcessRegistration) Key() string  { return r.key }
+func (r *ProcessRegistration) Version() int  { return r.version }
+func (r *ProcessRegistration) ID() string    { return r.id }
+```
+
+### 3.2 The versioned registry (`pkg/thresher/thresher.go`)
+
+The `snapshots` and `starters` maps collapse into one ordered-by-version map; each
+version's snapshot and starters live on its `ProcessRegistration`. `instances`,
+`seenKeys`, `m`, and `state` are unchanged by this SRD.
+
+```go
+// registrations maps a process key (process id) to its versions in registration
+// order: index i is version i+1; the last element is the latest.
+registrations map[string][]*ProcessRegistration
+instances     map[string]instanceReg   // unchanged
+seenKeys      map[string]struct{}       // unchanged (see §4.5)
+```
+
+### 3.3 `snapshot.New` clones the definition directly; a shared wiring helper keeps it DRY (`internal/instance/snapshot/snapshot.go`)
+
+`New` already makes one pass over the definition's nodes (`p.Nodes()`,
+`snapshot.go:67`) to validate the process (start/end/instantiating-node checks).
+That same pass now **clones** each node (`n.Clone()`) into `s.Nodes` instead of
+sharing it by reference (`snapshot.go:68`), so the snapshot is born isolated —
+with no throwaway model-sharing intermediate and no redundant second pass over
+the definition (the `return s.Clone()` shape would build a shared snapshot only
+to re-clone it).
+
+The graph still needs the post-node-clone wiring that `Clone` performs — relink
+the flows between the cloned nodes (`flow.MustCloneFlow`), remap gateway default
+flows, rebind boundary events onto their cloned hosts (`snapshot.go:166-234`).
+That wiring is identical whether the cloned nodes came from a process or from a
+snapshot, so it is the one piece extracted into an unexported helper (the
+node-cloning loop differs per source; the wiring does not):
+
+```go
+// wireClonedGraph relinks the flow graph between an already-cloned node set,
+// remaps gateway default flows, and rebinds boundary events onto their cloned
+// hosts. Shared by New (cloning from the process definition) and Clone (cloning
+// from the snapshot). Signature finalized in implementation; conceptually it
+// takes the cloned nodes + the source nodes/flows and returns the cloned flows.
+func wireClonedGraph(
+	clonedNodes map[string]flow.Node,
+	srcNodes map[string]flow.Node,
+	srcFlows map[string]*flow.SequenceFlow,
+) (map[string]*flow.SequenceFlow, error)
+```
+
+`New` clones nodes in its validation pass and then calls `wireClonedGraph`;
+`Clone` clones `s.Nodes` and calls the same helper. Neither duplicates the
+relink/remap/rebind logic, and `New` touches the definition only in its single
+existing pass. `RegisterProcess` then runs `scanInstantiatingStarts` on the
+isolated snapshot, so starters reference the frozen graph. Properties/CorrelationKeys
+stay shared (immutable; the `Clone` shares-Properties invariant anchored by
+`TestSnapshotCloneSharesProperties` on master remains true).
+
+## 4. Analysis
+
+### 4.1 New clones the definition directly; Clone-shared wiring (decided)
+
+The snapshot is born isolated: `New` clones each node in the single validation
+pass it already makes over the definition, rather than sharing the model and then
+re-cloning it. The non-trivial post-clone wiring — relink flows, remap default
+flows, rebind boundary events — is identical for a process source and a snapshot
+source, so it is the one piece extracted into a shared helper (`wireClonedGraph`,
+§3.3); the per-source node-cloning loop stays in each of `New` and `Clone`. This
+gives single-pass construction with no duplicated wiring logic, and the two
+isolation hops still compose cleanly (instance graph ⊂ snapshot graph ⊂ model).
+
+**Rejected alternatives:** (a) `return s.Clone()` from `New` — simplest to write,
+but builds a throwaway model-sharing snapshot and re-clones it, a redundant pass
+over the definition; (b) inline the full relink/remap/rebind in `New` as well as
+`Clone` — single-pass, but duplicates ~40 lines of tricky graph-wiring in two
+places that must stay correct in lockstep.
+
+### 4.2 Version assignment and the latest pointer (decided)
+
+A version is its 1-based index in `registrations[key]`; the latest is the last
+element. This keeps assignment, lookup-by-version (FR-5), and latest (FR-6) all
+O(1)/O(len) with no separate counter to keep consistent. Registration appends
+under `t.m`; the supersession hub calls run **outside** `t.m` (§4.4).
+
+### 4.3 Latest-supersedes composes existing primitives (decided)
+
+FR-7 is the existing teardown + register sequence applied across versions: on
+registering a new auto version when the engine is `Started`, unregister the prior
+latest's starters (`eventHub.UnregisterEvent(st, st.eDef.ID())`, as
+`UnregisterProcess` already does, `thresher.go:544`) and register the new
+version's (`registerStarters`, `thresher.go:561`). No new hub mechanism. This is
+the direct analogue of Camunda's "subscriptions of the previous version are
+canceled" (ADR-019 §2.5). Before `Run` (engine not yet `Started`) nothing is on
+the hub yet, so supersession is deferred to `Run`/`registerAllStarters`, which
+registers only each key's **latest** version's starters.
+
+### 4.4 Lock discipline preserved (decided; hardening deferred to SRD-031.B)
+
+This SRD keeps the current discipline: mutate `registrations` under `t.m`; run
+hub calls (register/unregister starters) and `launchInstance` **outside** `t.m`
+(FIX-002 RC2, `thresher.go:498-501`). The fragile-comment problem the audit flags
+(§2.6) is **not** fixed here — it is the sibling SRD-031.B's subject, landed next
+on the same branch so the hardening operates on this SRD's final registry shape.
+
+### 4.5 `seenKeys` stays keyed by process id across versions (decided)
+
+Correlation dedup namespaces by `s.ProcessID` (`thresher.go:613`), which is the
+key — shared across a key's versions. Because only the latest version auto-starts
+(FR-7), create-or-join stays coherent in practice. Cross-version correlation (a
+conversation begun under v1 routed into a v2 instance) is an ADR-019 §2.8
+non-goal; `seenKeys` semantics are unchanged here.
+
+### 4.6 The handle is engine-scoped (decided)
+
+`StartProcess`/`UnregisterProcess` validate the handle is non-nil (NFR-1);
+`UnregisterProcess` additionally verifies the handle is a member of this engine's
+`registrations` (else `ObjectNotFound`), since removal is bookkeeping on this
+registry. `StartProcess` launches `reg.snapshot` directly. Passing a foreign
+handle is a programming error surfaced by the membership check on unregister.
+
+## 5. Public API surface
+
+```go
+// pkg/thresher
+func (t *Thresher) RegisterProcess(p *process.Process, opts ...RegisterOption) (*ProcessRegistration, error)
+func (t *Thresher) StartProcess(reg *ProcessRegistration) (*InstanceHandle, error)
+func (t *Thresher) StartVersion(key string, version int) (*InstanceHandle, error)
+func (t *Thresher) StartLatest(key string) (*InstanceHandle, error)
+func (t *Thresher) UnregisterProcess(reg *ProcessRegistration) error
+
+func (r *ProcessRegistration) Key() string
+func (r *ProcessRegistration) Version() int
+func (r *ProcessRegistration) ID() string
+```
+
+Method names are kept (`RegisterProcess`/`StartProcess`/`UnregisterProcess`); only
+their parameters/returns change, plus the two new `StartVersion`/`StartLatest`.
+`snapshot.New`'s signature is unchanged (its behavior — deep copy — changes).
+`Thresher.Instance(id)` and the SRD-019 discovery surface are unaffected.
+
+## 6. Test scenarios
+
+| # | Scenario | FR | Where |
+|---|---|---|---|
+| T-1 | After `RegisterProcess`, mutating the source process (Add a node) leaves the registration's snapshot unchanged; an instance started from it runs the registered shape | FR-1 | `snapshot/snapshot_test.go` (isolation) + `thresher/versioning_test.go` |
+| T-2 | `snapshot.New` graph nodes are distinct pointers from the model's nodes (isolation); a per-instance `Clone` of the snapshot still produces a working instance graph | FR-1 | `snapshot/snapshot_test.go` |
+| T-3 | `RegisterProcess` returns a handle with Key=process id, Version=1; ID non-empty | FR-2 | `thresher/versioning_test.go` |
+| T-4 | Re-registering the same key yields Version=2,3,…; both versions independently startable | FR-3 | `thresher/versioning_test.go` |
+| T-5 | A process with no explicit id is a singleton v1 (distinct UUID keys) | FR-3 | `thresher/versioning_test.go` |
+| T-6 | `StartProcess(reg)` starts the exact version; nil handle → self-identifying error | FR-4, NFR-1 | `thresher/versioning_test.go` |
+| T-7 | `StartVersion(key, n)` starts version n; unknown key/version → ObjectNotFound; version<1 → error | FR-5, NFR-1 | `thresher/versioning_test.go` |
+| T-8 | `StartLatest(key)` starts the newest version; unknown/empty key → error | FR-6, NFR-1 | `thresher/versioning_test.go` |
+| T-9 | Registering v2 (auto, message-start) moves the start subscription: a trigger spawns a v2 instance, not v1; a running v1 instance is unaffected | FR-7 | `thresher/versioning_internal_test.go` |
+| T-10 | `UnregisterProcess(reg)` removes that version; a running instance of it survives; foreign/nil handle → error | FR-8, NFR-1 | `thresher/versioning_internal_test.go` |
+| T-11 | Unregistering the latest auto version stops auto-start for the key (no promotion of the prior version) | FR-8 | `thresher/versioning_internal_test.go` |
+| T-12 | `go test -race ./pkg/thresher/...` green under concurrent register/start | NFR-2 | existing + new |
+
+## 7. Milestones
+
+- **A1 — Snapshot isolation.** `New` clones nodes in its validation pass and wires
+  the graph via the shared `wireClonedGraph` helper (also used by `Clone`), so the
+  snapshot is born isolated in one pass; T-1/T-2. (`internal/instance/snapshot/`.)
+- **A2 — Handle + versioned registry.** `ProcessRegistration`; `registrations`
+  map; `RegisterProcess` returns the handle and appends a version (drop the
+  no-op); T-3/T-4/T-5.
+- **A3 — Start addressing.** `StartProcess(reg)`, `StartVersion`, `StartLatest`,
+  with validation; T-6/T-7/T-8.
+- **A4 — Latest-supersedes + unregister.** Supersession on register;
+  `UnregisterProcess(reg)`; no auto-promotion; T-9/T-10/T-11.
+- **A5 — Migration.** All examples, `pkg/thresher/*_test.go`, `README*.md`,
+  `examples/README.md`; examples build+run; `CHANGELOG` migration note (NFR-5).
+- **A6 — Verify & land.** `/check-style`, `/check-srd`, `make ci`, fill §10, flip
+  status. (T-12 throughout.)
+
+## 8. Cross-doc
+
+- **Implements** [ADR-019 v.1](../design/ADR-019-definition-versioning.md) — §2.1
+  key, §2.2 handle, §2.3 isolation, §2.4 three start modes, §2.5 latest-supersedes,
+  §2.7 (concurrency → SRD-031.B), §2.8 deferrals.
+- [ADR-009 v.1](../design/ADR-009-per-instance-node-graph.md) — the per-instance
+  clone model FR-1 extends with the missing model→snapshot hop.
+- [ADR-015 v.1](../design/ADR-015-event-triggered-instantiation.md) — the
+  instance-starters FR-7 supersedes across versions; the manual-start mode.
+- [ADR-016 v.1](../design/ADR-016-message-correlation.md) — the create-or-join
+  dedup (§4.5) that stays coherent because only the latest auto-starts.
+- [ADR-013 v.1](../design/ADR-013-instance-observability.md) — the read-only
+  `InstanceHandle` pattern `ProcessRegistration` mirrors.
+- Architecture audit 2026-06-11 — **§3.3** resolved here (isolation); **§2.6** is
+  the sibling **SRD-031.B**.
+- Siblings SRD-006 (per-instance node graph / the `Clone` reused), SRD-018
+  (the handle), SRD-015 (the starters) — number-only sideways refs.
+
+## 9. Definition of Done
+
+- [ ] FR-1..FR-9 wired and covered by T-1..T-12.
+- [ ] All examples build **and run** (`go run`) green; `examples/README` + both
+  `README*.md` migrated.
+- [ ] `pkg/thresher/*_test.go` migrated; no reference to the removed `StartProcess(id)`
+  form remains in current (non-frozen) code/docs.
+- [ ] `CHANGELOG.md` carries the breaking-change migration note (NFR-5).
+- [ ] `/check-style` clean; `/check-srd` PASS.
+- [ ] `make ci` green incl. diff-coverage ≥95% on touched files (NFR-4);
+  `go test -race ./pkg/thresher/...` green (NFR-2).
+- [ ] §8 cross-doc pins consistent; frozen one-shot SRD/FIX (SRD-015/018/025,
+  FIX-002) **not** retro-edited.
+- [ ] §10 filled; status flipped Draft → Accepted (user's call).
+
+## 10. Implementation summary
+
+_(filled at landing: files/lines, T-results, milestone SHAs.)_
+
+## Open questions
+
+None. Scope: in-memory definition versioning — isolation, handle, versioned
+registry, three start modes, latest-supersedes, unregister-by-handle, and the
+caller migration. The registry **concurrency hardening** (audit §2.6) is the
+sibling **SRD-031.B**; the **model-editing API** is a separate ADR; durable
+versioning / migration / cross-version correlation / version tags are ADR-019
+§2.8 deferrals.

--- a/examples/README.md
+++ b/examples/README.md
@@ -107,18 +107,15 @@ proc.Add(endEvent)
 // 5. Link elements with sequence flows
 flow.Link(startEvent, endEvent)
 
-// 6. Create process snapshot
-snap, err := snapshot.New(proc)
+// 6. Register the process — returns a (key, version) registration handle
+reg, err := engine.RegisterProcess(proc)
 
-// 7. Register process with engine
-engine.RegisterProcess(snap)
-
-// 8. Start engine
+// 7. Start engine
 ctx := context.Background()
 engine.Run(ctx)
 
-// 9. Execute process
-engine.StartProcess(snap.ProcessId)
+// 8. Launch an instance — by handle, or by StartLatest(proc.ID())
+engine.StartProcess(reg)
 ```
 
 ### Error Handling

--- a/examples/basic-process/main.go
+++ b/examples/basic-process/main.go
@@ -48,7 +48,7 @@ func run() error {
 		return fmt.Errorf("build process: %w", err)
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/basic-process/main.go
+++ b/examples/basic-process/main.go
@@ -59,7 +59,7 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	h, err := engine.StartProcess(proc.ID())
+	h, err := engine.StartLatest(proc.ID())
 	if err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}

--- a/examples/boundary-events/main.go
+++ b/examples/boundary-events/main.go
@@ -50,7 +50,7 @@ func run() error {
 		return fmt.Errorf("build process: %w", err)
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/boundary-events/main.go
+++ b/examples/boundary-events/main.go
@@ -61,7 +61,7 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	h, err := engine.StartProcess(proc.ID())
+	h, err := engine.StartLatest(proc.ID())
 	if err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}

--- a/examples/complex-gateway/main.go
+++ b/examples/complex-gateway/main.go
@@ -51,7 +51,7 @@ func run() error {
 		return fmt.Errorf("build process: %w", err)
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/complex-gateway/main.go
+++ b/examples/complex-gateway/main.go
@@ -64,7 +64,7 @@ func run() error {
 
 	fmt.Printf("order amount = %d (needs 2 approvals)\n", amount)
 
-	h, err := engine.StartProcess(proc.ID())
+	h, err := engine.StartLatest(proc.ID())
 	if err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}

--- a/examples/conversation-routing/main.go
+++ b/examples/conversation-routing/main.go
@@ -65,7 +65,7 @@ func run() error {
 		return err
 	}
 
-	if err := engine.RegisterProcess(handler); err != nil {
+	if _, err := engine.RegisterProcess(handler); err != nil {
 		return fmt.Errorf("register handler: %w", err)
 	}
 

--- a/examples/event-based-gateway/main.go
+++ b/examples/event-based-gateway/main.go
@@ -52,7 +52,7 @@ func run() error {
 		return fmt.Errorf("build process: %w", err)
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/event-based-gateway/main.go
+++ b/examples/event-based-gateway/main.go
@@ -65,7 +65,7 @@ func run() error {
 
 	fmt.Println("deferred choice: waiting for an approval message OR a 10s timeout...")
 
-	h, err := engine.StartProcess(proc.ID())
+	h, err := engine.StartLatest(proc.ID())
 	if err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}

--- a/examples/event-based-parallel-start/main.go
+++ b/examples/event-based-parallel-start/main.go
@@ -44,7 +44,7 @@ func run() error {
 		return fmt.Errorf("build process: %w", err)
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/gateway-routing/main.go
+++ b/examples/gateway-routing/main.go
@@ -60,7 +60,7 @@ func run() error {
 
 	fmt.Printf("order amount = %d\n", amount)
 
-	h, err := engine.StartProcess(proc.ID())
+	h, err := engine.StartLatest(proc.ID())
 	if err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}

--- a/examples/gateway-routing/main.go
+++ b/examples/gateway-routing/main.go
@@ -47,7 +47,7 @@ func run() error {
 		return fmt.Errorf("build process: %w", err)
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/inclusive-join/main.go
+++ b/examples/inclusive-join/main.go
@@ -63,7 +63,7 @@ func run() error {
 
 	fmt.Printf("order amount = %d\n", amount)
 
-	h, err := engine.StartProcess(proc.ID())
+	h, err := engine.StartLatest(proc.ID())
 	if err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}

--- a/examples/inclusive-join/main.go
+++ b/examples/inclusive-join/main.go
@@ -50,7 +50,7 @@ func run() error {
 		return fmt.Errorf("build process: %w", err)
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/inter-instance-correlation/main.go
+++ b/examples/inter-instance-correlation/main.go
@@ -83,7 +83,7 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	if _, err := engine.StartProcess(producer.ID()); err != nil {
+	if _, err := engine.StartLatest(producer.ID()); err != nil {
 		return fmt.Errorf("start producer: %w", err)
 	}
 

--- a/examples/inter-instance-correlation/main.go
+++ b/examples/inter-instance-correlation/main.go
@@ -68,11 +68,11 @@ func run() error {
 
 	// the handler is registered for auto-instantiation (a matching message
 	// spawns it); the source is started explicitly below.
-	if err := engine.RegisterProcess(consumer); err != nil {
+	if _, err := engine.RegisterProcess(consumer); err != nil {
 		return fmt.Errorf("register consumer: %w", err)
 	}
 
-	if err := engine.RegisterProcess(producer); err != nil {
+	if _, err := engine.RegisterProcess(producer); err != nil {
 		return fmt.Errorf("register producer: %w", err)
 	}
 

--- a/examples/message-intermediate-events/main.go
+++ b/examples/message-intermediate-events/main.go
@@ -138,7 +138,7 @@ func run() error {
 		}
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/message-intermediate-events/main.go
+++ b/examples/message-intermediate-events/main.go
@@ -149,7 +149,7 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	if _, err := engine.StartProcess(proc.ID()); err != nil {
+	if _, err := engine.StartLatest(proc.ID()); err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}
 

--- a/examples/message-send-receive/main.go
+++ b/examples/message-send-receive/main.go
@@ -157,7 +157,7 @@ func run() error {
 		}
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/message-send-receive/main.go
+++ b/examples/message-send-receive/main.go
@@ -168,7 +168,7 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	if _, err := engine.StartProcess(proc.ID()); err != nil {
+	if _, err := engine.StartLatest(proc.ID()); err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}
 

--- a/examples/parallel-gateway/main.go
+++ b/examples/parallel-gateway/main.go
@@ -113,7 +113,7 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	if _, err := engine.StartProcess(proc.ID()); err != nil {
+	if _, err := engine.StartLatest(proc.ID()); err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}
 

--- a/examples/parallel-gateway/main.go
+++ b/examples/parallel-gateway/main.go
@@ -102,7 +102,7 @@ func run() error {
 		}
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/process-data/main.go
+++ b/examples/process-data/main.go
@@ -123,7 +123,7 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	if _, err := engine.StartProcess(proc.ID()); err != nil {
+	if _, err := engine.StartLatest(proc.ID()); err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}
 

--- a/examples/process-data/main.go
+++ b/examples/process-data/main.go
@@ -112,7 +112,7 @@ func run() error {
 		}
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/signal-broadcast/main.go
+++ b/examples/signal-broadcast/main.go
@@ -64,12 +64,12 @@ func run() error {
 	}
 
 	// Two independent watcher instances, both waiting on the one signal.
-	h1, err := engine.StartProcess(catcher.ID())
+	h1, err := engine.StartLatest(catcher.ID())
 	if err != nil {
 		return fmt.Errorf("start watcher 1: %w", err)
 	}
 
-	h2, err := engine.StartProcess(catcher.ID())
+	h2, err := engine.StartLatest(catcher.ID())
 	if err != nil {
 		return fmt.Errorf("start watcher 2: %w", err)
 	}
@@ -77,7 +77,7 @@ func run() error {
 	time.Sleep(200 * time.Millisecond) // both reach and park on the catch
 	fmt.Println("  ▶ two watcher instances are waiting on \"order-cancelled\"")
 
-	if _, err := engine.StartProcess(thrower.ID()); err != nil { // one broadcast
+	if _, err := engine.StartLatest(thrower.ID()); err != nil { // one broadcast
 		return fmt.Errorf("start canceller: %w", err)
 	}
 	fmt.Println("  ▶ one canceller threw the signal once")

--- a/examples/signal-broadcast/main.go
+++ b/examples/signal-broadcast/main.go
@@ -48,11 +48,11 @@ func run() error {
 		return fmt.Errorf("build thrower: %w", err)
 	}
 
-	if err := engine.RegisterProcess(catcher); err != nil {
+	if _, err := engine.RegisterProcess(catcher); err != nil {
 		return fmt.Errorf("register catcher: %w", err)
 	}
 
-	if err := engine.RegisterProcess(thrower); err != nil {
+	if _, err := engine.RegisterProcess(thrower); err != nil {
 		return fmt.Errorf("register thrower: %w", err)
 	}
 

--- a/examples/signal-start/main.go
+++ b/examples/signal-start/main.go
@@ -49,7 +49,7 @@ func run() error {
 	}
 
 	for _, p := range []*process.Process{fulfillment, audit} {
-		if err := engine.RegisterProcess(p); err != nil {
+		if _, err := engine.RegisterProcess(p); err != nil {
 			return fmt.Errorf("register %s: %w", p.ID(), err)
 		}
 	}

--- a/examples/simple-timer/main.go
+++ b/examples/simple-timer/main.go
@@ -95,7 +95,7 @@ func main() {
 	}
 
 	// Register and start engine
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		log.Fatal("Failed to register process:", err)
 	}
 

--- a/examples/terminate-end-event/main.go
+++ b/examples/terminate-end-event/main.go
@@ -47,7 +47,7 @@ func run() error {
 		return fmt.Errorf("build process: %w", err)
 	}
 
-	if err := engine.RegisterProcess(proc); err != nil {
+	if _, err := engine.RegisterProcess(proc); err != nil {
 		return fmt.Errorf("register process: %w", err)
 	}
 

--- a/examples/terminate-end-event/main.go
+++ b/examples/terminate-end-event/main.go
@@ -58,7 +58,7 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	h, err := engine.StartProcess(proc.ID())
+	h, err := engine.StartLatest(proc.ID())
 	if err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}

--- a/examples/timer-event/main.go
+++ b/examples/timer-event/main.go
@@ -107,7 +107,7 @@ func main() {
 	}
 
 	// Register process with engine
-	err = engine.RegisterProcess(proc)
+	_, err = engine.RegisterProcess(proc)
 	if err != nil {
 		log.Fatal("Failed to register process:", err)
 	}

--- a/examples/timer-event/main.go
+++ b/examples/timer-event/main.go
@@ -121,7 +121,7 @@ func main() {
 	}
 
 	// Start process execution
-	_, err = engine.StartProcess(proc.ID())
+	_, err = engine.StartLatest(proc.ID())
 	if err != nil {
 		log.Fatal("Failed to start process:", err)
 	}

--- a/internal/eventproc/eventhub/waiters/message.go
+++ b/internal/eventproc/eventhub/waiters/message.go
@@ -237,7 +237,7 @@ func (mw *messageWaiter) Service(ctx context.Context) error {
 	mw.rt.Logger().Debug("message waiter serviced",
 		"waiter_id", mw.id, "message_name", mw.name)
 
-	go mw.runMessageService(ctx, sub.C())
+	go mw.runMessageService(ctx, sub)
 
 	return nil
 }
@@ -250,9 +250,22 @@ func (mw *messageWaiter) Service(ctx context.Context) error {
 // hub when its track consumes the event and unregisters.
 func (mw *messageWaiter) runMessageService(
 	ctx context.Context,
-	ch <-chan messaging.Envelope,
+	sub messaging.Subscription,
 ) {
-	defer close(mw.done) // signal goroutine exit for EventHub.Shutdown drain
+	// Every exit path tears the broker subscription down: a stopped waiter that
+	// stayed subscribed would keep claiming published messages into its abandoned
+	// (buffered) channel, swallowing them away from a live waiter on the same
+	// message name — e.g. a superseding process version (SRD-031.A FR-7).
+	defer func() {
+		if err := sub.Unsubscribe(); err != nil {
+			mw.rt.Logger().Warn("message waiter unsubscribe failed",
+				"waiter_id", mw.id, "error", err.Error())
+		}
+
+		close(mw.done) // signal goroutine exit for EventHub.Shutdown drain
+	}()
+
+	ch := sub.C()
 
 	for {
 		select {
@@ -357,6 +370,20 @@ func (mw *messageWaiter) Stop() error {
 	mw.state = eventproc.WSStopped
 
 	close(mw.stopCh)
+
+	// Unsubscribe synchronously so the broker has dropped this subscription by the
+	// time Stop returns: EventHub.UnregisterEvent may immediately register a
+	// replacement waiter on the same message name (a superseding process version),
+	// and a subsequent publish must not be claimed into this now-dead, buffered
+	// channel (SRD-031.A FR-7). The service goroutine's deferred Unsubscribe (which
+	// covers the ctx-cancel / channel-closed exit paths that never call Stop) is
+	// idempotent, so the double call is harmless.
+	if mw.sub != nil {
+		if err := mw.sub.Unsubscribe(); err != nil {
+			mw.rt.Logger().Warn("message waiter unsubscribe failed on stop",
+				"waiter_id", mw.id, "error", err.Error())
+		}
+	}
 
 	return nil
 }

--- a/internal/eventproc/eventhub/waiters/message_test.go
+++ b/internal/eventproc/eventhub/waiters/message_test.go
@@ -414,3 +414,44 @@ func TestMessageWaiterSubscribeError(t *testing.T) {
 	require.Error(t, w.Service(context.Background()))
 	require.Equal(t, eventproc.WSFailed, w.State())
 }
+
+// errUnsubSub never closes its channel and always fails to unsubscribe.
+type errUnsubSub struct{ ch <-chan messaging.Envelope }
+
+func (s errUnsubSub) C() <-chan messaging.Envelope { return s.ch }
+func (errUnsubSub) AddKey(string) error            { return nil }
+func (errUnsubSub) Unsubscribe() error             { return fmt.Errorf("unsubscribe failed") }
+
+// errUnsubBroker hands out subscriptions whose Unsubscribe always errors.
+type errUnsubBroker struct{}
+
+func (errUnsubBroker) Publish(context.Context, messaging.Envelope) error { return nil }
+
+func (errUnsubBroker) Subscribe(
+	context.Context, string, ...string,
+) (messaging.Subscription, error) {
+	return errUnsubSub{ch: make(chan messaging.Envelope)}, nil
+}
+
+// TestMessageWaiterUnsubscribeErrorIsLogged drives a subscription that fails to
+// unsubscribe: Stop still succeeds (the failure is logged, not propagated) and
+// the service goroutine still exits. It exercises both unsubscribe-failure
+// branches — the synchronous one in Stop and the deferred one on goroutine exit.
+func TestMessageWaiterUnsubscribeErrorIsLogged(t *testing.T) {
+	ep := mockeventproc.NewMockEventProcessor(t)
+	hub := mockeventproc.NewMockEventHub(t)
+
+	rt := brokerRT{EngineRuntime: enginert.Default(), broker: errUnsubBroker{}}
+
+	w, err := waiters.NewMessageWaiter(hub, ep, msgEventDef(t), "", rt)
+	require.NoError(t, err)
+	require.NoError(t, w.Service(context.Background()))
+
+	require.NoError(t, w.Stop())
+
+	select {
+	case <-w.Done():
+	case <-time.After(time.Second):
+		t.Fatal("Done did not close after Stop despite the unsubscribe error")
+	}
+}

--- a/internal/eventproc/eventhub/waiters/message_test.go
+++ b/internal/eventproc/eventhub/waiters/message_test.go
@@ -47,6 +47,7 @@ type chanSub struct{ ch <-chan messaging.Envelope }
 
 func (s chanSub) C() <-chan messaging.Envelope { return s.ch }
 func (chanSub) AddKey(string) error            { return nil }
+func (chanSub) Unsubscribe() error             { return nil }
 
 // closedChBroker returns an already-closed subscription channel.
 type closedChBroker struct{}

--- a/internal/instance/snapshot/snapshot.go
+++ b/internal/instance/snapshot/snapshot.go
@@ -54,7 +54,6 @@ func New(
 		ProcessID:   p.ID(),
 		ProcessName: p.Name(),
 		Nodes:       map[string]flow.Node{},
-		Flows:       map[string]*flow.SequenceFlow{},
 		Properties:  p.Properties(),
 	}
 
@@ -64,8 +63,14 @@ func New(
 	eeExists := false
 	instStartExists := false
 
+	// srcNodes keeps the original process nodes for wireClonedGraph's boundary
+	// rebind; s.Nodes gets their clones so the snapshot owns an isolated graph
+	// (ADR-019 §2.3) — edits to the process after registration can't reach it.
+	srcNodes := make(map[string]flow.Node, len(p.Nodes()))
+
 	for _, n := range p.Nodes() {
-		s.Nodes[n.ID()] = n
+		srcNodes[n.ID()] = n
+		s.Nodes[n.ID()] = n.Clone()
 
 		// An instantiate ReceiveTask with no incoming flow is a valid process
 		// instantiation point on its own (BPMN §13.3.3) — the task-shaped peer
@@ -109,9 +114,20 @@ func New(
 					"with an EndEvent"))
 	}
 
+	srcFlows := make(map[string]*flow.SequenceFlow, len(p.Flows()))
 	for _, f := range p.Flows() {
-		s.Flows[f.ID()] = f
+		srcFlows[f.ID()] = f
 	}
+
+	// Wire the cloned graph the same way Clone does — relink flows between the
+	// clones, remap default flows, rebind boundary events — so the snapshot is
+	// born isolated in a single pass over the definition (SRD-031.A §3.3).
+	flows, err := wireClonedGraph(s.Nodes, srcNodes, srcFlows)
+	if err != nil {
+		return nil, err
+	}
+
+	s.Flows = flows
 
 	return &s, nil
 }
@@ -152,20 +168,46 @@ func (s *Snapshot) Clone() (*Snapshot, error) {
 		ProcessID:       s.ProcessID,
 		ProcessName:     s.ProcessName,
 		Nodes:           make(map[string]flow.Node, len(s.Nodes)),
-		Flows:           make(map[string]*flow.SequenceFlow, len(s.Flows)),
 		Properties:      s.Properties,
 		CorrelationKeys: s.CorrelationKeys,
 	}
 
-	// 1. clone every node; the clone starts with empty flows and any default
-	//    flow still points at the original edge (remapped in step 3).
+	// Clone every node (its immutable configuration shared by reference, its
+	// runtime state fresh); the clone starts with empty flows and any default
+	// flow still points at the original edge until wireClonedGraph remaps it.
 	for id, n := range s.Nodes {
 		clone.Nodes[id] = n.Clone()
 	}
 
-	// 2. relink the flow graph between the cloned nodes.
-	for id, f := range s.Flows {
-		src, ok := clone.Nodes[f.Source().ID()].(flow.SequenceSource)
+	flows, err := wireClonedGraph(clone.Nodes, s.Nodes, s.Flows)
+	if err != nil {
+		return nil, err
+	}
+
+	clone.Flows = flows
+
+	return &clone, nil
+}
+
+// wireClonedGraph completes a freshly cloned node set into a runnable graph: it
+// relinks the flow graph between the clones, remaps each gateway's default flow
+// onto its cloned edge, and rebinds each boundary event onto its cloned host
+// activity. It is shared by Snapshot.New (cloning from the process definition)
+// and Clone (cloning from the snapshot) — the node-cloning loop differs by
+// source, the wiring does not. clonedNodes is the already-cloned node set
+// (mutated in place for the default-flow and boundary rebinds); srcNodes and
+// srcFlows are the originals the clones were made from. It returns the cloned
+// flow set.
+func wireClonedGraph(
+	clonedNodes map[string]flow.Node,
+	srcNodes map[string]flow.Node,
+	srcFlows map[string]*flow.SequenceFlow,
+) (map[string]*flow.SequenceFlow, error) {
+	clonedFlows := make(map[string]*flow.SequenceFlow, len(srcFlows))
+
+	// 1. relink the flow graph between the cloned nodes.
+	for id, f := range srcFlows {
+		src, ok := clonedNodes[f.Source().ID()].(flow.SequenceSource)
 		if !ok {
 			return nil, errs.New(
 				errs.M("cloned source %q isn't a sequence source",
@@ -173,7 +215,7 @@ func (s *Snapshot) Clone() (*Snapshot, error) {
 				errs.C(errorClass, errs.TypeCastingError))
 		}
 
-		trg, ok := clone.Nodes[f.Target().ID()].(flow.SequenceTarget)
+		trg, ok := clonedNodes[f.Target().ID()].(flow.SequenceTarget)
 		if !ok {
 			return nil, errs.New(
 				errs.M("cloned target %q isn't a sequence target",
@@ -183,11 +225,11 @@ func (s *Snapshot) Clone() (*Snapshot, error) {
 
 		// src and trg are cloned graph nodes and f is a valid edge, so the
 		// edge can always be rebuilt; use the panicking form.
-		clone.Flows[id] = flow.MustCloneFlow(f, src, trg)
+		clonedFlows[id] = flow.MustCloneFlow(f, src, trg)
 	}
 
-	// 3. remap each gateway's default flow onto its cloned edge.
-	for _, n := range clone.Nodes {
+	// 2. remap each gateway's default flow onto its cloned edge.
+	for _, n := range clonedNodes {
 		dfh, ok := n.(flow.DefaultFlowHolder)
 		if !ok {
 			continue
@@ -200,31 +242,30 @@ func (s *Snapshot) Clone() (*Snapshot, error) {
 
 		// the default flow is one of this node's outgoing flows by
 		// construction, so the remap onto its clone cannot fail.
-		dfh.MustUpdateDefaultFlow(clone.Flows[df.ID()])
+		dfh.MustUpdateDefaultFlow(clonedFlows[df.ID()])
 	}
 
-	// 4. rebind each boundary event onto its cloned host activity. The cloned
+	// 3. rebind each boundary event onto its cloned host activity. The cloned
 	//    activities start with no boundaries (activity.clone leaves them for this
 	//    step), so re-attaching the cloned boundary points BOTH cross-references
-	//    (host→boundary and boundary→host) at this instance's own nodes — a
-	//    boundary fire then acts on the instance graph, not the shared model
-	//    (SRD-029 M3a). Iterating the originals gives the host mapping via the
-	//    boundary's AttachedTo.
-	for id, n := range s.Nodes {
+	//    (host→boundary and boundary→host) at the cloned nodes — a boundary fire
+	//    then acts on this graph, not the shared source (SRD-029 M3a). Iterating
+	//    the originals gives the host mapping via the boundary's AttachedTo.
+	for id, n := range srcNodes {
 		origBE, ok := n.(flow.BoundaryEvent)
 		if !ok {
 			continue
 		}
 
-		// The clones are cloned from valid model nodes — a BoundaryEvent's clone
-		// is a BoundaryEvent and its host's clone an ActivityNode — so, as with the
+		// The clones are cloned from valid nodes — a BoundaryEvent's clone is a
+		// BoundaryEvent and its host's clone an ActivityNode — so, as with the
 		// flow relink above, these casts cannot fail (panicking form).
-		cloneBE := clone.Nodes[id].(flow.BoundaryEvent)
-		cloneHost := clone.Nodes[origBE.AttachedTo().ID()].(flow.ActivityNode)
+		cloneBE := clonedNodes[id].(flow.BoundaryEvent)
+		cloneHost := clonedNodes[origBE.AttachedTo().ID()].(flow.ActivityNode)
 
 		// The cloned host starts with no boundaries (activity.clone), so the
-		// already-model-validated binding re-attaches without a multiplicity
-		// conflict; an error here can only mean a corrupt clone.
+		// already-validated binding re-attaches without a multiplicity conflict;
+		// an error here can only mean a corrupt clone.
 		if err := cloneBE.BoundTo(cloneHost); err != nil {
 			return nil, errs.New(
 				errs.M("rebind boundary %q to its cloned host failed", id),
@@ -233,5 +274,5 @@ func (s *Snapshot) Clone() (*Snapshot, error) {
 		}
 	}
 
-	return &clone, nil
+	return clonedFlows, nil
 }

--- a/internal/instance/snapshot/snapshot_test.go
+++ b/internal/instance/snapshot/snapshot_test.go
@@ -388,3 +388,84 @@ func TestSnapshotCloneSharesProperties(t *testing.T) {
 	require.Same(t, s.Properties[0], clone.Properties[0],
 		"Clone must share the immutable Property, not copy it")
 }
+
+// TestSnapshotNewIsolatesFromModel verifies that New takes its own copy of the
+// definition's graph: editing the source process after registration — here,
+// adding a node — does not reach the already-taken snapshot. This is the
+// isolation that lets the process model stay mutable without a freeze (ADR-019
+// §2.3, SRD-031.A FR-1), and it closes the audit §3.3 leak where the snapshot
+// shared the model's nodes by reference.
+func TestSnapshotNewIsolatesFromModel(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	p, err := process.New("p-iso")
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	require.NoError(t, p.Add(start))
+	require.NoError(t, p.Add(end))
+
+	_, err = flow.Link(start, end)
+	require.NoError(t, err)
+
+	s, err := snapshot.New(p)
+	require.NoError(t, err)
+
+	before := len(s.Nodes)
+
+	// mutate the source process after the snapshot was taken.
+	extra, err := events.NewEndEvent("extra-end")
+	require.NoError(t, err)
+	require.NoError(t, p.Add(extra))
+
+	// the snapshot is unchanged — the post-registration edit cannot reach it.
+	require.Len(t, s.Nodes, before)
+
+	_, inSnap := s.Nodes[extra.ID()]
+	require.False(t, inSnap,
+		"a node added to the process after New must not appear in the snapshot")
+}
+
+// TestSnapshotNewClonesGraph verifies that New stores clones of the definition's
+// nodes (distinct pointers), not the model objects themselves, and that the
+// resulting snapshot is fully wired so a per-instance Clone still produces a
+// working graph (SRD-031.A FR-1, T-2).
+func TestSnapshotNewClonesGraph(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	p, err := process.New("p-clone")
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	require.NoError(t, p.Add(start))
+	require.NoError(t, p.Add(end))
+
+	_, err = flow.Link(start, end)
+	require.NoError(t, err)
+
+	s, err := snapshot.New(p)
+	require.NoError(t, err)
+
+	// the snapshot's node is a clone, not the model object.
+	require.NotSame(t, flow.Node(start), s.Nodes[start.ID()],
+		"New must clone the node, not store the model object")
+	require.Len(t, s.Flows, 1)
+
+	// the isolated snapshot is fully wired, so a per-instance Clone still works.
+	clone, err := s.Clone()
+	require.NoError(t, err)
+	require.Len(t, clone.Nodes, len(s.Nodes))
+	require.Len(t, clone.Flows, len(s.Flows))
+	require.NotSame(t, s.Nodes[start.ID()], clone.Nodes[start.ID()],
+		"Clone must clone the snapshot's node, not share it")
+}

--- a/pkg/messaging/membroker/membroker.go
+++ b/pkg/messaging/membroker/membroker.go
@@ -105,6 +105,27 @@ func (h brokerSub) AddKey(key string) error {
 	return nil
 }
 
+// Unsubscribe removes the subscription from the broker so no further published
+// message is routed to it. Idempotent — unsubscribing twice (or after the broker
+// already dropped it) finds nothing and is a no-op. Envelopes still buffered on
+// the subscription channel are abandoned with it.
+func (h brokerSub) Unsubscribe() error {
+	h.b.mu.Lock()
+	defer h.b.mu.Unlock()
+
+	for i, s := range h.b.subs {
+		if s == h.sub {
+			h.b.subs = append(h.b.subs[:i], h.b.subs[i+1:]...)
+
+			h.b.logger.Debug("membroker: unsubscribed", "name", h.sub.name)
+
+			break
+		}
+	}
+
+	return nil
+}
+
 // Option configures a Broker.
 type Option func(*Broker)
 

--- a/pkg/messaging/membroker/membroker_test.go
+++ b/pkg/messaging/membroker/membroker_test.go
@@ -315,3 +315,44 @@ func TestMaxInboxDisabled(t *testing.T) {
 		t.Fatalf("inbox kept %d, want 5 (cap disabled)", len(got))
 	}
 }
+
+// TestUnsubscribeStopsDelivery verifies that after Unsubscribe the broker no
+// longer routes to the dropped subscription: a later publish must reach a fresh
+// subscriber on the same name, not get swallowed into the dead one's channel.
+// This backs the EventHub teardown a superseded process version relies on.
+func TestUnsubscribeStopsDelivery(t *testing.T) {
+	b := New()
+	ctx := context.Background()
+
+	first := subscribe(t, b, "order") // wildcard
+	if err := first.Unsubscribe(); err != nil {
+		t.Fatalf("unsubscribe: %v", err)
+	}
+
+	// the published message must not land in the dropped subscription's channel.
+	_ = b.Publish(ctx, env("order", "k"))
+	if e, ok := recv(first.C()); ok {
+		t.Fatalf("dropped subscription still received: %+v", e)
+	}
+
+	// a fresh subscriber drains it from the inbox — it was buffered, not stolen.
+	second := subscribe(t, b, "order")
+	if e, ok := recv(second.C()); !ok || e.Name != "order" {
+		t.Fatalf("replacement subscriber did not receive: %+v, %v", e, ok)
+	}
+}
+
+// TestUnsubscribeIsIdempotent verifies a second Unsubscribe (the synchronous Stop
+// path plus the service goroutine's deferred call both fire) is a harmless no-op.
+func TestUnsubscribeIsIdempotent(t *testing.T) {
+	b := New()
+
+	s := subscribe(t, b, "order")
+	if err := s.Unsubscribe(); err != nil {
+		t.Fatalf("first unsubscribe: %v", err)
+	}
+
+	if err := s.Unsubscribe(); err != nil {
+		t.Fatalf("second unsubscribe must be a no-op: %v", err)
+	}
+}

--- a/pkg/messaging/messagebroker.go
+++ b/pkg/messaging/messagebroker.go
@@ -28,6 +28,12 @@ type Subscription interface {
 	// lazy secondary-key association (SRD-017): a conversation that learns a new
 	// key becomes reachable by it. An empty key is rejected.
 	AddKey(key string) error
+	// Unsubscribe removes the subscription from the broker; no further published
+	// message is routed to it. A stopped subscriber MUST Unsubscribe, otherwise
+	// its (buffered) channel keeps claiming matching messages and silently
+	// swallows them away from live subscribers. Idempotent: a second call, or one
+	// after the broker already dropped the subscription, is a no-op.
+	Unsubscribe() error
 }
 
 // MessageBroker delivers incoming messages to interested subscribers, buffering

--- a/pkg/thresher/complex_gateway_test.go
+++ b/pkg/thresher/complex_gateway_test.go
@@ -83,7 +83,7 @@ func TestComplexDiscriminator(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -135,7 +135,7 @@ func TestComplexPartialJoin(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -190,7 +190,7 @@ func TestComplexDataAware(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -241,7 +241,7 @@ func TestComplexRequiredGate(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -304,7 +304,7 @@ func TestComplexAbortOnDeath(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)

--- a/pkg/thresher/control_test.go
+++ b/pkg/thresher/control_test.go
@@ -60,7 +60,7 @@ func TestInstanceHandleCancel(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	time.Sleep(150 * time.Millisecond) // let the track reach the blocking op
@@ -87,7 +87,7 @@ func TestCancelCtxBounded(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	time.Sleep(150 * time.Millisecond)
@@ -108,7 +108,7 @@ func TestSuspendResumeReserved(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	require.ErrorIs(t, h.Suspend(context.Background()), thresher.ErrNotImplemented)
@@ -123,7 +123,7 @@ func TestThresherShutdown(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	time.Sleep(150 * time.Millisecond) // reach the blocking op
@@ -136,7 +136,7 @@ func TestThresherShutdown(t *testing.T) {
 	require.Equal(t, thresher.StateTerminated, h.State())
 
 	// A stopped engine rejects further lifecycle operations.
-	_, err = th.StartProcess(proc.ID())
+	_, err = th.StartLatest(proc.ID())
 	require.Error(t, err)
 	_, err = th.RegisterProcess(blockingProcess(t, "sd-after"))
 	require.Error(t, err)
@@ -154,7 +154,7 @@ func TestThresherShutdownCtxBounded(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	_, err := th.StartProcess(proc.ID())
+	_, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	time.Sleep(150 * time.Millisecond)

--- a/pkg/thresher/control_test.go
+++ b/pkg/thresher/control_test.go
@@ -138,7 +138,8 @@ func TestThresherShutdown(t *testing.T) {
 	// A stopped engine rejects further lifecycle operations.
 	_, err = th.StartProcess(proc.ID())
 	require.Error(t, err)
-	require.Error(t, th.RegisterProcess(blockingProcess(t, "sd-after")))
+	_, err = th.RegisterProcess(blockingProcess(t, "sd-after"))
+	require.Error(t, err)
 	require.Error(t, th.Run(context.Background()))
 
 	// Idempotent.

--- a/pkg/thresher/conversation_routing_test.go
+++ b/pkg/thresher/conversation_routing_test.go
@@ -136,7 +136,8 @@ func TestConversationRouting(t *testing.T) {
 	require.NoError(t, err)
 
 	done := make(chan string, 2)
-	require.NoError(t, th.RegisterProcess(orderConversationProcess(t, done)))
+	_, err = th.RegisterProcess(orderConversationProcess(t, done))
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/thresher/discovery.go
+++ b/pkg/thresher/discovery.go
@@ -86,6 +86,23 @@ func (t *Thresher) Forget(ids ...string) error {
 	return nil
 }
 
+// Registrations returns the registered versions of a process key, ascending by
+// version (an empty slice for an unknown key). Each element is a live handle —
+// read its `Version()` / `ID()`, or pass it straight to `StartProcess` /
+// `UnregisterProcess`. Because removing a non-latest version may leave gaps
+// (v1, v3, …), this is how a caller discovers which versions exist before
+// addressing one by `StartVersion`. Snapshot-consistent under the engine lock.
+func (t *Thresher) Registrations(key string) []*ProcessRegistration {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	regs := t.registrations[key]
+	out := make([]*ProcessRegistration, len(regs))
+	copy(out, regs)
+
+	return out
+}
+
 // StarterInfo describes one event-start registration (SRD-019): a process
 // awaiting an event to instantiate — there is no instance yet, so it cannot
 // appear under Instances. A manual-start process registers no starter, so every

--- a/pkg/thresher/discovery.go
+++ b/pkg/thresher/discovery.go
@@ -102,15 +102,17 @@ func (t *Thresher) Starters() []StarterInfo {
 	t.m.Lock()
 	defer t.m.Unlock()
 
-	out := make([]StarterInfo, 0, len(t.starters))
+	out := make([]StarterInfo, 0, len(t.registrations))
 
-	for procID, sts := range t.starters {
-		for _, s := range sts {
-			out = append(out, StarterInfo{
-				ProcessID: procID,
-				StartNode: s.startNode.Name(),
-				Trigger:   triggerName(s.eDef),
-			})
+	for key, regs := range t.registrations {
+		for _, reg := range regs {
+			for _, s := range reg.starters {
+				out = append(out, StarterInfo{
+					ProcessID: key,
+					StartNode: s.startNode.Name(),
+					Trigger:   triggerName(s.eDef),
+				})
+			}
 		}
 	}
 

--- a/pkg/thresher/discovery.go
+++ b/pkg/thresher/discovery.go
@@ -104,15 +104,20 @@ func (t *Thresher) Starters() []StarterInfo {
 
 	out := make([]StarterInfo, 0, len(t.registrations))
 
+	// Only the latest version of a key has live starters (latest-supersedes), so
+	// the live starter set is the latest registration's per key.
 	for key, regs := range t.registrations {
-		for _, reg := range regs {
-			for _, s := range reg.starters {
-				out = append(out, StarterInfo{
-					ProcessID: key,
-					StartNode: s.startNode.Name(),
-					Trigger:   triggerName(s.eDef),
-				})
-			}
+		n := len(regs)
+		if n == 0 {
+			continue
+		}
+
+		for _, s := range regs[n-1].starters {
+			out = append(out, StarterInfo{
+				ProcessID: key,
+				StartNode: s.startNode.Name(),
+				Trigger:   triggerName(s.eDef),
+			})
 		}
 	}
 

--- a/pkg/thresher/discovery_test.go
+++ b/pkg/thresher/discovery_test.go
@@ -108,14 +108,22 @@ func TestStarters(t *testing.T) {
 // a live instance, which keeps running (FR-8).
 func TestUnregisterProcessWithLiveInstance(t *testing.T) {
 	bp := blockingProcess(t, "unreg-live")
-	th, cancel := runEngine(t, bp)
-	defer cancel()
 
-	h, err := th.StartLatest(bp.ID())
+	th, err := thresher.New("test-unreg-live")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	reg, err := th.RegisterProcess(bp)
+	require.NoError(t, err)
+
+	h, err := th.StartProcess(reg)
 	require.NoError(t, err)
 	time.Sleep(150 * time.Millisecond)
 
-	require.NoError(t, th.UnregisterProcess(bp.ID()))
+	require.NoError(t, th.UnregisterProcess(reg))
 
 	// The live instance is unaffected: still Active and looked-up-able.
 	require.Equal(t, thresher.StateActive, h.State())

--- a/pkg/thresher/discovery_test.go
+++ b/pkg/thresher/discovery_test.go
@@ -104,8 +104,10 @@ func TestStarters(t *testing.T) {
 	require.Len(t, th.Starters(), 1)
 }
 
-// TestUnregisterProcessWithLiveInstance verifies UnregisterProcess succeeds with
-// a live instance, which keeps running (FR-8).
+// TestUnregisterProcessWithLiveInstance verifies UnregisterVersion succeeds with
+// a live instance, which keeps running (SRD-031.A FR-8; the name predates the
+// UnregisterProcess→UnregisterVersion split and is kept to honor SRD-019's
+// frozen reference).
 func TestUnregisterProcessWithLiveInstance(t *testing.T) {
 	bp := blockingProcess(t, "unreg-live")
 
@@ -123,7 +125,7 @@ func TestUnregisterProcessWithLiveInstance(t *testing.T) {
 	require.NoError(t, err)
 	time.Sleep(150 * time.Millisecond)
 
-	require.NoError(t, th.UnregisterProcess(reg))
+	require.NoError(t, th.UnregisterVersion(reg))
 
 	// The live instance is unaffected: still Active and looked-up-able.
 	require.Equal(t, thresher.StateActive, h.State())

--- a/pkg/thresher/discovery_test.go
+++ b/pkg/thresher/discovery_test.go
@@ -20,9 +20,9 @@ func TestInstancesFilter(t *testing.T) {
 	_, err := th.RegisterProcess(lp)
 	require.NoError(t, err)
 
-	running, err := th.StartProcess(bp.ID())
+	running, err := th.StartLatest(bp.ID())
 	require.NoError(t, err)
-	doneH, err := th.StartProcess(lp.ID())
+	doneH, err := th.StartLatest(lp.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -56,9 +56,9 @@ func TestForget(t *testing.T) {
 	_, err := th.RegisterProcess(lp)
 	require.NoError(t, err)
 
-	running, err := th.StartProcess(bp.ID())
+	running, err := th.StartLatest(bp.ID())
 	require.NoError(t, err)
-	doneH, err := th.StartProcess(lp.ID())
+	doneH, err := th.StartLatest(lp.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -111,7 +111,7 @@ func TestUnregisterProcessWithLiveInstance(t *testing.T) {
 	th, cancel := runEngine(t, bp)
 	defer cancel()
 
-	h, err := th.StartProcess(bp.ID())
+	h, err := th.StartLatest(bp.ID())
 	require.NoError(t, err)
 	time.Sleep(150 * time.Millisecond)
 
@@ -123,6 +123,6 @@ func TestUnregisterProcessWithLiveInstance(t *testing.T) {
 	require.True(t, ok)
 
 	// The definition is gone — a new start is rejected.
-	_, err = th.StartProcess(bp.ID())
+	_, err = th.StartLatest(bp.ID())
 	require.Error(t, err)
 }

--- a/pkg/thresher/discovery_test.go
+++ b/pkg/thresher/discovery_test.go
@@ -17,7 +17,8 @@ func TestInstancesFilter(t *testing.T) {
 
 	th, cancel := runEngine(t, bp)
 	defer cancel()
-	require.NoError(t, th.RegisterProcess(lp))
+	_, err := th.RegisterProcess(lp)
+	require.NoError(t, err)
 
 	running, err := th.StartProcess(bp.ID())
 	require.NoError(t, err)
@@ -52,7 +53,8 @@ func TestForget(t *testing.T) {
 
 	th, cancel := runEngine(t, bp)
 	defer cancel()
-	require.NoError(t, th.RegisterProcess(lp))
+	_, err := th.RegisterProcess(lp)
+	require.NoError(t, err)
 
 	running, err := th.StartProcess(bp.ID())
 	require.NoError(t, err)
@@ -97,7 +99,8 @@ func TestStarters(t *testing.T) {
 	require.Equal(t, "order placed", starters[0].Trigger)
 
 	// A none-start process adds no starter.
-	require.NoError(t, th.RegisterProcess(blockingProcess(t, "no-starter")))
+	_, err := th.RegisterProcess(blockingProcess(t, "no-starter"))
+	require.NoError(t, err)
 	require.Len(t, th.Starters(), 1)
 }
 

--- a/pkg/thresher/event_gateway_parallel_start_test.go
+++ b/pkg/thresher/event_gateway_parallel_start_test.go
@@ -136,7 +136,8 @@ func runParallelGate(
 	th, err := thresher.New(name, thresher.WithMessageBroker(broker))
 	require.NoError(t, err)
 
-	require.NoError(t, th.RegisterProcess(instParallelGateProcess(t, done)))
+	_, err = th.RegisterProcess(instParallelGateProcess(t, done))
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)

--- a/pkg/thresher/event_gateway_start_test.go
+++ b/pkg/thresher/event_gateway_start_test.go
@@ -122,7 +122,8 @@ func TestEventGatewayExclusiveStart(t *testing.T) {
 	require.NoError(t, err)
 
 	done := make(chan string, 4)
-	require.NoError(t, th.RegisterProcess(instExclusiveGateProcess(t, done)))
+	_, err = th.RegisterProcess(instExclusiveGateProcess(t, done))
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -155,7 +156,8 @@ func TestEventGatewayExclusiveStartEachEventNewInstance(t *testing.T) {
 	require.NoError(t, err)
 
 	done := make(chan string, 4)
-	require.NoError(t, th.RegisterProcess(instExclusiveGateProcess(t, done)))
+	_, err = th.RegisterProcess(instExclusiveGateProcess(t, done))
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/thresher/event_gateway_test.go
+++ b/pkg/thresher/event_gateway_test.go
@@ -87,7 +87,8 @@ func TestEventGatewaySignalDeferredChoice(t *testing.T) {
 			defer cancel()
 
 			thrower := signalThrowProcess(t, "throw-"+tc.fire, tc.fire)
-			require.NoError(t, th.RegisterProcess(thrower))
+			_, err = th.RegisterProcess(thrower)
+			require.NoError(t, err)
 
 			h, err := th.StartProcess(proc.ID())
 			require.NoError(t, err)
@@ -159,7 +160,8 @@ func TestEventGatewayReceiveTaskArm(t *testing.T) {
 	link(t, paid, endP)
 	link(t, canceled, endC)
 
-	require.NoError(t, th.RegisterProcess(proc))
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/thresher/event_gateway_test.go
+++ b/pkg/thresher/event_gateway_test.go
@@ -90,12 +90,12 @@ func TestEventGatewaySignalDeferredChoice(t *testing.T) {
 			_, err = th.RegisterProcess(thrower)
 			require.NoError(t, err)
 
-			h, err := th.StartProcess(proc.ID())
+			h, err := th.StartLatest(proc.ID())
 			require.NoError(t, err)
 
 			time.Sleep(150 * time.Millisecond) // gate parks on both arms
 
-			_, err = th.StartProcess(thrower.ID()) // throws tc.fire
+			_, err = th.StartLatest(thrower.ID()) // throws tc.fire
 			require.NoError(t, err)
 
 			ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -167,7 +167,7 @@ func TestEventGatewayReceiveTaskArm(t *testing.T) {
 	defer cancel()
 	require.NoError(t, th.Run(ctx))
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	time.Sleep(150 * time.Millisecond) // gate parks on both arms

--- a/pkg/thresher/gateway_routing_test.go
+++ b/pkg/thresher/gateway_routing_test.go
@@ -128,7 +128,7 @@ func TestExclusiveRoutingEndToEnd(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -183,7 +183,7 @@ func TestInclusiveSplitEndToEnd(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)

--- a/pkg/thresher/handle_test.go
+++ b/pkg/thresher/handle_test.go
@@ -122,7 +122,8 @@ func runEngine(t *testing.T, proc *process.Process) (*thresher.Thresher, context
 
 	ctx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, th.Run(ctx))
-	require.NoError(t, th.RegisterProcess(proc))
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
 
 	return th, cancel
 }

--- a/pkg/thresher/handle_test.go
+++ b/pkg/thresher/handle_test.go
@@ -135,7 +135,7 @@ func TestStartProcessReturnsHandle(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 	require.NotNil(t, h)
 	require.NotEmpty(t, h.ID())
@@ -157,7 +157,7 @@ func TestWaitCompletion(t *testing.T) {
 		th, cancel := runEngine(t, proc)
 		defer cancel()
 
-		h, err := th.StartProcess(proc.ID())
+		h, err := th.StartLatest(proc.ID())
 		require.NoError(t, err)
 
 		ctx, c := context.WithTimeout(context.Background(), 3*time.Second)
@@ -173,7 +173,7 @@ func TestWaitCompletion(t *testing.T) {
 		th, cancel := runEngine(t, proc)
 		defer cancel()
 
-		h, err := th.StartProcess(proc.ID())
+		h, err := th.StartLatest(proc.ID())
 		require.NoError(t, err)
 
 		ctx, c := context.WithTimeout(context.Background(), 50*time.Millisecond)
@@ -192,7 +192,7 @@ func TestTokensSnapshot(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	time.Sleep(150 * time.Millisecond) // let the token reach the service node
@@ -214,7 +214,7 @@ func TestHistoryIncludesMerged(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, c := context.WithTimeout(context.Background(), 3*time.Second)
@@ -251,7 +251,7 @@ func TestHandleDataRead(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	st, err := h.Data().GetData("RUNTIME/STATE")

--- a/pkg/thresher/instance_starter_internal_test.go
+++ b/pkg/thresher/instance_starter_internal_test.go
@@ -416,6 +416,83 @@ func TestRunRegisterStartersError(t *testing.T) {
 	require.Error(t, th.Run(ctx))
 }
 
+// TestRegisterProcessSupersedeHubErrors covers the two latest-supersedes error
+// paths in RegisterProcess: tearing down the previous latest's starters, then
+// registering the new version's, each surfaces a hub failure (SRD-031.A FR-7).
+func TestRegisterProcessSupersedeHubErrors(t *testing.T) {
+	proc := msgStartProcess(t, "p-sup-err", "order placed")
+
+	seedV1 := func(t *testing.T, th *Thresher) string {
+		t.Helper()
+
+		s1, err := snapshot.New(proc)
+		require.NoError(t, err)
+
+		v1 := &ProcessRegistration{
+			key: s1.ProcessID, version: 1, snapshot: s1,
+			starters: scanInstantiatingStarts(s1, th),
+		}
+
+		th.m.Lock()
+		th.registrations[s1.ProcessID] = []*ProcessRegistration{v1}
+		th.state = Started
+		th.m.Unlock()
+
+		return s1.ProcessID
+	}
+
+	t.Run("teardown of the superseded version errors", func(t *testing.T) {
+		th, err := New("sup-teardown")
+		require.NoError(t, err)
+
+		mh := mockeventproc.NewMockEventHub(t)
+		mh.EXPECT().
+			UnregisterEvent(mock.Anything, mock.Anything).
+			Return(fmt.Errorf("hub teardown rejected")).
+			Once()
+		th.eventHub = mh
+
+		seedV1(t, th)
+
+		_, err = th.RegisterProcess(proc) // v2 supersedes → teardown fails
+		require.Error(t, err)
+	})
+
+	t.Run("re-register of the new version errors", func(t *testing.T) {
+		th, err := New("sup-rereg")
+		require.NoError(t, err)
+
+		mh := mockeventproc.NewMockEventHub(t)
+		mh.EXPECT().
+			UnregisterEvent(mock.Anything, mock.Anything).
+			Return(nil).
+			Once()
+		mh.EXPECT().
+			RegisterPersistentEvent(mock.Anything, mock.Anything).
+			Return(fmt.Errorf("hub register rejected")).
+			Once()
+		th.eventHub = mh
+
+		seedV1(t, th)
+
+		_, err = th.RegisterProcess(proc) // teardown ok, re-register fails
+		require.Error(t, err)
+	})
+}
+
+// TestStartersSkipsEmptyVersionSlice covers the defensive empty-slice guard in
+// Starters: a key mapped to a zero-length version slice contributes no starter.
+func TestStartersSkipsEmptyVersionSlice(t *testing.T) {
+	th, err := New("empty-slice")
+	require.NoError(t, err)
+
+	th.m.Lock()
+	th.registrations["ghost"] = nil
+	th.m.Unlock()
+
+	require.Empty(t, th.Starters())
+}
+
 // corrStartProcess builds a message-start process declaring a CorrelationKey
 // whose single property extracts the payload value (read from the message item)
 // as the key. The start is wired to an EndEvent.

--- a/pkg/thresher/instance_starter_internal_test.go
+++ b/pkg/thresher/instance_starter_internal_test.go
@@ -247,7 +247,7 @@ func TestStarterLifecycle(t *testing.T) {
 		require.NoError(t, err)
 
 		proc := msgStartProcess(t, "p-life", "order placed")
-		_, err = th.RegisterProcess(proc)
+		reg, err := th.RegisterProcess(proc)
 		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -257,7 +257,7 @@ func TestStarterLifecycle(t *testing.T) {
 		// A clean UnregisterProcess proves the starter WAS registered on the hub
 		// at Run (the hub's UnregisterEvent would error ObjectNotFound were it
 		// not), and clears the bookkeeping.
-		require.NoError(t, th.UnregisterProcess(proc.ID()))
+		require.NoError(t, th.UnregisterProcess(reg))
 
 		th.m.Lock()
 		_, hasReg := th.registrations[proc.ID()]
@@ -274,9 +274,9 @@ func TestStarterLifecycle(t *testing.T) {
 		require.NoError(t, th.Run(ctx))
 
 		proc := msgStartProcess(t, "p-after", "order placed")
-		_, err = th.RegisterProcess(proc)
+		reg, err := th.RegisterProcess(proc)
 		require.NoError(t, err)
-		require.NoError(t, th.UnregisterProcess(proc.ID()))
+		require.NoError(t, th.UnregisterProcess(reg))
 	})
 
 	t.Run("manual-start: no starter, clean teardown", func(t *testing.T) {
@@ -288,17 +288,24 @@ func TestStarterLifecycle(t *testing.T) {
 		require.NoError(t, th.Run(ctx))
 
 		proc := msgStartProcess(t, "p-mlife", "order placed")
-		_, err = th.RegisterProcess(proc, WithManualStart())
+		reg, err := th.RegisterProcess(proc, WithManualStart())
 		require.NoError(t, err)
-		require.NoError(t, th.UnregisterProcess(proc.ID()))
+		require.NoError(t, th.UnregisterProcess(reg))
 	})
 
-	t.Run("unregister unknown / empty id rejected", func(t *testing.T) {
+	t.Run("nil / foreign handle rejected", func(t *testing.T) {
 		th, err := New("life-bad")
 		require.NoError(t, err)
 
-		require.Error(t, th.UnregisterProcess("nope"))
-		require.Error(t, th.UnregisterProcess("   "))
+		require.Error(t, th.UnregisterProcess(nil))
+
+		// a handle for a process never registered in this engine is rejected.
+		other, err := New("life-other")
+		require.NoError(t, err)
+		foreign, err := other.RegisterProcess(
+			msgStartProcess(t, "p-foreign", "order placed"))
+		require.NoError(t, err)
+		require.Error(t, th.UnregisterProcess(foreign))
 	})
 }
 
@@ -366,14 +373,16 @@ func TestUnregisterProcessHubError(t *testing.T) {
 		Once()
 	th.eventHub = mh
 
-	th.m.Lock()
-	th.registrations[s.ProcessID] = []*ProcessRegistration{
-		{key: s.ProcessID, version: 1, snapshot: s, starters: starters},
+	reg := &ProcessRegistration{
+		key: s.ProcessID, version: 1, snapshot: s, starters: starters,
 	}
+
+	th.m.Lock()
+	th.registrations[s.ProcessID] = []*ProcessRegistration{reg}
 	th.state = Started
 	th.m.Unlock()
 
-	require.Error(t, th.UnregisterProcess(s.ProcessID))
+	require.Error(t, th.UnregisterProcess(reg))
 }
 
 // TestRunRegisterStartersError covers Run's startup-registration error path: a

--- a/pkg/thresher/instance_starter_internal_test.go
+++ b/pkg/thresher/instance_starter_internal_test.go
@@ -257,7 +257,7 @@ func TestStarterLifecycle(t *testing.T) {
 		// A clean UnregisterProcess proves the starter WAS registered on the hub
 		// at Run (the hub's UnregisterEvent would error ObjectNotFound were it
 		// not), and clears the bookkeeping.
-		require.NoError(t, th.UnregisterProcess(reg))
+		require.NoError(t, th.UnregisterVersion(reg))
 
 		th.m.Lock()
 		_, hasReg := th.registrations[proc.ID()]
@@ -276,7 +276,7 @@ func TestStarterLifecycle(t *testing.T) {
 		proc := msgStartProcess(t, "p-after", "order placed")
 		reg, err := th.RegisterProcess(proc)
 		require.NoError(t, err)
-		require.NoError(t, th.UnregisterProcess(reg))
+		require.NoError(t, th.UnregisterVersion(reg))
 	})
 
 	t.Run("manual-start: no starter, clean teardown", func(t *testing.T) {
@@ -290,14 +290,14 @@ func TestStarterLifecycle(t *testing.T) {
 		proc := msgStartProcess(t, "p-mlife", "order placed")
 		reg, err := th.RegisterProcess(proc, WithManualStart())
 		require.NoError(t, err)
-		require.NoError(t, th.UnregisterProcess(reg))
+		require.NoError(t, th.UnregisterVersion(reg))
 	})
 
 	t.Run("nil / foreign handle rejected", func(t *testing.T) {
 		th, err := New("life-bad")
 		require.NoError(t, err)
 
-		require.Error(t, th.UnregisterProcess(nil))
+		require.Error(t, th.UnregisterVersion(nil))
 
 		// a handle for a process never registered in this engine is rejected.
 		other, err := New("life-other")
@@ -305,7 +305,7 @@ func TestStarterLifecycle(t *testing.T) {
 		foreign, err := other.RegisterProcess(
 			msgStartProcess(t, "p-foreign", "order placed"))
 		require.NoError(t, err)
-		require.Error(t, th.UnregisterProcess(foreign))
+		require.Error(t, th.UnregisterVersion(foreign))
 	})
 }
 
@@ -355,8 +355,9 @@ func TestRegisterStartersError(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestUnregisterProcessHubError covers the UnregisterProcess teardown error
-// path: a hub that rejects UnregisterEvent surfaces a wrapped error.
+// TestUnregisterProcessHubError covers the UnregisterVersion teardown error
+// path: a hub that rejects UnregisterEvent surfaces a wrapped error. (Name kept
+// across the UnregisterProcess→UnregisterVersion split.)
 func TestUnregisterProcessHubError(t *testing.T) {
 	th, err := New("unreg-err")
 	require.NoError(t, err)
@@ -382,7 +383,7 @@ func TestUnregisterProcessHubError(t *testing.T) {
 	th.state = Started
 	th.m.Unlock()
 
-	require.Error(t, th.UnregisterProcess(reg))
+	require.Error(t, th.UnregisterVersion(reg))
 }
 
 // TestRunRegisterStartersError covers Run's startup-registration error path: a

--- a/pkg/thresher/instance_starter_internal_test.go
+++ b/pkg/thresher/instance_starter_internal_test.go
@@ -185,12 +185,14 @@ func TestRegisterProcessStarters(t *testing.T) {
 		require.NoError(t, err)
 
 		proc := msgStartProcess(t, "p-auto", "order placed")
-		require.NoError(t, th.RegisterProcess(proc))
+		_, err = th.RegisterProcess(proc)
+		require.NoError(t, err)
 
 		th.m.Lock()
-		got := th.starters[proc.ID()]
+		regs := th.registrations[proc.ID()]
 		th.m.Unlock()
-		require.Len(t, got, 1)
+		require.Len(t, regs, 1)
+		require.Len(t, regs[0].starters, 1)
 	})
 
 	t.Run("manual-start registers none", func(t *testing.T) {
@@ -198,12 +200,14 @@ func TestRegisterProcessStarters(t *testing.T) {
 		require.NoError(t, err)
 
 		proc := msgStartProcess(t, "p-manual", "order placed")
-		require.NoError(t, th.RegisterProcess(proc, WithManualStart()))
+		_, err = th.RegisterProcess(proc, WithManualStart())
+		require.NoError(t, err)
 
 		th.m.Lock()
-		got := th.starters[proc.ID()]
+		regs := th.registrations[proc.ID()]
 		th.m.Unlock()
-		require.Empty(t, got)
+		require.Len(t, regs, 1)
+		require.Empty(t, regs[0].starters)
 	})
 
 	t.Run("a failing register option is surfaced", func(t *testing.T) {
@@ -213,21 +217,27 @@ func TestRegisterProcessStarters(t *testing.T) {
 		boom := func(*registerConfig) error {
 			return fmt.Errorf("bad register option")
 		}
-		require.Error(t, th.RegisterProcess(noneStartProcess(t, "p-opt"), boom))
+		_, err = th.RegisterProcess(noneStartProcess(t, "p-opt"), boom)
+		require.Error(t, err)
 	})
 
-	t.Run("re-registration is idempotent", func(t *testing.T) {
-		th, err := New("idem")
+	t.Run("re-registration creates a new version", func(t *testing.T) {
+		th, err := New("versioned")
 		require.NoError(t, err)
 
-		proc := msgStartProcess(t, "p-idem", "order placed")
-		require.NoError(t, th.RegisterProcess(proc))
-		require.NoError(t, th.RegisterProcess(proc))
+		proc := msgStartProcess(t, "p-ver", "order placed")
+		reg1, err := th.RegisterProcess(proc)
+		require.NoError(t, err)
+		reg2, err := th.RegisterProcess(proc)
+		require.NoError(t, err)
+
+		require.Equal(t, 1, reg1.Version())
+		require.Equal(t, 2, reg2.Version())
 
 		th.m.Lock()
-		got := th.starters[proc.ID()]
+		regs := th.registrations[proc.ID()]
 		th.m.Unlock()
-		require.Len(t, got, 1)
+		require.Len(t, regs, 2)
 	})
 }
 
@@ -237,7 +247,8 @@ func TestStarterLifecycle(t *testing.T) {
 		require.NoError(t, err)
 
 		proc := msgStartProcess(t, "p-life", "order placed")
-		require.NoError(t, th.RegisterProcess(proc))
+		_, err = th.RegisterProcess(proc)
+		require.NoError(t, err)
 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
@@ -249,11 +260,9 @@ func TestStarterLifecycle(t *testing.T) {
 		require.NoError(t, th.UnregisterProcess(proc.ID()))
 
 		th.m.Lock()
-		_, hasStarters := th.starters[proc.ID()]
-		_, hasSnap := th.snapshots[proc.ID()]
+		_, hasReg := th.registrations[proc.ID()]
 		th.m.Unlock()
-		require.False(t, hasStarters)
-		require.False(t, hasSnap)
+		require.False(t, hasReg)
 	})
 
 	t.Run("register after Run wires immediately", func(t *testing.T) {
@@ -265,7 +274,8 @@ func TestStarterLifecycle(t *testing.T) {
 		require.NoError(t, th.Run(ctx))
 
 		proc := msgStartProcess(t, "p-after", "order placed")
-		require.NoError(t, th.RegisterProcess(proc))
+		_, err = th.RegisterProcess(proc)
+		require.NoError(t, err)
 		require.NoError(t, th.UnregisterProcess(proc.ID()))
 	})
 
@@ -278,7 +288,8 @@ func TestStarterLifecycle(t *testing.T) {
 		require.NoError(t, th.Run(ctx))
 
 		proc := msgStartProcess(t, "p-mlife", "order placed")
-		require.NoError(t, th.RegisterProcess(proc, WithManualStart()))
+		_, err = th.RegisterProcess(proc, WithManualStart())
+		require.NoError(t, err)
 		require.NoError(t, th.UnregisterProcess(proc.ID()))
 	})
 
@@ -356,8 +367,9 @@ func TestUnregisterProcessHubError(t *testing.T) {
 	th.eventHub = mh
 
 	th.m.Lock()
-	th.snapshots[s.ProcessID] = s
-	th.starters[s.ProcessID] = starters
+	th.registrations[s.ProcessID] = []*ProcessRegistration{
+		{key: s.ProcessID, version: 1, snapshot: s, starters: starters},
+	}
 	th.state = Started
 	th.m.Unlock()
 
@@ -385,8 +397,9 @@ func TestRunRegisterStartersError(t *testing.T) {
 	th.eventHub = mh
 
 	th.m.Lock()
-	th.snapshots[s.ProcessID] = s
-	th.starters[s.ProcessID] = starters
+	th.registrations[s.ProcessID] = []*ProcessRegistration{
+		{key: s.ProcessID, version: 1, snapshot: s, starters: starters},
+	}
 	th.m.Unlock()
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -468,7 +481,8 @@ func TestCorrelationDedup(t *testing.T) {
 	require.NoError(t, err)
 
 	proc := corrStartProcess(t, "p-corr", "order placed", "order placed")
-	require.NoError(t, th.RegisterProcess(proc))
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -501,7 +515,8 @@ func TestCorrelationNoKeyEachInstantiates(t *testing.T) {
 	th, err := New("nocorr", WithMessageBroker(broker))
 	require.NoError(t, err)
 
-	require.NoError(t, th.RegisterProcess(msgStartProcess(t, "p-nocorr", "order placed")))
+	_, err = th.RegisterProcess(msgStartProcess(t, "p-nocorr", "order placed"))
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -517,7 +532,6 @@ func TestCorrelationNoKeyEachInstantiates(t *testing.T) {
 		"without a key, each message instantiates")
 }
 
-
 // TestCorrelationUnderivableKeyInstantiates: a declared key whose retrieval
 // expression doesn't apply to the message (MessageRef mismatch) can't be
 // derived (ok=false), so the message instantiates without dedup.
@@ -529,7 +543,8 @@ func TestCorrelationUnderivableKeyInstantiates(t *testing.T) {
 
 	// the retrieval MessageRef ("other") differs from the start message name.
 	proc := corrStartProcess(t, "p-mm", "order placed", "other")
-	require.NoError(t, th.RegisterProcess(proc))
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/thresher/instantiation_test.go
+++ b/pkg/thresher/instantiation_test.go
@@ -219,7 +219,7 @@ func TestManualStartNotInstantiated(t *testing.T) {
 	// Started explicitly, the instance's message-start node waits as an
 	// in-instance catch; on subscribe it drains the buffered message and
 	// completes — proving manual = start-as-catch, StartProcess-driven.
-	_, serr := th.StartProcess(proc.ID())
+	_, serr := th.StartLatest(proc.ID())
 	require.NoError(t, serr)
 
 	select {

--- a/pkg/thresher/instantiation_test.go
+++ b/pkg/thresher/instantiation_test.go
@@ -88,7 +88,8 @@ func TestEventTriggeredInstantiation(t *testing.T) {
 	require.NoError(t, err)
 
 	done := make(chan string, 1)
-	require.NoError(t, th.RegisterProcess(msgStartConfirmProcess(t, done)))
+	_, err = th.RegisterProcess(msgStartConfirmProcess(t, done))
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -167,7 +168,8 @@ func TestInstantiateReceiveTask(t *testing.T) {
 	require.NoError(t, err)
 
 	done := make(chan string, 1)
-	require.NoError(t, th.RegisterProcess(recvTaskConfirmProcess(t, done)))
+	_, err = th.RegisterProcess(recvTaskConfirmProcess(t, done))
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -196,7 +198,8 @@ func TestManualStartNotInstantiated(t *testing.T) {
 
 	done := make(chan string, 1)
 	proc := msgStartConfirmProcess(t, done)
-	require.NoError(t, th.RegisterProcess(proc, thresher.WithManualStart()))
+	_, err = th.RegisterProcess(proc, thresher.WithManualStart())
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/thresher/merge_edge_test.go
+++ b/pkg/thresher/merge_edge_test.go
@@ -47,7 +47,7 @@ func TestMergedIntoRecorded(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)

--- a/pkg/thresher/observer_test.go
+++ b/pkg/thresher/observer_test.go
@@ -107,7 +107,7 @@ func TestObserverReceivesLifecycleEvents(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	c := &collector{}
@@ -133,7 +133,7 @@ func TestSlowObserverDropsNeverBlocks(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	blk := &blockingObserver{release: make(chan struct{})}
@@ -161,7 +161,7 @@ func TestObserverPanicRecovered(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	psub := h.Observe(panicObserver{})

--- a/pkg/thresher/or_join_test.go
+++ b/pkg/thresher/or_join_test.go
@@ -62,7 +62,7 @@ func TestORJoinUntakenBranch(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -129,7 +129,7 @@ func TestORJoinDeathTriggered(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -184,7 +184,7 @@ func TestORJoinAllBranchesArrive(t *testing.T) {
 	th, cancel := runEngine(t, proc)
 	defer cancel()
 
-	h, err := th.StartProcess(proc.ID())
+	h, err := th.StartLatest(proc.ID())
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)

--- a/pkg/thresher/registration.go
+++ b/pkg/thresher/registration.go
@@ -1,0 +1,27 @@
+package thresher
+
+import "github.com/dr-dobermann/gobpm/internal/instance/snapshot"
+
+// ProcessRegistration is the receipt for one registered version of a process
+// definition (ADR-019 §2.2). RegisterProcess returns it; it names the
+// (key, version) that StartProcess and UnregisterProcess address. It is
+// read-only — it exposes identity, never the engine-internal snapshot or
+// starters it wraps — mirroring InstanceHandle.
+type ProcessRegistration struct {
+	key      string             // the versioning key = process id
+	id       string             // opaque, unique registration id
+	snapshot *snapshot.Snapshot // the frozen version of the definition
+	starters []*instanceStarter // auto-start starters of this version (nil in manual mode)
+	version  int                // 1-based, increments per key in registration order
+	manual   bool               // registered WithManualStart
+}
+
+// Key returns the versioning key — the process id shared by every version of
+// this definition.
+func (r *ProcessRegistration) Key() string { return r.key }
+
+// Version returns this registration's 1-based version number within its key.
+func (r *ProcessRegistration) Version() int { return r.version }
+
+// ID returns the opaque, unique registration id of this version.
+func (r *ProcessRegistration) ID() string { return r.id }

--- a/pkg/thresher/signal_test.go
+++ b/pkg/thresher/signal_test.go
@@ -75,7 +75,8 @@ func TestSignalCatchThrow(t *testing.T) {
 
 	th, cancel := runEngine(t, catcher)
 	defer cancel()
-	require.NoError(t, th.RegisterProcess(thrower))
+	_, err := th.RegisterProcess(thrower)
+	require.NoError(t, err)
 
 	ch, err := th.StartProcess(catcher.ID())
 	require.NoError(t, err)
@@ -100,7 +101,8 @@ func TestSignalBroadcast(t *testing.T) {
 
 	th, cancel := runEngine(t, catcher)
 	defer cancel()
-	require.NoError(t, th.RegisterProcess(thrower))
+	_, err := th.RegisterProcess(thrower)
+	require.NoError(t, err)
 
 	c1, err := th.StartProcess(catcher.ID())
 	require.NoError(t, err)
@@ -130,9 +132,10 @@ func TestSignalThrownIntoVoid(t *testing.T) {
 
 	th, cancel := runEngine(t, thrower)
 	defer cancel()
-	require.NoError(t, th.RegisterProcess(catcher))
+	_, err := th.RegisterProcess(catcher)
+	require.NoError(t, err)
 
-	_, err := th.StartProcess(thrower.ID()) // throw GO with no catcher → no-op
+	_, err = th.StartProcess(thrower.ID()) // throw GO with no catcher → no-op
 	require.NoError(t, err)
 
 	time.Sleep(150 * time.Millisecond)
@@ -155,7 +158,8 @@ func TestSignalSingleShotConsume(t *testing.T) {
 
 	th, cancel := runEngine(t, catcher)
 	defer cancel()
-	require.NoError(t, th.RegisterProcess(thrower))
+	_, err := th.RegisterProcess(thrower)
+	require.NoError(t, err)
 
 	ch, err := th.StartProcess(catcher.ID())
 	require.NoError(t, err)
@@ -256,7 +260,8 @@ func TestSignalStartBroadcastInstantiatesAll(t *testing.T) {
 
 	th, cancel := runEngine(t, procA)
 	defer cancel()
-	require.NoError(t, th.RegisterProcess(procB))
+	_, err := th.RegisterProcess(procB)
+	require.NoError(t, err)
 
 	require.NoError(t, th.PropagateEvent(context.Background(), sigDef(t, "GO")))
 

--- a/pkg/thresher/signal_test.go
+++ b/pkg/thresher/signal_test.go
@@ -78,12 +78,12 @@ func TestSignalCatchThrow(t *testing.T) {
 	_, err := th.RegisterProcess(thrower)
 	require.NoError(t, err)
 
-	ch, err := th.StartProcess(catcher.ID())
+	ch, err := th.StartLatest(catcher.ID())
 	require.NoError(t, err)
 
 	time.Sleep(150 * time.Millisecond) // catcher reaches and parks on the catch
 
-	_, err = th.StartProcess(thrower.ID()) // throws GO
+	_, err = th.StartLatest(thrower.ID()) // throws GO
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -104,14 +104,14 @@ func TestSignalBroadcast(t *testing.T) {
 	_, err := th.RegisterProcess(thrower)
 	require.NoError(t, err)
 
-	c1, err := th.StartProcess(catcher.ID())
+	c1, err := th.StartLatest(catcher.ID())
 	require.NoError(t, err)
-	c2, err := th.StartProcess(catcher.ID())
+	c2, err := th.StartLatest(catcher.ID())
 	require.NoError(t, err)
 
 	time.Sleep(150 * time.Millisecond) // both catchers park on the catch
 
-	_, err = th.StartProcess(thrower.ID()) // one throw of GO
+	_, err = th.StartLatest(thrower.ID()) // one throw of GO
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -135,12 +135,12 @@ func TestSignalThrownIntoVoid(t *testing.T) {
 	_, err := th.RegisterProcess(catcher)
 	require.NoError(t, err)
 
-	_, err = th.StartProcess(thrower.ID()) // throw GO with no catcher → no-op
+	_, err = th.StartLatest(thrower.ID()) // throw GO with no catcher → no-op
 	require.NoError(t, err)
 
 	time.Sleep(150 * time.Millisecond)
 
-	ch, err := th.StartProcess(catcher.ID()) // starts AFTER the throw
+	ch, err := th.StartLatest(catcher.ID()) // starts AFTER the throw
 	require.NoError(t, err)
 
 	// The earlier signal is not retro-delivered: the catcher stays parked.
@@ -161,12 +161,12 @@ func TestSignalSingleShotConsume(t *testing.T) {
 	_, err := th.RegisterProcess(thrower)
 	require.NoError(t, err)
 
-	ch, err := th.StartProcess(catcher.ID())
+	ch, err := th.StartLatest(catcher.ID())
 	require.NoError(t, err)
 
 	time.Sleep(150 * time.Millisecond)
 
-	_, err = th.StartProcess(thrower.ID()) // throw 1 → catcher fires
+	_, err = th.StartLatest(thrower.ID()) // throw 1 → catcher fires
 	require.NoError(t, err)
 
 	ctx, cc := context.WithTimeout(context.Background(), 3*time.Second)
@@ -176,7 +176,7 @@ func TestSignalSingleShotConsume(t *testing.T) {
 	require.Equal(t, thresher.StateCompleted, st)
 
 	// The catch is consumed; a second throw finds no catcher → clean no-op.
-	_, err = th.StartProcess(thrower.ID())
+	_, err = th.StartLatest(thrower.ID())
 	require.NoError(t, err)
 }
 

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -703,36 +703,111 @@ func (t *Thresher) launchInstanceFromEvent(
 	return nil
 }
 
-// StartProcess runs process with processId without any event even if
-// process awaits them.
-func (t *Thresher) StartProcess(processID string) (*InstanceHandle, error) {
-	if st := t.State(); st != Started {
+// StartProcess launches a new instance of the exact registered version named by
+// reg — the receipt RegisterProcess returned — and returns its read-only
+// observation handle. A nil reg is rejected. To start by key instead, use
+// StartLatest (the newest version) or StartVersion (a specific one).
+func (t *Thresher) StartProcess(reg *ProcessRegistration) (*InstanceHandle, error) {
+	if reg == nil {
 		return nil, errs.New(
-			errs.M("thresher isn't started"),
-			errs.C(errorClass, errs.InvalidState),
-			errs.D("current_state", st.String()))
+			errs.M("StartProcess: a nil ProcessRegistration isn't allowed"),
+			errs.C(errorClass, errs.EmptyNotAllowed))
+	}
+
+	if err := t.ensureStarted(); err != nil {
+		return nil, err
+	}
+
+	// launchInstance re-acquires t.m, so reg.snapshot is read lock-free here: a
+	// registration handle is immutable, and its snapshot is frozen (ADR-019).
+	return t.launchInstance(reg.snapshot)
+}
+
+// StartLatest launches a new instance of the LATEST registered version of the
+// process key, returning its observation handle. It errors if the key is empty
+// or no version is registered for it. This is the "just run the current one"
+// path; hold a ProcessRegistration and use StartProcess to pin an exact version.
+func (t *Thresher) StartLatest(key string) (*InstanceHandle, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, errs.New(
+			errs.M("StartLatest: empty process key isn't allowed"),
+			errs.C(errorClass, errs.EmptyNotAllowed))
+	}
+
+	if err := t.ensureStarted(); err != nil {
+		return nil, err
 	}
 
 	// Hold the engine lock only for the registry lookup; release it BEFORE
-	// launchInstance. launchInstance (and, for event-start nodes, the
-	// construction-time RegisterEvent -> Thresher.State()) re-acquire t.m, which
-	// would self-deadlock a non-reentrant mutex if held across them (FIX-002
-	// RC2). A bare process id starts the LATEST registered version of that key
-	// (A3 adds handle- and version-addressed starts).
+	// launchInstance, which re-acquires t.m and would self-deadlock a
+	// non-reentrant mutex if held across it (FIX-002 RC2).
 	t.m.Lock()
 	var s *snapshot.Snapshot
-	if regs := t.registrations[processID]; len(regs) > 0 {
+	if regs := t.registrations[key]; len(regs) > 0 {
 		s = regs[len(regs)-1].snapshot
 	}
 	t.m.Unlock()
 
 	if s == nil {
 		return nil, errs.New(
-			errs.M("couldn't find snapshot for process ID %q", processID),
+			errs.M("no registered version for process key %q", key),
 			errs.C(errorClass, errs.ObjectNotFound))
 	}
 
 	return t.launchInstance(s)
+}
+
+// StartVersion launches a new instance of a SPECIFIC registered version (1-based)
+// of the process key, returning its observation handle. It errors if the key is
+// empty, the version is below 1, or no such key/version is registered. Use it to
+// re-run an older version by its (key, version) without holding its handle.
+func (t *Thresher) StartVersion(key string, version int) (*InstanceHandle, error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil, errs.New(
+			errs.M("StartVersion: empty process key isn't allowed"),
+			errs.C(errorClass, errs.EmptyNotAllowed))
+	}
+
+	if version < 1 {
+		return nil, errs.New(
+			errs.M("StartVersion: version must be >= 1, got %d", version),
+			errs.C(errorClass, errs.InvalidParameter))
+	}
+
+	if err := t.ensureStarted(); err != nil {
+		return nil, err
+	}
+
+	// Lock only for the lookup (FIX-002 RC2, as in StartLatest).
+	t.m.Lock()
+	var s *snapshot.Snapshot
+	if regs := t.registrations[key]; version <= len(regs) {
+		s = regs[version-1].snapshot
+	}
+	t.m.Unlock()
+
+	if s == nil {
+		return nil, errs.New(
+			errs.M("no version %d registered for process key %q", version, key),
+			errs.C(errorClass, errs.ObjectNotFound))
+	}
+
+	return t.launchInstance(s)
+}
+
+// ensureStarted returns an InvalidState error unless the engine is Started — the
+// precondition every Start* entry point shares.
+func (t *Thresher) ensureStarted() error {
+	if st := t.State(); st != Started {
+		return errs.New(
+			errs.M("thresher isn't started"),
+			errs.C(errorClass, errs.InvalidState),
+			errs.D("current_state", st.String()))
+	}
+
+	return nil
 }
 
 // Instance returns the observation handle of a running instance by its id, or

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -113,6 +113,7 @@ type Thresher struct {
 	cfg           thresherConfig
 	eventHub      eventproc.EventHub
 	registrations map[string][]*ProcessRegistration
+	nextVersion   map[string]int
 	instances     map[string]instanceReg
 	seenKeys      map[string]struct{}
 	id            string
@@ -147,6 +148,7 @@ func New(id string, opts ...Option) (*Thresher, error) {
 		cfg:           cfg,
 		state:         NotStarted,
 		registrations: map[string][]*ProcessRegistration{},
+		nextVersion:   map[string]int{},
 		instances:     map[string]instanceReg{},
 		seenKeys:      map[string]struct{}{},
 	}
@@ -489,9 +491,14 @@ func (t *Thresher) RegisterProcess(
 	if len(prev) > 0 {
 		prevLatest = prev[len(prev)-1]
 	}
+	// Version numbers come from a per-key monotonic counter, never the slice
+	// length: removing a non-latest version must not make the next registration
+	// reuse a still-live version number. The counter resets only when the key is
+	// fully unregistered (UnregisterProcess drops it with the key).
+	t.nextVersion[s.ProcessID]++
 	reg := &ProcessRegistration{
 		key:      s.ProcessID,
-		version:  len(prev) + 1,
+		version:  t.nextVersion[s.ProcessID],
 		id:       foundation.GenerateID(),
 		snapshot: s,
 		starters: starters,
@@ -523,20 +530,22 @@ func (t *Thresher) RegisterProcess(
 	return reg, nil
 }
 
-// UnregisterProcess removes one registered version — the one named by reg — by
+// UnregisterVersion removes ONE registered version — the one named by reg — by
 // tearing down its live instance-starter subscriptions (if any) and dropping it
-// from the registry. It is the teardown counterpart of RegisterProcess. Running
-// instances of that version are unaffected — they keep executing against their
-// own frozen snapshot; stop everything via Shutdown (SRD-019 FR-8).
+// from the registry. To remove the whole process (every version of a key) use
+// UnregisterProcess. Running instances of that version are unaffected — they keep
+// executing against their own frozen snapshot; stop everything via Shutdown
+// (SRD-019 FR-8).
 //
 // Only the latest version of a key has live starters (latest-supersedes), so a
 // superseded version has nothing on the hub to tear down. Removing the latest
-// version does NOT re-arm the previous one: auto-start for the key ceases until a
-// new version is registered (ADR-019 §2.5; no auto-promotion).
-func (t *Thresher) UnregisterProcess(reg *ProcessRegistration) error {
+// version PROMOTES the now-newest remaining version to live auto-start, so the
+// invariant "latest registration == live starter set" keeps holding
+// (ADR-019 §2.5; promote-on-removal).
+func (t *Thresher) UnregisterVersion(reg *ProcessRegistration) error {
 	if reg == nil {
 		return errs.New(
-			errs.M("UnregisterProcess: a nil ProcessRegistration isn't allowed"),
+			errs.M("UnregisterVersion: a nil ProcessRegistration isn't allowed"),
 			errs.C(errorClass, errs.EmptyNotAllowed))
 	}
 
@@ -561,6 +570,9 @@ func (t *Thresher) UnregisterProcess(reg *ProcessRegistration) error {
 		regs = append(regs[:idx], regs[idx+1:]...)
 		if len(regs) == 0 {
 			delete(t.registrations, reg.key)
+			// Fully removed: forget the version counter so a later re-registration
+			// of this key starts a fresh v1 (no live version is left to collide).
+			delete(t.nextVersion, reg.key)
 		} else {
 			t.registrations[reg.key] = regs
 			if wasLatest {
@@ -590,6 +602,49 @@ func (t *Thresher) UnregisterProcess(reg *ProcessRegistration) error {
 		if len(promote) > 0 {
 			return t.registerStarters(promote)
 		}
+	}
+
+	return nil
+}
+
+// UnregisterProcess removes the WHOLE process — every registered version of key
+// — dropping them all from the registry and resetting the version counter (a
+// later registration of this key is v1 again). It is the bulk counterpart of
+// RegisterProcess; to remove a single version use UnregisterVersion. Running
+// instances of any version survive on their own frozen snapshots (stop them via
+// Shutdown). Only the latest version holds live starters, so only those are torn
+// down from the hub. Errors ObjectNotFound if key is unknown, EmptyNotAllowed if
+// key is empty.
+func (t *Thresher) UnregisterProcess(key string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return errs.New(
+			errs.M("UnregisterProcess: an empty process key isn't allowed"),
+			errs.C(errorClass, errs.EmptyNotAllowed))
+	}
+
+	// Under the lock: take the key's versions out and forget its counter. The
+	// latest version's starters are the only live ones (latest-supersedes); tear
+	// them down OUTSIDE the lock (FIX-002 RC2).
+	t.m.Lock()
+	regs := t.registrations[key]
+	var liveStarters []*instanceStarter
+	if n := len(regs); n > 0 {
+		liveStarters = regs[n-1].starters
+	}
+	started := t.state == Started
+	delete(t.registrations, key)
+	delete(t.nextVersion, key)
+	t.m.Unlock()
+
+	if len(regs) == 0 {
+		return errs.New(
+			errs.M("no registered version for process key %q", key),
+			errs.C(errorClass, errs.ObjectNotFound))
+	}
+
+	if started {
+		return t.unregisterStarters(liveStarters)
 	}
 
 	return nil
@@ -797,6 +852,8 @@ func (t *Thresher) StartLatest(key string) (*InstanceHandle, error) {
 	// Hold the engine lock only for the registry lookup; release it BEFORE
 	// launchInstance, which re-acquires t.m and would self-deadlock a
 	// non-reentrant mutex if held across it (FIX-002 RC2).
+	// The slice is appended in monotonic version order and removals preserve that
+	// order, so the last element is always the highest version = the latest.
 	t.m.Lock()
 	var s *snapshot.Snapshot
 	if regs := t.registrations[key]; len(regs) > 0 {
@@ -835,11 +892,17 @@ func (t *Thresher) StartVersion(key string, version int) (*InstanceHandle, error
 		return nil, err
 	}
 
-	// Lock only for the lookup (FIX-002 RC2, as in StartLatest).
+	// Lock only for the lookup (FIX-002 RC2, as in StartLatest). Address by the
+	// version NUMBER, not the slice position: removals can leave gaps (v1, v3, …),
+	// so scan for the matching version rather than indexing regs[version-1].
 	t.m.Lock()
 	var s *snapshot.Snapshot
-	if regs := t.registrations[key]; version <= len(regs) {
-		s = regs[version-1].snapshot
+	for _, r := range t.registrations[key] {
+		if r.version == version {
+			s = r.snapshot
+
+			break
+		}
 	}
 	t.m.Unlock()
 

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -46,6 +46,7 @@ import (
 	"github.com/dr-dobermann/gobpm/internal/scope"
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 	"github.com/dr-dobermann/gobpm/pkg/model/process"
 )
 
@@ -107,17 +108,16 @@ type instanceReg struct {
 
 // Thresher represents the main BPMN process execution engine.
 type Thresher struct {
-	ctx          context.Context
-	engineCancel context.CancelFunc
-	cfg          thresherConfig
-	eventHub     eventproc.EventHub
-	snapshots    map[string]*snapshot.Snapshot
-	instances    map[string]instanceReg
-	starters     map[string][]*instanceStarter
-	seenKeys     map[string]struct{}
-	id           string
-	m            sync.Mutex
-	state        State
+	ctx           context.Context
+	engineCancel  context.CancelFunc
+	cfg           thresherConfig
+	eventHub      eventproc.EventHub
+	registrations map[string][]*ProcessRegistration
+	instances     map[string]instanceReg
+	seenKeys      map[string]struct{}
+	id            string
+	m             sync.Mutex
+	state         State
 }
 
 // New creates a new empty Thresher in NotStarted state. Engine-level extensions
@@ -143,13 +143,12 @@ func New(id string, opts ...Option) (*Thresher, error) {
 	}
 
 	t := &Thresher{
-		id:        id,
-		cfg:       cfg,
-		state:     NotStarted,
-		snapshots: map[string]*snapshot.Snapshot{},
-		instances: map[string]instanceReg{},
-		starters:  map[string][]*instanceStarter{},
-		seenKeys:  map[string]struct{}{},
+		id:            id,
+		cfg:           cfg,
+		state:         NotStarted,
+		registrations: map[string][]*ProcessRegistration{},
+		instances:     map[string]instanceReg{},
+		seenKeys:      map[string]struct{}{},
 	}
 
 	// The EventHub receives the engine's resolved runtime (&t.cfg implements
@@ -442,15 +441,15 @@ func (t *Thresher) PropagateEvent(
 func (t *Thresher) RegisterProcess(
 	p *process.Process,
 	opts ...RegisterOption,
-) error {
+) (*ProcessRegistration, error) {
 	if p == nil {
-		return errs.New(
+		return nil, errs.New(
 			errs.M("empty process"),
 			errs.C(errorClass, errs.EmptyNotAllowed))
 	}
 
 	if st := t.State(); st == Stopped {
-		return errs.New(
+		return nil, errs.New(
 			errs.M("thresher is shut down; process registration rejected"),
 			errs.C(errorClass, errs.InvalidState),
 			errs.D("current_state", st.String()))
@@ -459,17 +458,19 @@ func (t *Thresher) RegisterProcess(
 	var rc registerConfig
 	for _, o := range opts {
 		if err := o(&rc); err != nil {
-			return errs.New(
+			return nil, errs.New(
 				errs.M("invalid register option"),
 				errs.C(errorClass, errs.InvalidParameter),
 				errs.E(err))
 		}
 	}
 
-	// Create snapshot from process
+	// Snapshot the process: an isolated, immutable version of the definition
+	// (ADR-019 §2.3). Re-registering the same key mints a NEW version rather than
+	// a silent no-op, so editing the process and registering again is meaningful.
 	s, err := snapshot.New(p)
 	if err != nil {
-		return errs.New(
+		return nil, errs.New(
 			errs.M("failed to create snapshot from process"),
 			errs.C(errorClass, errs.BulidingFailed),
 			errs.E(err))
@@ -483,27 +484,30 @@ func (t *Thresher) RegisterProcess(
 	}
 
 	t.m.Lock()
-	if _, ok := t.snapshots[s.ProcessID]; ok {
-		// Already registered — idempotent, keep the first registration.
-		t.m.Unlock()
-
-		return nil
+	reg := &ProcessRegistration{
+		key:      s.ProcessID,
+		version:  len(t.registrations[s.ProcessID]) + 1,
+		id:       foundation.GenerateID(),
+		snapshot: s,
+		starters: starters,
+		manual:   rc.manualStart,
 	}
-
-	t.snapshots[s.ProcessID] = s
-	t.starters[s.ProcessID] = starters
+	t.registrations[s.ProcessID] = append(t.registrations[s.ProcessID], reg)
 	started := t.state == Started
 	t.m.Unlock()
 
 	// Register the starters on the EventHub OUTSIDE t.m: the hub path is
 	// independent of t.m, and holding the engine lock across an engine-subsystem
 	// call is the deadlock class FIX-002 RC2 warns about. Before Run the hub
-	// isn't started yet, so registration is deferred to Run.
+	// isn't started yet, so registration is deferred to Run. (Latest-supersedes
+	// teardown of a prior version's starters is milestone A4.)
 	if started {
-		return t.registerStarters(starters)
+		if err := t.registerStarters(starters); err != nil {
+			return nil, err
+		}
 	}
 
-	return nil
+	return reg, nil
 }
 
 // UnregisterProcess removes a registered process: it tears down every
@@ -521,12 +525,10 @@ func (t *Thresher) UnregisterProcess(processID string) error {
 	}
 
 	t.m.Lock()
-	_, ok := t.snapshots[processID]
-	starters := t.starters[processID]
+	regs, ok := t.registrations[processID]
 	started := t.state == Started
 	if ok {
-		delete(t.snapshots, processID)
-		delete(t.starters, processID)
+		delete(t.registrations, processID)
 	}
 	t.m.Unlock()
 
@@ -536,18 +538,20 @@ func (t *Thresher) UnregisterProcess(processID string) error {
 			errs.C(errorClass, errs.ObjectNotFound))
 	}
 
-	// Tear down the hub subscriptions OUTSIDE t.m (same reason as
-	// RegisterProcess). Starters are only on the hub once the engine is Started;
-	// before Run they were never registered, so nothing to unregister.
+	// Tear down the hub subscriptions of every version OUTSIDE t.m (same reason
+	// as RegisterProcess). Starters are only on the hub once the engine is
+	// Started; before Run they were never registered, so nothing to unregister.
 	if started {
-		for _, st := range starters {
-			if err := t.eventHub.UnregisterEvent(st, st.eDef.ID()); err != nil {
-				return errs.New(
-					errs.M("couldn't unregister instance-starter subscription"),
-					errs.C(errorClass, errs.OperationFailed),
-					errs.D("process_id", processID),
-					errs.D("event_definition_id", st.eDef.ID()),
-					errs.E(err))
+		for _, reg := range regs {
+			for _, st := range reg.starters {
+				if err := t.eventHub.UnregisterEvent(st, st.eDef.ID()); err != nil {
+					return errs.New(
+						errs.M("couldn't unregister instance-starter subscription"),
+						errs.C(errorClass, errs.OperationFailed),
+						errs.D("process_id", processID),
+						errs.D("event_definition_id", st.eDef.ID()),
+						errs.E(err))
+				}
 			}
 		}
 	}
@@ -577,9 +581,11 @@ func (t *Thresher) registerStarters(starters []*instanceStarter) error {
 // registered before Run (the hub only accepts registrations once Started).
 func (t *Thresher) registerAllStarters() error {
 	t.m.Lock()
-	all := make([]*instanceStarter, 0, len(t.starters))
-	for _, sts := range t.starters {
-		all = append(all, sts...)
+	var all []*instanceStarter
+	for _, regs := range t.registrations {
+		for _, reg := range regs {
+			all = append(all, reg.starters...)
+		}
 	}
 	t.m.Unlock()
 
@@ -707,16 +713,20 @@ func (t *Thresher) StartProcess(processID string) (*InstanceHandle, error) {
 			errs.D("current_state", st.String()))
 	}
 
-	// Hold the engine lock only for the snapshot lookup; release it BEFORE
+	// Hold the engine lock only for the registry lookup; release it BEFORE
 	// launchInstance. launchInstance (and, for event-start nodes, the
 	// construction-time RegisterEvent -> Thresher.State()) re-acquire t.m, which
 	// would self-deadlock a non-reentrant mutex if held across them (FIX-002
-	// RC2).
+	// RC2). A bare process id starts the LATEST registered version of that key
+	// (A3 adds handle- and version-addressed starts).
 	t.m.Lock()
-	s, ok := t.snapshots[processID]
+	var s *snapshot.Snapshot
+	if regs := t.registrations[processID]; len(regs) > 0 {
+		s = regs[len(regs)-1].snapshot
+	}
 	t.m.Unlock()
 
-	if !ok {
+	if s == nil {
 		return nil, errs.New(
 			errs.M("couldn't find snapshot for process ID %q", processID),
 			errs.C(errorClass, errs.ObjectNotFound))

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -484,24 +484,37 @@ func (t *Thresher) RegisterProcess(
 	}
 
 	t.m.Lock()
+	prev := t.registrations[s.ProcessID]
+	var prevLatest *ProcessRegistration
+	if len(prev) > 0 {
+		prevLatest = prev[len(prev)-1]
+	}
 	reg := &ProcessRegistration{
 		key:      s.ProcessID,
-		version:  len(t.registrations[s.ProcessID]) + 1,
+		version:  len(prev) + 1,
 		id:       foundation.GenerateID(),
 		snapshot: s,
 		starters: starters,
 		manual:   rc.manualStart,
 	}
-	t.registrations[s.ProcessID] = append(t.registrations[s.ProcessID], reg)
+	t.registrations[s.ProcessID] = append(prev, reg)
 	started := t.state == Started
 	t.m.Unlock()
 
-	// Register the starters on the EventHub OUTSIDE t.m: the hub path is
-	// independent of t.m, and holding the engine lock across an engine-subsystem
-	// call is the deadlock class FIX-002 RC2 warns about. Before Run the hub
-	// isn't started yet, so registration is deferred to Run. (Latest-supersedes
-	// teardown of a prior version's starters is milestone A4.)
+	// Touch the EventHub OUTSIDE t.m: the hub path is independent of t.m, and
+	// holding the engine lock across an engine-subsystem call is the deadlock
+	// class FIX-002 RC2 warns about. Before Run the hub isn't started yet, so
+	// registration is deferred to Run (registerAllStarters wires latest-only).
 	if started {
+		// Latest-supersedes (ADR-019 §2.5): the new version takes over auto-start,
+		// so the previous latest's starters stop firing. A superseded version only
+		// finishes its already-running instances.
+		if prevLatest != nil {
+			if err := t.unregisterStarters(prevLatest.starters); err != nil {
+				return nil, err
+			}
+		}
+
 		if err := t.registerStarters(starters); err != nil {
 			return nil, err
 		}
@@ -510,49 +523,72 @@ func (t *Thresher) RegisterProcess(
 	return reg, nil
 }
 
-// UnregisterProcess removes a registered process: it tears down every
-// persistent instance-starter subscription registered for it and drops its
-// snapshot. It is the teardown counterpart of RegisterProcess (SRD-015 FR-2).
-// Running instances of the process are unaffected — they keep executing against
-// their already-built snapshot; release finished instances via Forget, or stop
-// everything via Shutdown (SRD-019 FR-8).
-func (t *Thresher) UnregisterProcess(processID string) error {
-	processID = strings.TrimSpace(processID)
-	if processID == "" {
+// UnregisterProcess removes one registered version — the one named by reg — by
+// tearing down its live instance-starter subscriptions (if any) and dropping it
+// from the registry. It is the teardown counterpart of RegisterProcess. Running
+// instances of that version are unaffected — they keep executing against their
+// own frozen snapshot; stop everything via Shutdown (SRD-019 FR-8).
+//
+// Only the latest version of a key has live starters (latest-supersedes), so a
+// superseded version has nothing on the hub to tear down. Removing the latest
+// version does NOT re-arm the previous one: auto-start for the key ceases until a
+// new version is registered (ADR-019 §2.5; no auto-promotion).
+func (t *Thresher) UnregisterProcess(reg *ProcessRegistration) error {
+	if reg == nil {
 		return errs.New(
-			errs.M("empty process id"),
+			errs.M("UnregisterProcess: a nil ProcessRegistration isn't allowed"),
 			errs.C(errorClass, errs.EmptyNotAllowed))
 	}
 
 	t.m.Lock()
-	regs, ok := t.registrations[processID]
+	regs := t.registrations[reg.key]
+	idx := -1
+	for i, r := range regs {
+		if r == reg {
+			idx = i
+
+			break
+		}
+	}
+	wasLatest := idx >= 0 && idx == len(regs)-1
 	started := t.state == Started
-	if ok {
-		delete(t.registrations, processID)
+
+	// promote holds the now-newest remaining version's starters when the latest
+	// is removed — it is promoted to the live auto-start version so the invariant
+	// "latest registration == live starter set" keeps holding (FR-8).
+	var promote []*instanceStarter
+	if idx >= 0 {
+		regs = append(regs[:idx], regs[idx+1:]...)
+		if len(regs) == 0 {
+			delete(t.registrations, reg.key)
+		} else {
+			t.registrations[reg.key] = regs
+			if wasLatest {
+				promote = regs[len(regs)-1].starters
+			}
+		}
 	}
 	t.m.Unlock()
 
-	if !ok {
+	if idx < 0 {
 		return errs.New(
-			errs.M("process %q isn't registered", processID),
+			errs.M("registration %q (process %q v%d) isn't registered in this engine",
+				reg.id, reg.key, reg.version),
 			errs.C(errorClass, errs.ObjectNotFound))
 	}
 
-	// Tear down the hub subscriptions of every version OUTSIDE t.m (same reason
-	// as RegisterProcess). Starters are only on the hub once the engine is
-	// Started; before Run they were never registered, so nothing to unregister.
-	if started {
-		for _, reg := range regs {
-			for _, st := range reg.starters {
-				if err := t.eventHub.UnregisterEvent(st, st.eDef.ID()); err != nil {
-					return errs.New(
-						errs.M("couldn't unregister instance-starter subscription"),
-						errs.C(errorClass, errs.OperationFailed),
-						errs.D("process_id", processID),
-						errs.D("event_definition_id", st.eDef.ID()),
-						errs.E(err))
-				}
-			}
+	// Maintain the hub subscriptions OUTSIDE t.m. Only the latest version's
+	// starters are live (latest-supersedes), so removing a superseded version
+	// touches nothing; before Run nothing is on the hub at all.
+	if started && wasLatest {
+		if err := t.unregisterStarters(reg.starters); err != nil {
+			return err
+		}
+
+		// promote the now-newest remaining version to live auto-start (empty for
+		// a manual-start version or when the key had a single version).
+		if len(promote) > 0 {
+			return t.registerStarters(promote)
 		}
 	}
 
@@ -577,14 +613,33 @@ func (t *Thresher) registerStarters(starters []*instanceStarter) error {
 	return nil
 }
 
-// registerAllStarters registers the instance-starters of every process
-// registered before Run (the hub only accepts registrations once Started).
+// unregisterStarters tears down each instance-starter's persistent subscription
+// on the engine EventHub. Shared by UnregisterProcess and the latest-supersedes
+// teardown in RegisterProcess.
+func (t *Thresher) unregisterStarters(starters []*instanceStarter) error {
+	for _, st := range starters {
+		if err := t.eventHub.UnregisterEvent(st, st.eDef.ID()); err != nil {
+			return errs.New(
+				errs.M("couldn't unregister instance-starter subscription"),
+				errs.C(errorClass, errs.OperationFailed),
+				errs.D("process_id", st.snapshot.ProcessID),
+				errs.D("event_definition_id", st.eDef.ID()),
+				errs.E(err))
+		}
+	}
+
+	return nil
+}
+
+// registerAllStarters registers, at Run, the instance-starters of the LATEST
+// version of every process registered before Run (only the latest auto-starts —
+// latest-supersedes; the hub accepts registrations once Started).
 func (t *Thresher) registerAllStarters() error {
 	t.m.Lock()
 	var all []*instanceStarter
 	for _, regs := range t.registrations {
-		for _, reg := range regs {
-			all = append(all, reg.starters...)
+		if n := len(regs); n > 0 {
+			all = append(all, regs[n-1].starters...)
 		}
 	}
 	t.m.Unlock()

--- a/pkg/thresher/thresher_launch_test.go
+++ b/pkg/thresher/thresher_launch_test.go
@@ -67,7 +67,7 @@ func TestStartProcess_RunsToCompletion(t *testing.T) {
 
 	_, err = th.RegisterProcess(proc)
 	require.NoError(t, err)
-	_, serr := th.StartProcess(proc.ID())
+	_, serr := th.StartLatest(proc.ID())
 	require.NoError(t, serr)
 
 	select {

--- a/pkg/thresher/thresher_launch_test.go
+++ b/pkg/thresher/thresher_launch_test.go
@@ -65,7 +65,8 @@ func TestStartProcess_RunsToCompletion(t *testing.T) {
 	_, err = flow.Link(work, end)
 	require.NoError(t, err)
 
-	require.NoError(t, th.RegisterProcess(proc))
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
 	_, serr := th.StartProcess(proc.ID())
 	require.NoError(t, serr)
 

--- a/pkg/thresher/thresher_process_test.go
+++ b/pkg/thresher/thresher_process_test.go
@@ -38,7 +38,7 @@ func TestThresher_ProcessManagement(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, thresher.NotStarted, th.State())
 
-		_, err = th.StartProcess("some-process-id")
+		_, err = th.StartLatest("some-process-id")
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "thresher isn't started")
 	})
@@ -55,9 +55,9 @@ func TestThresher_ProcessManagement(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, thresher.Started, th.State())
 
-		_, err = th.StartProcess("non-existent-process")
+		_, err = th.StartLatest("non-existent-process")
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "couldn't find snapshot for process ID")
+		require.Contains(t, err.Error(), "no registered version for process key")
 	})
 
 	// Note: Testing actual process start would require complex setup with
@@ -96,7 +96,7 @@ func TestStartProcess_NoReentrantDeadlock(t *testing.T) {
 	require.NoError(t, err)
 
 	done := make(chan error, 1)
-	go func() { _, e := th.StartProcess(proc.ID()); done <- e }()
+	go func() { _, e := th.StartLatest(proc.ID()); done <- e }()
 
 	select {
 	case err := <-done:

--- a/pkg/thresher/thresher_process_test.go
+++ b/pkg/thresher/thresher_process_test.go
@@ -17,7 +17,7 @@ func TestThresher_ProcessManagement(t *testing.T) {
 		th, err := thresher.New("test-thresher")
 		require.NoError(t, err)
 
-		err = th.RegisterProcess(nil)
+		_, err = th.RegisterProcess(nil)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty process")
 	})
@@ -29,7 +29,7 @@ func TestThresher_ProcessManagement(t *testing.T) {
 		proc, err := process.New("dummy process")
 		require.NoError(t, err)
 
-		err = th.RegisterProcess(proc)
+		_, err = th.RegisterProcess(proc)
 		require.NoError(t, err)
 	})
 
@@ -92,7 +92,8 @@ func TestStartProcess_NoReentrantDeadlock(t *testing.T) {
 	_, err = flow.Link(start, end)
 	require.NoError(t, err)
 
-	require.NoError(t, th.RegisterProcess(proc))
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
 
 	done := make(chan error, 1)
 	go func() { _, e := th.StartProcess(proc.ID()); done <- e }()

--- a/pkg/thresher/versioning_internal_test.go
+++ b/pkg/thresher/versioning_internal_test.go
@@ -1,0 +1,92 @@
+package thresher
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/messaging"
+	"github.com/dr-dobermann/gobpm/pkg/messaging/membroker"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLatestSupersedesAutoStart verifies that registering a newer version of a
+// key transfers auto-start to it: only the latest version owns the trigger, so
+// a single fired event spawns exactly one instance, not one per registered
+// version (SRD-031.A FR-7, T-9).
+func TestLatestSupersedesAutoStart(t *testing.T) {
+	broker := membroker.New()
+
+	th, err := New("supersede", WithMessageBroker(broker))
+	require.NoError(t, err)
+
+	proc := msgStartProcess(t, "p-sup", "order placed")
+	reg1, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	// re-registering the same key after Run supersedes v1's live starter with v2's.
+	reg2, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	require.Equal(t, reg1.Key(), reg2.Key())
+	require.Equal(t, 2, reg2.Version())
+
+	// one trigger spawns exactly one instance — the superseded v1 starter is no
+	// longer live, so it does not also fire.
+	require.NoError(t, broker.Publish(ctx,
+		messaging.Envelope{Name: "order placed", Payload: "x"}))
+	require.Eventually(t, func() bool { return instanceCount(th) == 1 },
+		3*time.Second, 10*time.Millisecond,
+		"the superseding version owns the trigger")
+	require.Never(t, func() bool { return instanceCount(th) > 1 },
+		300*time.Millisecond, 50*time.Millisecond,
+		"the superseded version must not also spawn")
+
+	// the live starter set is the latest version's only.
+	require.Len(t, th.Starters(), 1)
+}
+
+// TestUnregisterLatestPromotesPrevious verifies promote-on-removal: removing the
+// latest version makes the now-newest remaining version the live auto-start
+// version, so it owns the trigger again. This is how a user re-activates a
+// previous version's auto-start (SRD-031.A FR-8, T-11).
+func TestUnregisterLatestPromotesPrevious(t *testing.T) {
+	broker := membroker.New()
+
+	th, err := New("promote", WithMessageBroker(broker))
+	require.NoError(t, err)
+
+	proc := msgStartProcess(t, "p-prom", "order placed")
+	reg1, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	reg2, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	require.Equal(t, 1, reg1.Version())
+	require.Equal(t, 2, reg2.Version())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	// removing the latest (v2) promotes v1 to the live auto-start version.
+	require.NoError(t, th.UnregisterProcess(reg2))
+
+	th.m.Lock()
+	regs := th.registrations[reg1.Key()]
+	th.m.Unlock()
+	require.Len(t, regs, 1)
+	require.Equal(t, 1, regs[0].version)
+
+	// the promoted v1 owns the trigger again: a message spawns an instance.
+	require.NoError(t, broker.Publish(ctx,
+		messaging.Envelope{Name: "order placed", Payload: "x"}))
+	require.Eventually(t, func() bool { return instanceCount(th) == 1 },
+		3*time.Second, 10*time.Millisecond,
+		"removing the latest promotes the previous version to live auto-start")
+
+	// Starters now lists the promoted previous version.
+	require.Len(t, th.Starters(), 1)
+}

--- a/pkg/thresher/versioning_internal_test.go
+++ b/pkg/thresher/versioning_internal_test.go
@@ -72,7 +72,7 @@ func TestUnregisterLatestPromotesPrevious(t *testing.T) {
 	require.NoError(t, th.Run(ctx))
 
 	// removing the latest (v2) promotes v1 to the live auto-start version.
-	require.NoError(t, th.UnregisterProcess(reg2))
+	require.NoError(t, th.UnregisterVersion(reg2))
 
 	th.m.Lock()
 	regs := th.registrations[reg1.Key()]

--- a/pkg/thresher/versioning_test.go
+++ b/pkg/thresher/versioning_test.go
@@ -1,0 +1,67 @@
+package thresher_test
+
+import (
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/pkg/thresher"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisterProcessReturnsHandle verifies RegisterProcess returns a
+// registration handle naming the (key, version) of the registered definition
+// (SRD-031.A FR-2, T-3): the key is the process id, the first version is 1, and
+// the registration id is non-empty.
+func TestRegisterProcessReturnsHandle(t *testing.T) {
+	th, err := thresher.New("reg-handle")
+	require.NoError(t, err)
+
+	proc := linearProcess(t, "p-handle", 0)
+
+	reg, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	require.NotNil(t, reg)
+	require.Equal(t, proc.ID(), reg.Key())
+	require.Equal(t, 1, reg.Version())
+	require.NotEmpty(t, reg.ID())
+}
+
+// TestReRegisterCreatesNewVersion verifies that re-registering the same key
+// mints a new version rather than the old silent no-op (SRD-031.A FR-3, T-4):
+// versions increment per key in registration order, the key is shared, and each
+// registration has a distinct registration id.
+func TestReRegisterCreatesNewVersion(t *testing.T) {
+	th, err := thresher.New("reg-version")
+	require.NoError(t, err)
+
+	proc := linearProcess(t, "p-version", 0)
+
+	reg1, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	reg2, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	require.Equal(t, reg1.Key(), reg2.Key())
+	require.Equal(t, 1, reg1.Version())
+	require.Equal(t, 2, reg2.Version())
+	require.NotEqual(t, reg1.ID(), reg2.ID())
+}
+
+// TestAnonymousProcessesAreDistinctKeys verifies that processes registered
+// without an explicit id (each gets a generated unique id) are distinct keys,
+// each a singleton version 1 (SRD-031.A FR-3, T-5) — there is no shared identity
+// to form a version lineage.
+func TestAnonymousProcessesAreDistinctKeys(t *testing.T) {
+	th, err := thresher.New("reg-anon")
+	require.NoError(t, err)
+
+	reg1, err := th.RegisterProcess(linearProcess(t, "anon-a", 0))
+	require.NoError(t, err)
+
+	reg2, err := th.RegisterProcess(linearProcess(t, "anon-b", 0))
+	require.NoError(t, err)
+
+	require.NotEqual(t, reg1.Key(), reg2.Key())
+	require.Equal(t, 1, reg1.Version())
+	require.Equal(t, 1, reg2.Version())
+}

--- a/pkg/thresher/versioning_test.go
+++ b/pkg/thresher/versioning_test.go
@@ -1,6 +1,7 @@
 package thresher_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dr-dobermann/gobpm/pkg/thresher"
@@ -64,4 +65,108 @@ func TestAnonymousProcessesAreDistinctKeys(t *testing.T) {
 	require.NotEqual(t, reg1.Key(), reg2.Key())
 	require.Equal(t, 1, reg1.Version())
 	require.Equal(t, 1, reg2.Version())
+}
+
+// TestStartProcessByHandle verifies StartProcess starts the exact version named
+// by its registration handle, and rejects a nil handle with a self-identifying
+// error (SRD-031.A FR-4, NFR-1, T-6).
+func TestStartProcessByHandle(t *testing.T) {
+	th, err := thresher.New("start-handle")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	reg, err := th.RegisterProcess(linearProcess(t, "p-byhandle", 0))
+	require.NoError(t, err)
+
+	h, err := th.StartProcess(reg)
+	require.NoError(t, err)
+	require.NotNil(t, h)
+
+	_, err = th.StartProcess(nil)
+	require.Error(t, err)
+}
+
+// TestStartVersion verifies StartVersion starts a specific registered version of
+// a key and rejects unknown keys/versions and out-of-range versions (SRD-031.A
+// FR-5, NFR-1, T-7).
+func TestStartVersion(t *testing.T) {
+	th, err := thresher.New("start-version")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	proc := linearProcess(t, "p-ver-start", 0)
+	reg1, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	reg2, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	key := reg1.Key()
+
+	// each registered version starts.
+	h1, err := th.StartVersion(key, reg1.Version())
+	require.NoError(t, err)
+	require.NotNil(t, h1)
+
+	h2, err := th.StartVersion(key, reg2.Version())
+	require.NoError(t, err)
+	require.NotNil(t, h2)
+
+	// an unregistered version, an unknown key, a sub-1 version, and an empty key
+	// are each rejected.
+	_, err = th.StartVersion(key, 3)
+	require.Error(t, err)
+	_, err = th.StartVersion("no-such-key", 1)
+	require.Error(t, err)
+	_, err = th.StartVersion(key, 0)
+	require.Error(t, err)
+	_, err = th.StartVersion("", 1)
+	require.Error(t, err)
+}
+
+// TestStartLatest verifies StartLatest starts the newest registered version of a
+// key and rejects unknown/empty keys (SRD-031.A FR-6, NFR-1, T-8).
+func TestStartLatest(t *testing.T) {
+	th, err := thresher.New("start-latest")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	reg, err := th.RegisterProcess(linearProcess(t, "p-latest", 0))
+	require.NoError(t, err)
+
+	h, err := th.StartLatest(reg.Key())
+	require.NoError(t, err)
+	require.NotNil(t, h)
+
+	_, err = th.StartLatest("no-such-key")
+	require.Error(t, err)
+	_, err = th.StartLatest("")
+	require.Error(t, err)
+}
+
+// TestStartMethodsRejectWhenNotStarted verifies every Start* entry point refuses
+// to launch before the engine is Run, even with a valid registration in hand
+// (SRD-031.A NFR-1). RegisterProcess itself works before Run.
+func TestStartMethodsRejectWhenNotStarted(t *testing.T) {
+	th, err := thresher.New("not-started")
+	require.NoError(t, err)
+
+	reg, err := th.RegisterProcess(linearProcess(t, "p-ns", 0))
+	require.NoError(t, err)
+
+	_, err = th.StartProcess(reg)
+	require.Error(t, err)
+
+	_, err = th.StartVersion(reg.Key(), 1)
+	require.Error(t, err)
+
+	_, err = th.StartLatest(reg.Key())
+	require.Error(t, err)
 }

--- a/pkg/thresher/versioning_test.go
+++ b/pkg/thresher/versioning_test.go
@@ -151,6 +151,129 @@ func TestStartLatest(t *testing.T) {
 	require.Error(t, err)
 }
 
+// regVersions extracts the version numbers from a registration list.
+func regVersions(regs []*thresher.ProcessRegistration) []int {
+	out := make([]int, len(regs))
+	for i, r := range regs {
+		out[i] = r.Version()
+	}
+
+	return out
+}
+
+// TestGappedVersionRemoval verifies that removing a non-latest version leaves a
+// gap addressed correctly: StartVersion finds a version by NUMBER (not slice
+// position), version numbers are never reused while the key lives, StartLatest
+// stays the highest present version, Registrations enumerates the gap, and a
+// fully-removed key resets to v1 (SRD-031.A FR-3, FR-5, FR-8, FR-10, T-13).
+func TestGappedVersionRemoval(t *testing.T) {
+	th, err := thresher.New("gap")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	proc := linearProcess(t, "p-gap", 0)
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
+	reg2, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	reg3, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	key := reg2.Key()
+	require.Equal(t, []int{1, 2, 3}, regVersions(th.Registrations(key)))
+
+	// remove the MIDDLE version (v2) while v3 is latest.
+	require.NoError(t, th.UnregisterVersion(reg2))
+	require.Equal(t, []int{1, 3}, regVersions(th.Registrations(key)))
+
+	// StartVersion addresses by number: v3 still starts, the removed v2 errors,
+	// v1 still starts.
+	h3, err := th.StartVersion(key, 3)
+	require.NoError(t, err)
+	require.NotNil(t, h3)
+	_, err = th.StartVersion(key, 2)
+	require.Error(t, err)
+	h1, err := th.StartVersion(key, 1)
+	require.NoError(t, err)
+	require.NotNil(t, h1)
+
+	// StartLatest resolves to the highest present version (v3, not the removed v2).
+	require.Equal(t, 3, reg3.Version())
+	hL, err := th.StartLatest(key)
+	require.NoError(t, err)
+	require.NotNil(t, hL)
+
+	// re-registering reuses neither the removed 2 nor the live 3: the monotonic
+	// counter yields 4.
+	reg4, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	require.Equal(t, 4, reg4.Version())
+	require.Equal(t, []int{1, 3, 4}, regVersions(th.Registrations(key)))
+
+	// an unknown key enumerates as empty.
+	require.Empty(t, th.Registrations("no-such-key"))
+
+	// the returned handles are live: each is accepted by UnregisterVersion.
+	// Removing every version one by one resets the key — a later registration is
+	// v1 again (exercises UnregisterVersion's drop-the-counter-on-empty path).
+	for _, r := range th.Registrations(key) {
+		require.NoError(t, th.UnregisterVersion(r))
+	}
+	require.Empty(t, th.Registrations(key))
+
+	regReset, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	require.Equal(t, 1, regReset.Version())
+}
+
+// TestUnregisterProcessRemovesAllVersions verifies the whole-process teardown:
+// UnregisterProcess(key) drops every registered version at once, errors on an
+// unknown/empty key, and resets the version counter so a later registration is
+// v1 again (SRD-031.A FR-11, T-14).
+func TestUnregisterProcessRemovesAllVersions(t *testing.T) {
+	th, err := thresher.New("unreg-all")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	proc := linearProcess(t, "p-unreg-all", 0)
+	for range 3 {
+		_, err = th.RegisterProcess(proc)
+		require.NoError(t, err)
+	}
+	key := proc.ID()
+	require.Equal(t, []int{1, 2, 3}, regVersions(th.Registrations(key)))
+
+	// an empty key and an unknown key are rejected.
+	require.Error(t, th.UnregisterProcess(""))
+	require.Error(t, th.UnregisterProcess("no-such-key"))
+
+	// the whole process goes in one call.
+	require.NoError(t, th.UnregisterProcess(key))
+	require.Empty(t, th.Registrations(key))
+	_, err = th.StartLatest(key)
+	require.Error(t, err)
+
+	// the counter reset: a later registration of the same key restarts at v1.
+	regNew, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	require.Equal(t, 1, regNew.Version())
+
+	// before Run (engine not started) UnregisterProcess still drops the key —
+	// nothing is on the hub to tear down.
+	th2, err := thresher.New("unreg-all-prerun")
+	require.NoError(t, err)
+	pre := linearProcess(t, "p-prerun", 0)
+	_, err = th2.RegisterProcess(pre)
+	require.NoError(t, err)
+	require.NoError(t, th2.UnregisterProcess(pre.ID()))
+	require.Empty(t, th2.Registrations(pre.ID()))
+}
+
 // TestStartMethodsRejectWhenNotStarted verifies every Start* entry point refuses
 // to launch before the engine is Run, even with a valid registration in hand
 // (SRD-031.A NFR-1). RegisterProcess itself works before Run.


### PR DESCRIPTION
Definition versioning (ADR-019 / SRD-031.A)

Camunda-style process-definition versioning for the Thresher engine.

Registration & versioning
- RegisterProcess(p) now returns a (*ProcessRegistration, error) handle naming the (key, version). The key is the process id (BPMN identity); an anonymous process (generated id) is a singleton
v1.
- Re-registering the same id mints a new version. Version numbers come from a per-key monotonic counter — never reused while the key lives — so removing a non-latest version leaves a gap (v1, v3,
…) rather than renumbering.
- Snapshots are isolated from the model at registration, so post-registration edits can't leak into a registered version (closes audit §3.3's leak/race by construction).

Starting (three addressing modes)
- StartProcess(reg) — exact version by handle.
- StartVersion(key, n) — a specific version by number (gap-safe; scans, doesn't index).
- StartLatest(key) — the highest registered version.

Auto-start / supersession
- The latest registered version is always the live auto-starter, both directions: registering a newer version supersedes the previous one's starters; unregistering the latest promotes the
now-newest version back to live. Running instances of any version finish on their own frozen snapshots.

Removal & discovery
- UnregisterVersion(reg) removes one version; UnregisterProcess(key) removes the whole process (every version, resets the counter). Running instances survive either way.
- Registrations(key) enumerates a key's registered versions (live handles) — discover what exists, gaps included, before addressing one.

Also fixes a latent membroker bug surfaced by supersession: a stopped message waiter never unsubscribed, so a later publish on the same name was swallowed by the dead subscription.
messaging.Subscription gains Unsubscribe(); the waiter tears down on every exit path.

Breaking changes (CHANGELOG migration note included): RegisterProcess return signature; StartProcess(id) → StartProcess(reg) / StartLatest(id); UnregisterProcess(reg) → UnregisterVersion(reg) (or
UnregisterProcess(key) to drop all versions).
