### PR TITLE
feat(example): runnable definition-versioning demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ examples/signal-start/signal-start
 examples/boundary-events/boundary-events
 examples/terminate-end-event/terminate-end-event
 examples/usertask/usertask
+examples/versioning/versioning

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,6 +51,20 @@ A minimal example focusing on timer functionality:
 cd simple-timer && go run main.go
 ```
 
+### Definition Versioning (`versioning/`)
+Demonstrates Camunda-style definition versioning (ADR-019 / SRD-031.A): one
+process **key** carries many **versions**, addressable by latest, by number, or
+by the registration handle.
+
+**Key concepts:**
+- Registering under the same key yields versions `v1`, `v2`, … of one definition
+- `StartLatest(key)`, `StartVersion(key, n)`, `StartProcess(reg)` start modes
+- `Registrations(key)` enumeration and **promote-on-removal** on unregister
+
+```bash
+cd versioning && go run .
+```
+
 ## 🚀 Running Examples
 
 ### Prerequisites

--- a/examples/versioning/README.md
+++ b/examples/versioning/README.md
@@ -1,0 +1,47 @@
+# Definition Versioning Example
+
+Demonstrates Camunda-style definition versioning (ADR-019 / SRD-031.A): one
+process **key** carries many **versions**, and each version can be addressed by
+latest, by number, or by the registration handle.
+
+## What it demonstrates
+
+- Registering a process twice under the **same key** (the process id) yields
+  versions `v1`, `v2`, … — not two unrelated processes.
+- `RegisterProcess` returns a **`ProcessRegistration`** handle naming `(key, version)`.
+- Three start modes:
+  - `StartLatest(key)` — run the highest version number.
+  - `StartVersion(key, n)` — pin a specific version without holding its handle.
+  - `StartProcess(reg)` — run the exact version the handle names.
+- `Registrations(key)` — enumerate a key's live versions.
+- **Promote-on-removal**: `UnregisterVersion` of the latest promotes the
+  now-newest remaining version back to latest — symmetric with how registering a
+  newer version supersedes the previous one.
+
+Each version's service task prints its own label, so the console shows exactly
+which version executed for every start call.
+
+## Running
+
+```bash
+go run .
+```
+
+## Expected output
+
+```
+  registered v1 → key="greeter" version=1
+  registered v2 → key="greeter" version=2
+      ▶ [v2] hello from the greeter
+  StartLatest        → expects v2  [instance Completed]
+      ▶ [v1] hello from the greeter
+  StartVersion(key,1)→ expects v1  [instance Completed]
+      ▶ [v1] hello from the greeter
+  StartProcess(v1)   → expects v1  [instance Completed]
+  registered versions of "greeter": [1 2]
+  after UnregisterVersion(v2), versions: [1]
+      ▶ [v1] hello from the greeter
+  StartLatest        → expects v1 (promoted)  [instance Completed]
+
+✓ versioning example completed
+```

--- a/examples/versioning/go.mod
+++ b/examples/versioning/go.mod
@@ -1,0 +1,11 @@
+module versioning
+
+go 1.25
+
+toolchain go1.25.11
+
+replace github.com/dr-dobermann/gobpm => ../..
+
+require github.com/dr-dobermann/gobpm v0.0.0-00010101000000-000000000000
+
+require golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d // indirect

--- a/examples/versioning/go.sum
+++ b/examples/versioning/go.sum
@@ -1,0 +1,14 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d h1:N0hmiNbwsSNwHBAvR3QB5w25pUwH4tK0Y/RltD1j1h4=
+golang.org/x/exp v0.0.0-20240525044651-4c93da0ed11d/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/examples/versioning/main.go
+++ b/examples/versioning/main.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/thresher"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	fmt.Print(`
+  versioning:
+    register two versions of one key ("greeter"), then address them by
+    latest / version-number / handle, and watch promote-on-removal.
+
+`)
+	if err := data.CreateDefaultStates(); err != nil {
+		return fmt.Errorf("init data states: %w", err)
+	}
+
+	engine, err := thresher.New("versioning-engine")
+	if err != nil {
+		return fmt.Errorf("create engine: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := engine.Run(ctx); err != nil {
+		return fmt.Errorf("run engine: %w", err)
+	}
+
+	if err := demonstrateVersioning(ctx, engine); err != nil {
+		return err
+	}
+
+	fmt.Println("\n✓ versioning example completed")
+
+	return nil
+}

--- a/examples/versioning/process.go
+++ b/examples/versioning/process.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/model/service/gooper"
+)
+
+// processKey is the shared versioning key — the process id (ADR-019 §2.1: the
+// key is the BPMN id, not the display name). Every build below carries this
+// same id, so successive registrations become versions v1, v2, … of ONE
+// definition rather than separate unrelated processes.
+const processKey = "greeter"
+
+// buildGreeter builds a trivial start → service task → end process whose task
+// prints the given release label, so the console shows WHICH version ran when a
+// version is later addressed by latest / number / handle.
+func buildGreeter(label string) (*process.Process, error) {
+	proc, err := process.New("greeter", foundation.WithID(processKey))
+	if err != nil {
+		return nil, fmt.Errorf("create process: %w", err)
+	}
+
+	start, err := events.NewStartEvent("start")
+	if err != nil {
+		return nil, fmt.Errorf("create start: %w", err)
+	}
+
+	op, err := greetOp(label)
+	if err != nil {
+		return nil, fmt.Errorf("create operation: %w", err)
+	}
+
+	task, err := activities.NewServiceTask("greet", op, activities.WithoutParams())
+	if err != nil {
+		return nil, fmt.Errorf("create service task: %w", err)
+	}
+
+	end, err := events.NewEndEvent("end")
+	if err != nil {
+		return nil, fmt.Errorf("create end: %w", err)
+	}
+
+	for _, e := range []flow.Element{start, task, end} {
+		if err := proc.Add(e); err != nil {
+			return nil, fmt.Errorf("add element: %w", err)
+		}
+	}
+
+	if _, err := flow.Link(start, task); err != nil {
+		return nil, fmt.Errorf("link start->task: %w", err)
+	}
+
+	if _, err := flow.Link(task, end); err != nil {
+		return nil, fmt.Errorf("link task->end: %w", err)
+	}
+
+	return proc, nil
+}
+
+// greetOp returns a Go operation that prints the release label of the running
+// version.
+func greetOp(label string) (service.Operation, error) {
+	return gooper.New("greet",
+		func(_ context.Context, _ service.DataReader,
+			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			fmt.Printf("      ▶ [%s] hello from the greeter\n", label)
+
+			return nil, nil
+		})
+}

--- a/examples/versioning/scenario.go
+++ b/examples/versioning/scenario.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dr-dobermann/gobpm/pkg/thresher"
+)
+
+// demonstrateVersioning walks the ADR-019 versioning lifecycle on one key:
+// register two versions, address them by latest / number / handle, list them,
+// then unregister the latest and watch the previous version get promoted back
+// to "latest". Each greeter run prints its own label, so the console proves
+// which version actually executed.
+func demonstrateVersioning(
+	ctx context.Context,
+	engine *thresher.Thresher,
+) error {
+	v1, err := register(engine, "v1")
+	if err != nil {
+		return err
+	}
+
+	v2, err := register(engine, "v2")
+	if err != nil {
+		return err
+	}
+
+	// Latest is now v2 — StartLatest resolves the highest version number.
+	h, err := engine.StartLatest(processKey)
+	if err := startAndWait(ctx, "StartLatest        → expects v2", h, err); err != nil {
+		return err
+	}
+
+	// Pin an older version explicitly, by number, without holding its handle.
+	h, err = engine.StartVersion(processKey, 1)
+	if err := startAndWait(ctx, "StartVersion(key,1)→ expects v1", h, err); err != nil {
+		return err
+	}
+
+	// Same version, addressed by the registration handle returned earlier.
+	h, err = engine.StartProcess(v1)
+	if err := startAndWait(ctx, "StartProcess(v1)   → expects v1", h, err); err != nil {
+		return err
+	}
+
+	fmt.Printf("  registered versions of %q: %s\n",
+		processKey, versionList(engine))
+
+	// Unregister the latest (v2): promote-on-removal makes v1 the latest again,
+	// symmetric with how registering v2 superseded v1.
+	if err := engine.UnregisterVersion(v2); err != nil {
+		return fmt.Errorf("unregister v2: %w", err)
+	}
+
+	fmt.Printf("  after UnregisterVersion(v2), versions: %s\n",
+		versionList(engine))
+
+	h, err = engine.StartLatest(processKey)
+	if err := startAndWait(ctx, "StartLatest        → expects v1 (promoted)", h, err); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// register builds a fresh greeter carrying the given release label under the
+// shared key and registers it, reporting the version the engine assigned.
+func register(
+	engine *thresher.Thresher,
+	label string,
+) (*thresher.ProcessRegistration, error) {
+	proc, err := buildGreeter(label)
+	if err != nil {
+		return nil, fmt.Errorf("build %s: %w", label, err)
+	}
+
+	reg, err := engine.RegisterProcess(proc)
+	if err != nil {
+		return nil, fmt.Errorf("register %s: %w", label, err)
+	}
+
+	fmt.Printf("  registered %s → key=%q version=%d\n",
+		label, reg.Key(), reg.Version())
+
+	return reg, nil
+}
+
+// startAndWait consumes a Start* call's (handle, error) result, runs the
+// instance to completion, and prints the labelled outcome. Threading the Start*
+// result straight in keeps each call site a single readable line.
+func startAndWait(
+	ctx context.Context,
+	label string,
+	h *thresher.InstanceHandle,
+	err error,
+) error {
+	if err != nil {
+		return fmt.Errorf("%s: %w", label, err)
+	}
+
+	state, err := h.WaitCompletion(ctx)
+	if err != nil {
+		return fmt.Errorf("%s: wait completion: %w", label, err)
+	}
+
+	fmt.Printf("  %s  [instance %s]\n", label, state)
+
+	return nil
+}
+
+// versionList renders the live version numbers registered for the key, e.g.
+// "[1 2]", so the console shows the registry shrink after an unregister.
+func versionList(engine *thresher.Thresher) string {
+	regs := engine.Registrations(processKey)
+
+	nums := make([]int, 0, len(regs))
+	for _, r := range regs {
+		nums = append(nums, r.Version())
+	}
+
+	return fmt.Sprintf("%v", nums)
+}


### PR DESCRIPTION
The versioning epic (ADR-019 / SRD-031.A / SRD-031.B) landed with no runnable example — this adds examples/versioning/, a self-contained demo of the feature's public surface:

  - registering a process twice under the same key ("greeter") yields versions v1, v2 of one definition;
  - the three start modes — StartLatest(key), StartVersion(key, n), StartProcess(reg) — each resolve the expected version;
  - Registrations(key) enumerates the live versions;
  - UnregisterVersion of the latest promotes the previous version back to latest (promote-on-removal), symmetric with supersession on register.

Each version's service task prints its own label, so the console proves which version executed for every start call.

Split by concern per the examples convention: process.go (model), scenario.go (the version lifecycle walk), main.go (engine wiring). Adds the example to examples/README.md and gitignores its built binary.