### PR TITLE
FIX-017 — node-property clone isolation and value-less rejection

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -22,14 +22,18 @@ Design decisions we've surfaced but not yet made.
 BPMN makes an `ItemAwareElement`'s `itemSubjectRef`/structure optional (`0..1`),
 so a Property/DataObject MAY be declared underspecified. gobpm can't use one: an
 `ItemDefinition`'s structure *is* its value (an immutable `Variable[T]` bound at
-construction, no setter), so a value-less Data can never be filled. Today it's a
-silent footgun the lenient constructor admits; FIX-016 now makes `snapshot.New`
-reject a process carrying one, and SAD-001 §14.1 records the non-execution
-deviation. Open decision:
-- **(B) reject at construction** (recommended) — `NewProperty`/`NewIAE` refuse a
-  nil structure everywhere, fail-fast; the "declare empty, fill later" pattern
-  uses a typed-zero value (`NewVariable(0)`/`""`). Small; aligns with the
-  typed-valued model and validate-all-public-params.
+construction, no setter), so a value-less Data can never be filled. It was a
+silent footgun the lenient constructor admits. **Registration-time rejection is
+now settled and landed:** FIX-016 made `snapshot.New` reject a value-less
+*process* property, and **FIX-017** extended that — via clone-is-validation — to
+*activity and event* properties, so a process carrying any value-less property is
+now rejected at registration uniformly. SAD-001 §14.1 records the non-execution
+deviation. The practical footgun (admit-then-crash-at-runtime) is therefore
+closed; what remains open is only *how early / whether to also mutate*:
+- **(B) reject at construction** — `NewProperty`/`NewIAE` refuse a nil structure
+  everywhere, fail-fast (earlier than registration); the "declare empty, fill
+  later" pattern uses a typed-zero value (`NewVariable(0)`/`""`). Now lower-stakes
+  since registration already rejects; a small consistency improvement.
 - **(A) support fill-on-write** — mutable structure (install-on-first-write),
   dynamic/`any`-typed values, `Undefined → Ready` transition. A real data-model
   change with marginal payoff; deferred unless concrete need appears.
@@ -50,6 +54,22 @@ implemented), and leaves this list.
   polymorphic `SubscriptionKey()` (replacing the isolated signal name-scan). Its
   trigger is met — **Link events have landed** (`pkg/model/events/link.go`) — so
   the pass is now due.
+- **Property configuration missing on some Activity/Event constructors.** Per
+  BPMN, only Processes, Activities, and Events MAY carry Properties — but gobpm
+  wires property options into only *some* constructors. `NewServiceTask` /
+  `NewSendTask` / `NewReceiveTask` and `NewStartEvent` / `NewEndEvent` accept
+  `data.WithProperties`; `NewUserTask` rejects it (`invalid option type`), and
+  `NewIntermediateCatchEvent` / `NewIntermediateThrowEvent` / `NewBoundaryEvent`
+  reject it (`config doesn't support PropertyConfigurator`). So those four node
+  types cannot declare properties at all, though they structurally hold a
+  properties collection (via the embedded `activity` / `Event`). Consequence:
+  the FIX-017 node-clone error branch is unreachable (dead defensive code) on
+  exactly those four types — it becomes live once they gain property support.
+  Discovered 2026-07-02 during FIX-017; fix is to route the property option
+  through those constructors' configs (make each config a `PropertyConfigurator`
+  / accept the activity property option) — likely a small FIX. Grounding:
+  `data.WithProperties` (`pkg/model/data/property_option.go`), the accepting vs
+  rejecting constructors listed above.
 
 ### Tracked elsewhere (not duplicated here)
 - **Instance god-object — size decomposition** (event-loop seam): the audit §2.3

--- a/docs/fix/FIX-017-node-property-clone-isolation.md
+++ b/docs/fix/FIX-017-node-property-clone-isolation.md
@@ -2,7 +2,7 @@
 
 | Field    | Value                                                  |
 | -------- | ------------------------------------------------------ |
-| Status   | Draft                                                  |
+| Status   | Accepted                                               |
 | Date     | 2026-07-02                                             |
 | Owner    | Руслан Габитов                                         |
 | Related  | ADR-010 v.2, SAD-001 v.1 §14.1, FIX-016                |
@@ -111,9 +111,9 @@ separate value-less predicate, no redundant re-clone.
 
 #### 3.2.1 `flow.Node.Clone()` gains an error — interface + implementors
 
-`pkg/model/flow/node.go:88` — `Clone() Node` → `Clone() (Node, error)`.
-`BaseNode.Clone` (`node.go:199`, panics) matches the new signature. All **15**
-concrete implementors are updated:
+`pkg/model/flow/node.go` — `Clone() Node` → `Clone() (Node, error)`.
+`BaseNode.Clone` (panics) matches the new signature. All **14** concrete
+implementors are updated:
 
 - Property-owning, real logic (§3.2.2–3.2.3): the activities (`ServiceTask`,
   `UserTask`, `SendTask`, `ReceiveTask`) and events (`StartEvent`, `EndEvent`,
@@ -126,29 +126,37 @@ The internal `clone()` helpers on the path propagate the error:
 (`event.go:287,423`), `Gateway.clone()` (`gateway.go:146`, `nil`). Generated
 mocks that implement `flow.Node` are regenerated (`make gen_mock_files`).
 
+A single `data.CloneProperties([]*Property) ([]*Property, error)` helper carries
+the deep-copy-and-validate logic (it clones each `*Property`, returning an error
+on the first value-less one). It replaces snapshot's now-duplicate local
+`cloneProperties`, so the process level (FIX-016) and the node level share one
+cloner.
+
 #### 3.2.2 `activity.clone()` deep-copies properties, fails on value-less
 
-`pkg/model/activities/activity.go:91` — `clone() activity` →
-`clone() (activity, error)`; the shared `properties: a.properties` becomes a
-deep copy built by cloning each `*Property` (`Property.Clone`), returning the
-error if any property is value-less. The clone now owns private property objects.
+`pkg/model/activities/activity.go` — `clone() activity` →
+`clone() (activity, error)`; the shared `properties: a.properties` map becomes a
+deep copy via `data.CloneProperties(maps.Values(a.properties))`, re-keyed by
+name, returning the error if any property is value-less. The clone now owns
+private property objects.
 
 #### 3.2.3 `Event.clone()` deep-copies properties, fails on value-less
 
-`pkg/model/events/event.go:161` — `clone() Event` → `clone() (Event, error)`;
-the shared `properties: e.properties` slice becomes a deep copy via
-`Property.Clone` per element, propagating a value-less error.
+`pkg/model/events/event.go` — `clone() Event` → `clone() (Event, error)`; the
+shared `properties: e.properties` slice becomes `data.CloneProperties(e.properties)`,
+propagating a value-less error.
 
-#### 3.2.4 Call sites propagate; process-level path unchanged
+#### 3.2.4 Call sites propagate
 
-`snapshot.New` (`snapshot.go:91`) and `snapshot.Clone` (`snapshot.go:242`) —
-`s.Nodes[n.ID()] = n.Clone()` → capture and return the error. A value-less
-activity/event property now rejects the process at `snapshot.New`, alongside the
-process-level rejection FIX-016 already performs there (its `cloneProperties`
-call is unchanged). Value-less properties can only enter at `snapshot.New` (a raw
-process); at per-instance `snapshot.Clone` the snapshot's properties are already
-validated, so that path's clone error is always `nil` in practice — but the
-signature stays honest.
+`snapshot.New` and `snapshot.Clone` (`snapshot.go`) clone each node via an
+extracted `cloneNode` helper that wraps the error with the node identity; both
+functions already return errors. A value-less activity/event property now rejects
+the process at `snapshot.New`, alongside the process-level rejection FIX-016
+performs there (both now via `data.CloneProperties`). Value-less properties can
+only enter at `snapshot.New` (a raw process); at per-instance `snapshot.Clone`
+the snapshot's properties are already validated, so that path's clone error is
+`nil` in practice — but the signature stays honest (exercised by an internal
+guard-test).
 
 ## 4. Verification
 
@@ -156,16 +164,23 @@ signature stays honest.
 
 | Test | Site | Asserts |
 | ---- | ---- | ------- |
-| `TestActivityCloneIsolatesProperties` | `pkg/model/activities/activity_test.go` | a cloned task's property is a distinct object from the source's (mutating one does not affect the other); the clone succeeds for valued properties. |
-| `TestActivityCloneRejectsValueLessProperty` | `pkg/model/activities/activity_test.go` | `Clone()` returns an error for a task carrying a value-less property; the error names the property and is `DATA_ERRORS`. |
-| `TestEventCloneIsolatesProperties` | `pkg/model/events/event_test.go` | same isolation guarantee for an event property. |
-| `TestEventCloneRejectsValueLessProperty` | `pkg/model/events/event_test.go` | `Clone()` errors for a value-less event property. |
-| `TestSnapshotNewRejectsValueLessActivityProperty` | `internal/instance/snapshot/property_isolation_test.go` | a process whose activity carries a value-less property is rejected at `snapshot.New` (previously surfaced only at run time). |
-| `TestSnapshotNewRejectsValueLessEventProperty` | `internal/instance/snapshot/property_isolation_test.go` | same for an event property. |
-| `TestSnapshotEditAfterRegistrationDoesNotLeak` | `internal/instance/snapshot/property_isolation_test.go` | removing/altering a task property on the source process after `snapshot.New` does not change the snapshot's cloned node. |
+| `TestActivityCloneIsolatesProperties` | `activities/clone_test.go` | a cloned task's property is a distinct object; a write through the source does not reach the clone. |
+| `TestActivityCloneRejectsValueLessProperty` | `activities/clone_test.go` | `ServiceTask.Clone()` errors for a value-less property. |
+| `TestSendTaskCloneRejectsValueLessProperty` | `activities/clone_test.go` | same for a `SendTask`. |
+| `TestReceiveTaskCloneRejectsValueLessProperty` | `activities/clone_test.go` | same for a `ReceiveTask`. |
+| `TestUserTaskCloneRejectsValueLessProperty` | `activities/clone_internal_test.go` | `UserTask.Clone()` error branch — value-less property injected directly (its constructor doesn't accept properties yet; see §8). |
+| `TestEventCloneIsolatesProperties` | `events/clone_test.go` | a cloned event's property is distinct; a source write does not leak. |
+| `TestEventCloneRejectsValueLessProperty` | `events/clone_test.go` | `StartEvent.Clone()` errors for a value-less property. |
+| `TestEndEventCloneRejectsValueLessProperty` | `events/clone_test.go` | same for an `EndEvent`. |
+| `TestIntermediateCatchEventCloneRejectsValueLessProperty`, `…Throw…`, `TestBoundaryEventCloneRejectsValueLessProperty` | `events/clone_internal_test.go` | Clone error branches — value-less property injected directly (see §8). |
+| `TestCloneProperties` | `data/property_test.go` | `data.CloneProperties`: nil→nil, valued→deep copies, value-less→error. |
+| `TestSnapshotNewRejectsValueLessNodeProperty` | `snapshot/property_isolation_test.go` | a process whose node carries a value-less property is rejected at `snapshot.New` (previously surfaced only at run time). |
+| `TestSnapshotNodeEditAfterRegistrationDoesNotLeak` | `snapshot/property_isolation_test.go` | a node-property edit on the source after `snapshot.New` does not reach the snapshot's cloned node. |
+| `TestCloneRejectsValuelessNodeProperty` | `snapshot/clone_internal_test.go` | `snapshot.Clone`'s node-clone error path. |
 
-The existing FIX-016 tests (`TestSnapshotNewRejectsValuelessProperty` for the
-process level, `TestCloneRejectsValuelessProperty`) stay green.
+`TestStartEventClone` was updated to use a valued property (properties are now
+deep-copied, not shared). The existing FIX-016 tests (`TestSnapshotNewRejectsValuelessProperty`,
+`TestCloneRejectsValuelessProperty`) stay green.
 
 ### 4.2 Gate
 
@@ -185,8 +200,7 @@ rather than patching each symptom.
 
 - **Public API:** `flow.Node.Clone()` signature changes to `(Node, error)`. All
   in-tree implementors and call sites are updated; embedders that implement
-  `flow.Node` must add the error return. Noted in SAD-001 (Snapshot-Based State /
-  §14.1 clone contract).
+  `flow.Node` must add the error return.
 - A process carrying a value-less property on an **activity or event** is now
   rejected at `snapshot.New` (was accepted at registration, failed later or never
   until execution reached it). Such a process was never executable.
@@ -199,18 +213,45 @@ rather than patching each symptom.
 - **ADR-010 v.2** — process data model: an `ItemDefinition`'s structure *is* its
   value (immutable, typed, no setter) — why a value-less property can never be
   filled.
-- **SAD-001 v.1 §14.1** — records the deviation from BPMN's optional
+- **SAD-001 v.1 §14.1** — already records the deviation from BPMN's optional
   `itemSubjectRef`/structure (`0..1`): a gobpm process declaring an
   underspecified item-aware element cannot be executed and is rejected at
-  registration. Updated at landing to note the `flow.Node.Clone()` error contract
-  and node-property isolation.
+  snapshot/registration. FIX-017 makes that rejection uniform (node-level as well
+  as process-level), so the deviation statement needs no change.
 - **FIX-016** — snapshot property isolation for process-level properties; this
   FIX generalizes it to node-level properties and unifies value-less rejection
   through the clone.
 
 ## 8. Implementation summary
 
-_(filled at landing: files/lines, V-results, milestone SHAs.)_
+- **Commits (branch `fix/reject-value-less-properties`):** doc `f2bd5e3`;
+  implementation `31a2269` (M1 signature ripple + M2 deep-copy/validation landed
+  together — M1 alone could not meet the diff-coverage gate, as its error
+  branches only become reachable with M2's deep-copy).
+- **Production (20 files):** `flow/node.go` (interface + `BaseNode`); the 4 task
+  and 5 event concrete `Clone` + their internal `clone()` helpers
+  (`activity/task`, `Event/catchEvent/throwEvent`); the 5 gateway `Clone` +
+  `Gateway.clone` (no error — gateways carry no properties);
+  `data/property.go` (`CloneProperties`); `snapshot.go` (`cloneNode`, `New`,
+  `Clone`, local `cloneProperties` removed in favour of `data.CloneProperties`).
+- **Tests (20 files):** the M1 call-site updates across every node package, plus
+  the §4.1 additions (2 new internal guard-test files:
+  `activities/clone_internal_test.go`, `events/clone_internal_test.go`).
+  Regenerated mocks (gitignored).
+- **Verification:** `make ci` exit 0 — tidy · lint · build · `-race` ·
+  **diff-coverage 100.0% of 148 changed coverable lines** (min 95%) ·
+  govulncheck clean across all modules.
+- **Discovery — constructor property gap.** Only `NewServiceTask` /
+  `NewSendTask` / `NewReceiveTask` and `NewStartEvent` / `NewEndEvent` accept
+  `data.WithProperties`; `NewUserTask`, `NewIntermediateCatchEvent`,
+  `NewIntermediateThrowEvent`, and `NewBoundaryEvent` reject it, so those four
+  node types cannot declare a property today. Their `Clone` error branch is
+  therefore a defensive guard (like the gateways'), exercised by internal
+  guard-tests that inject a value-less property directly — the same pattern the
+  snapshot package uses for a guard `New` prevents. The constructor gap is
+  recorded in `docs/backlog.md` (*Property configuration missing on some
+  Activity/Event constructors*); when it is closed those branches become
+  reachable through the public API.
 
 ## 9. Open questions
 

--- a/docs/fix/FIX-017-node-property-clone-isolation.md
+++ b/docs/fix/FIX-017-node-property-clone-isolation.md
@@ -1,0 +1,219 @@
+# FIX-017 — Node-property clone isolation and value-less rejection at registration
+
+| Field    | Value                                                  |
+| -------- | ------------------------------------------------------ |
+| Status   | Draft                                                  |
+| Date     | 2026-07-02                                             |
+| Owner    | Руслан Габитов                                         |
+| Related  | ADR-010 v.2, SAD-001 v.1 §14.1, FIX-016                |
+
+## 1. Symptoms
+
+Two defects with a single root, both at the process → snapshot → instance clone
+boundary for **activity and event properties** (per BPMN, "only Processes,
+Activities, and Events MAY contain Properties" — `pkg/model/data/property.go:11`).
+
+### 1.1 Node properties leak across the clone boundary
+
+`activity.clone()` (`pkg/model/activities/activity.go:91`) copies the property
+**map by reference**:
+
+```go
+func (a *activity) clone() activity {
+	return activity{
+		...
+		properties: a.properties,   // shared map header → same underlying map + same *Property objects
+		...
+	}
+}
+```
+
+`Event.clone()` (`pkg/model/events/event.go:161`) does the same with the property
+**slice**:
+
+```go
+func (e *Event) clone() Event {
+	return Event{
+		...
+		properties: e.properties,   // shared slice header → same backing array + same *Property objects
+		...
+	}
+}
+```
+
+So a task's/event's cloned node — the snapshot template *and* every per-instance
+node — shares the source node's property objects. An edit to the source process
+after registration (removing a property from a task/event, or updating a
+property's value) leaks into the already-registered snapshot and any running
+instance; conversely, per-instance execution that mutated a node property would
+cross-contaminate. Only per-execution-frame cloning
+(`Frame.LoadProperties → instantiate → src.Clone()`) hides this today, and only
+because there is currently no API to mutate a built node's properties — the
+isolation is *absent*, not merely unexercised. FIX-016 fixed exactly this class
+for **process-level** properties (`cloneProperties` in `snapshot.New`) but left
+**node-level** properties shared.
+
+### 1.2 Value-less node properties are not rejected at registration
+
+A *value-less* property — one whose `ItemAwareElement` has no `structure`, so
+`Value()` returns `nil` (`pkg/model/data/item.go:339`) — can never be filled: an
+`ItemDefinition`'s structure *is* its value, an immutable typed `Variable[T]`
+bound at construction with no setter (ADR-010 v.2). A process declaring one
+cannot be executed. FIX-016 makes `snapshot.New` reject a value-less **process**
+property (its clone fails). But a value-less property on an **activity or event**
+is not rejected at registration — it surfaces only later, per-frame, when
+execution reaches the owner and `src.Clone()` fails deep inside instance
+execution. Asymmetric and late.
+
+### 1.3 Common root
+
+Both stem from the same limitation: node clones do not clone their properties —
+they share them — and `flow.Node.Clone() Node` (`pkg/model/flow/node.go:88`) has
+**no error channel**, so `activity.clone()` / `Event.clone()` cannot deep-copy
+with validation (a value-less property can't be cloned). FIX-016 could only fix
+the process level because `snapshot.New` — where process properties are cloned —
+*does* return an error; the node-level clone path does not.
+
+## 2. Root cause
+
+`flow.Node.Clone()` returns only a `Node`. Cloning a property can fail (a
+value-less property is unclonable — `ItemAwareElement.Clone` rejects a `nil`
+value, `property.go:110`). With no error return, the node-clone helpers took the
+only option available to a non-failing function: share the properties by
+reference. That single missing error channel is the cause of both the isolation
+gap (1.1) and the value-less asymmetry (1.2).
+
+## 3. Solution
+
+Give `flow.Node.Clone()` an error return, so the node-clone helpers can
+**deep-copy** their properties (isolation) and **fail** on a value-less one
+(validation). One clone operation does both — the clone *is* the validation. No
+separate value-less predicate, no redundant re-clone.
+
+### 3.1 Alternatives considered
+
+- **(A) `Clone()` returns `(Node, error)`; the clone deep-copies properties and
+  fails on a value-less one.** Chosen. A single operation isolates and validates;
+  value-less rejection becomes structural at registration for every owner
+  (process — already via FIX-016; activity/event — new); and the missing error
+  channel that caused this whole class is removed permanently.
+- **(B) Deep-copy in the clone helpers, but keep `Clone()` errorless and add a
+  separate `Value()==nil` inspection (or a second `cloneProperties`) in
+  `snapshot.New` to reject value-less.** Rejected: it re-clones or re-inspects
+  properties the clone already processed — redundant work — and leaves the
+  no-error-channel limitation in place for the next clone-failure class.
+- **(C) A dedicated `Property.Validate()` predicate wired into `Process.Validate`,
+  properties still shared by reference.** Rejected: it does not fix the isolation
+  gap (1.1) at all, and it duplicates, as a `Value()==nil` predicate, the exact
+  knowledge the clone already has (it can't clone a value-less property).
+
+### 3.2 Fix sites
+
+#### 3.2.1 `flow.Node.Clone()` gains an error — interface + implementors
+
+`pkg/model/flow/node.go:88` — `Clone() Node` → `Clone() (Node, error)`.
+`BaseNode.Clone` (`node.go:199`, panics) matches the new signature. All **15**
+concrete implementors are updated:
+
+- Property-owning, real logic (§3.2.2–3.2.3): the activities (`ServiceTask`,
+  `UserTask`, `SendTask`, `ReceiveTask`) and events (`StartEvent`, `EndEvent`,
+  `IntermediateCatchEvent`, `IntermediateThrowEvent`, `BoundaryEvent`).
+- Property-less, mechanical (`return node, nil`): the five gateways
+  (`Exclusive`, `Inclusive`, `Parallel`, `Complex`, `EventBased`).
+
+The internal `clone()` helpers on the path propagate the error:
+`task.clone()` (`task.go:60`), `catchEvent.clone()` / `throwEvent.clone()`
+(`event.go:287,423`), `Gateway.clone()` (`gateway.go:146`, `nil`). Generated
+mocks that implement `flow.Node` are regenerated (`make gen_mock_files`).
+
+#### 3.2.2 `activity.clone()` deep-copies properties, fails on value-less
+
+`pkg/model/activities/activity.go:91` — `clone() activity` →
+`clone() (activity, error)`; the shared `properties: a.properties` becomes a
+deep copy built by cloning each `*Property` (`Property.Clone`), returning the
+error if any property is value-less. The clone now owns private property objects.
+
+#### 3.2.3 `Event.clone()` deep-copies properties, fails on value-less
+
+`pkg/model/events/event.go:161` — `clone() Event` → `clone() (Event, error)`;
+the shared `properties: e.properties` slice becomes a deep copy via
+`Property.Clone` per element, propagating a value-less error.
+
+#### 3.2.4 Call sites propagate; process-level path unchanged
+
+`snapshot.New` (`snapshot.go:91`) and `snapshot.Clone` (`snapshot.go:242`) —
+`s.Nodes[n.ID()] = n.Clone()` → capture and return the error. A value-less
+activity/event property now rejects the process at `snapshot.New`, alongside the
+process-level rejection FIX-016 already performs there (its `cloneProperties`
+call is unchanged). Value-less properties can only enter at `snapshot.New` (a raw
+process); at per-instance `snapshot.Clone` the snapshot's properties are already
+validated, so that path's clone error is always `nil` in practice — but the
+signature stays honest.
+
+## 4. Verification
+
+### 4.1 Tests
+
+| Test | Site | Asserts |
+| ---- | ---- | ------- |
+| `TestActivityCloneIsolatesProperties` | `pkg/model/activities/activity_test.go` | a cloned task's property is a distinct object from the source's (mutating one does not affect the other); the clone succeeds for valued properties. |
+| `TestActivityCloneRejectsValueLessProperty` | `pkg/model/activities/activity_test.go` | `Clone()` returns an error for a task carrying a value-less property; the error names the property and is `DATA_ERRORS`. |
+| `TestEventCloneIsolatesProperties` | `pkg/model/events/event_test.go` | same isolation guarantee for an event property. |
+| `TestEventCloneRejectsValueLessProperty` | `pkg/model/events/event_test.go` | `Clone()` errors for a value-less event property. |
+| `TestSnapshotNewRejectsValueLessActivityProperty` | `internal/instance/snapshot/property_isolation_test.go` | a process whose activity carries a value-less property is rejected at `snapshot.New` (previously surfaced only at run time). |
+| `TestSnapshotNewRejectsValueLessEventProperty` | `internal/instance/snapshot/property_isolation_test.go` | same for an event property. |
+| `TestSnapshotEditAfterRegistrationDoesNotLeak` | `internal/instance/snapshot/property_isolation_test.go` | removing/altering a task property on the source process after `snapshot.New` does not change the snapshot's cloned node. |
+
+The existing FIX-016 tests (`TestSnapshotNewRejectsValuelessProperty` for the
+process level, `TestCloneRejectsValuelessProperty`) stay green.
+
+### 4.2 Gate
+
+`make ci` green (tidy · lint · build · `-race` · diff-coverage ≥95% ·
+govulncheck); examples smoke exit 0. Mocks regenerated.
+
+## 5. Prevention
+
+Property isolation and usability are now enforced by the clone itself, uniformly
+for all three BPMN property owners, at registration. The `flow.Node.Clone()`
+error channel means a future clone-failure class (any node component that can't
+be safely copied) has a place to report, instead of silently degrading to
+shared-by-reference — closing the structural gap that produced both defects,
+rather than patching each symptom.
+
+## 6. Regressions / behavioural change
+
+- **Public API:** `flow.Node.Clone()` signature changes to `(Node, error)`. All
+  in-tree implementors and call sites are updated; embedders that implement
+  `flow.Node` must add the error return. Noted in SAD-001 (Snapshot-Based State /
+  §14.1 clone contract).
+- A process carrying a value-less property on an **activity or event** is now
+  rejected at `snapshot.New` (was accepted at registration, failed later or never
+  until execution reached it). Such a process was never executable.
+- Node properties are now **isolated** source → snapshot → instance; a
+  post-registration edit to a node property no longer leaks into a registered
+  snapshot or a running instance. No previously-correct process changes behaviour.
+
+## 7. Related
+
+- **ADR-010 v.2** — process data model: an `ItemDefinition`'s structure *is* its
+  value (immutable, typed, no setter) — why a value-less property can never be
+  filled.
+- **SAD-001 v.1 §14.1** — records the deviation from BPMN's optional
+  `itemSubjectRef`/structure (`0..1`): a gobpm process declaring an
+  underspecified item-aware element cannot be executed and is rejected at
+  registration. Updated at landing to note the `flow.Node.Clone()` error contract
+  and node-property isolation.
+- **FIX-016** — snapshot property isolation for process-level properties; this
+  FIX generalizes it to node-level properties and unifies value-less rejection
+  through the clone.
+
+## 8. Implementation summary
+
+_(filled at landing: files/lines, V-results, milestone SHAs.)_
+
+## 9. Open questions
+
+None. This resolves backlog **Q1** in the "reject via cloning at registration"
+direction for all three BPMN property owners (distinct from the broader
+construction-time / fill-on-write data-model question, which remains recorded).

--- a/internal/instance/snapshot/clone_internal_test.go
+++ b/internal/instance/snapshot/clone_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/stretchr/testify/require"
 )
@@ -24,5 +25,26 @@ func TestCloneRejectsValuelessProperty(t *testing.T) {
 	}
 
 	_, err := s.Clone()
+	require.Error(t, err)
+}
+
+// TestCloneRejectsValuelessNodeProperty covers Clone's node-clone error path: a
+// snapshot whose node carries a value-less property fails to clone. New rejects
+// such a node up front (FIX-017), so the snapshot is built directly — with empty
+// process Properties so the node clone, not the process-property clone, is the
+// failing step.
+func TestCloneRejectsValuelessNodeProperty(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	start, err := events.NewStartEvent("start",
+		data.WithProperties(data.MustProperty("empty",
+			data.MustItemDefinition(nil), data.UnavailableDataState)))
+	require.NoError(t, err)
+
+	s := &Snapshot{
+		Nodes: map[string]flow.Node{start.ID(): start},
+	}
+
+	_, err = s.Clone()
 	require.Error(t, err)
 }

--- a/internal/instance/snapshot/property_isolation_test.go
+++ b/internal/instance/snapshot/property_isolation_test.go
@@ -137,3 +137,70 @@ func TestSnapshotCloneConcurrentPropertyWrites(t *testing.T) {
 
 	wg.Wait()
 }
+
+// nodePropProcess builds a minimal valid process (start -> end) whose start
+// event carries the given property, so a node-level property flows through
+// snapshot.New's node clone.
+func nodePropProcess(
+	t *testing.T,
+	prop *data.Property,
+) (*process.Process, flow.Node) {
+	t.Helper()
+
+	require.NoError(t, data.CreateDefaultStates())
+
+	start, err := events.NewStartEvent("start", data.WithProperties(prop))
+	require.NoError(t, err)
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	p, err := process.New("node-prop")
+	require.NoError(t, err)
+	require.NoError(t, p.Add(start))
+	require.NoError(t, p.Add(end))
+	_, err = flow.Link(start, end)
+	require.NoError(t, err)
+
+	return p, start
+}
+
+// TestSnapshotNewRejectsValueLessNodeProperty covers FIX-017 3.2.4: a value-less
+// property on a node (here a start event) can't be cloned, so snapshot.New
+// rejects the process at registration instead of failing later at execution.
+func TestSnapshotNewRejectsValueLessNodeProperty(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	prop := data.MustProperty("empty",
+		data.MustItemDefinition(nil), data.UnavailableDataState)
+
+	p, _ := nodePropProcess(t, prop)
+
+	_, err := snapshot.New(p)
+	require.Error(t, err)
+}
+
+// TestSnapshotNodeEditAfterRegistrationDoesNotLeak covers FIX-017 1.1: a node
+// property mutated on the source process after snapshot.New does not reach the
+// registered snapshot — the cloned node owns a private property copy.
+func TestSnapshotNodeEditAfterRegistrationDoesNotLeak(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	prop := data.MustProperty("counter",
+		data.MustItemDefinition(values.NewVariable(0), foundation.WithID("counter")),
+		data.ReadyDataState)
+
+	p, start := nodePropProcess(t, prop)
+
+	s, err := snapshot.New(p)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, prop.Value().Update(ctx, 7))
+
+	cloned, ok := s.Nodes[start.ID()].(interface {
+		Properties() []*data.Property
+	})
+	require.True(t, ok)
+	require.Equal(t, 0, cloned.Properties()[0].Value().Get(ctx),
+		"a node-property edit after snapshot.New must not reach the snapshot")
+}

--- a/internal/instance/snapshot/snapshot.go
+++ b/internal/instance/snapshot/snapshot.go
@@ -59,7 +59,7 @@ func New(
 	// private property objects — like the node graph cloned below — and a process
 	// edit after registration can't reach the registered version (FIX-016,
 	// ADR-019 §2.3).
-	props, err := cloneProperties(p.Properties())
+	props, err := data.CloneProperties(p.Properties())
 	if err != nil {
 		return nil, errs.New(
 			errs.M("couldn't clone process properties into snapshot"),
@@ -88,7 +88,13 @@ func New(
 
 	for _, n := range p.Nodes() {
 		srcNodes[n.ID()] = n
-		s.Nodes[n.ID()] = n.Clone()
+
+		cn, cerr := cloneNode(n)
+		if cerr != nil {
+			return nil, cerr
+		}
+
+		s.Nodes[n.ID()] = cn
 
 		// An instantiate ReceiveTask with no incoming flow is a valid process
 		// instantiation point on its own (BPMN §13.3.3) — the task-shaped peer
@@ -187,29 +193,19 @@ func hasInstantiationPoint(seExists, eeExists, instStartExists bool) bool {
 	return !eeExists || seExists || instStartExists
 }
 
-// cloneProperties deep-copies a property set so a Snapshot — a frozen template
-// (New) or a per-instance clone (Clone) — owns private property objects rather
-// than sharing one mutable set across registrations and instances. It is the
-// property counterpart of node cloning (FIX-016). A nil input yields a nil set.
-func cloneProperties(props []*data.Property) ([]*data.Property, error) {
-	if props == nil {
-		return nil, nil
+// cloneNode returns a clone of process node n, wrapping a clone failure with the
+// node's identity. A node clone fails when a property is value-less and thus
+// unclonable (FIX-017); a node without properties never errors.
+func cloneNode(n flow.Node) (flow.Node, error) {
+	cn, err := n.Clone()
+	if err != nil {
+		return nil, errs.New(
+			errs.M("couldn't clone node %q", n.ID()),
+			errs.C(errorClass, errs.BulidingFailed),
+			errs.E(err))
 	}
 
-	cloned := make([]*data.Property, len(props))
-	for i, p := range props {
-		c, err := p.Clone()
-		if err != nil {
-			return nil, errs.New(
-				errs.M("couldn't clone property %q", p.Name()),
-				errs.C(errorClass, errs.OperationFailed),
-				errs.E(err))
-		}
-
-		cloned[i] = c
-	}
-
-	return cloned, nil
+	return cn, nil
 }
 
 // Clone returns a per-instance copy of the Snapshot. Every node is cloned (its
@@ -220,7 +216,7 @@ func cloneProperties(props []*data.Property) ([]*data.Property, error) {
 // immutable header — process id/name, correlation-key definitions and
 // instantiating-start descriptors — is shared by reference. See ADR-009.
 func (s *Snapshot) Clone() (*Snapshot, error) {
-	props, err := cloneProperties(s.Properties)
+	props, err := data.CloneProperties(s.Properties)
 	if err != nil {
 		return nil, err
 	}
@@ -239,7 +235,12 @@ func (s *Snapshot) Clone() (*Snapshot, error) {
 	// runtime state fresh); the clone starts with empty flows and any default
 	// flow still points at the original edge until wireClonedGraph remaps it.
 	for id, n := range s.Nodes {
-		clone.Nodes[id] = n.Clone()
+		cn, cerr := cloneNode(n)
+		if cerr != nil {
+			return nil, cerr
+		}
+
+		clone.Nodes[id] = cn
 	}
 
 	flows, err := wireClonedGraph(clone.Nodes, s.Nodes, s.Flows)

--- a/pkg/model/activities/activity.go
+++ b/pkg/model/activities/activity.go
@@ -77,30 +77,44 @@ func newActivity(
 	return cfg.newActivity()
 }
 
-// clone returns a per-instance copy of the activity: every configuration field
-// (loop characteristics, roles, default flow, properties, IoSpec, data
-// associations, quantities, flags) is shared by reference; the BaseNode shell is
-// fresh (empty flows, no container). Execution data lives in the per-execution
-// frame, never on the node (ADR-010 §2.4).
+// clone returns a per-instance copy of the activity: the properties are
+// deep-copied so the clone owns private Property objects — a later edit to the
+// source process (removing or re-valuing a property) can't leak into a
+// registered snapshot or a running instance, and a value-less property is
+// rejected here (FIX-017). The other configuration fields (loop characteristics,
+// roles, default flow, IoSpec, data associations, quantities, flags) are shared
+// by reference; the BaseNode shell is fresh (empty flows, no container).
+// Execution data lives in the per-execution frame, never on the node
+// (ADR-010 §2.4).
 //
 // boundaryEvents is deliberately left empty: a boundary's cross-references (host
 // ↔ boundary) must point at the instance's own cloned nodes, not the shared
 // model, so the per-instance graph build (snapshot.Clone) rebinds the cloned
 // boundaries onto this cloned host (SRD-029 M3a). Copying the model boundaries
 // here would leak shared nodes into the instance.
-func (a *activity) clone() activity {
+func (a *activity) clone() (activity, error) {
+	props, err := data.CloneProperties(maps.Values(a.properties))
+	if err != nil {
+		return activity{}, err
+	}
+
+	properties := make(map[string]*data.Property, len(props))
+	for _, p := range props {
+		properties[p.Name()] = p
+	}
+
 	return activity{
 		BaseNode:            a.CloneShell(),
 		loopCharacteristics: a.loopCharacteristics,
 		roles:               a.roles,
 		defaultFlow:         a.defaultFlow,
-		properties:          a.properties,
+		properties:          properties,
 		IoSpec:              a.IoSpec,
 		dataAssociations:    a.dataAssociations,
 		startQuantity:       a.startQuantity,
 		completionQuantity:  a.completionQuantity,
 		isForCompensation:   a.isForCompensation,
-	}
+	}, nil
 }
 
 // Roles returns list of ResourceRoles of the activity.

--- a/pkg/model/activities/clone_internal_test.go
+++ b/pkg/model/activities/clone_internal_test.go
@@ -1,0 +1,27 @@
+package activities
+
+import (
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/stretchr/testify/require"
+)
+
+// TestUserTaskCloneRejectsValueLessProperty covers the FIX-017 defensive error
+// branch in UserTask.Clone. NewUserTask does not accept property options today
+// (see docs/backlog.md — property configuration missing on some Activity/Event
+// constructors), so a value-less property is injected directly to exercise the
+// guard, the same way the snapshot package tests a guard its constructor
+// prevents.
+func TestUserTaskCloneRejectsValueLessProperty(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	ut := &UserTask{}
+	ut.properties = map[string]*data.Property{
+		"empty": data.MustProperty("empty",
+			data.MustItemDefinition(nil), data.UnavailableDataState),
+	}
+
+	_, err := ut.Clone()
+	require.Error(t, err)
+}

--- a/pkg/model/activities/clone_test.go
+++ b/pkg/model/activities/clone_test.go
@@ -53,7 +53,10 @@ func TestServiceTaskClone(t *testing.T) {
 	_, err = flow.Link(st, ee)
 	require.NoError(t, err)
 
-	clone, ok := st.Clone().(*activities.ServiceTask)
+	cn, err := st.Clone()
+	require.NoError(t, err)
+
+	clone, ok := cn.(*activities.ServiceTask)
 	require.True(t, ok)
 
 	// independent object, same id, shared implementation description.
@@ -87,7 +90,10 @@ func TestUserTaskClone(t *testing.T) {
 	_, err = flow.Link(se, ut)
 	require.NoError(t, err)
 
-	clone, ok := ut.Clone().(*activities.UserTask)
+	cn, err := ut.Clone()
+	require.NoError(t, err)
+
+	clone, ok := cn.(*activities.UserTask)
 	require.True(t, ok)
 
 	// independent object, same id, shared renderers/outputs.
@@ -109,5 +115,96 @@ func TestUserTaskClone(t *testing.T) {
 	mrenv.EXPECT().InstanceID().Return("clone-test").Maybe()
 
 	_, err = clone.Exec(context.Background(), mrenv)
+	require.Error(t, err)
+}
+
+// cloneOp builds a minimal service operation for a task under test.
+func cloneOp(t *testing.T) service.Operation {
+	t.Helper()
+
+	return service.MustOperation("op",
+		bpmncommon.MustMessage("in", data.MustItemDefinition(values.NewVariable(1))),
+		bpmncommon.MustMessage("out", data.MustItemDefinition(values.NewVariable(2))),
+		cloneExctr{})
+}
+
+// TestActivityCloneIsolatesProperties covers FIX-017 3.2.2: activity.clone
+// deep-copies its properties, so a task clone owns distinct Property objects and
+// a write through the source doesn't reach the clone.
+func TestActivityCloneIsolatesProperties(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	prop, err := data.NewProperty(
+		"counter",
+		data.MustItemDefinition(values.NewVariable(0)),
+		data.ReadyDataState)
+	require.NoError(t, err)
+
+	st, err := activities.NewServiceTask("service", cloneOp(t),
+		data.WithProperties(prop), activities.WithoutParams())
+	require.NoError(t, err)
+
+	cn, err := st.Clone()
+	require.NoError(t, err)
+
+	clone, ok := cn.(*activities.ServiceTask)
+	require.True(t, ok)
+
+	require.NotSame(t, st.Properties()[0], clone.Properties()[0],
+		"clone must own a distinct property object")
+
+	ctx := context.Background()
+	require.NoError(t, st.Properties()[0].Value().Update(ctx, 7))
+	require.Equal(t, 0, clone.Properties()[0].Value().Get(ctx),
+		"a property write on the source must not leak into the clone")
+}
+
+// TestActivityCloneRejectsValueLessProperty covers FIX-017 3.2.2/3.2.4: a task
+// carrying a value-less property (no structure, unfillable) can't be cloned, so
+// Clone fails rather than sharing a degenerate object.
+func TestActivityCloneRejectsValueLessProperty(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	prop, err := data.NewProperty(
+		"empty", data.MustItemDefinition(nil), data.UnavailableDataState)
+	require.NoError(t, err)
+
+	st, err := activities.NewServiceTask("service", cloneOp(t),
+		data.WithProperties(prop), activities.WithoutParams())
+	require.NoError(t, err)
+
+	_, err = st.Clone()
+	require.Error(t, err)
+}
+
+// TestSendTaskCloneRejectsValueLessProperty covers FIX-017 3.2.2/3.2.4 for a
+// SendTask.
+func TestSendTaskCloneRejectsValueLessProperty(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	prop := data.MustProperty("empty",
+		data.MustItemDefinition(nil), data.UnavailableDataState)
+
+	st, err := activities.NewSendTask("notify", sendMessage(t),
+		activities.WithoutParams(), data.WithProperties(prop))
+	require.NoError(t, err)
+
+	_, err = st.Clone()
+	require.Error(t, err)
+}
+
+// TestReceiveTaskCloneRejectsValueLessProperty covers FIX-017 3.2.2/3.2.4 for a
+// ReceiveTask.
+func TestReceiveTaskCloneRejectsValueLessProperty(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	prop := data.MustProperty("empty",
+		data.MustItemDefinition(nil), data.UnavailableDataState)
+
+	rt, err := activities.NewReceiveTask("await", recvMessage(t),
+		activities.WithoutParams(), data.WithProperties(prop))
+	require.NoError(t, err)
+
+	_, err = rt.Clone()
 	require.Error(t, err)
 }

--- a/pkg/model/activities/receive_task.go
+++ b/pkg/model/activities/receive_task.go
@@ -132,16 +132,21 @@ func (rt *ReceiveTask) TaskType() flow.TaskType {
 
 // Clone returns a per-instance copy of the ReceiveTask as a flow.Node. The
 // captured payload is per-instance runtime state and is not carried over.
-func (rt *ReceiveTask) Clone() flow.Node {
+func (rt *ReceiveTask) Clone() (flow.Node, error) {
+	t, err := rt.clone()
+	if err != nil {
+		return nil, err
+	}
+
 	clonedMsg := rt.message.Clone()
 
 	return &ReceiveTask{
-		task:           rt.clone(),
+		task:           t,
 		implementation: rt.implementation,
 		instantiate:    rt.instantiate,
 		message:        clonedMsg,
 		eDef:           events.MustMessageEventDefinition(clonedMsg, nil),
-	}
+	}, nil
 }
 
 // Definitions returns the task's single message event definition, so the track

--- a/pkg/model/activities/receive_task_test.go
+++ b/pkg/model/activities/receive_task_test.go
@@ -89,7 +89,10 @@ func TestReceiveTaskClone(t *testing.T) {
 		activities.WithoutParams())
 	require.NoError(t, err)
 
-	cl, ok := rt.Clone().(*activities.ReceiveTask)
+	cn, err := rt.Clone()
+	require.NoError(t, err)
+
+	cl, ok := cn.(*activities.ReceiveTask)
 	require.True(t, ok)
 	require.Equal(t, "order placed", cl.Message().Name())
 	require.NotSame(t, rt.Message(), cl.Message())
@@ -204,7 +207,10 @@ func TestReceiveTaskInstantiate(t *testing.T) {
 	require.True(t, inst.Instantiate())
 
 	// the flag survives Clone.
-	cl, ok := inst.Clone().(*activities.ReceiveTask)
+	cn, err := inst.Clone()
+	require.NoError(t, err)
+
+	cl, ok := cn.(*activities.ReceiveTask)
 	require.True(t, ok)
 	require.True(t, cl.Instantiate())
 }

--- a/pkg/model/activities/send_task.go
+++ b/pkg/model/activities/send_task.go
@@ -102,13 +102,18 @@ func (st *SendTask) Node() flow.Node {
 }
 
 // Clone returns a deep copy of the SendTask as a flow.Node.
-func (st *SendTask) Clone() flow.Node {
+func (st *SendTask) Clone() (flow.Node, error) {
+	t, err := st.clone()
+	if err != nil {
+		return nil, err
+	}
+
 	return &SendTask{
-		task:           st.clone(),
+		task:           t,
 		implementation: st.implementation,
 		message:        st.message.Clone(),
 		correlationKey: st.correlationKey,
-	}
+	}, nil
 }
 
 // TaskType returns the BPMN task type.

--- a/pkg/model/activities/send_task_test.go
+++ b/pkg/model/activities/send_task_test.go
@@ -80,7 +80,10 @@ func TestSendTaskClone(t *testing.T) {
 		activities.WithoutParams())
 	require.NoError(t, err)
 
-	cl, ok := st.Clone().(*activities.SendTask)
+	cn, err := st.Clone()
+	require.NoError(t, err)
+
+	cl, ok := cn.(*activities.SendTask)
 	require.True(t, ok)
 	require.Equal(t, "order placed", cl.Message().Name())
 	require.NotSame(t, st.Message(), cl.Message())
@@ -169,7 +172,10 @@ func TestSendTaskCorrelationKey(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, key, st.CorrelationKey())
 
-	cl, ok := st.Clone().(*activities.SendTask)
+	cn, err := st.Clone()
+	require.NoError(t, err)
+
+	cl, ok := cn.(*activities.SendTask)
 	require.True(t, ok)
 	require.Same(t, key, cl.CorrelationKey())
 }

--- a/pkg/model/activities/service_task.go
+++ b/pkg/model/activities/service_task.go
@@ -101,12 +101,17 @@ func (st *ServiceTask) Node() flow.Node {
 // the implementation string is copied. The operation gets a per-instance clone
 // (shared definition, fresh message carriers) so the exec-mutated message item
 // state is not shared across concurrent instances.
-func (st *ServiceTask) Clone() flow.Node {
+func (st *ServiceTask) Clone() (flow.Node, error) {
+	t, err := st.clone()
+	if err != nil {
+		return nil, err
+	}
+
 	return &ServiceTask{
-		task:           st.clone(),
+		task:           t,
 		implementation: st.implementation,
 		operation:      st.operation.Clone(),
-	}
+	}, nil
 }
 
 // ------------------ flow.Task interface --------------------------------------

--- a/pkg/model/activities/task.go
+++ b/pkg/model/activities/task.go
@@ -57,11 +57,16 @@ func newTask(
 // clone returns a per-instance copy of the task: the embedded activity is cloned
 // (config shared by reference, fresh shell, zero dataPath) and the
 // multyInstance flag is copied as configuration.
-func (t *task) clone() task {
-	return task{
-		activity:      t.activity.clone(),
-		multyInstance: t.multyInstance,
+func (t *task) clone() (task, error) {
+	a, err := t.activity.clone()
+	if err != nil {
+		return task{}, err
 	}
+
+	return task{
+		activity:      a,
+		multyInstance: t.multyInstance,
+	}, nil
 }
 
 // IsMultyinstance returns Task multyinstance settings.

--- a/pkg/model/activities/user_task.go
+++ b/pkg/model/activities/user_task.go
@@ -141,12 +141,17 @@ func (ut *UserTask) Node() flow.Node {
 // Clone returns a per-instance copy of the UserTask. The embedded task is cloned
 // (config shared by reference, fresh activity shell); the outputs resource and
 // renderers are shared by reference as immutable configuration.
-func (ut *UserTask) Clone() flow.Node {
+func (ut *UserTask) Clone() (flow.Node, error) {
+	t, err := ut.clone()
+	if err != nil {
+		return nil, err
+	}
+
 	return &UserTask{
-		task:      ut.clone(),
+		task:      t,
 		outputs:   ut.outputs,
 		renderers: ut.renderers,
-	}
+	}, nil
 }
 
 // ------------------------ flow.Task interface -------------------------------

--- a/pkg/model/data/property.go
+++ b/pkg/model/data/property.go
@@ -124,6 +124,34 @@ func (p *Property) Clone() (*Property, error) {
 	}, nil
 }
 
+// CloneProperties returns deep copies of props so a node or snapshot clone owns
+// private Property objects instead of sharing the source's — a later edit to the
+// source (removing or re-valuing a property) can't leak into a registered
+// snapshot or a running instance (FIX-017). It returns an error if any property
+// is value-less: an ItemAwareElement with no structure is unclonable (its value
+// is nil, Clone rejects it) and a process declaring one can't be executed, so it
+// is rejected here at registration. A nil slice clones to nil.
+func CloneProperties(props []*Property) ([]*Property, error) {
+	if props == nil {
+		return nil, nil
+	}
+
+	cloned := make([]*Property, len(props))
+	for i, p := range props {
+		c, err := p.Clone()
+		if err != nil {
+			return nil, errs.New(
+				errs.M("couldn't clone property %q", p.Name()),
+				errs.C(errorClass, errs.OperationFailed),
+				errs.E(err))
+		}
+
+		cloned[i] = c
+	}
+
+	return cloned, nil
+}
+
 // ----------------------------------------------------------------------------
 // Test interfaces for Property.
 var _ Data = (*Property)(nil)

--- a/pkg/model/data/property_test.go
+++ b/pkg/model/data/property_test.go
@@ -130,3 +130,33 @@ func TestProperty(t *testing.T) {
 			require.Contains(t, pNames, "sex")
 		})
 }
+
+// TestCloneProperties covers FIX-017 CloneProperties: a nil set clones to nil,
+// valued properties are deep-copied (distinct objects, names preserved), and a
+// value-less member makes the clone fail.
+func TestCloneProperties(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	got, err := data.CloneProperties(nil)
+	require.NoError(t, err)
+	require.Nil(t, got)
+
+	src := []*data.Property{
+		data.MustProperty("a",
+			data.MustItemDefinition(values.NewVariable(0)), data.ReadyDataState),
+		data.MustProperty("b",
+			data.MustItemDefinition(values.NewVariable(1)), data.ReadyDataState),
+	}
+
+	cloned, err := data.CloneProperties(src)
+	require.NoError(t, err)
+	require.Len(t, cloned, 2)
+	require.NotSame(t, src[0], cloned[0])
+	require.Equal(t, src[0].Name(), cloned[0].Name())
+
+	_, err = data.CloneProperties([]*data.Property{
+		data.MustProperty("empty",
+			data.MustItemDefinition(nil), data.UnavailableDataState),
+	})
+	require.Error(t, err)
+}

--- a/pkg/model/events/boundary.go
+++ b/pkg/model/events/boundary.go
@@ -195,12 +195,17 @@ func (b *BoundaryEvent) Node() flow.Node {
 // Clone returns a per-instance copy. The host back-reference is shared and
 // rewired to the cloned activity at instance build; the captured payload is
 // per-instance runtime state and is not carried over.
-func (b *BoundaryEvent) Clone() flow.Node {
+func (b *BoundaryEvent) Clone() (flow.Node, error) {
+	ce, err := b.clone()
+	if err != nil {
+		return nil, err
+	}
+
 	return &BoundaryEvent{
-		catchEvent:     b.clone(),
+		catchEvent:     ce,
 		attachedTo:     b.attachedTo,
 		cancelActivity: b.cancelActivity,
-	}
+	}, nil
 }
 
 // AcceptIncomingFlow rejects an incoming sequence flow: a boundary event is

--- a/pkg/model/events/boundary_test.go
+++ b/pkg/model/events/boundary_test.go
@@ -251,7 +251,10 @@ func TestBoundaryEventNodeShape(t *testing.T) {
 	})
 
 	t.Run("Clone preserves cancelActivity and back-reference", func(t *testing.T) {
-		c, ok := be.Clone().(*events.BoundaryEvent)
+		cn, err := be.Clone()
+		require.NoError(t, err)
+
+		c, ok := cn.(*events.BoundaryEvent)
 		require.True(t, ok)
 		require.Equal(t, be.CancelActivity(), c.CancelActivity())
 		require.Equal(t, be.AttachedTo(), c.AttachedTo())

--- a/pkg/model/events/clone_for_instance_test.go
+++ b/pkg/model/events/clone_for_instance_test.go
@@ -58,8 +58,13 @@ func TestTimerReceiverPerInstanceClone(t *testing.T) {
 	start, err := events.NewStartEvent("start", events.WithTimerTrigger(ted))
 	require.NoError(t, err)
 
-	id1 := start.Clone().(flow.EventNode).Definitions()[0].ID()
-	id2 := start.Clone().(flow.EventNode).Definitions()[0].ID()
+	cn1, err := start.Clone()
+	require.NoError(t, err)
+	id1 := cn1.(flow.EventNode).Definitions()[0].ID()
+
+	cn2, err := start.Clone()
+	require.NoError(t, err)
+	id2 := cn2.(flow.EventNode).Definitions()[0].ID()
 
 	require.NotEqual(t, ted.ID(), id1, "cloned timer eDef must have a fresh id")
 	require.NotEqual(t, id1, id2, "two instances must get distinct timer eDef ids")
@@ -92,8 +97,13 @@ func TestMessageReceiverPerInstanceClone(t *testing.T) {
 	start, err := events.NewStartEvent("start", events.WithMessageTrigger(med))
 	require.NoError(t, err)
 
-	id1 := start.Clone().(flow.EventNode).Definitions()[0].ID()
-	id2 := start.Clone().(flow.EventNode).Definitions()[0].ID()
+	cn1, err := start.Clone()
+	require.NoError(t, err)
+	id1 := cn1.(flow.EventNode).Definitions()[0].ID()
+
+	cn2, err := start.Clone()
+	require.NoError(t, err)
+	id2 := cn2.(flow.EventNode).Definitions()[0].ID()
 
 	require.NotEqual(t, med.ID(), id1, "cloned message eDef must have a fresh id")
 	require.NotEqual(t, id1, id2, "two instances must get distinct message eDef ids")
@@ -110,6 +120,8 @@ func TestNonMessageDefSharedOnClone(t *testing.T) {
 	start, err := events.NewStartEvent("start", events.WithSignalTrigger(sed))
 	require.NoError(t, err)
 
-	id := start.Clone().(flow.EventNode).Definitions()[0].ID()
+	cn, err := start.Clone()
+	require.NoError(t, err)
+	id := cn.(flow.EventNode).Definitions()[0].ID()
 	require.Equal(t, sed.ID(), id, "non-message def must stay shared on clone")
 }

--- a/pkg/model/events/clone_internal_test.go
+++ b/pkg/model/events/clone_internal_test.go
@@ -1,0 +1,50 @@
+package events
+
+import (
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/stretchr/testify/require"
+)
+
+// valuelessProperty builds a property with no structure — Value() is nil, so it
+// can never be filled and is unclonable (FIX-017).
+func valuelessProperty(t *testing.T) *data.Property {
+	t.Helper()
+
+	require.NoError(t, data.CreateDefaultStates())
+
+	return data.MustProperty("empty",
+		data.MustItemDefinition(nil), data.UnavailableDataState)
+}
+
+// The three tests below cover the FIX-017 defensive error branch in the Clone of
+// the event types whose constructors do not accept property options today (see
+// docs/backlog.md). A value-less property is injected directly to exercise the
+// guard — the same pattern the snapshot package uses for a guard its constructor
+// prevents. Clone fails at property clone, before the node shell is copied, so a
+// bare struct suffices.
+
+func TestIntermediateCatchEventCloneRejectsValueLessProperty(t *testing.T) {
+	ice := &IntermediateCatchEvent{}
+	ice.properties = []*data.Property{valuelessProperty(t)}
+
+	_, err := ice.Clone()
+	require.Error(t, err)
+}
+
+func TestIntermediateThrowEventCloneRejectsValueLessProperty(t *testing.T) {
+	ite := &IntermediateThrowEvent{}
+	ite.properties = []*data.Property{valuelessProperty(t)}
+
+	_, err := ite.Clone()
+	require.Error(t, err)
+}
+
+func TestBoundaryEventCloneRejectsValueLessProperty(t *testing.T) {
+	be := &BoundaryEvent{}
+	be.properties = []*data.Property{valuelessProperty(t)}
+
+	_, err := be.Clone()
+	require.Error(t, err)
+}

--- a/pkg/model/events/clone_test.go
+++ b/pkg/model/events/clone_test.go
@@ -1,9 +1,11 @@
 package events_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
 	"github.com/dr-dobermann/gobpm/pkg/model/events"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/stretchr/testify/require"
@@ -17,7 +19,7 @@ func TestStartEventClone(t *testing.T) {
 
 	prop, err := data.NewProperty(
 		"prop",
-		data.MustItemDefinition(nil),
+		data.MustItemDefinition(values.NewVariable("v")),
 		data.ReadyDataState)
 	require.NoError(t, err)
 
@@ -30,21 +32,75 @@ func TestStartEventClone(t *testing.T) {
 	_, err = flow.Link(se, ee)
 	require.NoError(t, err)
 
-	clone, ok := se.Clone().(*events.StartEvent)
+	cn, err := se.Clone()
+	require.NoError(t, err)
+
+	clone, ok := cn.(*events.StartEvent)
 	require.True(t, ok)
 
 	// independent object, same id.
 	require.NotSame(t, se, clone)
 	require.Equal(t, se.ID(), clone.ID())
 
-	// configuration shared by reference.
-	require.Equal(t, se.Properties(), clone.Properties())
+	// properties are deep-copied — distinct objects, same name (FIX-017); value
+	// isolation is covered by TestEventCloneIsolatesProperties.
+	require.Len(t, clone.Properties(), 1)
+	require.Equal(t, se.Properties()[0].Name(), clone.Properties()[0].Name())
 	require.Equal(t, se.IsInterrupting(), clone.IsInterrupting())
 
 	// flows empty, no container.
 	require.Empty(t, clone.Outgoing())
 	require.Empty(t, clone.Incoming())
 	require.Nil(t, clone.Container())
+}
+
+// TestEventCloneIsolatesProperties covers FIX-017 3.2.3: Event.clone deep-copies
+// its properties, so a clone owns distinct Property objects and a write through
+// the source doesn't reach the clone.
+func TestEventCloneIsolatesProperties(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	prop, err := data.NewProperty(
+		"counter",
+		data.MustItemDefinition(values.NewVariable(0)),
+		data.ReadyDataState)
+	require.NoError(t, err)
+
+	se, err := events.NewStartEvent("start", data.WithProperties(prop))
+	require.NoError(t, err)
+
+	cn, err := se.Clone()
+	require.NoError(t, err)
+
+	clone, ok := cn.(*events.StartEvent)
+	require.True(t, ok)
+
+	require.NotSame(t, se.Properties()[0], clone.Properties()[0],
+		"clone must own a distinct property object")
+
+	ctx := context.Background()
+	require.NoError(t, se.Properties()[0].Value().Update(ctx, 7))
+	require.Equal(t, 0, clone.Properties()[0].Value().Get(ctx),
+		"a property write on the source must not leak into the clone")
+}
+
+// TestEventCloneRejectsValueLessProperty covers FIX-017 3.2.3/3.2.4: an event
+// carrying a value-less property (no structure, unfillable) can't be cloned, so
+// Clone fails rather than sharing a degenerate object.
+func TestEventCloneRejectsValueLessProperty(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	prop, err := data.NewProperty(
+		"empty",
+		data.MustItemDefinition(nil),
+		data.UnavailableDataState)
+	require.NoError(t, err)
+
+	se, err := events.NewStartEvent("start", data.WithProperties(prop))
+	require.NoError(t, err)
+
+	_, err = se.Clone()
+	require.Error(t, err)
 }
 
 // TestEndEventClone verifies that EndEvent.Clone shares configuration by
@@ -61,7 +117,10 @@ func TestEndEventClone(t *testing.T) {
 	_, err = flow.Link(se, ee)
 	require.NoError(t, err)
 
-	clone, ok := ee.Clone().(*events.EndEvent)
+	cn, err := ee.Clone()
+	require.NoError(t, err)
+
+	clone, ok := cn.(*events.EndEvent)
 	require.True(t, ok)
 
 	require.NotSame(t, ee, clone)
@@ -71,4 +130,19 @@ func TestEndEventClone(t *testing.T) {
 	require.Empty(t, clone.Outgoing())
 	require.Empty(t, clone.Incoming())
 	require.Nil(t, clone.Container())
+}
+
+// TestEndEventCloneRejectsValueLessProperty covers FIX-017 3.2.3/3.2.4 for an
+// EndEvent (a throwEvent): a value-less property makes the clone fail.
+func TestEndEventCloneRejectsValueLessProperty(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	prop := data.MustProperty("empty",
+		data.MustItemDefinition(nil), data.UnavailableDataState)
+
+	ee, err := events.NewEndEvent("end", data.WithProperties(prop))
+	require.NoError(t, err)
+
+	_, err = ee.Clone()
+	require.Error(t, err)
 }

--- a/pkg/model/events/end.go
+++ b/pkg/model/events/end.go
@@ -98,10 +98,15 @@ func (ee *EndEvent) Node() flow.Node {
 // Clone returns a per-instance copy of the EndEvent: the embedded throwEvent is
 // cloned (config shared by reference, fresh Event shell, zero dataPath, empty
 // flows, no container).
-func (ee *EndEvent) Clone() flow.Node {
-	return &EndEvent{
-		throwEvent: ee.clone(),
+func (ee *EndEvent) Clone() (flow.Node, error) {
+	te, err := ee.clone()
+	if err != nil {
+		return nil, err
 	}
+
+	return &EndEvent{
+		throwEvent: te,
+	}, nil
 }
 
 // ------------------ flow.EventNode interface ---------------------------------

--- a/pkg/model/events/event.go
+++ b/pkg/model/events/event.go
@@ -154,17 +154,25 @@ func newEvent(
 	return &e, nil
 }
 
-// clone returns a per-instance copy of the Event: properties, definitions and
-// triggers are shared by reference (immutable configuration); the BaseNode shell
-// is fresh (empty flows, no container). Execution data lives in the
-// per-execution frame, never on the node (ADR-010 §2.4).
-func (e *Event) clone() Event {
+// clone returns a per-instance copy of the Event: the properties are deep-copied
+// so the clone owns private Property objects — a later edit to the source
+// process can't leak into a registered snapshot or a running instance, and a
+// value-less property is rejected here (FIX-017). Definitions get per-instance
+// identity where supported (cloneDefsForInstance); triggers are shared by
+// reference; the BaseNode shell is fresh (empty flows, no container). Execution
+// data lives in the per-execution frame, never on the node (ADR-010 §2.4).
+func (e *Event) clone() (Event, error) {
+	props, err := data.CloneProperties(e.properties)
+	if err != nil {
+		return Event{}, err
+	}
+
 	return Event{
 		BaseNode:    e.CloneShell(),
-		properties:  e.properties,
+		properties:  props,
 		definitions: cloneDefsForInstance(e.definitions),
 		triggers:    e.triggers,
-	}
+	}, nil
 }
 
 // cloneDefsForInstance gives every event definition that supports per-instance
@@ -284,13 +292,18 @@ func newCatchEvent(
 // clone returns a per-instance copy of the catchEvent: the embedded Event is
 // cloned (fresh shell + dataPath, shared config), and the data outputs / output
 // associations are shared by reference as immutable configuration.
-func (ce *catchEvent) clone() catchEvent {
+func (ce *catchEvent) clone() (catchEvent, error) {
+	e, err := ce.Event.clone()
+	if err != nil {
+		return catchEvent{}, err
+	}
+
 	return catchEvent{
-		Event:              ce.Event.clone(),
+		Event:              e,
 		dataOutputs:        ce.dataOutputs,
 		outputAssociations: ce.outputAssociations,
 		parallelMultiple:   ce.parallelMultiple,
-	}
+	}, nil
 }
 
 // IsParallelMultiple returns parallelMultiple settings of the catchEvent.
@@ -420,12 +433,17 @@ func newThrowEvent(
 // clone returns a per-instance copy of the throwEvent: the embedded Event is
 // cloned (fresh shell + dataPath, shared config), and the data inputs / input
 // associations are shared by reference as immutable configuration.
-func (te *throwEvent) clone() throwEvent {
+func (te *throwEvent) clone() (throwEvent, error) {
+	e, err := te.Event.clone()
+	if err != nil {
+		return throwEvent{}, err
+	}
+
 	return throwEvent{
-		Event:             te.Event.clone(),
+		Event:             e,
 		dataInputs:        te.dataInputs,
 		inputAssociations: te.inputAssociations,
-	}
+	}, nil
 }
 
 // ---------------- exec.NodeDataConsumer interface ----------------------------

--- a/pkg/model/events/intermediate_catch.go
+++ b/pkg/model/events/intermediate_catch.go
@@ -76,8 +76,13 @@ func (ice *IntermediateCatchEvent) Node() flow.Node {
 
 // Clone returns a per-instance copy. The captured payload is per-instance
 // runtime state and is not carried over.
-func (ice *IntermediateCatchEvent) Clone() flow.Node {
-	return &IntermediateCatchEvent{catchEvent: ice.clone()}
+func (ice *IntermediateCatchEvent) Clone() (flow.Node, error) {
+	ce, err := ice.clone()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IntermediateCatchEvent{catchEvent: ce}, nil
 }
 
 // EventClass classifies the event as intermediate (a mid-flow wait).

--- a/pkg/model/events/intermediate_catch_test.go
+++ b/pkg/model/events/intermediate_catch_test.go
@@ -90,7 +90,10 @@ func TestIntermediateCatchEventClone(t *testing.T) {
 	ice, err := events.NewIntermediateCatchEvent("await", catchMessageDef(t))
 	require.NoError(t, err)
 
-	cl, ok := ice.Clone().(*events.IntermediateCatchEvent)
+	cn, err := ice.Clone()
+	require.NoError(t, err)
+
+	cl, ok := cn.(*events.IntermediateCatchEvent)
 	require.True(t, ok)
 	require.Equal(t, flow.IntermediateEventClass, cl.EventClass())
 	require.Len(t, cl.Definitions(), 1)

--- a/pkg/model/events/intermediate_throw.go
+++ b/pkg/model/events/intermediate_throw.go
@@ -82,8 +82,13 @@ func (ite *IntermediateThrowEvent) Node() flow.Node {
 }
 
 // Clone returns a per-instance copy of the event.
-func (ite *IntermediateThrowEvent) Clone() flow.Node {
-	return &IntermediateThrowEvent{throwEvent: ite.clone()}
+func (ite *IntermediateThrowEvent) Clone() (flow.Node, error) {
+	te, err := ite.clone()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IntermediateThrowEvent{throwEvent: te}, nil
 }
 
 // EventClass classifies the event as intermediate.

--- a/pkg/model/events/intermediate_throw_test.go
+++ b/pkg/model/events/intermediate_throw_test.go
@@ -86,7 +86,10 @@ func TestIntermediateThrowEventClone(t *testing.T) {
 	ite, err := events.NewIntermediateThrowEvent("send", throwMessageDef(t))
 	require.NoError(t, err)
 
-	cl, ok := ite.Clone().(*events.IntermediateThrowEvent)
+	cn, err := ite.Clone()
+	require.NoError(t, err)
+
+	cl, ok := cn.(*events.IntermediateThrowEvent)
 	require.True(t, ok)
 	require.Equal(t, flow.IntermediateEventClass, cl.EventClass())
 }

--- a/pkg/model/events/start.go
+++ b/pkg/model/events/start.go
@@ -112,12 +112,17 @@ func (se *StartEvent) Node() flow.Node {
 // Clone returns a per-instance copy of the StartEvent: the embedded catchEvent
 // is cloned (config shared by reference, fresh Event shell, zero dataPath, empty
 // flows, no container) and the interrupting flag is copied as configuration.
-func (se *StartEvent) Clone() flow.Node {
+func (se *StartEvent) Clone() (flow.Node, error) {
+	ce, err := se.clone()
+	if err != nil {
+		return nil, err
+	}
+
 	return &StartEvent{
-		catchEvent:     se.clone(),
+		catchEvent:     ce,
 		correlationKey: se.correlationKey,
 		interrupting:   se.interrupting,
-	}
+	}, nil
 }
 
 // CorrelationKey returns the CorrelationKey this start event correlates on, or

--- a/pkg/model/events/start_test.go
+++ b/pkg/model/events/start_test.go
@@ -268,7 +268,10 @@ func TestStartEventCorrelationKey(t *testing.T) {
 	require.NoError(t, err)
 	require.Same(t, key, se.CorrelationKey())
 
-	cl, ok := se.Clone().(*events.StartEvent)
+	cn, err := se.Clone()
+	require.NoError(t, err)
+
+	cl, ok := cn.(*events.StartEvent)
 	require.True(t, ok)
 	require.Same(t, key, cl.CorrelationKey())
 

--- a/pkg/model/flow/clone_test.go
+++ b/pkg/model/flow/clone_test.go
@@ -56,9 +56,14 @@ func TestCloneFlow(t *testing.T) {
 				flow.WithCondition(cond))
 			require.NoError(t, err)
 
-			seClone, ok := se.Clone().(*events.StartEvent)
+			seCn, err := se.Clone()
+			require.NoError(t, err)
+			seClone, ok := seCn.(*events.StartEvent)
 			require.True(t, ok)
-			eeClone, ok := ee.Clone().(*events.EndEvent)
+
+			eeCn, err := ee.Clone()
+			require.NoError(t, err)
+			eeClone, ok := eeCn.(*events.EndEvent)
 			require.True(t, ok)
 
 			require.Empty(t, seClone.Outgoing())
@@ -101,9 +106,14 @@ func TestMustCloneFlow(t *testing.T) {
 	orig, err := flow.Link(se, ee, foundation.WithID("edge-1"))
 	require.NoError(t, err)
 
-	seClone, ok := se.Clone().(*events.StartEvent)
+	seCn, err := se.Clone()
+	require.NoError(t, err)
+	seClone, ok := seCn.(*events.StartEvent)
 	require.True(t, ok)
-	eeClone, ok := ee.Clone().(*events.EndEvent)
+
+	eeCn, err := ee.Clone()
+	require.NoError(t, err)
+	eeClone, ok := eeCn.(*events.EndEvent)
 	require.True(t, ok)
 
 	t.Run("success returns cloned edge",
@@ -129,5 +139,5 @@ func TestBaseNodeCloneStub(t *testing.T) {
 
 	// The generic BaseNode has no standalone identity as a graph node: each
 	// concrete node type implements Clone; calling it on the bare base panics.
-	require.Panics(t, func() { _ = bn.Clone() })
+	require.Panics(t, func() { _, _ = bn.Clone() })
 }

--- a/pkg/model/flow/node.go
+++ b/pkg/model/flow/node.go
@@ -84,8 +84,10 @@ type Node interface {
 	// Clone returns a per-instance copy of the Node: immutable configuration is
 	// shared by reference, per-instance runtime state is fresh, the flow
 	// collections are empty (rewired between clones afterwards) and the clone
-	// carries no container back-reference.
-	Clone() Node
+	// carries no container back-reference. Clone returns an error because
+	// copying a node's properties can fail — a value-less property is
+	// unclonable (FIX-017); a node without properties never errors.
+	Clone() (Node, error)
 }
 
 // ============================================================================
@@ -196,10 +198,10 @@ func (fn *BaseNode) NodeType() NodeType {
 
 // Clone panics for the generic BaseNode: each concrete node type implements its
 // own Clone. The shell-clone helper CloneShell is used by those implementations.
-func (fn *BaseNode) Clone() Node {
+func (fn *BaseNode) Clone() (Node, error) {
 	errs.Panic("don't use Clone from generic BaseNode")
 
-	return nil
+	return nil, nil
 }
 
 // ----------------- Element interface -----------------------------------------

--- a/pkg/model/gateways/clone_test.go
+++ b/pkg/model/gateways/clone_test.go
@@ -114,7 +114,10 @@ func TestExclusiveGatewayClone(t *testing.T) {
 	require.NotEmpty(t, eg.Outgoing())
 	require.NotEmpty(t, eg.Incoming())
 
-	clone, ok := eg.Clone().(*gateways.ExclusiveGateway)
+	cn, err := eg.Clone()
+	require.NoError(t, err)
+
+	clone, ok := cn.(*gateways.ExclusiveGateway)
 	require.True(t, ok)
 
 	// independent object, same id.

--- a/pkg/model/gateways/complex.go
+++ b/pkg/model/gateways/complex.go
@@ -248,12 +248,12 @@ func NewComplexGateway(opts ...options.Option) (*ComplexGateway, error) {
 // Clone returns a per-instance copy: the embedded Gateway is cloned and the
 // synchronizing-join state starts fresh (ADR-009); the activation rule is shared by
 // reference (immutable after construction).
-func (cg *ComplexGateway) Clone() flow.Node {
+func (cg *ComplexGateway) Clone() (flow.Node, error) {
 	return &ComplexGateway{
 		Gateway:    cg.clone(),
 		activation: cg.activation,
 		arrived:    map[string]string{},
-	}
+	}, nil
 }
 
 // Node returns the gateway as its concrete flow node.

--- a/pkg/model/gateways/complex_test.go
+++ b/pkg/model/gateways/complex_test.go
@@ -302,7 +302,8 @@ func TestComplexGatewayClone(t *testing.T) {
 	cg, err := gateways.NewComplexGateway(gateways.WithActivationThreshold(2))
 	require.NoError(t, err)
 
-	c := cg.Clone()
+	c, err := cg.Clone()
+	require.NoError(t, err)
 	require.NotNil(t, c)
 	require.IsType(t, &gateways.ComplexGateway{}, c)
 	require.NotSame(t, cg, c)

--- a/pkg/model/gateways/event_based.go
+++ b/pkg/model/gateways/event_based.go
@@ -199,13 +199,13 @@ func (g *EventBasedGateway) Node() flow.Node {
 // cloned (fresh shell, empty flows) and the static instantiate/gwType policy is carried
 // over (ADR-009). The gate holds no per-instance arm state at the model layer — the
 // winner (mid-flow) / completion gate (Parallel-start) is decided by the runtime.
-func (g *EventBasedGateway) Clone() flow.Node {
+func (g *EventBasedGateway) Clone() (flow.Node, error) {
 	return &EventBasedGateway{
 		Gateway:     g.clone(),
 		instantiate: g.instantiate,
 		gwType:      g.gwType,
 		corrKey:     g.corrKey,
-	}
+	}, nil
 }
 
 // arms returns the gateway's arm nodes — the targets of its outgoing flows.

--- a/pkg/model/gateways/event_based_test.go
+++ b/pkg/model/gateways/event_based_test.go
@@ -182,7 +182,8 @@ func TestEventBasedGatewayClone(t *testing.T) {
 	g, err := gateways.NewEventBasedGateway()
 	require.NoError(t, err)
 
-	c := g.Clone()
+	c, err := g.Clone()
+	require.NoError(t, err)
 	require.NotNil(t, c)
 
 	cg, ok := c.(*gateways.EventBasedGateway)
@@ -214,7 +215,10 @@ func TestEventBasedGatewayCloneCarriesStart(t *testing.T) {
 		gateways.WithEventGatewayType(gateways.ParallelEvents))
 	require.NoError(t, err)
 
-	cg, ok := g.Clone().(*gateways.EventBasedGateway)
+	cn, err := g.Clone()
+	require.NoError(t, err)
+
+	cg, ok := cn.(*gateways.EventBasedGateway)
 	require.True(t, ok)
 	require.True(t, cg.Instantiate())
 	require.Equal(t, gateways.ParallelEvents, cg.EventGatewayType())

--- a/pkg/model/gateways/exclusive.go
+++ b/pkg/model/gateways/exclusive.go
@@ -44,10 +44,10 @@ func NewExclusiveGateway(opts ...options.Option) (*ExclusiveGateway, error) {
 // shell, empty flows, no container). The gateway holds no execution data —
 // condition evaluation reads variables through the per-execution environment
 // (ADR-010 §2.4).
-func (eg *ExclusiveGateway) Clone() flow.Node {
+func (eg *ExclusiveGateway) Clone() (flow.Node, error) {
 	return &ExclusiveGateway{
 		Gateway: eg.clone(),
-	}
+	}, nil
 }
 
 // Node returns the gateway as its concrete flow node, so a track reaching it via

--- a/pkg/model/gateways/inclusive.go
+++ b/pkg/model/gateways/inclusive.go
@@ -60,11 +60,11 @@ func NewInclusiveGateway(opts ...options.Option) (*InclusiveGateway, error) {
 // shell) and the synchronizing-join state (mutex, arrival table, order log,
 // fired flag) starts fresh (ADR-009). Condition evaluation reads variables
 // through the per-execution environment (ADR-010 §2.4).
-func (ig *InclusiveGateway) Clone() flow.Node {
+func (ig *InclusiveGateway) Clone() (flow.Node, error) {
 	return &InclusiveGateway{
 		Gateway: ig.clone(),
 		arrived: map[string]string{},
-	}
+	}, nil
 }
 
 // Node returns the gateway as its concrete flow node, so a track reaching it via

--- a/pkg/model/gateways/inclusive_test.go
+++ b/pkg/model/gateways/inclusive_test.go
@@ -330,7 +330,8 @@ func TestInclusiveGatewayClone(t *testing.T) {
 	ig, err := gateways.NewInclusiveGateway()
 	require.NoError(t, err)
 
-	c := ig.Clone()
+	c, err := ig.Clone()
+	require.NoError(t, err)
 	require.NotNil(t, c)
 	require.IsType(t, &gateways.InclusiveGateway{}, c)
 	require.NotSame(t, ig, c)

--- a/pkg/model/gateways/parallel.go
+++ b/pkg/model/gateways/parallel.go
@@ -49,11 +49,11 @@ func NewParallelGateway(opts ...options.Option) (*ParallelGateway, error) {
 // is cloned (direction and default flow shared by reference, fresh shell, empty
 // flows, no container) and the synchronizing-join state (mutex, arrival set)
 // starts fresh. See ADR-009.
-func (pg *ParallelGateway) Clone() flow.Node {
+func (pg *ParallelGateway) Clone() (flow.Node, error) {
 	return &ParallelGateway{
 		Gateway: pg.clone(),
 		arrived: map[string]string{},
-	}
+	}, nil
 }
 
 // Arrive records that arrivingTrackID reached the join on incomingFlowID and

--- a/pkg/model/gateways/parallel_test.go
+++ b/pkg/model/gateways/parallel_test.go
@@ -151,7 +151,10 @@ func TestParallelGatewayClone(t *testing.T) {
 	require.NotEmpty(t, pg.Outgoing())
 	require.NotEmpty(t, pg.Incoming())
 
-	clone, ok := pg.Clone().(*gateways.ParallelGateway)
+	cn, err := pg.Clone()
+	require.NoError(t, err)
+
+	clone, ok := cn.(*gateways.ParallelGateway)
 	require.True(t, ok)
 
 	// independent object, same id, shared configuration.


### PR DESCRIPTION
---Summary

flow.Node.Clone() now returns (Node, error). A node's clone deep-copies its properties, so a cloned node — a snapshot template or a per-instance node — owns private Property objects instead of
sharing the source's. A later edit to the source process (removing or re-valuing a task/event property) can no longer leak into a registered snapshot or a running instance. FIX-016 fixed this
class for process-level properties; this generalizes it to node-level (activity/event) properties.

The same clone is the validation: a value-less property (no structure, so it can never be filled — ADR-010) is unclonable, so cloning it fails and the process is rejected at snapshot.New. No
separate value-less predicate — the clone error is the single mechanism.

Changes

- flow.Node.Clone() Node → (Node, error): BaseNode, 14 concrete implementors, and the internal clone() helpers (activity/task, Event/catchEvent/throwEvent). Gateways carry no properties, so their
clone never errors.
- activity.clone / Event.clone deep-copy via one data.CloneProperties helper, which also replaces snapshot's now-duplicate local cloneProperties.
- snapshot.New / snapshot.Clone propagate the node-clone error (extracted cloneNode).

Testing

make ci green — lint · build · -race · diff-coverage 100% of 148 changed lines · govulncheck. New tests cover deep-copy isolation + value-less rejection for every property-capable node type,
snapshot-level rejection and no-leak, and data.CloneProperties.

Follow-up (recorded in docs/backlog.md)

NewUserTask / NewIntermediateCatchEvent / NewIntermediateThrowEvent / NewBoundaryEvent don't accept data.WithProperties, so those four node types can't declare properties today — their Clone
error branch is a defensive guard (tested via internal injection). Closing that constructor gap is a separate small FIX.
