### PR TITLE
refactor: precompute snapshot start-events + encapsulate instance data-plane (SRD-032)

### DIFF
--- a/docs/srd/SRD-032-snapshot-starts-instance-scope.md
+++ b/docs/srd/SRD-032-snapshot-starts-instance-scope.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Draft |
+| Status | Accepted |
 | Version | v.1 |
 | Date | 2026-06-29 |
 | Owner | Ruslan Gabitov |
@@ -298,21 +298,74 @@ file is not decomposed here.
 
 ## 9. Definition of Done
 
-- [ ] FR-1..FR-5 wired; covered by T-1..T-7.
-- [ ] `Snapshot.InstantiatingStarts` populated in `New` post-wiring; probes moved
+- [x] FR-1..FR-5 wired; covered by T-1..T-7.
+- [x] `Snapshot.InstantiatingStarts` populated in `New` post-wiring; probes moved
   to the snapshot package; `scanInstantiatingStarts` is the thin adapter; `Clone`
   shares the section.
-- [ ] `instanceScope` owns the data-plane wiring; `Instance` delegates; no
+- [x] `instanceScope` owns the data-plane wiring; `Instance` delegates; no
   back-reference; `RuntimeVar`/`RuntimeVarNames` behavior unchanged.
-- [ ] `/check-style` clean; `/check-srd` PASS.
-- [ ] `make ci` green incl. diff-coverage ≥95% on touched files (NFR-3) and
+- [x] `/check-style` clean; `/check-srd` PASS.
+- [x] `make ci` green incl. diff-coverage ≥95% on touched files (NFR-3) and
   `go test -race ./...` (NFR-2); 18 examples run.
-- [ ] §8 cross-doc pins consistent (up/sideways, versioned); no downward ref.
-- [ ] §10 filled; status flipped Draft → Accepted (user's call).
+- [x] §8 cross-doc pins consistent (up/sideways, versioned); no downward ref.
+- [x] §10 filled; status flipped Draft → Accepted.
 
 ## 10. Implementation summary
 
-_(filled at landing: files/lines, T-results, milestone SHAs.)_
+Landed on `feat/srd-032-snapshot-starts-scope` over master `c1319cc` in two
+milestones plus the doc commit.
+
+**Commits**
+
+| Commit | Scope |
+|---|---|
+| `c721c41` | doc — SRD-032 |
+| `d55162a` | M1 — snapshot start-events precompute (FR-1/2/3) |
+| `d34d858` | M2 — `instanceScope` encapsulation (FR-4) |
+
+**M1 — files**
+
+- `internal/instance/snapshot/instantiating_starts.go` (new) — `InstantiatingStart`
+  descriptor; `discoverInstantiatingStarts` (the predicate / Event-Based arm /
+  correlation-key loop lifted from the thresher); the moved `isInstantiatingStartNode`
+  and `correlationKeyOf` probes.
+- `internal/instance/snapshot/snapshot.go` — `Snapshot.InstantiatingStarts` field;
+  populated in `New` after `wireClonedGraph`; shared by reference in `Clone`.
+- `pkg/thresher/instance_starter.go` — `scanInstantiatingStarts` reduced to a thin
+  adapter wrapping each descriptor into an `*instanceStarter`; the two probes deleted
+  (moved to the snapshot package).
+- `internal/instance/snapshot/instantiating_starts_test.go` (new) — T-1 (each start
+  kind / exclusions), T-2 (Event-Based arm: exclusive→arm, parallel→gate), T-4
+  (`Clone` share + no-alias).
+
+**M2 — files**
+
+- `internal/instance/scope.go` (new) — `instanceScope{plane, reader, root}` with
+  `load` (build plane + commit properties, supplier passed in — no `Instance`
+  back-ref), `openFrame` (consolidates the three `scope.NewFrame` sites),
+  `bindEventPayload`.
+- `internal/instance/instance.go` — three data-plane fields collapsed to one
+  `sc instanceScope`; `loadProperties`/`bindEventPayload` removed; call sites +
+  `DataReader` delegate to `inst.sc`.
+- `internal/instance/{activation.go,track.go}` — the guard frame and per-node
+  execution frame now go through `inst.sc.openFrame`.
+
+**Verification (V-results)**
+
+- `make ci` exit 0 (tidy-check · lint 0 issues · build-all · `-race` tests ·
+  diff-coverage · govulncheck) across all modules.
+- Combined diff-coverage **96.0% of 124 changed lines — PASS** (min 95%):
+  `snapshot.go` 100%, `track.go` 100%, `instance_starter.go` 100%,
+  `instantiating_starts.go` 98.2%, `scope.go` 90.0%. The 5 uncovered lines are
+  unreachable defensive error-returns (`scope.New`/`openFrame` cannot fail on a
+  valid-by-construction path; the non-`EventNode` guard) — the branch ceiling.
+- Behaviour preserved: 156 thresher + 180 instance tests pass unchanged
+  (characterization); all 18 examples run end-to-end (exit 0).
+- `/check-srd` PASS (HEAD `d34d858`).
+
+**Deferred (named in §7 Non-goals):** the real Instance god-object decomposition
+(event-loop / token-tracking extraction, ADR-012 §2.5) and the `track`-package
+split — each its own future ADR + SRD.
 
 ## Open questions
 

--- a/docs/srd/SRD-032-snapshot-starts-instance-scope.md
+++ b/docs/srd/SRD-032-snapshot-starts-instance-scope.md
@@ -1,0 +1,319 @@
+# SRD-032 — Snapshot start-events precompute and instance-scope encapsulation
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-06-29 |
+| Owner | Ruslan Gabitov |
+| Implements | [ADR-012 v.1 §2.5 Execution layering](../design/ADR-012-execution-layering.md) |
+
+Two behavior-preserving internal refactors in the instance/registry area, landed
+together because both shrink the same overgrown surfaces:
+
+1. **Snapshot start-events precompute (M1).** Compute the instantiating start
+   triggers once, during `snapshot.New`'s single node pass, into an immutable
+   `Snapshot` section — so `scanInstantiatingStarts` stops re-walking every node
+   on a second O(nodes) pass.
+2. **`instanceScope` encapsulation (M2).** Pull the data-plane wiring out of the
+   1646-line `internal/instance/instance.go` into a small `instanceScope` value,
+   closing the audit's literal §2.3 "Scope role" line and honoring one-entity-per-file.
+
+**No public API change; no behavior change.**
+
+---
+
+## 1. Background & §2.3 reconciliation (verified against the code)
+
+The 2026-06-11 architecture audit (§2.3) flagged `internal/instance/instance.go`
+as an 852-line god-object and recommended **"extract `InstanceScope` to fix the
+`addData` race."** That first step is **already done**:
+
+- `scope.Scope` (`internal/scope/scope.go:27`) is a standalone type owning the
+  scope map under **its own mutex** `m sync.Mutex` (`:33`); the class comment
+  (`scope.go:15-19`) states no compound operation spans lock acquisitions.
+- Instance no longer implements `scope.Scope` — it holds `dataPlane *scope.Scope`
+  and builds it via `scope.New(inst.rootScope, inst)` (`instance.go:527`), passing
+  itself as the narrow 2-method `scope.RuntimeVarsSupplier` (`RuntimeVar`
+  `instance.go:1459`, `RuntimeVarNames` `:1507`). The old `addData`/`getData`
+  Instance methods were removed in **SRD-007** (data-plane/frames). **The
+  `addData` race is structurally gone** — Instance cannot touch the scope map
+  except through `scope.Scope`'s atomic methods.
+
+So §2.3's **bug-half is closed**. What remains is the **god-object size**:
+`instance.go` has since grown to **1646 lines** (≈2× the audited size) as
+SRD-022/025/027/028/029 piled the **event loop + token/track tracking** onto it.
+That decomposition (the event-loop extraction) is **out of scope here** — ADR-012
+v.1 §2.5 (`:138`) already names *"Splitting the `Instance` god-object (audit
+2.3)"* as a deferred sibling refactor, and it relocates ADR-001's
+single-goroutine ownership model, so it needs its own ADR + SRD + heavy `-race`
+validation (see §7 Non-goals). This SRD does the two **safe, behavior-preserving**
+pieces: the snapshot precompute and the scope-wiring encapsulation.
+
+### 1.1 The snapshot two-pass redundancy
+
+Instantiating start triggers are found by **two** O(nodes) passes today:
+
+- **Pass 1 — `snapshot.New`** (`snapshot/snapshot.go:71-105`): loops every
+  `p.Nodes()`, clones each into `s.Nodes`, then `wireClonedGraph` (`:125`)
+  populates each clone's `Incoming()`.
+- **Pass 2 — `scanInstantiatingStarts`** (`thresher/instance_starter.go:109`):
+  re-walks `s.Nodes` and, per node with `len(n.Incoming()) == 0` and
+  `isInstantiatingStartNode` (`:212`), inspects each `eDef` — keeping a message
+  (`correlationKeyOf`, `:197`) or signal definition (others `continue`), resolving
+  the Event-Based-gateway arm (`ArmFor`/`ParallelStart` probes, `:129-158`) — and
+  builds an `*instanceStarter` (`:160`).
+
+The expensive part (the scan + predicate + arm/corr-key resolution) is
+**engine-agnostic** and produces, per qualifying `(node, eDef)`, exactly the
+triple `(startNode, eDef, corrKey)`. Only `instanceStarter.thr` (`:24`) and its
+fresh `id` are **engine-bound** — so the starter itself cannot live on the
+engine-agnostic `Snapshot`, but the triple can.
+
+---
+
+## 2. Requirements
+
+### Functional
+
+- **FR-1 — Snapshot carries its instantiating starts.** `Snapshot` gains an
+  immutable section `InstantiatingStarts []InstantiatingStart`, where
+  `InstantiatingStart` is a plain descriptor `{ StartNode flow.Node; EventDef
+  flow.EventDefinition; CorrelationKey *bpmncommon.CorrelationKey }`. It is
+  populated by `snapshot.New` **after** `wireClonedGraph` (incoming-flow info only
+  exists post-wiring), applying the same predicate `scanInstantiatingStarts` uses
+  today. It holds **raw model descriptors only** — never a `*Thresher` or
+  `*instanceStarter`.
+- **FR-2 — `scanInstantiatingStarts` becomes a thin adapter.** It iterates
+  `s.InstantiatingStarts` and wraps each descriptor into an `*instanceStarter`
+  (binding `thr` + `foundation.GenerateID()`). The node re-scan, the
+  `isInstantiatingStartNode`/`correlationKeyOf` probes, and the arm-resolution move
+  into the snapshot package; the thresher keeps only the engine binding. The
+  produced starters are **identical** (same start nodes, eDefs, corr-keys; ids
+  stay fresh per build).
+- **FR-3 — `Clone` shares the section by reference.** `InstantiatingStarts` is a
+  definition-level concern read once by the Thresher at registration against the
+  *template* snapshot; instances never re-scan starts. `Clone`
+  (`snapshot.go:165`) shares it by reference alongside `Properties`/`CorrelationKeys`
+  (the immutable header), or omits it — instances do not read it.
+- **FR-4 — `instanceScope` owns the data-plane wiring.** A new
+  `internal/instance/scope.go` defines an unexported `instanceScope` value owning
+  `dataPlane *scope.Scope`, `rootScope scope.DataPath`, and `reader
+  service.DataReader`, plus the data-plane mechanics (`loadProperties` and
+  `bindEventPayload`, which call `plane.Commit` internally). `Instance` holds `sc
+  instanceScope` and
+  delegates. The `scope.RuntimeVarsSupplier` methods (`RuntimeVar`/`RuntimeVarNames`)
+  **stay on `Instance`** — they read instance lifecycle state (`STATE`,
+  `TRACKS_CNT`, `STARTED_AT`) — and `Instance` is still the supplier passed when
+  the plane is built. No `instanceScope → Instance` back-reference is introduced.
+- **FR-5 — Behavior preserved.** Registration, auto/manual start, supersession,
+  message/signal instantiation, Event-Based start (exclusive + parallel),
+  correlation, and the data plane behave exactly as before. This is an internal
+  refactor.
+
+### Non-functional
+
+- **NFR-1 — One fewer O(nodes) pass.** Registration computes the instantiating
+  starts once (in `New`) instead of twice; the thresher does O(starts) wrapping,
+  not O(nodes) scanning.
+- **NFR-2 — No race regression.** `go test -race ./...` stays green; the
+  data-plane concurrency (the audit's `addData` class) stays fixed — a `-race`
+  test pins two forked tracks committing concurrently.
+- **NFR-3 — Coverage.** Diff-coverage ≥ project standard (95%, aim 100%) on every
+  touched file; `make ci` green; the 18 examples still run.
+- **NFR-4 — No new package cycles.** `internal/instance/snapshot` may import
+  `pkg/model/events`/`msgflow` for the moved probes (no cycle — `events` does not
+  import `snapshot`); `pkg/model ↛ internal` depguard stays clean.
+
+---
+
+## 3. Models
+
+### 3.1 The Snapshot section (`internal/instance/snapshot/snapshot.go`)
+
+```go
+// InstantiatingStart is one resolved instantiating start trigger of a process,
+// precomputed at snapshot build time: the node a born instance runs from, the
+// event definition that fires it, and the correlation key (nil = name-match
+// only). Raw model descriptors — engine-agnostic, no *Thresher.
+type InstantiatingStart struct {
+	StartNode      flow.Node
+	EventDef       flow.EventDefinition
+	CorrelationKey *bpmncommon.CorrelationKey
+}
+
+type Snapshot struct {
+	foundation.ID
+	ProcessID       string
+	ProcessName     string
+	Nodes           map[string]flow.Node
+	Flows           map[string]*flow.SequenceFlow
+	Properties      []*data.Property
+	CorrelationKeys []*bpmncommon.CorrelationKey
+	// InstantiatingStarts is the precomputed set of instantiating start triggers
+	// (FR-1), populated in New after wiring; shared by Clone (definition-level).
+	InstantiatingStarts []InstantiatingStart
+}
+```
+
+The predicate/arm/corr-key logic relocates from `instance_starter.go:113-158` into
+a snapshot-package helper called by `New` after `wireClonedGraph`; the structural
+probes `isInstantiatingStartNode` and `correlationKeyOf` move with it (pure
+`flow`/`bpmncommon` interface probes, no thresher dependency).
+
+### 3.2 The thin thresher adapter (`pkg/thresher/instance_starter.go`)
+
+```go
+func scanInstantiatingStarts(s *snapshot.Snapshot, thr *Thresher) []*instanceStarter {
+	starters := make([]*instanceStarter, 0, len(s.InstantiatingStarts))
+	for _, is := range s.InstantiatingStarts {
+		starters = append(starters, &instanceStarter{
+			thr:       thr,
+			snapshot:  s,
+			startNode: is.StartNode,
+			eDef:      is.EventDef,
+			corrKey:   is.CorrelationKey,
+			id:        foundation.GenerateID(),
+		})
+	}
+	return starters
+}
+```
+
+### 3.3 `instanceScope` (`internal/instance/scope.go`, new)
+
+```go
+// instanceScope owns the instance's data-plane wiring (the scope.Scope plane,
+// its root path, and the read view), extracted from Instance to keep the role
+// in one file. The scope map's lock lives in scope.Scope (the addData race is
+// already fixed there); this type adds no lock of its own.
+type instanceScope struct {
+	plane  *scope.Scope
+	root   scope.DataPath
+	reader service.DataReader
+}
+```
+
+`Instance` gains `sc instanceScope`; `loadProperties` and `bindEventPayload` (both
+of which commit into `plane`) move onto it; `Instance` retains
+`RuntimeVar`/`RuntimeVarNames` (the supplier) and passes itself when
+`instanceScope` builds the plane.
+
+---
+
+## 4. Analysis
+
+### 4.1 Precompute in `New`, after wiring (decided)
+The predicate needs `Incoming()`, which is populated only by `wireClonedGraph`
+(`snapshot.go:125`). So the precompute runs as a short post-wire pass over
+`s.Nodes` (or folds into one). It cannot run inside the existing clone loop
+(`:71`) because incoming flows aren't wired yet there. It is still **one build**,
+not a separate registration pass.
+
+### 4.2 Raw descriptors, not starters (decided)
+`instanceStarter` binds `*Thresher` (`:24`) and calls `s.thr.resolveAndLaunch`
+(`:63`); the snapshot is engine-agnostic (ADR-019 §2.3) and must not import
+`pkg/thresher`. So the section stores the engine-agnostic triple; the thresher
+adds the binding. This keeps the dependency direction intact.
+
+### 4.3 `Clone` shares by reference (decided)
+The instantiating-starts list is read once at `RegisterProcess` against the
+template snapshot; an instance is *already* launched (it consumes a start node by
+id, it does not discover starts). So the section is definition-level — it lives on
+the immutable header and `Clone` shares it by reference (like `Properties`/
+`CorrelationKeys`, `snapshot.go:171-172`). The descriptors point into the
+template's `s.Nodes`, exactly as the starters do today, so the pointers stay
+template-bound and valid (no aliasing into per-instance clones).
+
+### 4.4 The `instanceScope` extraction is a tidy-up, not a fix (decided)
+The audit framed §2.3's scope step as a race-fix; that race was already closed by
+SRD-007. So M2 is **encapsulation only** — pulling the data-plane wiring out of
+the 1646-line file. The `RuntimeVarsSupplier` methods stay on `Instance` because
+they read lifecycle state, which avoids an `instanceScope → Instance` back-ref;
+the cleaner split is "data-plane mechanics in `instanceScope`, instance-state
+glue on `Instance`."
+
+### 4.5 What stays the same (decided)
+No public API changes; no new locks; the event loop, token tracking,
+EventProducer delegation, message correlation, and observation all stay on
+`Instance` (their decomposition is the deferred event-loop ADR). The snapshot's
+existing `seExists`/`eeExists`/`instStartExists` validation booleans (`:62-64`)
+are unaffected.
+
+---
+
+## 5. API / contract surface
+
+**No public API change.** `Snapshot` gains an exported field
+`InstantiatingStarts` and the exported descriptor type `InstantiatingStart` (the
+`snapshot` package is `internal/`, so this is not part of the library's public
+surface). `scanInstantiatingStarts`, `instanceScope`, and the moved probes are
+unexported. `Thresher`'s registration/start API is untouched; the engine behaves
+identically.
+
+---
+
+## 6. Test scenarios
+
+| # | Scenario | FR | Where |
+|---|---|---|---|
+| T-1 | `New` precomputes `InstantiatingStarts` matching the old scan for: plain message StartEvent; signal StartEvent; instantiate ReceiveTask; non-instantiating node excluded; node-with-incoming excluded | FR-1 | `snapshot/*_test.go` |
+| T-2 | Event-Based start: exclusive-start resolves each arm as the start node + arm corr-key; parallel-start keeps the gate as start node + gate corr-key | FR-1 | `snapshot/*_test.go` |
+| T-3 | `scanInstantiatingStarts` output is equivalent (same start nodes / eDefs / corr-keys, ids fresh) to the pre-refactor scan — characterization test | FR-2 | `thresher/*_internal_test.go` |
+| T-4 | `Clone` shares `InstantiatingStarts`; a registered process still launches event-born instances after an instance is cloned (no pointer aliasing) | FR-3 | `thresher/*_test.go` |
+| T-5 | `RuntimeVar` still serves `STARTED_AT`/`STATE`/`TRACKS_CNT` and `RuntimeVarNames` lists them, through the `instanceScope` wiring | FR-4 | `instance/*_internal_test.go` |
+| T-6 | Data-plane `-race`: two forked tracks `Commit` concurrently — detector clean (the addData class stays fixed) | NFR-2 | `instance/*_test.go` |
+| T-7 | Existing thresher start suites (`StartProcess`/`StartLatest`/`StartVersion`, message/signal instantiation, event-based start) stay green | FR-5 | existing |
+
+---
+
+## 7. Milestones & non-goals
+
+- **M1 — Snapshot start-events precompute.** FR-1/FR-2/FR-3: the `Snapshot`
+  section + descriptor, the post-wire precompute in `New`, the moved probes, the
+  thin `scanInstantiatingStarts`, `Clone` sharing. T-1..T-4, T-7.
+- **M2 — `instanceScope` encapsulation.** FR-4: the new `scope.go`, the
+  data-plane wiring moved off `Instance`, delegation kept behavior-identical.
+  T-5, T-6.
+
+**Non-goals (deferred to a future ADR + SRD):** the event-loop / token-tracking
+extraction (the real god-object mass — ADR-012 §2.5) and the `track`-package split.
+This SRD shrinks `instance.go` only modestly (the scope wiring); the 1646-line
+file is not decomposed here.
+
+## 8. Cross-doc
+
+- **Implements** [ADR-012 v.1](../design/ADR-012-execution-layering.md) §2.5 —
+  advances the deferred Instance-decomposition item (the scope-wiring slice; the
+  event-loop split stays deferred there).
+- [ADR-010 v.2](../design/ADR-010-process-data-model.md) — the data plane /
+  `scope.Scope` the `instanceScope` wraps.
+- [ADR-009 v.1](../design/ADR-009-per-instance-node-graph.md) — per-instance
+  `Clone`; grounds the §4.3 share-by-reference decision.
+- [ADR-019 v.1](../design/ADR-019-definition-versioning.md) §2.3 — the snapshot is
+  the engine-agnostic isolation boundary (why the section holds raw descriptors).
+- SRD-007 — closed §2.3's `addData` race (data plane / frames); number-only ref.
+- SRD-024/025/026 — the Event-Based-start / signal-start semantics the precompute
+  preserves; number-only refs.
+
+## 9. Definition of Done
+
+- [ ] FR-1..FR-5 wired; covered by T-1..T-7.
+- [ ] `Snapshot.InstantiatingStarts` populated in `New` post-wiring; probes moved
+  to the snapshot package; `scanInstantiatingStarts` is the thin adapter; `Clone`
+  shares the section.
+- [ ] `instanceScope` owns the data-plane wiring; `Instance` delegates; no
+  back-reference; `RuntimeVar`/`RuntimeVarNames` behavior unchanged.
+- [ ] `/check-style` clean; `/check-srd` PASS.
+- [ ] `make ci` green incl. diff-coverage ≥95% on touched files (NFR-3) and
+  `go test -race ./...` (NFR-2); 18 examples run.
+- [ ] §8 cross-doc pins consistent (up/sideways, versioned); no downward ref.
+- [ ] §10 filled; status flipped Draft → Accepted (user's call).
+
+## 10. Implementation summary
+
+_(filled at landing: files/lines, T-results, milestone SHAs.)_
+
+## Open questions
+
+None.

--- a/internal/instance/activation.go
+++ b/internal/instance/activation.go
@@ -3,7 +3,6 @@ package instance
 import (
 	"context"
 
-	"github.com/dr-dobermann/gobpm/internal/scope"
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/exec"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
@@ -18,9 +17,7 @@ import (
 // only process data does, so there is no name collision.
 func (inst *Instance) guardEval(ctx context.Context) exec.GuardEval {
 	return func(cond data.FormalExpression) (bool, error) {
-		f, err := scope.NewFrame(
-			"complex-guard", "complex-guard",
-			inst.dataPlane.Root(), inst.dataPlane)
+		f, err := inst.sc.openFrame("complex-guard", "complex-guard")
 		if err != nil {
 			return false,
 				errs.New(

--- a/internal/instance/data_flow_test.go
+++ b/internal/instance/data_flow_test.go
@@ -134,7 +134,7 @@ func TestDataCrossingParallelFork(t *testing.T) {
 		"res-a": "from-A",
 		"res-b": "from-B",
 	} {
-		d, err := inst.dataPlane.GetDataByID(inst.rootScope, id)
+		d, err := inst.sc.plane.GetDataByID(inst.sc.root, id)
 		require.NoError(t, err, "result %q must be committed", id)
 		require.Equal(t, want, d.Value().Get(ctx))
 	}
@@ -199,6 +199,6 @@ func TestFrameDiscardOnFailure(t *testing.T) {
 		"the failing task must fail its track")
 
 	// nothing of the failed execution reached the container scope.
-	_, err = inst.dataPlane.GetDataByID(inst.rootScope, "res-bad")
+	_, err = inst.sc.plane.GetDataByID(inst.sc.root, "res-bad")
 	require.Error(t, err, "a discarded frame must leave no scope residue")
 }

--- a/internal/instance/execenv_test.go
+++ b/internal/instance/execenv_test.go
@@ -24,7 +24,7 @@ func TestExecEnv(t *testing.T) {
 	require.NoError(t, err)
 
 	f, err := scope.NewFrame("track-x", "node-x",
-		inst.dataPlane.Root(), inst.dataPlane)
+		inst.sc.plane.Root(), inst.sc.plane)
 	require.NoError(t, err)
 
 	env := newExecEnv(inst, f)

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -88,8 +88,7 @@ type Instance struct {
 	rr                  interactor.Registrator
 	parentEventProducer eventproc.EventProducer
 	events              chan trackEvent
-	dataPlane           *scope.Scope
-	reader              service.DataReader
+	sc                  instanceScope
 	convKeys            map[string]string
 	now                 func() time.Time
 	tracksSnap          atomic.Pointer[[]*track]
@@ -97,7 +96,6 @@ type Instance struct {
 	s                   *snapshot.Snapshot
 	tracks              map[string]*track
 	loopDone            chan struct{}
-	rootScope           scope.DataPath
 	foundation.BaseElement
 	observers  []obsReg
 	trackCount atomic.Int64
@@ -212,7 +210,8 @@ func New(
 	}
 	inst.state.Store(uint32(Created))
 
-	if err := inst.loadProperties(parentRoot); err != nil {
+	if err := inst.sc.load(
+		parentRoot, inst.s.ProcessName, inst.s.Properties, &inst); err != nil {
 		return nil, errs.New(
 			errs.M("couldn't load process'es properties into Instance scope"),
 			errs.E(err),
@@ -236,7 +235,7 @@ func New(
 
 		bornStart = bs
 
-		if err := inst.bindEventPayload(cfg.bornEvent); err != nil {
+		if err := inst.sc.bindEventPayload(cfg.bornEvent); err != nil {
 			return nil, err
 		}
 	}
@@ -292,27 +291,6 @@ func NewFromEvent(
 	return New(s, parentRoot, er, ep, rr,
 		withBornEvent(startNodeID, eDef),
 		withConversationKey(keyName, keyValue))
-}
-
-// bindEventPayload binds the payload carried by a born-from-event start into the
-// instance root scope: each item the fired event definition carries is committed
-// as a Ready datum keyed by its item id (the msgflow.Bind shape, at root), so a
-// downstream node reading that item observes the message payload (SRD-015 §4.4).
-func (inst *Instance) bindEventPayload(eDef flow.EventDefinition) error {
-	items := eDef.GetItemsList()
-	if len(items) == 0 {
-		return nil
-	}
-
-	dd := make([]data.Data, 0, len(items))
-	for _, item := range items {
-		dd = append(dd, data.MustParameter(item.ID(),
-			data.MustItemAwareElement(item, data.ReadyDataState)))
-	}
-
-	// Commit returns a self-classifying errs error (container/writable/name
-	// checks); pass it through rather than re-wrapping at this internal seam.
-	return inst.dataPlane.Commit(inst.rootScope, dd...)
 }
 
 // AssociateConversationKey records value under the conversation key named name
@@ -509,45 +487,6 @@ func (inst *Instance) extendReceivers(value string) {
 	}
 }
 
-// loadProperties creates the instance's data plane rooted under parentRoot
-// and commits the process properties into the root container scope.
-func (inst *Instance) loadProperties(parentRoot scope.DataPath) error {
-	root := parentRoot
-	if root == scope.EmptyDataPath {
-		root = scope.RootDataPath
-	}
-
-	var err error
-
-	inst.rootScope, err = root.Append(inst.s.ProcessName)
-	if err != nil {
-		return fmt.Errorf("couldn't create instance's scope data path: %w", err)
-	}
-
-	inst.dataPlane, err = scope.New(inst.rootScope, inst)
-	if err != nil {
-		return fmt.Errorf("couldn't create instance's data plane: %w", err)
-	}
-
-	// Build the read-only root data reader once (it backs host observation via
-	// the InstanceHandle, SRD-018): an empty frame at the open root scope reads
-	// live, so it sees the properties committed just below plus runtime vars.
-	reader, ferr := scope.NewFrame(
-		"observe", "observe", inst.dataPlane.Root(), inst.dataPlane)
-	if ferr != nil {
-		return fmt.Errorf("couldn't build instance data reader: %w", ferr)
-	}
-
-	inst.reader = reader
-
-	dd := make([]data.Data, 0, len(inst.s.Properties))
-	for _, p := range inst.s.Properties {
-		dd = append(dd, p)
-	}
-
-	return inst.dataPlane.Commit(inst.rootScope, dd...)
-}
-
 // State returns current state of the Instance.
 func (inst *Instance) State() State {
 	return State(inst.state.Load())
@@ -585,7 +524,7 @@ func (inst *Instance) Done() <-chan struct{} {
 // service.DataReader surface, never a mutating method. Built once in New (an
 // empty frame at the process-root scope), so this getter cannot fail.
 func (inst *Instance) DataReader() service.DataReader {
-	return inst.reader
+	return inst.sc.reader
 }
 
 // Run starts the process instance execution. Execution could be stopped by

--- a/internal/instance/message_flow_test.go
+++ b/internal/instance/message_flow_test.go
@@ -129,7 +129,7 @@ func TestSendReceiveMidFlow(t *testing.T) {
 	require.NoError(t, inst.LastErr())
 
 	// the received payload reached the container scope on the receive's commit.
-	d, err := inst.dataPlane.GetDataByID(inst.rootScope, "order_in")
+	d, err := inst.sc.plane.GetDataByID(inst.sc.root, "order_in")
 	require.NoError(t, err)
 	require.Equal(t, "ORD-7", d.Value().Get(ctx))
 }
@@ -271,7 +271,7 @@ func TestSendToIntermediateCatchEvent(t *testing.T) {
 		"the send/intermediate-catch round-trip must complete")
 	require.NoError(t, inst.LastErr())
 
-	d, err := inst.dataPlane.GetDataByID(inst.rootScope, "order_in")
+	d, err := inst.sc.plane.GetDataByID(inst.sc.root, "order_in")
 	require.NoError(t, err)
 	require.Equal(t, "ORD-7", d.Value().Get(ctx))
 }

--- a/internal/instance/message_instantiation_test.go
+++ b/internal/instance/message_instantiation_test.go
@@ -97,7 +97,7 @@ func TestNewFromEventBornInstance(t *testing.T) {
 	require.NoError(t, inst.LastErr())
 
 	// the payload was bound into the root scope under the message item id.
-	d, err := inst.dataPlane.GetDataByID(inst.rootScope, "order_in")
+	d, err := inst.sc.plane.GetDataByID(inst.sc.root, "order_in")
 	require.NoError(t, err)
 	require.Equal(t, "ORD-99", d.Value().Get(ctx))
 }
@@ -204,7 +204,7 @@ func TestBindEventPayloadNoItems(t *testing.T) {
 
 	// a signal definition carries no items.
 	require.NoError(t,
-		inst.bindEventPayload(events.MustSignalEventDefinition(&events.Signal{})))
+		inst.sc.bindEventPayload(events.MustSignalEventDefinition(&events.Signal{})))
 }
 
 // TestNewBlankProcessName covers New's loadProperties error path: a snapshot

--- a/internal/instance/scope.go
+++ b/internal/instance/scope.go
@@ -1,0 +1,101 @@
+package instance
+
+import (
+	"fmt"
+
+	"github.com/dr-dobermann/gobpm/internal/scope"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/service"
+)
+
+// instanceScope owns an instance's data-plane wiring: the scope tree rooted at
+// the process scope (plane), the root container data path commits target (root),
+// and the read-only observe reader host observation reads through (reader). It
+// groups what the architecture audit (§2.3) called the Instance's "Scope role"
+// into one value, so instance.go no longer carries the data-plane fields and
+// their setup inline. The runtime-variable supplier stays the Instance itself
+// (RuntimeVar / RuntimeVarNames), passed into load, so instanceScope holds no
+// back-reference to the Instance.
+type instanceScope struct {
+	plane  *scope.Scope
+	reader service.DataReader
+	root   scope.DataPath
+}
+
+// load builds the data plane rooted under parentRoot and commits the process
+// properties into the root container scope. Reads under the reserved RUNTIME
+// subtree delegate to supplier (the Instance); processName names the instance's
+// root scope segment; props are the process's declared properties.
+func (sc *instanceScope) load(
+	parentRoot scope.DataPath,
+	processName string,
+	props []*data.Property,
+	supplier scope.RuntimeVarsSupplier,
+) error {
+	root := parentRoot
+	if root == scope.EmptyDataPath {
+		root = scope.RootDataPath
+	}
+
+	var err error
+
+	sc.root, err = root.Append(processName)
+	if err != nil {
+		return fmt.Errorf("couldn't create instance's scope data path: %w", err)
+	}
+
+	sc.plane, err = scope.New(sc.root, supplier)
+	if err != nil {
+		return fmt.Errorf("couldn't create instance's data plane: %w", err)
+	}
+
+	// Build the read-only root data reader once (it backs host observation via
+	// the InstanceHandle, SRD-018): an empty frame at the open root scope reads
+	// live, so it sees the properties committed just below plus runtime vars.
+	reader, ferr := sc.openFrame("observe", "observe")
+	if ferr != nil {
+		return fmt.Errorf("couldn't build instance data reader: %w", ferr)
+	}
+
+	sc.reader = reader
+
+	dd := make([]data.Data, 0, len(props))
+	for _, p := range props {
+		dd = append(dd, p)
+	}
+
+	return sc.plane.Commit(sc.root, dd...)
+}
+
+// openFrame opens a fresh execution frame at the data plane's open root scope for
+// track trackID executing node nodeID. A root frame reads live (it sees committed
+// process data plus runtime vars) — it backs the observe reader, the Complex
+// gateway guard, and per-node execution. A transient frame is Discarded by its
+// caller; the observe frame is kept for the instance's lifetime.
+func (sc *instanceScope) openFrame(
+	trackID, nodeID string,
+) (*scope.Frame, error) {
+	return scope.NewFrame(trackID, nodeID, sc.plane.Root(), sc.plane)
+}
+
+// bindEventPayload binds the payload carried by a born-from-event start into the
+// instance root scope: each item the fired event definition carries is committed
+// as a Ready datum keyed by its item id (the msgflow.Bind shape, at root), so a
+// downstream node reading that item observes the message payload (SRD-015 §4.4).
+func (sc *instanceScope) bindEventPayload(eDef flow.EventDefinition) error {
+	items := eDef.GetItemsList()
+	if len(items) == 0 {
+		return nil
+	}
+
+	dd := make([]data.Data, 0, len(items))
+	for _, item := range items {
+		dd = append(dd, data.MustParameter(item.ID(),
+			data.MustItemAwareElement(item, data.ReadyDataState)))
+	}
+
+	// Commit returns a self-classifying errs error (container/writable/name
+	// checks); pass it through rather than re-wrapping at this internal seam.
+	return sc.plane.Commit(sc.root, dd...)
+}

--- a/internal/instance/snapshot/instantiating_starts.go
+++ b/internal/instance/snapshot/instantiating_starts.go
@@ -1,0 +1,121 @@
+package snapshot
+
+import (
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+)
+
+// InstantiatingStart is an engine-agnostic descriptor of one instantiating start
+// trigger discovered in a snapshot: the start node a new instance runs from, the
+// message or signal definition that fires it, and the correlation key it declares
+// (nil for a signal, or a name-match-only message). It deliberately carries no
+// engine binding (no *Thresher, no starter id) so it can live on the immutable,
+// engine-agnostic Snapshot (ADR-019 §2.3); the thresher wraps each descriptor into
+// an instanceStarter at registration.
+type InstantiatingStart struct {
+	StartNode      flow.Node
+	EventDef       flow.EventDefinition // message (optionally correlated) or signal
+	CorrelationKey *bpmncommon.CorrelationKey
+}
+
+// discoverInstantiatingStarts walks the snapshot's cloned node graph once and
+// builds an InstantiatingStart for every instantiating start trigger: a StartEvent
+// (or instantiate ReceiveTask) carrying a message or signal definition with no
+// incoming sequence flow (BPMN §13.2 / §13.5.1; signals SRD-026). It is computed
+// in New after wireClonedGraph (so each clone's Incoming() is populated) and stored
+// on the snapshot, replacing a second O(nodes) re-scan at registration. The arm and
+// correlation-key logic mirrors what the thresher's starter setup used to do — only
+// the engine binding (the *Thresher and a fresh id) is left for the caller.
+func discoverInstantiatingStarts(nodes map[string]flow.Node) []InstantiatingStart {
+	var starts []InstantiatingStart
+
+	for _, n := range nodes {
+		if len(n.Incoming()) != 0 || !isInstantiatingStartNode(n) {
+			continue
+		}
+
+		en, ok := n.(flow.EventNode)
+		if !ok {
+			continue
+		}
+
+		// An instantiating Event-Based gateway exposes its arms' definitions as its
+		// union (SRD-024), detected structurally so the snapshot stays free of the
+		// gateways package. Exclusive-start: each fired arm's instance runs from that
+		// ARM's continuation, so the arm is the start node (SRD-025 §4.2). Parallel-start:
+		// the instance is born from the GATE (seedParallelStart pre-fires the firing arm,
+		// arms the others), so the gate stays the start node and the arms share the
+		// gate's CorrelationKey, so resolveAndLaunch dedups to one instance (§4.3).
+		router, isGate := n.(interface {
+			ArmFor(flow.EventDefinition) (flow.Node, bool)
+		})
+
+		parallel := false
+		if ps, ok := n.(interface{ ParallelStart() bool }); ok {
+			parallel = ps.ParallelStart()
+		}
+
+		for _, eDef := range en.Definitions() {
+			// A start trigger backs an instance-starter when it is a message
+			// (point-to-point, optionally correlated) or a signal (broadcast, never
+			// correlated — BPMN §10.5.7, SRD-026). Other kinds don't instantiate here.
+			var corrKey *bpmncommon.CorrelationKey
+			switch eDef.(type) {
+			case *events.MessageEventDefinition:
+				corrKey = correlationKeyOf(n)
+			case *events.SignalEventDefinition:
+				// signals carry no correlation — corrKey stays nil
+			default:
+				continue
+			}
+
+			startNode := n
+			if isGate {
+				if arm, ok := router.ArmFor(eDef); ok && !parallel {
+					startNode = arm
+					corrKey = correlationKeyOf(arm)
+				}
+			}
+
+			starts = append(starts, InstantiatingStart{
+				StartNode:      startNode,
+				EventDef:       eDef,
+				CorrelationKey: corrKey,
+			})
+		}
+	}
+
+	return starts
+}
+
+// isInstantiatingStartNode reports whether n is an instantiating start trigger:
+// a StartEvent, or an instantiate ReceiveTask (BPMN §13.2 / §13.3.3 / §13.5.1).
+// The incoming-flow check is the caller's. The ReceiveTask is matched structurally
+// (Instantiate() bool) to avoid coupling the snapshot to the activities package.
+func isInstantiatingStartNode(n flow.Node) bool {
+	if en, ok := n.(flow.EventNode); ok &&
+		en.EventClass() == flow.StartEventClass {
+		return true
+	}
+
+	if rt, ok := n.(interface{ Instantiate() bool }); ok && rt.Instantiate() {
+		return true
+	}
+
+	return false
+}
+
+// correlationKeyOf returns the CorrelationKey a start node declares, read
+// structurally so the snapshot needn't depend on the concrete node package
+// (StartEvent / instantiate ReceiveTask both expose CorrelationKey()). nil =
+// name-match only.
+func correlationKeyOf(n flow.Node) *bpmncommon.CorrelationKey {
+	if ck, ok := n.(interface {
+		CorrelationKey() *bpmncommon.CorrelationKey
+	}); ok {
+		return ck.CorrelationKey()
+	}
+
+	return nil
+}

--- a/internal/instance/snapshot/instantiating_starts_test.go
+++ b/internal/instance/snapshot/instantiating_starts_test.go
@@ -1,0 +1,288 @@
+package snapshot_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/internal/instance/snapshot"
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/gateways"
+	"github.com/dr-dobermann/gobpm/pkg/model/options"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/stretchr/testify/require"
+)
+
+// msgEDef builds a MessageEventDefinition named name for a start trigger.
+func msgEDef(t *testing.T, name string) *events.MessageEventDefinition {
+	t.Helper()
+
+	return events.MustMessageEventDefinition(
+		bpmncommon.MustMessage(name,
+			data.MustItemDefinition(values.NewVariable(""),
+				foundation.WithID(name+"_in"))),
+		nil)
+}
+
+// sigEDef builds a SignalEventDefinition named name for a start trigger.
+func sigEDef(t *testing.T, name string) *events.SignalEventDefinition {
+	t.Helper()
+
+	sig, err := events.NewSignal(name, nil)
+	require.NoError(t, err)
+
+	def, err := events.NewSignalEventDefinition(sig)
+	require.NoError(t, err)
+
+	return def
+}
+
+// timerEDef builds a date-only TimerEventDefinition — a non-instantiating start
+// trigger, used to exercise the "other kinds don't instantiate" branch.
+func timerEDef(t *testing.T) *events.TimerEventDefinition {
+	t.Helper()
+
+	return events.MustTimerEventDefinition(
+		goexpr.Must(nil,
+			data.MustItemDefinition(
+				values.NewVariable(time.Now().Add(time.Second))),
+			func(_ context.Context, _ data.Source) (data.Value, error) {
+				return values.NewVariable(time.Now().Add(time.Second)), nil
+			}),
+		nil, nil)
+}
+
+// procWithStart wraps a single start node into a runnable process: start → end.
+func procWithStart(t *testing.T, id string, start flow.Node) *process.Process {
+	t.Helper()
+
+	require.NoError(t, data.CreateDefaultStates())
+
+	proc, err := process.New(id)
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	require.NoError(t, proc.Add(start))
+	require.NoError(t, proc.Add(end))
+
+	_, err = flow.Link(start.(flow.SequenceSource), end)
+	require.NoError(t, err)
+
+	return proc
+}
+
+// startNames lists the StartNode name of every discovered descriptor.
+func startNames(starts []snapshot.InstantiatingStart) []string {
+	names := make([]string, 0, len(starts))
+	for _, s := range starts {
+		names = append(names, s.StartNode.Name())
+	}
+
+	return names
+}
+
+// TestInstantiatingStarts_Kinds covers the discovery of each instantiating start
+// kind (message / signal / instantiate ReceiveTask) and the exclusion of the
+// non-instantiating ones (timer trigger, none start). This is the snapshot-side
+// equivalent of the thresher's former scanInstantiatingStarts kind handling.
+func TestInstantiatingStarts_Kinds(t *testing.T) {
+	t.Run("message start is discovered", func(t *testing.T) {
+		start, err := events.NewStartEvent("start",
+			events.WithMessageTrigger(msgEDef(t, "order placed")))
+		require.NoError(t, err)
+
+		s, err := snapshot.New(procWithStart(t, "p-msg", start))
+		require.NoError(t, err)
+
+		require.Len(t, s.InstantiatingStarts, 1)
+		require.Equal(t, "start", s.InstantiatingStarts[0].StartNode.Name())
+		require.IsType(t, &events.MessageEventDefinition{},
+			s.InstantiatingStarts[0].EventDef)
+	})
+
+	t.Run("signal start is discovered with no correlation key", func(t *testing.T) {
+		start, err := events.NewStartEvent("start",
+			events.WithSignalTrigger(sigEDef(t, "go signal")))
+		require.NoError(t, err)
+
+		s, err := snapshot.New(procWithStart(t, "p-sig", start))
+		require.NoError(t, err)
+
+		require.Len(t, s.InstantiatingStarts, 1)
+		require.IsType(t, &events.SignalEventDefinition{},
+			s.InstantiatingStarts[0].EventDef)
+		require.Nil(t, s.InstantiatingStarts[0].CorrelationKey,
+			"a signal carries no correlation key")
+	})
+
+	t.Run("instantiate ReceiveTask is discovered", func(t *testing.T) {
+		require.NoError(t, data.CreateDefaultStates())
+
+		recv, err := activities.NewReceiveTask("recv",
+			bpmncommon.MustMessage("order placed",
+				data.MustItemDefinition(values.NewVariable(""),
+					foundation.WithID("in"))),
+			activities.WithoutParams(), activities.WithInstantiate())
+		require.NoError(t, err)
+
+		s, err := snapshot.New(procWithStart(t, "p-recv", recv))
+		require.NoError(t, err)
+
+		require.Len(t, s.InstantiatingStarts, 1)
+		require.Equal(t, "recv", s.InstantiatingStarts[0].StartNode.Name())
+	})
+
+	t.Run("timer start is not an instantiating trigger", func(t *testing.T) {
+		start, err := events.NewStartEvent("start",
+			events.WithTimerTrigger(timerEDef(t)))
+		require.NoError(t, err)
+
+		s, err := snapshot.New(procWithStart(t, "p-timer", start))
+		require.NoError(t, err)
+
+		require.Empty(t, s.InstantiatingStarts,
+			"a timer start instantiates by schedule, not as a starter here")
+	})
+
+	t.Run("none start yields no descriptors", func(t *testing.T) {
+		start, err := events.NewStartEvent("start")
+		require.NoError(t, err)
+
+		s, err := snapshot.New(procWithStart(t, "p-none", start))
+		require.NoError(t, err)
+
+		require.Empty(t, s.InstantiatingStarts)
+	})
+}
+
+// ebArm builds a Message IntermediateCatchEvent arm named name on msgName.
+func ebArm(t *testing.T, name, msgName string) *events.IntermediateCatchEvent {
+	t.Helper()
+
+	ice, err := events.NewIntermediateCatchEvent(name,
+		events.MustMessageEventDefinition(
+			bpmncommon.MustMessage(msgName,
+				data.MustItemDefinition(values.NewVariable(""),
+					foundation.WithID(name+"_in"))),
+			nil))
+	require.NoError(t, err)
+
+	return ice
+}
+
+// gateProcess builds a process started by an instantiating Event-Based gateway
+// with two message arms, each arm → end. parallel selects the gateway type.
+func gateProcess(
+	t *testing.T, id string, parallel bool,
+) (*process.Process, flow.Node) {
+	t.Helper()
+
+	require.NoError(t, data.CreateDefaultStates())
+
+	opts := []options.Option{gateways.WithInstantiate()}
+	if parallel {
+		opts = append(opts,
+			gateways.WithEventGatewayType(gateways.ParallelEvents))
+	}
+
+	gate, err := gateways.NewEventBasedGateway(opts...)
+	require.NoError(t, err)
+
+	armA := ebArm(t, "armA", "order A")
+	armB := ebArm(t, "armB", "order B")
+
+	endA, err := events.NewEndEvent("endA")
+	require.NoError(t, err)
+
+	endB, err := events.NewEndEvent("endB")
+	require.NoError(t, err)
+
+	proc, err := process.New(id)
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{gate, armA, armB, endA, endB} {
+		require.NoError(t, proc.Add(e))
+	}
+
+	for _, l := range [][2]flow.Element{
+		{gate, armA}, {armA, endA},
+		{gate, armB}, {armB, endB},
+	} {
+		_, err := flow.Link(
+			l[0].(flow.SequenceSource), l[1].(flow.SequenceTarget))
+		require.NoError(t, err)
+	}
+
+	return proc, gate
+}
+
+// TestInstantiatingStarts_EventBasedGate covers the Event-Based gateway arm
+// resolution: an Exclusive-start gate yields one descriptor per arm with the ARM
+// as the start node (SRD-025 §4.2); a Parallel-start gate yields one descriptor
+// per arm but with the GATE as the start node (§4.3).
+func TestInstantiatingStarts_EventBasedGate(t *testing.T) {
+	t.Run("exclusive gate starts from each arm", func(t *testing.T) {
+		proc, gate := gateProcess(t, "p-eb-excl", false)
+
+		s, err := snapshot.New(proc)
+		require.NoError(t, err)
+
+		require.Len(t, s.InstantiatingStarts, 2)
+		require.ElementsMatch(t,
+			[]string{"armA", "armB"}, startNames(s.InstantiatingStarts))
+
+		for _, is := range s.InstantiatingStarts {
+			require.NotEqual(t, gate.ID(), is.StartNode.ID(),
+				"exclusive start runs from the arm, not the gate")
+		}
+	})
+
+	t.Run("parallel gate starts from the gate", func(t *testing.T) {
+		proc, gate := gateProcess(t, "p-eb-par", true)
+
+		s, err := snapshot.New(proc)
+		require.NoError(t, err)
+
+		require.Len(t, s.InstantiatingStarts, 2)
+		for _, is := range s.InstantiatingStarts {
+			require.Equal(t, gate.ID(), is.StartNode.ID(),
+				"parallel start is born from the gate, not the arm")
+		}
+	})
+}
+
+// TestInstantiatingStarts_CloneSharesByReference verifies Clone shares the
+// instantiating-starts section by reference and keeps the descriptors bound to
+// the registration template (no aliasing into the per-instance node clones).
+func TestInstantiatingStarts_CloneSharesByReference(t *testing.T) {
+	start, err := events.NewStartEvent("start",
+		events.WithMessageTrigger(msgEDef(t, "order placed")))
+	require.NoError(t, err)
+
+	s, err := snapshot.New(procWithStart(t, "p-clone", start))
+	require.NoError(t, err)
+	require.Len(t, s.InstantiatingStarts, 1)
+
+	clone, err := s.Clone()
+	require.NoError(t, err)
+	require.Len(t, clone.InstantiatingStarts, 1)
+
+	// the descriptor's StartNode is the same template node in both — the section
+	// is shared by reference, not deep-copied.
+	tmplNode := s.InstantiatingStarts[0].StartNode
+	require.Same(t, tmplNode, clone.InstantiatingStarts[0].StartNode)
+
+	// and that template node is NOT the clone's own per-instance node of the same
+	// id — the descriptor stays template-bound, it does not alias into the clone.
+	require.NotSame(t, tmplNode, clone.Nodes[tmplNode.ID()],
+		"descriptor must not alias into the per-instance node clone")
+}

--- a/internal/instance/snapshot/snapshot.go
+++ b/internal/instance/snapshot/snapshot.go
@@ -27,6 +27,12 @@ type Snapshot struct {
 	// an incoming message's payload to grow the instance's conversation key-set
 	// (lazy association — SRD-017 §4.5). Immutable config, shared by Clone.
 	CorrelationKeys []*bpmncommon.CorrelationKey
+	// InstantiatingStarts are the process's instantiating start triggers
+	// (message / signal StartEvents and instantiate ReceiveTasks), discovered
+	// once by New after the graph is wired. The thresher wraps each into a
+	// persistent instance-starter at registration instead of re-scanning the
+	// node graph. Engine-agnostic descriptors only; immutable, shared by Clone.
+	InstantiatingStarts []InstantiatingStart
 }
 
 // New creates a new snapshot from the Process p and returns its
@@ -129,6 +135,11 @@ func New(
 
 	s.Flows = flows
 
+	// With the graph wired (each clone's Incoming() now populated), discover the
+	// instantiating start triggers once and store them, so registration wraps the
+	// descriptors into starters instead of re-walking the node graph.
+	s.InstantiatingStarts = discoverInstantiatingStarts(s.Nodes)
+
 	return &s, nil
 }
 
@@ -160,16 +171,17 @@ func isInstantiatingTask(n flow.Node) bool {
 // Clone returns a per-instance copy of the Snapshot. Every node is cloned (its
 // immutable configuration shared by reference, its runtime state fresh) and the
 // flow graph is relinked between the clones, so an instance built from the clone
-// mutates only its own nodes. The immutable header — process id/name and
-// properties — is shared. See ADR-009.
+// mutates only its own nodes. The immutable header — process id/name, properties,
+// correlation keys and instantiating starts — is shared. See ADR-009.
 func (s *Snapshot) Clone() (*Snapshot, error) {
 	clone := Snapshot{
-		ID:              *foundation.NewID(),
-		ProcessID:       s.ProcessID,
-		ProcessName:     s.ProcessName,
-		Nodes:           make(map[string]flow.Node, len(s.Nodes)),
-		Properties:      s.Properties,
-		CorrelationKeys: s.CorrelationKeys,
+		ID:                  *foundation.NewID(),
+		ProcessID:           s.ProcessID,
+		ProcessName:         s.ProcessName,
+		Nodes:               make(map[string]flow.Node, len(s.Nodes)),
+		Properties:          s.Properties,
+		CorrelationKeys:     s.CorrelationKeys,
+		InstantiatingStarts: s.InstantiatingStarts,
 	}
 
 	// Clone every node (its immutable configuration shared by reference, its

--- a/internal/instance/track.go
+++ b/internal/instance/track.go
@@ -716,9 +716,7 @@ func (t *track) executeNode(
 				errs.C(errorClass, errs.TypeCastingError))
 	}
 
-	f, err := scope.NewFrame(
-		t.ID(), step.node.ID(),
-		t.instance.dataPlane.Root(), t.instance.dataPlane)
+	f, err := t.instance.sc.openFrame(t.ID(), step.node.ID())
 	if err != nil {
 		return nil,
 			errs.New(

--- a/pkg/thresher/instance_starter.go
+++ b/pkg/thresher/instance_starter.go
@@ -97,75 +97,27 @@ func (s *instanceStarter) deriveKey(
 	return key, nil
 }
 
-// scanInstantiatingStarts walks a process snapshot and builds an instanceStarter
-// for every instantiating start trigger: a StartEvent (or instantiate
-// ReceiveTask) carrying a message or signal definition with no incoming sequence
-// flow (§13.2 / §13.5.1; signals SRD-026). It builds the starters but does not
-// register them — the Thresher decides when (auto mode, at the later of
-// RegisterProcess/Run) and whether (manual mode registers none, FR-9).
+// scanInstantiatingStarts wraps each of the snapshot's precomputed instantiating
+// start descriptors (snapshot.InstantiatingStarts, discovered once in
+// snapshot.New) into an instanceStarter, binding the engine: the live Thresher and
+// a fresh starter id. It builds the starters but does not register them — the
+// Thresher decides when (auto mode, at the later of RegisterProcess/Run) and
+// whether (manual mode registers none, FR-9).
 //
 // It is an unexported helper called only by RegisterProcess with a freshly built
 // snapshot and the live Thresher, so it takes both as guaranteed non-nil.
 func scanInstantiatingStarts(s *snapshot.Snapshot, thr *Thresher) []*instanceStarter {
-	var starters []*instanceStarter
+	starters := make([]*instanceStarter, 0, len(s.InstantiatingStarts))
 
-	for _, n := range s.Nodes {
-		if len(n.Incoming()) != 0 || !isInstantiatingStartNode(n) {
-			continue
-		}
-
-		en, ok := n.(flow.EventNode)
-		if !ok {
-			continue
-		}
-
-		// An instantiating Event-Based gateway exposes its arms' definitions as its
-		// union (SRD-024), detected structurally so the thresher stays free of the
-		// gateways package. Exclusive-start: each fired arm's instance runs from that
-		// ARM's continuation, so the arm is the start node (SRD-025 §4.2). Parallel-start:
-		// the instance is born from the GATE (seedParallelStart pre-fires the firing arm,
-		// arms the others), so the gate stays the start node and the arms share the
-		// gate's CorrelationKey, so resolveAndLaunch dedups to one instance (§4.3).
-		router, isGate := n.(interface {
-			ArmFor(flow.EventDefinition) (flow.Node, bool)
+	for _, is := range s.InstantiatingStarts {
+		starters = append(starters, &instanceStarter{
+			thr:       thr,
+			snapshot:  s,
+			startNode: is.StartNode,
+			eDef:      is.EventDef,
+			corrKey:   is.CorrelationKey,
+			id:        foundation.GenerateID(),
 		})
-
-		parallel := false
-		if ps, ok := n.(interface{ ParallelStart() bool }); ok {
-			parallel = ps.ParallelStart()
-		}
-
-		for _, eDef := range en.Definitions() {
-			// A start trigger backs an instance-starter when it is a message
-			// (point-to-point, optionally correlated) or a signal (broadcast, never
-			// correlated — BPMN §10.5.7, SRD-026). Other kinds don't instantiate here.
-			var corrKey *bpmncommon.CorrelationKey
-			switch eDef.(type) {
-			case *events.MessageEventDefinition:
-				corrKey = correlationKeyOf(n)
-			case *events.SignalEventDefinition:
-				// signals carry no correlation — corrKey stays nil
-			default:
-				continue
-			}
-
-			startNode := n
-			if isGate {
-				if arm, ok := router.ArmFor(eDef); ok && !parallel {
-					startNode = arm
-					corrKey = correlationKeyOf(arm)
-				}
-			}
-
-			starters = append(starters, &instanceStarter{
-				thr:       thr,
-				snapshot:  s,
-				startNode: startNode,
-				eDef:      eDef,
-				corrKey:   corrKey,
-				id:        foundation.GenerateID(),
-			})
-		}
 	}
 
 	return starters
@@ -188,38 +140,6 @@ func triggerName(eDef flow.EventDefinition) string {
 	}
 
 	return ""
-}
-
-// correlationKeyOf returns the CorrelationKey a start node declares, read
-// structurally so the thresher needn't depend on the concrete node package
-// (StartEvent / instantiate ReceiveTask both expose CorrelationKey()). nil =
-// name-match only.
-func correlationKeyOf(n flow.Node) *bpmncommon.CorrelationKey {
-	if ck, ok := n.(interface {
-		CorrelationKey() *bpmncommon.CorrelationKey
-	}); ok {
-		return ck.CorrelationKey()
-	}
-
-	return nil
-}
-
-// isInstantiatingStartNode reports whether n is an instantiating start trigger:
-// a message StartEvent, or an instantiate ReceiveTask (BPMN §13.2 / §13.3.3 /
-// §13.5.1). The incoming-flow check is the caller's. The ReceiveTask is matched
-// structurally (Instantiate() bool) to avoid coupling the thresher to the
-// activities package.
-func isInstantiatingStartNode(n flow.Node) bool {
-	if en, ok := n.(flow.EventNode); ok &&
-		en.EventClass() == flow.StartEventClass {
-		return true
-	}
-
-	if rt, ok := n.(interface{ Instantiate() bool }); ok && rt.Instantiate() {
-		return true
-	}
-
-	return false
 }
 
 // interface check


### PR DESCRIPTION
Summary

Two behavior-preserving internal refactors in the instance/registry area, implementing ADR-012 v.1 §2.5 (execution layering). No public API change, no behavior change.

M1 — Snapshot start-events precompute. snapshot.New already walks every node once to clone the graph and wire incoming flow; registration then walked the snapshot's nodes a second O(nodes) time
to rediscover the instantiating start triggers. That discovery now runs once inside snapshot.New (post-wiring) into an immutable Snapshot.InstantiatingStarts section of engine-agnostic
descriptors (StartNode, EventDef, CorrelationKey). thresher.scanInstantiatingStarts becomes a thin adapter that wraps each descriptor into an *instanceStarter; the predicate/arm/correlation-key
probes moved with it into the snapshot package.

M2 — instanceScope encapsulation. The data-plane wiring (three fields + loadProperties + bindEventPayload) moved off the 1600-line Instance into a small unexported instanceScope value
(plane/reader/root + load/openFrame/bindEventPayload). RuntimeVar/RuntimeVarNames stay on Instance (the supplier is passed into load, so instanceScope holds no back-reference). openFrame also
consolidates the three identical scope.NewFrame(...) sites. This closes the audit §2.3 "Scope role" line — the addData race it cited was already structurally closed by SRD-007; this is the
cosmetic remainder.

Non-goals (deferred — future ADR + SRD)

The real Instance god-object decomposition (event-loop / token-tracking extraction, ADR-012 §2.5) and the track-package split. instance.go shrinks only modestly here.

Testing

- make ci green (lint 0 issues · build-all · -race · diff-coverage · govulncheck) across all modules.
- Combined diff-coverage 96.0% of 124 changed lines — PASS (the 5 uncovered lines are unreachable defensive error-returns — the branch ceiling).
- 156 thresher + 180 instance tests pass unchanged (characterization for behavior equivalence).
- All 18 examples run end-to-end (exit 0).
- /check-srd PASS.
