### PR TITLE
Test/harden core coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,12 @@ COVER_BASE ?= origin/master
 # observability, not logic, and shouldn't demand a test just to be "covered".
 # Matches the two logger-access forms in the codebase: `.logger.LEVEL(` and
 # `.Logger().LEVEL(`.
-COVER_EXCLUDE ?= \.(logger|Logger\(\))\.(Debug|Info|Warn|Error)\(
+#
+# Second regex: the `func (X) Option() {}` marker methods (FIX-020). Options
+# are dispatched by the constructor calling the underlying func directly, so
+# Option() is never invoked — it only makes the type satisfy options.Option at
+# compile time. An empty, never-called marker body is structurally uncoverable.
+COVER_EXCLUDE ?= \.(logger|Logger\(\))\.(Debug|Info|Warn|Error)\(,func \(.*\) Option\(\) \{\}
 
 # All Go modules in the monorepo (each with its own go.mod).
 # Discovered dynamically so adding a new module needs no Makefile edit.

--- a/docs/fix/FIX-019-errs-string-typed-details.md
+++ b/docs/fix/FIX-019-errs-string-typed-details.md
@@ -137,6 +137,15 @@ diagnostic serializer, not a hot path; hand-rolling JSON escaping trades a real
 correctness risk for a micro-optimization on a cold path. The hot
 `New`/`D`/`Error` paths become reflection-free either way.
 
+**JSON error handling (amended during implementation):** the original draft
+deleted `JSON()`'s marshal-failure branch as dead code. On review, silently
+swallowing a marshal error in a library is as objectionable as the old panic —
+so `JSON()` **propagates** it instead: the signature changes from `() []byte` to
+`() ([]byte, error)` and returns `json.Marshal(ae)` directly (no panic, no
+swallow, no fallback). With `map[string]string` the error is unreachable in
+practice, but a library surfaces it rather than hiding it. `JSON()` had **zero
+production callers** (only one test), so the signature change is free.
+
 ### §3.2 Changes by file
 
 #### §3.2.1 `pkg/errs/error_options.go` — string-typed details
@@ -158,9 +167,10 @@ copies `map[string]string`.
 - `ApplicationError.Details map[string]any` → `map[string]string`; `New`'s
   `details: map[string]any{}` init → `map[string]string{}`.
 - `Error()` detail loop uses `%s` (no reflection) and a `strings.Builder`.
-- `JSON()` — details are now always marshalable, so the `if err != nil {
-  Panic(...) }` branch (`errors.go:108-111`) is **unreachable → deleted**; keep
-  `json.Marshal` for the successful path.
+- `JSON()` — the old `if err != nil { Panic(...) }` branch is replaced by
+  **propagating** the error: signature `() []byte` → `() ([]byte, error)`,
+  body `return json.Marshal(ae)`. No panic, no swallow. Its one caller (a test)
+  is updated. (See the "JSON error handling" note in §3.1.)
 - `MarshalJSON()` anonymous struct field `Details map[string]any` →
   `map[string]string`.
 
@@ -203,11 +213,15 @@ Current `pkg/errs` coverage after slice-1 hardening: 96.7% (the residual is the
 |---|---|---|
 | `TestErrFuncApplyNil` | `errFunc(func(*errConfig) error { return nil }).apply(nil)` | returns the "empty error configuration" error (the guard `New` never reaches) |
 
-#### §4.1.3 Deleted-branch note
+#### §4.1.3 JSON error handling
 
-The `JSON()` marshal-failure branch (§1.3) is **removed**, not tested — a
-`map[string]string` cannot produce an `UnsupportedTypeError`. This is the FIX's
-whole point; §6.1 confirms no caller depends on the panic.
+The `JSON()` panic branch (§1.3) is replaced by **propagating** the marshal
+error (signature `() ([]byte, error)`). With `map[string]string` the error is
+unreachable — a `map[string]string`/scalar struct cannot produce an
+`UnsupportedTypeError` — so the error path isn't unit-testable, but surfacing
+it (rather than panicking or swallowing) is the honest library contract. The
+success path is covered by `TestJson`'s round-trip; §6.1 records the signature
+change's blast radius (one test caller).
 
 ### §4.5 Observability
 
@@ -242,9 +256,10 @@ functional output).
 - **JSON detail fidelity** — machine consumers parsing `errs` JSON `details` as
   native types (`{"count":3}`) now see strings (`{"count":"3"}`). Diagnostic
   output only; confirm no downstream parser asserts native types.
-- **`JSON()` panic contract** — nothing should depend on `JSON()` panicking on a
-  bad detail (it was a latent failure, never a feature). Grep
-  `grep -rn "\.JSON()" ...` — call sites expect bytes, not a panic.
+- **`JSON()` signature change** — `() []byte` → `() ([]byte, error)`. Grep
+  `grep -rn "\.JSON()" ...` confirmed **one** caller (a test), now updated to
+  handle the returned error. No caller depends on the old panic-on-bad-detail
+  behaviour (it was a latent failure, never a feature).
 
 ### §6.2 Rollback path
 

--- a/docs/fix/FIX-019-errs-string-typed-details.md
+++ b/docs/fix/FIX-019-errs-string-typed-details.md
@@ -1,0 +1,290 @@
+# FIX-019 «`errs` error details use `any`, forcing boxing + reflection on error paths»
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft v.1 (2026-07-04, branch `test/harden-core-coverage`, not yet implemented).
+**Date:** 2026-07-04.
+**Author:** dr-dobermann.
+**Branch:** `test/harden-core-coverage` (folded into the in-flight core-hardening work per the user's request — the `errs` redesign was surfaced while hardening `pkg/errs` coverage).
+**Paired doc:** none (local to `pkg/errs`).
+**Upstream:** self-contained per hierarchy-rule (no ADR/SAD governs the `errs` utility).
+
+**Grounded in (internal artifacts):**
+- `pkg/errs/{errors.go,error_options.go}` (current implementation).
+- Call-site survey: 206 `errs.D(...)` sites across `pkg/` + `internal/` (non-test).
+
+---
+
+## §1 Symptoms
+
+This is a **design/performance defect**, not a runtime crash: `errs` is invoked
+on every error-construction path but its detail-value machinery is built on
+`map[string]any`, which violates the package's intended contract — *fast,
+minimal-overhead, no runtime reflection, no long conversion*. Three concrete
+consequences, each with a code witness:
+
+### §1.1 `any` boxing on every `D()` with a non-pointer value
+
+```go
+// pkg/errs/error_options.go:15
+details map[string]any
+// pkg/errs/error_options.go:96
+func D(k string, v any) errOption {
+```
+
+Every `errs.D("count", n)` with a scalar (`int`, `Duration`, a named enum)
+**heap-boxes** the value into `any` to store it in the map. On error paths that
+build several details this is repeated allocation for values that are almost
+always strings already.
+
+### §1.2 Reflective `%v` formatting when rendering the error
+
+```go
+// pkg/errs/errors.go:129-131
+str += "Details:\n"
+for k, v := range ae.Details {
+    str += fmt.Sprintf(" %s: %v\n", k, v)
+}
+```
+
+`%v` over an `any` dispatches through `reflect` for every non-string detail each
+time `Error()` is called (i.e. whenever the error is logged/rendered). String
+concatenation in a loop also re-allocates.
+
+### §1.3 Reflective, runtime-**fallible** JSON serialization
+
+```go
+// pkg/errs/errors.go:107-112
+func (ae *ApplicationError) JSON() []byte {
+    js, err := json.Marshal(ae)
+    if err != nil {
+        Panic("couldn't convert application error to json: " + err.Error())
+        return nil
+    }
+    ...
+// pkg/errs/errors.go:157-168  (MarshalJSON marshals Details map[string]any directly)
+```
+
+`json.Marshal` reflects over the value, and because `Details` is `map[string]any`
+it **can genuinely fail** — a detail holding an unmarshalable value (a `chan`,
+`func`, …) makes `MarshalJSON` error, firing the `Panic` branch. So the `any`
+buys a latent panic-on-diagnostic on top of the reflection cost.
+
+**User-visible impact:** avoidable allocation + reflection on the error path
+(rendering is common under logging); a diagnostic serializer that can panic on
+otherwise-valid `ApplicationError`s.
+
+---
+
+## §2 Root Cause Analysis
+
+### §2.1 `map[string]any` is over-general for the actual detail values
+
+Survey of all 206 non-test `errs.D(...)` call sites: **~95% already pass a
+`string`** — `X.ID()`, `X.Name()`, `reflect.TypeOf(x).String()`, `st.String()`,
+`slot.String()`, string literals. The non-string minority is small and trivial
+to convert:
+
+- **`int`** — `pkg/model/gateways/complex.go:51,59,441-442`, `.../gateway.go:335-336`
+  (`count`, `len(...)`, `incoming_count`, …).
+- **named string types** — `errs.D("direction", d)` (`activity_options.go:183`,
+  `Direction`), `errs.D("event_definition_type", eDef.Type())`
+  (`thresher.go:523`, `track.go:944`, `flow.EventTrigger`), state values
+  (`signal.go:177`).
+- **object / func (a diagnostic smell)** — `goexpr.go:58-60` passes a
+  `data.Source`, an `*ItemDefinition`, and a **func**; two sites elsewhere pass a
+  whole `EventDefinition` where its `.ID()` was intended.
+
+`any` is therefore not earning its generality — the true shape is
+`map[string]string`. Error *context* being open-ended is a real argument for
+`any` in the abstract (cf. `slog.Any`), but the empirical call-set here does not
+exercise it.
+
+### §2.2 No tests exercise the reflective/fallible branches
+
+`grep` of `pkg/errs/*_test.go` for `JSON`/`Details`: the `JSON()` marshal-failure
+branch (§1.3) and the `Error()` detail loop (§1.2) have **no** direct coverage
+(the failure branch is why `pkg/errs` sat at 80.2% before this hardening pass).
+The absence let the `any`-driven cost and the latent panic persist unnoticed.
+
+### §2.3 Contract mismatch
+
+The package's implicit contract — a cheap, reflection-free error builder for hot
+paths — is contradicted by its own storage choice. This is a design defect, not
+a localized logic bug: the fix is to make the type match the contract.
+
+---
+
+## §3 Solution
+
+Narrow error-detail values to `string`: `Details map[string]any` →
+`map[string]string`, `D(k string, v any)` → `D(k, v string)`. The hot
+construction/rendering paths become allocation-lean and reflection-free; the
+`JSON()` failure branch becomes provably dead and is deleted.
+
+### §3.1 Alternatives considered
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| A. Generic `D[T any](k string, v T)` | type-inferred call sites | `T` erases to `any` at the `map[string]any` boundary — zero benefit; still boxes, still reflects | ❌ rejected |
+| B. Constrain `v` to `fmt.Stringer` | forces a string form | **rejects the common `string`/`int` values** (neither implements `Stringer`); still lossy; still doesn't guarantee marshalability | ❌ rejected |
+| C. Constrain `v` to a "JSON-compatible" type | compile-time safety | **inexpressible in Go** — constraints are allow-lists/method-sets; marshalability is a recursive structural runtime property (stdlib `json.Marshal` itself takes `any` + returns `error` for exactly this reason) | ❌ impossible |
+| D. Keep `any`, stringify inside `MarshalJSON` (`%v`) | removes the JSON failure branch | retains `any` boxing (§1.1) and reflective `Error()` (§1.2) — fixes only the rarest path | ❌ rejected: doesn't address the hot path |
+| E. **`map[string]string` + `D(k, v string)`** | no boxing; `Error()` uses `%s` (no reflection); `JSON()` can't fail → delete the branch; matches ~95% of call sites unchanged | ~20 non-string call sites need an explicit `strconv`/`string(...)`/`.ID()`; JSON details lose native-type fidelity (become strings) | ✅ chosen |
+
+**JSON depth (decided — pragmatic):** keep `json.Marshal(map[string]string)` on
+the opt-in `JSON()` path. It still reflects internally, but `JSON()` is a rare
+diagnostic serializer, not a hot path; hand-rolling JSON escaping trades a real
+correctness risk for a micro-optimization on a cold path. The hot
+`New`/`D`/`Error` paths become reflection-free either way.
+
+### §3.2 Changes by file
+
+#### §3.2.1 `pkg/errs/error_options.go` — string-typed details
+
+```go
+// before:
+details map[string]any
+func D(k string, v any) errOption { ... cfg.details[k] = v ... }
+// after:
+details map[string]string
+func D(k, v string) errOption { ... cfg.details[k] = v ... }
+```
+
+Doc-comment on `D` states the string-only contract and *why* (§5). `newError`
+copies `map[string]string`.
+
+#### §3.2.2 `pkg/errs/errors.go` — field type, reflection-free render, dead-branch delete
+
+- `ApplicationError.Details map[string]any` → `map[string]string`; `New`'s
+  `details: map[string]any{}` init → `map[string]string{}`.
+- `Error()` detail loop uses `%s` (no reflection) and a `strings.Builder`.
+- `JSON()` — details are now always marshalable, so the `if err != nil {
+  Panic(...) }` branch (`errors.go:108-111`) is **unreachable → deleted**; keep
+  `json.Marshal` for the successful path.
+- `MarshalJSON()` anonymous struct field `Details map[string]any` →
+  `map[string]string`.
+
+#### §3.2.3 Call-site migration (mechanical, by conversion kind)
+
+The ~13 `reflect.TypeOf(x).String()` sites are **already strings — unchanged**.
+The non-string sites get an explicit, non-reflective conversion:
+
+| Kind | Conversion | Sites (file:line) |
+|---|---|---|
+| `int` | `strconv.Itoa(n)` | `gateways/complex.go:51,59,60,441,442,453`, `gateways/gateway.go:335,336` |
+| named string type | `string(v)` | `activities/activity_options.go:183` (`direction`), `thresher/thresher.go:523`, `internal/instance/track.go:944`, `events/timer.go:59-61`, `eventhub/waiters/signal.go:177` (as applicable) |
+| object / func (smell) | pass `.ID()` / a meaningful string, or drop the detail | `data/goexpr/goexpr.go:58-60` (`ds`/`res`/`gfunc`), the 2 `EventDefinition()` sites |
+
+Each converted site is verified to compile; the full set is the `go build ./...`
+gate (a missed site is a compile error, not a silent slip).
+
+---
+
+## §4 Verification
+
+Current `pkg/errs` coverage after slice-1 hardening: 96.7% (the residual is the
+`JSON()` failure branch this FIX deletes, plus one white-box guard).
+
+### §4.1 Regression tests (mandatory)
+
+#### §4.1.1 `Error()` renders string details without reflection
+
+**Update:** `pkg/errs/errors_test.go` (existing `TestErrors`/`TestJson`).
+
+| Test | Setup | Assertion |
+|---|---|---|
+| detail rendering | `New(M("m"), D("id","x"), D("count","3"))` | `Error()` contains `id: x` and `count: 3`; `JSON()` round-trips `{"details":{"id":"x","count":"3"}}` |
+
+#### §4.1.2 `errFunc.apply` nil-config guard (white-box)
+
+**New:** `pkg/errs/apply_internal_test.go` (`package errs`).
+
+| Test | Setup | Assertion |
+|---|---|---|
+| `TestErrFuncApplyNil` | `errFunc(func(*errConfig) error { return nil }).apply(nil)` | returns the "empty error configuration" error (the guard `New` never reaches) |
+
+#### §4.1.3 Deleted-branch note
+
+The `JSON()` marshal-failure branch (§1.3) is **removed**, not tested — a
+`map[string]string` cannot produce an `UnsupportedTypeError`. This is the FIX's
+whole point; §6.1 confirms no caller depends on the panic.
+
+### §4.5 Observability
+
+No new logs; the win is fewer allocations + no `reflect` frames on the
+error-render path (visible in a CPU/alloc profile of an error-heavy run, not in
+functional output).
+
+---
+
+## §5 Prevention
+
+- **Doc comment on `D`** stating the contract: *values are pre-stringified by the
+  caller; `errs` stores and renders them without reflection or allocation. This
+  keeps error construction cheap on hot paths — do not reintroduce `any`.*
+- **Doc comment on `ApplicationError.Details`** noting the `map[string]string`
+  choice and the deleted failure mode.
+- **Canary:** `TestErrFuncApplyNil` + the `Error()`/`JSON()` round-trip in
+  §4.1.1 — if `Details` regains `any`, the round-trip's native-vs-string shape
+  changes and the test flags it.
+
+---
+
+## §6 Regressions / side-effects
+
+### §6.1 What may rely on the old behaviour
+
+- **Callers reading `ApplicationError.Details` as `map[string]any`** — grep:
+  `grep -rn "\.Details\[" --include=*.go pkg internal | grep -v _test` and
+  `grep -rn "range .*\.Details" ...`. Any consumer type-asserting a detail value
+  (`d.(int)`) breaks and must read the string. (Expected: none outside `errs`
+  itself; confirm pre-landing.)
+- **JSON detail fidelity** — machine consumers parsing `errs` JSON `details` as
+  native types (`{"count":3}`) now see strings (`{"count":"3"}`). Diagnostic
+  output only; confirm no downstream parser asserts native types.
+- **`JSON()` panic contract** — nothing should depend on `JSON()` panicking on a
+  bad detail (it was a latent failure, never a feature). Grep
+  `grep -rn "\.JSON()" ...` — call sites expect bytes, not a panic.
+
+### §6.2 Rollback path
+
+Single-commit revert of the `errs` core change + the call-site migration commit.
+No data/migration involved.
+
+### §6.3 Cross-team backlog
+
+None — `pkg/errs` is internal to gobpm; all call sites are in-repo.
+
+---
+
+## §7 Related
+
+- Self-contained per the hierarchy-rule; no ADR/SAD governs `errs`.
+- **Promote-to-ADR candidate:** the invariant *"`errs` is a hot-path utility —
+  reflection-free, allocation-lean, no `any` in its stored/rendered surface"* is
+  a reusable design principle. If a second low-overhead-utility decision appears
+  (e.g. a logging or metrics helper), promote this principle to a small ADR.
+- Sits within the broader core-hardening pass on branch
+  `test/harden-core-coverage` (coverage of `pkg/errs`, `pkg/model/data`, …).
+
+---
+
+## §8 Implementation summary (stage-by-stage actual landings + deltas vs draft)
+
+> ⚠️ TODO: fill AFTER landing; records the implementation history and empirical
+> findings vs the §3 draft.
+
+### §8.1 Stages by commit (branch `test/harden-core-coverage`)
+| Stage | Commit | Scope | Tests |
+|---|---|---|---|
+| 1 | `<sha>` | `errs` core: `map[string]string`, `D(k,v string)`, reflection-free `Error()`, delete `JSON()` failure branch | `<count + names>` |
+| 2 | `<sha>` | call-site migration (int/named/object conversions) | build gate |
+
+### §8.2 Empirical findings — where reality diverged from the §3 draft
+> ⚠️ TODO: e.g. any call site whose value could not be cheaply stringified;
+> any consumer of `.Details` found that needed a fix (would expand §3.2.3).
+
+### §8.3 Backlog (out of FIX-019 scope)
+- The `goexpr.go` / `EventDefinition()` detail sites that pass whole objects are
+  a diagnostic smell; this FIX converts them to `.ID()`/drop, but a broader
+  "detail hygiene" sweep (consistent id-only diagnostics) is future work.

--- a/docs/fix/FIX-019-errs-string-typed-details.md
+++ b/docs/fix/FIX-019-errs-string-typed-details.md
@@ -1,7 +1,7 @@
 # FIX-019 «`errs` error details use `any`, forcing boxing + reflection on error paths»
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft v.1 (2026-07-04, branch `test/harden-core-coverage`, not yet implemented).
+**Status:** Accepted (2026-07-04, branch `test/harden-core-coverage`, landed `1dd8eff`).
 **Date:** 2026-07-04.
 **Author:** dr-dobermann.
 **Branch:** `test/harden-core-coverage` (folded into the in-flight core-hardening work per the user's request — the `errs` redesign was surfaced while hardening `pkg/errs` coverage).
@@ -286,18 +286,31 @@ None — `pkg/errs` is internal to gobpm; all call sites are in-repo.
 
 ## §8 Implementation summary (stage-by-stage actual landings + deltas vs draft)
 
-> ⚠️ TODO: fill AFTER landing; records the implementation history and empirical
-> findings vs the §3 draft.
-
 ### §8.1 Stages by commit (branch `test/harden-core-coverage`)
 | Stage | Commit | Scope | Tests |
 |---|---|---|---|
-| 1 | `<sha>` | `errs` core: `map[string]string`, `D(k,v string)`, reflection-free `Error()`, delete `JSON()` failure branch | `<count + names>` |
-| 2 | `<sha>` | call-site migration (int/named/object conversions) | build gate |
+| 1 | `1dd8eff` | `errs` core (`map[string]string`, `D(k, v string)`, reflection-free `Error()` via `strings.Builder`, `JSON()` → `([]byte, error)`) **and** the call-site migration, landed atomically — the `D` signature change requires every call site to build | `pkg/errs` suite + `timer_test` state-detail assertion updated to `.String()` |
+
+The core + migration could not be split into separately-green commits: the
+`D(k, v string)` signature change breaks every non-string call site until each
+is converted, so both land in one commit.
 
 ### §8.2 Empirical findings — where reality diverged from the §3 draft
-> ⚠️ TODO: e.g. any call site whose value could not be cheaply stringified;
-> any consumer of `.Details` found that needed a fix (would expand §3.2.3).
+- **JSON error handling (§3.1/§4.1.3 amended mid-flight).** The draft deleted
+  `JSON()`'s marshal-failure branch as dead. On review, silently swallowing a
+  marshal error in a library is as objectionable as the old panic — so `JSON()`
+  now **propagates** it: signature `() []byte` → `() ([]byte, error)`. Its one
+  caller (a test) was updated.
+- **`eDefI` diagnostics — method, not reflection.** The bare
+  `reflect.TypeOf(eDefI)` sites in the signal/message/timer waiters became
+  `string(eDefI.Type())` (a method call, reflection-free, and semantically
+  better — the trigger type, not the Go type), dropping `reflect` from all
+  three files. An earlier attempt to use `reflect.TypeOf(eDefI).String()` was
+  rejected precisely because it *keeps* the reflection.
+- **Blast radius larger than the ~20 estimate.** ~30 call sites needed
+  conversion (enumerated by the compiler). The 16 `reflect.TypeOf(cfg).String()`
+  config sites were already strings (no change) and were left for FIX-020's
+  dead-assertion removal.
 
 ### §8.3 Backlog (out of FIX-019 scope)
 - The `goexpr.go` / `EventDefinition()` detail sites that pass whole objects are

--- a/docs/fix/FIX-020-option-dispatch-hardening.md
+++ b/docs/fix/FIX-020-option-dispatch-hardening.md
@@ -1,0 +1,340 @@
+# FIX-020 «Every option type carries a dead config-type assertion (with reflection) in its `Apply` method»
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft v.1 (2026-07-04, branch `test/harden-core-coverage`, not yet implemented).
+**Date:** 2026-07-04.
+**Author:** dr-dobermann.
+**Branch:** `test/harden-core-coverage` (folded into the in-flight core-hardening work; surfaced during [FIX-019] while making error paths reflection-free).
+**Paired doc:** none (local to the `options` mechanism across `pkg/model`).
+**Upstream:** self-contained per hierarchy-rule (no ADR/SAD governs the options utility).
+
+**Grounded in (internal artifacts):**
+- `pkg/model/options/option.go` (the `Option`/`Configurator` interfaces).
+- The 19 option-type files + ~18 dispatching constructors (inventory in §1–§2).
+- Reference implementations already hardened: `pkg/model/activities/receive_task.go:71`, `send_task.go:52`.
+
+---
+
+## §1 Symptoms
+
+A design/dead-code defect, the sibling of [FIX-019]. `options.Option` is
+`interface { Apply(cfg Configurator) error }`. **21 option types** across 7
+packages are func types (`func(*Xconfig) error`) that implement `Apply` by
+type-asserting the generic `Configurator` back to their concrete config and,
+on failure, returning an error carrying `reflect.TypeOf(cfg).String()`:
+
+```go
+// pkg/model/activities/activity_options.go:211
+func (ao ActivityOption) Apply(cfg options.Configurator) error {
+	if ac, ok := cfg.(*activityConfig); ok {
+		return ao(ac)
+	}
+	return errs.New(errs.M("cfg isn't an activityConfig"),
+		errs.C(errorClass, errs.InvalidParameter, errs.TypeCastingError),
+		errs.D("cfg_type", reflect.TypeOf(cfg).String()))  // dead + reflective
+}
+```
+
+Three consequences:
+
+### §1.1 The assertion branch is unreachable dead code
+
+Every constructor that dispatches these options **already** type-switches to
+identify the option and passes it the **matching** config (e.g.
+`newActivity` calls `o.Apply(&cfg)` with `&cfg` always `*activityConfig`). So
+`cfg.(*activityConfig)` always succeeds; the `else` never runs. All 21 rows in
+the §2 inventory are dead. Proof: `NewReceiveTask`/`NewSendTask`
+(`receive_task.go:71`, `send_task.go:52`) already bypass `Apply` and call the
+option func directly — their `Apply` methods are already orphaned.
+
+### §1.2 Runtime reflection in the option layer
+
+The dead branches carry `reflect.TypeOf(cfg).String()` (19 of the 21). FIX-019
+removed reflection from `errs`; this is the reflection those error paths still
+reference on the option-construction path. (Two — `ComplexOption`,
+`EventBasedOption` — have the dead assertion but no reflect.)
+
+### §1.3 Redundant indirection
+
+`Apply(Configurator)` **erases** the concrete config type only to re-assert it
+one call later — a round trip that exists solely to satisfy a single interface
+method the constructors don't actually need (they've already narrowed the type
+in their switch).
+
+**Impact:** 21 dead branches, 19 reflective, and a redundant interface method
+whose only real polymorphic consumer (`foundation.NewBaseElement`) can be a
+type-switch too.
+
+---
+
+## §2 Root Cause Analysis
+
+### §2.1 The erased-type round trip
+
+`options.Option.Apply(cfg Configurator)` is the sole unifier that lets
+`New(name string, ...options.Option)` take a **heterogeneous** option bag. But
+`Configurator` erases the concrete config type, so each option must re-assert
+it — and that re-assertion is the dead branch. The constructors, however,
+already `switch opt.(type)` to route options; once the switch has matched
+`case ActivityOption`, the concrete option type is known and its func can be
+called with the concrete config directly. The `Apply` indirection is redundant
+with the switch the constructors already perform.
+
+### §2.2 Inventory — the dead `Apply`-assertion sites (category **(a)**)
+
+| Option type | Type def | `Apply` | reflect(cfg) | Underlying func |
+|---|---|---|---|---|
+| `startOption` | events/start_options.go:16 | :56 | :62 | `func(*startConfig) error` |
+| `endOption` | events/end_options.go:15 | :36 | :42 | `func(*endConfig) error` |
+| `EventOption` | events/event_options.go:44 | :48 | :54 | `func(eventConfig) error` (iface) |
+| `ActivityOption` | activities/activity_options.go:30 | :211 | :219 | `func(*activityConfig) error` |
+| `taskOption` | activities/task_options.go:19 | :22 | :29 | `func(*multyInstance) error` |
+| `RcvTaskOption` | activities/receive_task_options.go:26 | :29 | :39 | `func(*rcvTaskConfig)` (already bypassed) |
+| `RoleOption` | activities/role_option.go:20 | :23 | :31 | `func(RoleConfigurator) error` (iface) |
+| `SndTaskOption` | activities/send_task_options.go:25 | :28 | :38 | `func(*sndTaskConfig)` (already bypassed) |
+| `UsrTaskOption` | activities/user_task_options.go:30 | :232 | :240 | `func(*usrTaskConfig) error` |
+| `asscOption` | data/data_options.go:84 | :161 | :166 | `func(*asscConfig) error` |
+| `PropertyOption` | data/property_option.go:21 | :72 | :80 | `func(PropertyAdder) error` (iface) |
+| `itemOption` | data/item_options.go:18 | :74 | :80 | `func(*itemConfig) error` |
+| `IAEOption` | data/item_options.go:104 | :169 | :174 | `func(*iaeConfig) error` |
+| `IAEAdderOption` | data/item_options.go:207 | :238 | :246 | `func(IAEAdder) error` (iface) |
+| `sflowOption` | flow/sequenceflow_options.go:20 | :23 | :31 | `func(*sflowConfig) error` |
+| `NameOption` | options/name_option.go:19 | :22 | :30 | `func(NameConfigurator) error` (iface) |
+| `GatewayOption` | gateways/gateway_options.go:20 | :60 | :68 | `func(*gatewayConfig) error` |
+| `ComplexOption` | gateways/complex.go:125 | :128 | — | `func(*complexConfig) error` |
+| `EventBasedOption` | gateways/event_based.go:63 | :66 | — | `func(*eventBasedConfig) error` |
+| `ciOption` | hinteraction/consinp/consinp_options.go:22 | :187 | :195 | `func(*consInpConfig) error` |
+| `BaseOption` | foundation/options.go:24 | :33 | :39 | `func(*baseConfig) error` |
+
+The 5 interface-typed options (`EventOption`, `RoleOption`, `PropertyOption`,
+`IAEAdderOption`, `NameOption`) still harden cleanly: the config the
+constructor passes **implements** that interface, so a direct `o(&cfg)`
+compiles — which is exactly why the assertion never fails.
+
+### §2.3 Reachable input-validation guards (category **(b)** — MUST STAY)
+
+Distinct from (a): the constructor-level `default:` "invalid option type" arms
+fire on genuine caller misuse (a wrong option passed to a constructor). They
+reflect on `o` (the option), not `cfg` — the reliable (a)/(b) tell. These stay:
+`activities/activity.go:63`, `user_task.go:113`; `data/item.go:101,261`,
+`association.go:105`; `flow/sequenceflow.go:111`; `gateways/gateway.go:128`;
+`process/process.go:70`; `events/start.go:77`, `end.go:72`;
+`consinp/consinp.go:94`.
+
+### §2.4 The one polymorphic consumer
+
+`foundation.NewBaseElement` (base.go:98) loops `for _, o := range opts {
+o.Apply(&bc) }` with **no** switch — the only place `Apply` is real polymorphic
+dispatch. It only ever receives `BaseOption` (every other constructor collects
+just `BaseOption` into `baseOpts` before delegating here). It also currently
+serves as the base-layer catch-all: options that leaked through a
+constructor without a category-(b) guard reach here and are rejected when
+`BaseOption.Apply(*baseConfig)` fails. Hardening it to a switch must add an
+explicit `default:` to preserve that rejection (§6.1).
+
+---
+
+## §3 Solution
+
+Harden every constructor to call the option's concrete func directly, delete
+all 21 `Apply` methods (removing every dead assertion + `reflect`), and
+redefine `options.Option` as a marker interface so `...options.Option` stays
+type-safe without a generic `Apply`. Category-(b) validation is fully
+preserved.
+
+### §3.1 Alternatives considered
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| A. Harden dispatch only, keep `Apply` (Depth 1) | no interface change; dead branches stop executing (no runtime reflection) | leaves 21 orphaned `Apply` methods — the exact dead-code smell being removed | ❌ rejected |
+| B. Keep `Apply`, only drop the `reflect.TypeOf(cfg)` detail | minimal diff; reflection-free | keeps the dead assertion + redundant indirection | ❌ rejected: half-measure |
+| C. **Full: harden dispatch + delete `Apply` + marker `Option` (Depth 2)** | removes all dead assertions, all option-layer reflection, and the redundant round trip; compile-time-safe option bag | wider mechanical churn (~21 files + interface + ~10 tests); marker must be exported (§3.1 note) | ✅ chosen |
+
+**Cross-package marker constraint (why the marker is exported):** Go only
+permits a type to implement an interface's **unexported** method within the
+defining package. The 21 option types live in 7 packages, so a sealed
+`interface { isOption() }` is impossible. The marker is therefore an
+**exported** no-op method (`Option()`). It's not perfectly sealed (an external
+type could implement it) but constrains `...options.Option` to real option
+types at compile time — which is the goal; sealing against out-of-tree
+imposters is a non-concern for a gobpm-internal utility.
+
+### §3.2 Changes by file
+
+#### §3.2.1 `pkg/model/options/option.go` — marker interface
+
+```go
+// before:
+type Option interface { Apply(cfg Configurator) error }
+// after:
+type Option interface { Option() }  // marker; options apply via constructor dispatch
+```
+
+Assess `Configurator` (`interface { Validate() error }`): if still used by
+config self-validation (`cfg.Validate()` in constructors) it stays; if only
+`Apply`'s signature referenced it, it's removed. (Determined at implementation
+by grep; recorded in §8.)
+
+#### §3.2.2 The 21 option types (§2.2 inventory) — delete `Apply`, add marker
+
+Per type, mechanically: delete the `Apply` method (with its dead assertion +
+reflect), add `func (X) Option() {}`, drop the now-unused `reflect` import.
+Uniform transformation; the inventory table is the complete file list.
+
+#### §3.2.3 The dispatching constructors — direct func dispatch
+
+Split each multi-type switch case into per-type cases that call the option
+func directly; convert single-case and concrete-assertion sites likewise.
+**Preserve every category-(b) `default:` guard.**
+
+- Multi-type: `events` start (start.go:73), `events` end (end.go:68),
+  `newActivity` (activity.go:56), `flow` newSequenceFlow (sequenceflow.go:104),
+  `process.New` (process.go:63), `gateways.New` (gateway.go:120).
+- Single-case: `newTask` (task.go:36), user-task (user_task.go:105),
+  `NewItemDefinition` (item.go:97), `NewIAE` (item.go:257), `NewAssociation`
+  (association.go:98), `NewRenderer` (consinp.go:82).
+- Concrete-assertion: `newEvent` (event.go:171), `NewProp` (property.go:105),
+  `NewComplexGateway` (complex.go:210), `NewEventBasedGateway`
+  (event_based.go:134).
+
+Example (`newActivity`):
+```go
+// before:
+case ActivityOption, RoleOption, data.PropertyOption:
+	if err := o.Apply(&cfg); err != nil { ee = append(ee, err) }
+// after:
+case ActivityOption:
+	if err := o(&cfg); err != nil { ee = append(ee, err) }
+case RoleOption:      // *activityConfig implements RoleConfigurator
+	if err := o(&cfg); err != nil { ee = append(ee, err) }
+case data.PropertyOption:  // *activityConfig implements PropertyAdder
+	if err := o(&cfg); err != nil { ee = append(ee, err) }
+```
+
+#### §3.2.4 `pkg/model/foundation/base.go` — switch-harden `NewBaseElement`
+
+Convert the polymorphic `for … { o.Apply(&bc) }` loop to
+`switch o := opt.(type) { case BaseOption: bo(&bc); default: <reject> }`. The
+new explicit `default:` replaces the base-layer catch-all that
+`BaseOption.Apply`'s dead assertion currently provided (§2.4, §6.1).
+
+#### §3.2.5 Test call sites — update `.Apply(...)`
+
+~10 sites call `.Apply(...)` directly: `property_test.go:87-128`,
+`options_test.go:51-64`, `base_test.go:60`, `complex_test.go:113`,
+`event_based_test.go:229`, and the `receive/send` internal tests. Update to
+call the underlying func (or assert the marker). Enumerated exactly at
+implementation.
+
+---
+
+## §4 Verification
+
+Coverage: this is a behavior-preserving refactor — the existing constructor
+tests are the regression net.
+
+### §4.1 Regression tests
+
+#### §4.1.1 Behavior unchanged — existing constructor suites pass
+
+**Existing:** every `New*` constructor test across `pkg/model` (activities,
+events, data, gateways, flow, foundation, process, consinp). A valid option set
+must build the same object; assertions on the built object are unchanged.
+
+#### §4.1.2 Category-(b) misuse still rejected
+
+**Existing / augment:** passing an option a constructor doesn't accept still
+returns an "invalid option type" error (the (b) guards). Where a package lacks
+such a test, add one (e.g. `NewServiceTask("x", op, <a gateway option>)` →
+error).
+
+#### §4.1.3 Compile-time safety of the marker
+
+`New("x", 42)` (a non-option) must **fail to compile** under the marker
+interface. Not a runtime test — noted as a property; verified by the
+`go build ./...` gate (an accidental `...Option` = `...any` regression would
+let non-options through).
+
+### §4.5 Observability
+
+None — no behavior change; the win is dead-code + reflection removal, visible
+in the diff and a `grep -rn "reflect" pkg/model` going quiet on the option
+layer.
+
+---
+
+## §5 Prevention
+
+- **Doc comment on `options.Option`**: it is a compile-time marker; options are
+  applied by each constructor's type-switch calling the option's concrete func
+  — there is no generic `Apply`. New option types add the marker + their func;
+  new constructors dispatch by direct func call (follow `NewReceiveTask` /
+  `NewServiceTask`), never reintroduce an `Apply(Configurator)` round trip.
+- **Canary:** the category-(b) misuse tests (§4.1.2) + the `go build` marker
+  constraint (§4.1.3).
+
+---
+
+## §6 Regressions / side-effects
+
+### §6.1 What may rely on the old behaviour
+
+- **`foundation.NewBaseElement` base-layer rejection** — options that leaked
+  past a guardless constructor were caught here by `BaseOption.Apply`'s failure.
+  The switch-hardening MUST add an explicit `default:` reject to preserve it
+  (§3.2.4). Audit: `grep -rn "NewBaseElement\|baseOpts" pkg/model` to confirm no
+  path depends on the old silent-collect-then-reject flow.
+- **Any external caller of `options.Option.Apply`** — grep `grep -rn "\.Apply(" pkg internal`
+  confirmed all call sites are in-tree constructors/tests; deleting `Apply`
+  breaks nothing outside those (updated in §3.2.3/§3.2.5).
+- **`Configurator`** — if it becomes unused after `Apply` deletion, remove it;
+  if config self-validation still uses it, keep. Confirm pre-landing.
+
+### §6.2 Rollback path
+
+Single-commit revert (or a small stack of stage commits). No data/migration.
+
+### §6.3 Cross-team backlog
+
+None — `pkg/model/options` and its consumers are all in-repo.
+
+---
+
+## §7 Related
+
+- **[FIX-019]** (string-typed reflection-free `errs` details) — surfaced these
+  `reflect.TypeOf(cfg)` sites during its call-site migration; FIX-019
+  deliberately left them for this FIX.
+- **Precedent:** the `eventConfig` fold (this session) — folded per-adder
+  assertions into the `eventConfig` interface so `WithXxxTrigger` calls
+  `cfg.setXxx` directly. Same "compile-enforce, delete the runtime assertion"
+  move, one layer down. FIX-020 completes it at the `options.Option` layer.
+- **Reference implementations:** `NewReceiveTask` / `NewSendTask` already use
+  direct func dispatch — the target pattern.
+- **Promote-to-ADR candidate:** the invariant "model options apply via
+  constructor type-switch + direct func call; `options.Option` is a marker, not
+  a generic applicator" could promote to a small ADR if a third options-related
+  decision appears.
+
+---
+
+## §8 Implementation summary (stage-by-stage actual landings + deltas vs draft)
+
+> ⚠️ TODO: fill AFTER landing.
+
+### §8.1 Stages by commit (branch `test/harden-core-coverage`)
+| Stage | Commit | Scope | Tests |
+|---|---|---|---|
+| 1 | `<sha>` | marker interface + delete 21 `Apply` methods | build gate |
+| 2 | `<sha>` | harden ~18 constructors + `NewBaseElement` switch | constructor suites |
+| 3 | `<sha>` | update ~10 test call sites | — |
+
+### §8.2 Empirical findings — where reality diverged from the §3 draft
+> ⚠️ TODO: e.g. `Configurator` kept-or-removed; any interface-typed option whose
+> config did NOT implement the interface (would break the direct-call harden);
+> any constructor lacking a (b) guard that needed one added.
+
+### §8.3 Backlog (out of FIX-020 scope)
+> ⚠️ TODO.
+
+[FIX-019]: FIX-019-errs-string-typed-details.md

--- a/docs/fix/FIX-020-option-dispatch-hardening.md
+++ b/docs/fix/FIX-020-option-dispatch-hardening.md
@@ -1,7 +1,7 @@
 # FIX-020 «Every option type carries a dead config-type assertion (with reflection) in its `Apply` method»
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft v.1 (2026-07-04, branch `test/harden-core-coverage`, not yet implemented).
+**Status:** Accepted (2026-07-04, branch `test/harden-core-coverage`, landed `8aacd72`).
 **Date:** 2026-07-04.
 **Author:** dr-dobermann.
 **Branch:** `test/harden-core-coverage` (folded into the in-flight core-hardening work; surfaced during [FIX-019] while making error paths reflection-free).
@@ -320,21 +320,37 @@ None — `pkg/model/options` and its consumers are all in-repo.
 
 ## §8 Implementation summary (stage-by-stage actual landings + deltas vs draft)
 
-> ⚠️ TODO: fill AFTER landing.
-
 ### §8.1 Stages by commit (branch `test/harden-core-coverage`)
 | Stage | Commit | Scope | Tests |
 |---|---|---|---|
-| 1 | `<sha>` | marker interface + delete 21 `Apply` methods | build gate |
-| 2 | `<sha>` | harden ~18 constructors + `NewBaseElement` switch | constructor suites |
-| 3 | `<sha>` | update ~10 test call sites | — |
+| 1 | `8aacd72` | marker `Option()` interface; deleted all 21 `Apply` methods; hardened ~18 constructors + `NewBaseElement` (switch + explicit reject); updated ~10 `.Apply` test call sites — landed atomically (the interface change ripples through all of it) | constructor suites unchanged; net −179 lines |
+| — | `8bbfa46` | error-path tests (see §8.2) | instance/thresher/eventhub |
+
+The 3 draft stages could not be separately-green: changing `options.Option` to
+the marker breaks every constructor that still calls `.Apply` until they all
+switch to direct dispatch, so it lands as one commit.
 
 ### §8.2 Empirical findings — where reality diverged from the §3 draft
-> ⚠️ TODO: e.g. `Configurator` kept-or-removed; any interface-typed option whose
-> config did NOT implement the interface (would break the direct-call harden);
-> any constructor lacking a (b) guard that needed one added.
+- **`Configurator` kept.** After deleting the `Apply` signatures, `Configurator`
+  is still referenced (embedded by `NameConfigurator`/`RoleConfigurator`/
+  `PropertyAdder`/`IAEAdder`/`eventConfig`; each config's `Validate()` is called
+  by its constructor), so it stays.
+- **All 5 interface-typed options compiled directly** — no config failed to
+  implement the required interface; the hardening had no exceptions.
+- **`errorClass` orphaned in `options`.** Deleting `NameOption.Apply` left
+  `options.errorClass` unused (golangci-lint `unused`); removed it. (No other
+  package's `errorClass` was affected — all still used by real errors.)
+- **Diff-coverage detour (`8bbfa46`).** The branch-wide diff-coverage gate
+  (measured vs `origin/master`, so it spans FIX-019+FIX-020) flagged 7 FIX-019
+  diagnostic-detail lines in error branches that were only *flakily* covered by
+  integration tests (FIX-019's own gate got lucky). Added deterministic unit
+  tests for `instance.Run`/`PropagateEvent` guards, `thresher.PropagateEvent`'s
+  hub-failure, and `eventhub`'s `Process`/`AddEventProcessor` failures → 96.8%.
 
 ### §8.3 Backlog (out of FIX-020 scope)
-> ⚠️ TODO.
+- Category-(b) constructor guards still reflect on the misused option
+  (`reflect.TypeOf(o).String()`); left in place (reachable input validation on a
+  cold misuse path, not a runtime hot path). De-reflecting them is a possible
+  follow-up.
 
 [FIX-019]: FIX-019-errs-string-typed-details.md

--- a/internal/eventproc/eventhub/eventhub.go
+++ b/internal/eventproc/eventhub/eventhub.go
@@ -236,7 +236,7 @@ func (eh *EventHub) registerWaiter(
 				errs.C(errorClass, errs.OperationFailed),
 				errs.D("waiter_id", w.ID()),
 				errs.D("event_definition_id", eDef.ID()),
-				errs.D("event_definition_type", eDef.Type()),
+				errs.D("event_definition_type", string(eDef.Type())),
 				errs.D("event_processor_id", ep.ID()))
 		}
 
@@ -403,7 +403,7 @@ func (eh *EventHub) UnregisterEvent(
 					errs.C(errorClass, errs.OperationFailed),
 					errs.D("waiter_id", w.ID()),
 					errs.D("event_definition_idf", w.EventDefinition().ID()),
-					errs.D("event_definition_type", w.EventDefinition().Type()))
+					errs.D("event_definition_type", string(w.EventDefinition().Type())))
 			}
 		}
 
@@ -475,7 +475,7 @@ func (eh *EventHub) PropagateEvent(
 			errs.C(errorClass, errs.OperationFailed),
 			errs.D("waiter_id", w.ID()),
 			errs.D("event_definition_id", eDef.ID()),
-			errs.D("event_definition_type", eDef.Type()),
+			errs.D("event_definition_type", string(eDef.Type())),
 			errs.E(err))
 	}
 

--- a/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
+++ b/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
@@ -1,0 +1,61 @@
+package eventhub
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/internal/enginert"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPropagateEventProcessError covers EventHub.PropagateEvent's
+// waiter-failure branch: a non-signal event with a registered waiter whose
+// Process fails yields a wrapped "processing failed" error.
+func TestPropagateEventProcessError(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	// a non-signal definition (terminate) is routed to eh.waiters[id].Process
+	def, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	w := mockeventproc.NewMockEventWaiter(t)
+	w.EXPECT().Process(mock.Anything).Return(errors.New("process boom"))
+	w.EXPECT().ID().Return("mock-waiter")
+
+	hub.m.Lock()
+	hub.waiters[def.ID()] = w
+	hub.m.Unlock()
+
+	require.Error(t, hub.PropagateEvent(context.Background(), def))
+}
+
+// TestRegisterEventAddProcessorError covers EventHub.RegisterEvent's
+// add-processor failure branch: when a waiter already exists for the event and
+// AddEventProcessor fails, the error is wrapped and returned.
+func TestRegisterEventAddProcessorError(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	def, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().ID().Return("ep-1").Maybe()
+
+	w := mockeventproc.NewMockEventWaiter(t)
+	w.EXPECT().AddEventProcessor(ep).Return(errors.New("add boom"))
+	w.EXPECT().ID().Return("w-1").Maybe()
+
+	hub.m.Lock()
+	hub.waiters[def.ID()] = w
+	hub.m.Unlock()
+
+	require.Error(t, hub.RegisterEvent(ep, def))
+}

--- a/internal/eventproc/eventhub/waiters/message.go
+++ b/internal/eventproc/eventhub/waiters/message.go
@@ -2,7 +2,6 @@ package waiters
 
 import (
 	"context"
-	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -87,7 +86,7 @@ func NewMessageWaiter(
 			errs.New(
 				errs.M("not a MessageEventDefinition"),
 				errs.C(MessageWaiterError, errs.TypeCastingError),
-				errs.D("event_definition_type", reflect.TypeOf(eDefI)))
+				errs.D("event_definition_type", string(eDefI.Type())))
 	}
 
 	msg := eDef.Message()
@@ -183,7 +182,7 @@ func (mw *messageWaiter) Process(eDef flow.EventDefinition) error {
 		errs.M("messageWaiter doesn't process propagated EventDefinitions"),
 		errs.C(MessageWaiterError, errs.InvalidState),
 		errs.D("event_definition_id", eDef.ID()),
-		errs.D("event_definition_type", eDef.Type()))
+		errs.D("event_definition_type", string(eDef.Type())))
 }
 
 // Service subscribes the broker for the waiter's message name and starts the
@@ -215,7 +214,7 @@ func (mw *messageWaiter) Service(ctx context.Context) error {
 		return errs.New(
 			errs.M("waiter isn't ready to start"),
 			errs.C(MessageWaiterError, errs.InvalidState),
-			errs.D("current_state", mw.state))
+			errs.D("current_state", mw.state.String()))
 	}
 
 	sub, err := mw.rt.MessageBroker().Subscribe(ctx, mw.name, mw.subscriptionKeys()...)
@@ -364,7 +363,7 @@ func (mw *messageWaiter) Stop() error {
 		return errs.New(
 			errs.M("couldn't stop a not-runned waiter"),
 			errs.C(MessageWaiterError, errs.InvalidState),
-			errs.D("current_state", mw.state))
+			errs.D("current_state", mw.state.String()))
 	}
 
 	mw.state = eventproc.WSStopped

--- a/internal/eventproc/eventhub/waiters/signal.go
+++ b/internal/eventproc/eventhub/waiters/signal.go
@@ -3,7 +3,6 @@ package waiters
 import (
 	"context"
 	"errors"
-	"reflect"
 	"slices"
 	"strings"
 	"sync"
@@ -66,7 +65,7 @@ func NewSignalWaiter(
 			errs.New(
 				errs.M("not a SignalEventDefinition"),
 				errs.C(SignalWaiterError, errs.TypeCastingError),
-				errs.D("event_definition_type", reflect.TypeOf(eDefI)))
+				errs.D("event_definition_type", string(eDefI.Type())))
 	}
 
 	sig := eDef.Signal()
@@ -174,7 +173,7 @@ func (sw *signalWaiter) Service(ctx context.Context) error {
 		return errs.New(
 			errs.M("waiter isn't ready to start"),
 			errs.C(SignalWaiterError, errs.InvalidState),
-			errs.D("current_state", sw.state))
+			errs.D("current_state", sw.state.String()))
 	}
 
 	sw.ctx = ctx

--- a/internal/eventproc/eventhub/waiters/timer.go
+++ b/internal/eventproc/eventhub/waiters/timer.go
@@ -5,8 +5,8 @@ package waiters
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -62,7 +62,7 @@ func NewTimeWaiter(
 			errs.New(
 				errs.M("not an TimerEventDefinition"),
 				errs.C(TimerWaiterError, errs.TypeCastingError),
-				errs.D("event_definition_type", reflect.TypeOf(eDefI)))
+				errs.D("event_definition_type", string(eDefI.Type())))
 	}
 
 	id = strings.TrimSpace(id)
@@ -249,8 +249,8 @@ func (tw *timeWaiter) Service(ctx context.Context) error {
 		return errs.New(
 			errs.M("waiter isn't ready to start"),
 			errs.C(TimerWaiterError, errs.InvalidState),
-			errs.D("current_state", tw.state),
-			errs.D("expected_state", eventproc.WSReady))
+			errs.D("current_state", tw.state.String()),
+			errs.D("expected_state", eventproc.WSReady.String()))
 	}
 
 	tw.state = eventproc.WSRunned
@@ -268,9 +268,9 @@ func (tw *timeWaiter) Service(ctx context.Context) error {
 			errs.M("waiter duration is not positive"),
 			errs.C(TimerWaiterError, errs.InvalidState),
 			errs.D("waiter_id", tw.ID()),
-			errs.D("next_time", tw.next),
-			errs.D("duration", tw.duration),
-			errs.D("cycles", tw.cyclesLeft))
+			errs.D("next_time", tw.next.String()),
+			errs.D("duration", tw.duration.String()),
+			errs.D("cycles", strconv.Itoa(tw.cyclesLeft)))
 	}
 
 	tw.stopCh = make(chan struct{})
@@ -406,7 +406,7 @@ func (tw *timeWaiter) Stop() error {
 		return errs.New(
 			errs.M("couldn't stop not runned waiter"),
 			errs.C(TimerWaiterError, errs.InvalidState),
-			errs.D("current_state", tw.state))
+			errs.D("current_state", tw.state.String()))
 	}
 
 	tw.state = eventproc.WSStopped

--- a/internal/eventproc/eventhub/waiters/timer_test.go
+++ b/internal/eventproc/eventhub/waiters/timer_test.go
@@ -509,8 +509,8 @@ func TestTimerWaiterServiceRejectsNonReady(t *testing.T) {
 
 	require.True(t, errors.As(err, &ae))
 	require.True(t, ae.HasClass(errs.InvalidState))
-	require.Equal(t, eventproc.WSRunned, ae.Details["current_state"])
-	require.Equal(t, eventproc.WSReady, ae.Details["expected_state"])
+	require.Equal(t, eventproc.WSRunned.String(), ae.Details["current_state"])
+	require.Equal(t, eventproc.WSReady.String(), ae.Details["expected_state"])
 }
 
 // TestTimerWaiterServiceRejectsElapsedTimer covers Service's non-positive

--- a/internal/eventproc/eventhub/waiters/waiters.go
+++ b/internal/eventproc/eventhub/waiters/waiters.go
@@ -74,7 +74,7 @@ func CreateWaiter(
 				eDef.Type()),
 			errs.C(errorClass, errs.ObjectNotFound),
 			errs.D("event_definition_id", eDef.ID()),
-			errs.D("event_definition_type", eDef.Type()))
+			errs.D("event_definition_type", string(eDef.Type())))
 	}
 
 	return w, err
@@ -128,6 +128,6 @@ func CreatePersistentWaiter(
 				"instance-starter, got %s", eDef.Type()),
 			errs.C(errorClass, errs.InvalidParameter),
 			errs.D("event_definition_id", eDef.ID()),
-			errs.D("event_definition_type", eDef.Type()))
+			errs.D("event_definition_type", string(eDef.Type())))
 	}
 }

--- a/internal/instance/errpaths_test.go
+++ b/internal/instance/errpaths_test.go
@@ -1,0 +1,53 @@
+package instance_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/internal/enginert"
+	"github.com/dr-dobermann/gobpm/internal/instance"
+	"github.com/dr-dobermann/gobpm/internal/scope"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/stretchr/testify/require"
+)
+
+// TestInstanceRunRejectsNonCreated covers Instance.Run's state guard: Run is
+// only valid from the Created state, so a second Run (after the first moved the
+// instance out of Created) is rejected with an invalid-state error.
+func TestInstanceRunRejectsNonCreated(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	s, err := getSnapshot("run_rejects_non_created")
+	require.NoError(t, err)
+
+	ep := mockeventproc.NewMockEventProducer(t)
+	inst, err := instance.New(s, scope.EmptyDataPath, enginert.Default(), ep, nil)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-canceled: the first Run settles terminally, out of Created
+
+	require.NoError(t, inst.Run(ctx))
+	require.Error(t, inst.Run(context.Background()))
+}
+
+// TestInstancePropagateEventNotActive covers Instance.PropagateEvent's active
+// guard: propagating a thrown event is only valid while the instance is Active,
+// so a freshly-created (not yet run) instance rejects it.
+func TestInstancePropagateEventNotActive(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	s, err := getSnapshot("propagate_not_active")
+	require.NoError(t, err)
+
+	ep := mockeventproc.NewMockEventProducer(t)
+	inst, err := instance.New(s, scope.EmptyDataPath, enginert.Default(), ep, nil)
+	require.NoError(t, err)
+
+	term, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	require.Error(t, inst.PropagateEvent(context.Background(), term))
+}

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -544,7 +544,7 @@ func (inst *Instance) Run(
 		return errs.New(
 			errs.M("invalid instance state to run"),
 			errs.C(errorClass, errs.InvalidState),
-			errs.D("current_state", inst.State()))
+			errs.D("current_state", inst.State().String()))
 	}
 
 	// Derive the instance's own cancellable context so Cancel() can terminate it
@@ -1571,7 +1571,7 @@ func (inst *Instance) PropagateEvent(
 		return errs.New(
 			errs.M("instance isn't active"),
 			errs.C(errorClass, errs.InvalidState),
-			errs.D("current_state", st),
+			errs.D("current_state", st.String()),
 			errs.D("instance_id", inst.ID()))
 	}
 
@@ -1580,7 +1580,7 @@ func (inst *Instance) PropagateEvent(
 			errs.M("event propagation failed"),
 			errs.C(errorClass, errs.OperationFailed),
 			errs.D("event_definition_id", eDef.ID()),
-			errs.D("event_definition_type", eDef.Type()),
+			errs.D("event_definition_type", string(eDef.Type())),
 			errs.E(err))
 	}
 

--- a/internal/instance/track.go
+++ b/internal/instance/track.go
@@ -941,7 +941,7 @@ func (t *track) unregisterEvent(n flow.Node) error {
 				errs.C(errorClass, errs.OperationFailed),
 				errs.D("track_id", t.ID()),
 				errs.D("event_definition_id", eDef.ID()),
-				errs.D("event_definition_type", eDef.Type()),
+				errs.D("event_definition_type", string(eDef.Type())),
 				errs.E(err))
 		}
 	}

--- a/pkg/errs/error_options.go
+++ b/pkg/errs/error_options.go
@@ -12,7 +12,7 @@ const (
 type (
 	errConfig struct {
 		err     error
-		details map[string]any
+		details map[string]string
 		msg     string
 		classes []string
 	}
@@ -92,8 +92,12 @@ func C(classes ...string) errOption {
 	return errFunc(f)
 }
 
-// D adds the errConfig details.
-func D(k string, v any) errOption {
+// D adds a key/value diagnostic detail to the errConfig. The value is a
+// pre-stringified string: errs stores and renders details without reflection
+// or boxing, keeping error construction cheap on hot paths (FIX-019). Callers
+// stringify non-string values explicitly (strconv.Itoa, string(namedType),
+// x.ID()) — do not reintroduce `any` here.
+func D(k, v string) errOption {
 	f := func(cfg *errConfig) error {
 		k = strings.Trim(k, " ")
 		if k != "" && v != "" {

--- a/pkg/errs/errors.go
+++ b/pkg/errs/errors.go
@@ -60,10 +60,13 @@ const (
 
 // ApplicationError represents a structured application error with classes, message, and details.
 type ApplicationError struct {
-	Err     error          `json:"error"`
-	Details map[string]any `json:"details"`
-	Message string         `json:"message"`
-	Classes []string       `json:"classes"`
+	Err error `json:"error"`
+	// Details are pre-stringified diagnostic key/values. Keeping them string
+	// (not any) makes error construction allocation-lean and Error()/JSON()
+	// reflection-free — and makes JSON() infallible (FIX-019).
+	Details map[string]string `json:"details"`
+	Message string            `json:"message"`
+	Classes []string          `json:"classes"`
 }
 
 // New returns pointer on created with errOptions ApplicationError.
@@ -72,7 +75,7 @@ func New(errOpts ...errOption) *ApplicationError {
 		err:     nil,
 		msg:     defaultMessage,
 		classes: []string{},
-		details: map[string]any{},
+		details: map[string]string{},
 	}
 
 	ee := make([]error, 0, len(errOpts)+1)
@@ -102,41 +105,52 @@ func (ae *ApplicationError) HasClass(class string) bool {
 	return false
 }
 
-// JSON returns the json representation of the ApplicationError ae.
-// On failure it panics.
-func (ae *ApplicationError) JSON() []byte {
-	js, err := json.Marshal(ae)
-	if err != nil {
-		Panic("couldn't convert application error to json: " + err.Error())
-		return nil
-	}
-
-	return js
+// JSON returns the JSON representation of the ApplicationError ae. It neither
+// panics nor swallows the marshal error — it propagates it, as a library
+// should. With Details map[string]string and scalar/slice-of-scalar fields the
+// error is unreachable in practice (FIX-019), but surfacing it keeps the
+// contract honest rather than hiding a theoretical failure.
+func (ae *ApplicationError) JSON() ([]byte, error) {
+	return json.Marshal(ae)
 }
 
-// Error returns a string representation of the ApplicationError.
+// Error returns a string representation of the ApplicationError. It builds the
+// text with a strings.Builder and plain string writes — no fmt/reflection —
+// since every part (classes, message, details, wrapped error) is already a
+// string (FIX-019).
 func (ae *ApplicationError) Error() string {
-	str := ""
+	var b strings.Builder
+
 	if len(ae.Classes) > 0 {
-		str += "Classes: [" + strings.Join(ae.Classes, ", ") + "]\n"
+		b.WriteString("Classes: [")
+		b.WriteString(strings.Join(ae.Classes, ", "))
+		b.WriteString("]\n")
 	}
 
 	if ae.Message != "" {
-		str += "Message: " + strings.Trim(ae.Message, " ") + "\n"
+		b.WriteString("Message: ")
+		b.WriteString(strings.Trim(ae.Message, " "))
+		b.WriteString("\n")
 	}
 
 	if len(ae.Details) > 0 {
-		str += "Details:\n"
+		b.WriteString("Details:\n")
 		for k, v := range ae.Details {
-			str += fmt.Sprintf(" %s: %v\n", k, v)
+			b.WriteString(" ")
+			b.WriteString(k)
+			b.WriteString(": ")
+			b.WriteString(v)
+			b.WriteString("\n")
 		}
 	}
 
 	if ae.Err != nil {
-		str += fmt.Errorf("Error: %w", ae.Err).Error() + "\n"
+		b.WriteString("Error: ")
+		b.WriteString(ae.Err.Error())
+		b.WriteString("\n")
 	}
 
-	return str
+	return b.String()
 }
 
 func (ae *ApplicationError) Unwrap() error {
@@ -156,10 +170,10 @@ func (ae ApplicationError) MarshalJSON() ([]byte, error) {
 
 	return json.Marshal(
 		struct {
-			Details map[string]any `json:"details"`
-			Err     string         `json:"error"`
-			Message string         `json:"message"`
-			Classes []string       `json:"classes"`
+			Details map[string]string `json:"details"`
+			Err     string            `json:"error"`
+			Message string            `json:"message"`
+			Classes []string          `json:"classes"`
 		}{
 			Err:     errS,
 			Message: ae.Message,

--- a/pkg/errs/errors_test.go
+++ b/pkg/errs/errors_test.go
@@ -37,8 +37,9 @@ func TestJson(t *testing.T) {
 		errs.E(fmt.Errorf("test error")),
 		errs.D("name", "value"))
 
-	js := string(ae.JSON())
-	require.Equal(t, testJson, js)
+	jsBytes, err := ae.JSON()
+	require.NoError(t, err)
+	require.Equal(t, testJson, string(jsBytes))
 }
 
 func TestDontPanic(t *testing.T) {

--- a/pkg/errs/helpers_test.go
+++ b/pkg/errs/helpers_test.go
@@ -1,0 +1,49 @@
+package errs_test
+
+import (
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCheckStr covers both branches of CheckStr plus the class trimming: a
+// non-empty string passes, an empty one fails with the message and only the
+// non-blank classes.
+func TestCheckStr(t *testing.T) {
+	require.NoError(t, errs.CheckStr("non-empty", "should not fail"))
+
+	err := errs.CheckStr("", "value is required", "MY_CLASS", "  ", "")
+	require.Error(t, err)
+
+	var ae *errs.ApplicationError
+	require.ErrorAs(t, err, &ae)
+	require.Equal(t, "value is required", ae.Message)
+	require.Equal(t, []string{"MY_CLASS"}, ae.Classes)
+}
+
+// TestHasClass covers the present and absent branches of HasClass.
+func TestHasClass(t *testing.T) {
+	ae := errs.New(errs.M("boom"), errs.C("ALPHA", "BETA"))
+
+	require.True(t, ae.HasClass("ALPHA"))
+	require.True(t, ae.HasClass("BETA"))
+	require.False(t, ae.HasClass("GAMMA"))
+}
+
+// TestHasPanicHandler covers both states of HasPanicHandler.
+func TestHasPanicHandler(t *testing.T) {
+	errs.DropPanicHandler()
+	require.False(t, errs.HasPanicHandler())
+
+	require.NoError(t, errs.RegisterPanicHandler(func(any) bool { return false }))
+	require.True(t, errs.HasPanicHandler())
+
+	errs.DropPanicHandler()
+	require.False(t, errs.HasPanicHandler())
+}
+
+// TestUnwrapNil covers ApplicationError.Unwrap when no error is wrapped.
+func TestUnwrapNil(t *testing.T) {
+	require.Nil(t, errs.New(errs.M("no wrapped error")).Unwrap())
+}

--- a/pkg/model/activities/activity.go
+++ b/pkg/model/activities/activity.go
@@ -52,8 +52,18 @@ func newActivity(
 
 	for _, opt := range actOpts {
 		switch o := opt.(type) {
-		case ActivityOption, RoleOption, data.PropertyOption:
-			if err := o.Apply(&cfg); err != nil {
+		case ActivityOption:
+			if err := o(&cfg); err != nil {
+				ee = append(ee, err)
+			}
+
+		case RoleOption: // *activityConfig implements RoleConfigurator
+			if err := o(&cfg); err != nil {
+				ee = append(ee, err)
+			}
+
+		case data.PropertyOption: // *activityConfig implements PropertyAdder
+			if err := o(&cfg); err != nil {
 				ee = append(ee, err)
 			}
 

--- a/pkg/model/activities/activity.go
+++ b/pkg/model/activities/activity.go
@@ -50,22 +50,22 @@ func newActivity(
 
 	ee := []error{}
 
+	addErr := func(err error) {
+		if err != nil {
+			ee = append(ee, err)
+		}
+	}
+
 	for _, opt := range actOpts {
 		switch o := opt.(type) {
 		case ActivityOption:
-			if err := o(&cfg); err != nil {
-				ee = append(ee, err)
-			}
+			addErr(o(&cfg))
 
 		case RoleOption: // *activityConfig implements RoleConfigurator
-			if err := o(&cfg); err != nil {
-				ee = append(ee, err)
-			}
+			addErr(o(&cfg))
 
 		case data.PropertyOption: // *activityConfig implements PropertyAdder
-			if err := o(&cfg); err != nil {
-				ee = append(ee, err)
-			}
+			addErr(o(&cfg))
 
 		case foundation.BaseOption:
 			cfg.baseOpts = append(cfg.baseOpts, opt)

--- a/pkg/model/activities/activity_options.go
+++ b/pkg/model/activities/activity_options.go
@@ -1,8 +1,6 @@
 package activities
 
 import (
-	"reflect"
-
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
@@ -207,17 +205,9 @@ func WithoutParams() ActivityOption {
 
 // --------------------- options.Option interface ------------------------------
 
-// Apply converts activityOption into options.Option.
-func (ao ActivityOption) Apply(cfg options.Configurator) error {
-	if ac, ok := cfg.(*activityConfig); ok {
-		return ao(ac)
-	}
-
-	return errs.New(
-		errs.M("cfg isn't an activityConfig"),
-		errs.C(errorClass, errs.InvalidParameter, errs.TypeCastingError),
-		errs.D("cfg_type", reflect.TypeOf(cfg).String()))
-}
+// Option marks ActivityOption as an options.Option; newActivity applies it by
+// calling the func directly after its type-switch matches.
+func (ActivityOption) Option() {}
 
 // ------------------ options.Configurator interface ---------------------------
 

--- a/pkg/model/activities/activity_options.go
+++ b/pkg/model/activities/activity_options.go
@@ -180,7 +180,7 @@ func WithParameters(
 					errs.M("WithParameters: a nil parameter isn't allowed"),
 					errs.C(errorClass, errs.EmptyNotAllowed,
 						errs.InvalidParameter),
-					errs.D("direction", d))
+					errs.D("direction", string(d)))
 			}
 		}
 

--- a/pkg/model/activities/receive_task_options.go
+++ b/pkg/model/activities/receive_task_options.go
@@ -1,12 +1,5 @@
 package activities
 
-import (
-	"reflect"
-
-	"github.com/dr-dobermann/gobpm/pkg/errs"
-	"github.com/dr-dobermann/gobpm/pkg/model/options"
-)
-
 // rcvTaskConfig collects the ReceiveTask-specific options (those that don't
 // belong to the embedded task) applied at NewReceiveTask.
 type rcvTaskConfig struct {
@@ -25,19 +18,9 @@ func (*rcvTaskConfig) Validate() error {
 // via Apply (whose only failure is a wrong configurator type).
 type RcvTaskOption func(*rcvTaskConfig)
 
-// Apply applies the receive-task option to the provided configurator.
-func (o RcvTaskOption) Apply(cfg options.Configurator) error {
-	if rc, ok := cfg.(*rcvTaskConfig); ok {
-		o(rc)
-
-		return nil
-	}
-
-	return errs.New(
-		errs.M("isn't rcvTaskConfig"),
-		errs.C(errorClass, errs.TypeCastingError),
-		errs.D("cfg_type", reflect.TypeOf(cfg).String()))
-}
+// Option marks RcvTaskOption as an options.Option; NewReceiveTask applies it by
+// calling the func directly.
+func (RcvTaskOption) Option() {}
 
 // WithInstantiate marks the ReceiveTask as instantiating: a ReceiveTask with no
 // incoming sequence flow and instantiate=true starts a new process instance on

--- a/pkg/model/activities/receive_task_options_internal_test.go
+++ b/pkg/model/activities/receive_task_options_internal_test.go
@@ -6,16 +6,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestRcvTaskOption covers the rcvTaskConfig Configurator + RcvTaskOption.Apply:
-// WithInstantiate sets the flag, Validate is a no-op, and Apply rejects a
-// configurator that isn't a *rcvTaskConfig.
+// TestRcvTaskOption covers rcvTaskConfig.Validate (no-op) and RcvTaskOption:
+// WithInstantiate sets the flag when the option func is applied directly (the
+// dispatch path NewReceiveTask uses).
 func TestRcvTaskOption(t *testing.T) {
 	require.NoError(t, (&rcvTaskConfig{}).Validate())
 
 	var rc rcvTaskConfig
-	require.NoError(t, WithInstantiate().Apply(&rc))
+	WithInstantiate()(&rc)
 	require.True(t, rc.instantiate)
-
-	// a configurator of a different type is rejected.
-	require.Error(t, WithInstantiate().Apply(&usrTaskConfig{}))
 }

--- a/pkg/model/activities/role_option.go
+++ b/pkg/model/activities/role_option.go
@@ -2,9 +2,7 @@ package activities
 
 import (
 	"errors"
-	"reflect"
 
-	"github.com/dr-dobermann/gobpm/pkg/errs"
 	hi "github.com/dr-dobermann/gobpm/pkg/model/hinteraction"
 	"github.com/dr-dobermann/gobpm/pkg/model/options"
 )
@@ -19,17 +17,9 @@ type RoleConfigurator interface {
 // RoleOption is a function type for configuring role-based access control.
 type RoleOption func(cfg RoleConfigurator) error
 
-// Apply converts roleOption into options.Option.
-func (ro RoleOption) Apply(cfg options.Configurator) error {
-	if rc, ok := cfg.(RoleConfigurator); ok {
-		return ro(rc)
-	}
-
-	return errs.New(
-		errs.M("config doesn't suppurt RoleConfigurator"),
-		errs.C(errorClass, errs.TypeCastingError),
-		errs.D("config_type", reflect.TypeOf(cfg).String()))
-}
+// Option marks RoleOption as an options.Option; the dispatching constructor
+// applies it by calling the func with a config that implements RoleConfigurator.
+func (RoleOption) Option() {}
 
 // WithRoles adds unique non-nil resources into the activityConfig.
 func WithRoles(ress ...*hi.ResourceRole) RoleOption {

--- a/pkg/model/activities/send_task_options.go
+++ b/pkg/model/activities/send_task_options.go
@@ -1,11 +1,7 @@
 package activities
 
 import (
-	"reflect"
-
-	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
-	"github.com/dr-dobermann/gobpm/pkg/model/options"
 )
 
 // sndTaskConfig collects the SendTask-specific options (those that don't belong
@@ -24,19 +20,9 @@ func (*sndTaskConfig) Validate() error {
 // options and applies them to the SendTask itself.
 type SndTaskOption func(*sndTaskConfig)
 
-// Apply applies the send-task option to the provided configurator.
-func (o SndTaskOption) Apply(cfg options.Configurator) error {
-	if sc, ok := cfg.(*sndTaskConfig); ok {
-		o(sc)
-
-		return nil
-	}
-
-	return errs.New(
-		errs.M("isn't sndTaskConfig"),
-		errs.C(errorClass, errs.TypeCastingError),
-		errs.D("cfg_type", reflect.TypeOf(cfg).String()))
-}
+// Option marks SndTaskOption as an options.Option; NewSendTask applies it by
+// calling the func directly.
+func (SndTaskOption) Option() {}
 
 // WithCorrelationKey declares the CorrelationKey the SendTask correlates its
 // outgoing message on (ADR-016 v.1 §2.2): Send derives the key from the message

--- a/pkg/model/activities/send_task_options_internal_test.go
+++ b/pkg/model/activities/send_task_options_internal_test.go
@@ -7,18 +7,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestSndTaskOption covers the sndTaskConfig Configurator + SndTaskOption.Apply:
-// WithCorrelationKey sets the key, Validate is a no-op, and Apply rejects a
-// configurator that isn't a *sndTaskConfig.
+// TestSndTaskOption covers sndTaskConfig.Validate (no-op) and SndTaskOption:
+// WithCorrelationKey sets the key when the option func is applied directly (the
+// dispatch path NewSendTask uses).
 func TestSndTaskOption(t *testing.T) {
 	require.NoError(t, (&sndTaskConfig{}).Validate())
 
 	key := &bpmncommon.CorrelationKey{Name: "orderKey"}
 
 	var sc sndTaskConfig
-	require.NoError(t, WithCorrelationKey(key).Apply(&sc))
+	WithCorrelationKey(key)(&sc)
 	require.Same(t, key, sc.correlationKey)
-
-	// a configurator of a different type is rejected.
-	require.Error(t, WithCorrelationKey(key).Apply(&rcvTaskConfig{}))
 }

--- a/pkg/model/activities/task.go
+++ b/pkg/model/activities/task.go
@@ -33,7 +33,7 @@ func newTask(
 	for _, to := range taskOpts {
 		switch o := to.(type) {
 		case taskOption:
-			err := o.Apply(&mInst)
+			err := o(&mInst)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/model/activities/task_options.go
+++ b/pkg/model/activities/task_options.go
@@ -1,9 +1,6 @@
 package activities
 
 import (
-	"reflect"
-
-	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/options"
 )
 
@@ -18,17 +15,9 @@ func (mi *multyInstance) Validate() error {
 // taskOption is task Task option configurator.
 type taskOption func(cfg *multyInstance) error
 
-// Apply implements options.Option interface for the taskOption.
-func (to taskOption) Apply(cfg options.Configurator) error {
-	if mi, ok := cfg.(*multyInstance); ok {
-		return to(mi)
-	}
-
-	return errs.New(
-		errs.M("not a multyInstance task config: %s",
-			reflect.TypeOf(cfg).String()),
-		errs.C(errorClass, errs.TypeCastingError))
-}
+// Option marks taskOption as an options.Option; newTask applies it by calling
+// the func directly after its type-switch matches.
+func (taskOption) Option() {}
 
 // WithMultyInstance sets multyinstance flag of the Task.
 func WithMultyInstance() options.Option {

--- a/pkg/model/activities/user_task.go
+++ b/pkg/model/activities/user_task.go
@@ -102,7 +102,7 @@ func NewUserTask(
 			utc.taskOpts = append(utc.taskOpts, opt)
 
 		case UsrTaskOption:
-			if err := opt.Apply(&utc); err != nil {
+			if err := opt(&utc); err != nil {
 				return nil,
 					errs.New(
 						errs.M("UserTask option applying failed"),

--- a/pkg/model/activities/user_task_options.go
+++ b/pkg/model/activities/user_task_options.go
@@ -2,7 +2,6 @@ package activities
 
 import (
 	"fmt"
-	"reflect"
 	"slices"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
@@ -228,17 +227,9 @@ func WithOutput(name, pType string, required bool) UsrTaskOption {
 
 // --------------------- options.Option interface ------------------------------
 
-// Apply applies the user task option to the provided configurator.
-func (uto UsrTaskOption) Apply(cfg options.Configurator) error {
-	if utc, ok := cfg.(*usrTaskConfig); ok {
-		return uto(utc)
-	}
-
-	return errs.New(
-		errs.M("isn't usrTaskConfig"),
-		errs.C(errorClass, errs.TypeCastingError),
-		errs.D("cfg_type", reflect.TypeOf(cfg).String()))
-}
+// Option marks UsrTaskOption as an options.Option; newUserTask applies it by
+// calling the func directly after its type-switch matches.
+func (UsrTaskOption) Option() {}
 
 // ------------------ options.Configurator interface ---------------------------
 

--- a/pkg/model/artifacts/artifact_test.go
+++ b/pkg/model/artifacts/artifact_test.go
@@ -93,3 +93,17 @@ func TestGroup(t *testing.T) {
 		require.Equal(t, groupName, group.CategoryValue.Value)
 	})
 }
+
+// TestNewGroupBaseElementError covers NewGroup's base-element build-failure
+// branch: an invalid base option (empty explicit id) fails NewBaseElement.
+func TestNewGroupBaseElementError(t *testing.T) {
+	_, err := artifacts.NewGroup("cat", foundation.WithID(""))
+	require.Error(t, err)
+}
+
+// TestMustGroupPanics covers MustGroup's panic branch on a NewGroup failure.
+func TestMustGroupPanics(t *testing.T) {
+	require.Panics(t, func() {
+		artifacts.MustGroup("cat", foundation.WithID(""))
+	})
+}

--- a/pkg/model/artifacts/category.go
+++ b/pkg/model/artifacts/category.go
@@ -47,10 +47,6 @@ func (c *Category) Name() string {
 // binds the added CategoryValue to the Category.
 // It returns a number of added CategoryValues.
 func (c *Category) AddCategoryValues(cvv ...*CategoryValue) int {
-	if c.categoryValues == nil {
-		c.categoryValues = map[string]*CategoryValue{}
-	}
-
 	n := 0
 	for _, cv := range cvv {
 		if cv == nil {
@@ -70,12 +66,6 @@ func (c *Category) AddCategoryValues(cvv ...*CategoryValue) int {
 // and for removed ones clears its binding to Category.
 // It returns a number of removed elements.
 func (c *Category) RemoveCategoryValues(cvVals ...string) int {
-	if c.categoryValues == nil {
-		c.categoryValues = map[string]*CategoryValue{}
-
-		return 0
-	}
-
 	n := 0
 
 	for _, cvVal := range cvVals {
@@ -93,11 +83,6 @@ func (c *Category) RemoveCategoryValues(cvVals ...string) int {
 // CategoryValues returns list of copies of CategoryValues binded to Category.
 func (c *Category) CategoryValues() []CategoryValue {
 	cvv := []CategoryValue{}
-
-	if c.categoryValues == nil {
-		c.categoryValues = map[string]*CategoryValue{}
-		return cvv
-	}
 
 	for _, cv := range c.categoryValues {
 		cvv = append(cvv, *cv)
@@ -140,10 +125,6 @@ func (cv *CategoryValue) Category() *Category {
 // AddBaseElement adds BaseElements to the CategoryValue.
 // It returns a number of added BaseElements
 func (cv *CategoryValue) AddBaseElement(fee ...flow.Element) int {
-	if cv.categorizedElements == nil {
-		cv.categorizedElements = map[string]flow.Element{}
-	}
-
 	n := 0
 
 	for _, fe := range fee {
@@ -161,12 +142,6 @@ func (cv *CategoryValue) AddBaseElement(fee ...flow.Element) int {
 
 // RemoveBaseElement removes BaseElements from the CategoryValue.
 func (cv *CategoryValue) RemoveBaseElement(feeID ...string) int {
-	if cv.categorizedElements == nil {
-		cv.categorizedElements = map[string]flow.Element{}
-
-		return 0
-	}
-
 	n := 0
 
 	for _, fe := range feeID {
@@ -187,10 +162,6 @@ func (cv *CategoryValue) RemoveBaseElement(feeID ...string) int {
 // BaseElements returns a list of categorized BaseElements from CategoryValue.
 func (cv *CategoryValue) BaseElements() []flow.Element {
 	fee := []flow.Element{}
-
-	if cv.categorizedElements == nil {
-		return fee
-	}
 
 	for _, fe := range cv.categorizedElements {
 		fee = append(fee, fe)

--- a/pkg/model/artifacts/category.go
+++ b/pkg/model/artifacts/category.go
@@ -82,7 +82,7 @@ func (c *Category) RemoveCategoryValues(cvVals ...string) int {
 
 // CategoryValues returns list of copies of CategoryValues binded to Category.
 func (c *Category) CategoryValues() []CategoryValue {
-	cvv := []CategoryValue{}
+	cvv := make([]CategoryValue, 0, len(c.categoryValues))
 
 	for _, cv := range c.categoryValues {
 		cvv = append(cvv, *cv)
@@ -161,7 +161,7 @@ func (cv *CategoryValue) RemoveBaseElement(feeID ...string) int {
 
 // BaseElements returns a list of categorized BaseElements from CategoryValue.
 func (cv *CategoryValue) BaseElements() []flow.Element {
-	fee := []flow.Element{}
+	fee := make([]flow.Element, 0, len(cv.categorizedElements))
 
 	for _, fe := range cv.categorizedElements {
 		fee = append(fee, fe)

--- a/pkg/model/data/association.go
+++ b/pkg/model/data/association.go
@@ -95,7 +95,7 @@ func NewAssociation(
 	for _, o := range opts {
 		switch opt := o.(type) {
 		case asscOption:
-			if err := opt.Apply(&aCfg); err != nil {
+			if err := opt(&aCfg); err != nil {
 				ee = append(ee, err)
 			}
 

--- a/pkg/model/data/data_options.go
+++ b/pkg/model/data/data_options.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"fmt"
-	"reflect"
 	"slices"
 
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
@@ -158,13 +157,9 @@ func WithSource(iae *ItemAwareElement) options.Option {
 
 // -------------------- options.Option interface ------------------------------
 
-func (ao asscOption) Apply(cfg options.Configurator) error {
-	if aCfg, ok := cfg.(*asscConfig); ok {
-		return ao(aCfg)
-	}
-
-	return fmt.Errorf("not a asscConfig (%s)", reflect.TypeOf(cfg).String())
-}
+// Option marks asscOption as an options.Option; NewAssociation applies it by
+// calling the func directly after its type-switch matches.
+func (asscOption) Option() {}
 
 // --------------------- options.Configurator interface -----------------------
 

--- a/pkg/model/data/defensive_internal_test.go
+++ b/pkg/model/data/defensive_internal_test.go
@@ -1,0 +1,32 @@
+package data
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAssociationNilTargetGuards covers the defensive target==nil guards in the
+// Association accessors. NewAssociation rejects a nil target, so these are
+// unreachable through the public constructor — exercised here white-box via a
+// zero-value Association to prove the guards behave (no nil-dereference).
+func TestAssociationNilTargetGuards(t *testing.T) {
+	a := &Association{} // target is nil
+
+	require.False(t, a.IsReady())
+	require.Equal(t, "", a.TargetItemDefID())
+
+	_, err := a.Value(context.Background())
+	require.Error(t, err)
+}
+
+// TestAssociationCalculateNoSources covers calculate's no-sources guard: no
+// transformation and an empty source set. Unreachable through NewAssociation
+// (which requires a source or a transformation), it guards a would-be
+// index-out-of-range on SourcesIDs()[0] and returns a classified error instead.
+func TestAssociationCalculateNoSources(t *testing.T) {
+	a := &Association{} // nil transformation, empty sources
+
+	require.Error(t, a.calculate(context.Background()))
+}

--- a/pkg/model/data/goexpr/goexpr.go
+++ b/pkg/model/data/goexpr/goexpr.go
@@ -5,6 +5,7 @@ package goexpr
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
@@ -55,9 +56,8 @@ func New(
 			errs.New(
 				errs.M("result, gfunc shouldn't be empty"),
 				errs.C(errorClass, errs.InvalidParameter),
-				errs.D("data_source", ds),
-				errs.D("result", res),
-				errs.D("gex_func", gfunc))
+				errs.D("result_is_nil", strconv.FormatBool(res == nil)),
+				errs.D("gfunc_is_nil", strconv.FormatBool(gfunc == nil)))
 	}
 
 	exp, err := data.NewExpression(opts...)

--- a/pkg/model/data/hardening_test.go
+++ b/pkg/model/data/hardening_test.go
@@ -1,0 +1,88 @@
+package data_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/generated/mockdata"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/options"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNewExpression covers the natural-language Expression constructor — the
+// success path and the base-element build failure (empty id).
+func TestNewExpression(t *testing.T) {
+	e, err := data.NewExpression(foundation.WithID("expr-1"))
+	require.NoError(t, err)
+	require.Equal(t, "expr-1", e.ID())
+
+	_, err = data.NewExpression(foundation.WithID(""))
+	require.Error(t, err)
+}
+
+// TestOpposite covers the Direction reversal helper.
+func TestOpposite(t *testing.T) {
+	require.Equal(t, data.Output, data.Opposite(data.Input))
+	require.Equal(t, data.Input, data.Opposite(data.Output))
+}
+
+// TestAssociationErrorPaths covers the remaining untested guard/error branches
+// of Association construction, option validation, and source access.
+func TestAssociationErrorPaths(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	newTarget := func() *data.ItemAwareElement {
+		return data.MustItemAwareElement(
+			data.MustItemDefinition(values.NewVariable(0),
+				foundation.WithID("out")),
+			data.ReadyDataState)
+	}
+	src := func(id string, v int, st *data.SrcState) *data.ItemAwareElement {
+		return data.MustItemAwareElement(
+			data.MustItemDefinition(values.NewVariable(v),
+				foundation.WithID(id)),
+			st)
+	}
+
+	// invalid option type (neither asscOption nor foundation.BaseOption)
+	_, err := data.NewAssociation(newTarget(), options.WithName("nope"))
+	require.Error(t, err)
+
+	// WithSource: nil source, and duplicate ItemDefinition id
+	_, err = data.NewAssociation(newTarget(), data.WithSource(nil))
+	require.Error(t, err)
+
+	_, err = data.NewAssociation(newTarget(),
+		data.WithSource(src("dup", 1, data.ReadyDataState)),
+		data.WithSource(src("dup", 2, data.ReadyDataState)))
+	require.Error(t, err)
+
+	// WithTransformation: nil expression, and set twice
+	_, err = data.NewAssociation(newTarget(), data.WithTransformation(nil))
+	require.Error(t, err)
+
+	_, err = data.NewAssociation(newTarget(),
+		data.WithTransformation(mockdata.NewMockFormalExpression(t)),
+		data.WithTransformation(mockdata.NewMockFormalExpression(t)))
+	require.Error(t, err)
+
+	// UpdateSource with a nil ItemDefinition
+	a, err := data.NewAssociation(newTarget(),
+		data.WithSource(src("s", 5, data.ReadyDataState)))
+	require.NoError(t, err)
+	require.Error(t, a.UpdateSource(context.Background(), nil, false))
+
+	// Find on an unknown source id
+	_, err = a.Find(context.Background(), "missing")
+	require.Error(t, err)
+
+	// calculate on a single non-Ready source → not-ready error surfaced via Value
+	aNR, err := data.NewAssociation(newTarget(),
+		data.WithSource(src("nr", 7, data.UndefinedSrcState)))
+	require.NoError(t, err)
+	_, err = aNR.Value(context.Background())
+	require.Error(t, err)
+}

--- a/pkg/model/data/item.go
+++ b/pkg/model/data/item.go
@@ -94,7 +94,7 @@ func NewItemDefinition(
 			cfg.baseOptions = append(cfg.baseOptions, opt)
 
 		case itemOption:
-			if err := opt.Apply(&cfg); err != nil {
+			if err := o(&cfg); err != nil {
 				return nil, err
 			}
 
@@ -254,7 +254,7 @@ func NewIAE(
 			iaeC.baseOpts = append(iaeC.baseOpts, o)
 
 		case IAEOption:
-			if err := opt.Apply(&iaeC); err != nil {
+			if err := opt(&iaeC); err != nil {
 				ee = append(ee, fmt.Errorf("IAE option applying error: %w", err))
 			}
 

--- a/pkg/model/data/item_options.go
+++ b/pkg/model/data/item_options.go
@@ -2,9 +2,7 @@ package data
 
 import (
 	"fmt"
-	"reflect"
 
-	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 	"github.com/dr-dobermann/gobpm/pkg/model/options"
 )
@@ -70,16 +68,9 @@ func WithImport(imp *foundation.Import) options.Option {
 }
 
 // --------------------- options.Option interface -----------------------------
-// Apply implements ItemOption interface for itemOption functor.
-func (o itemOption) Apply(cfg options.Configurator) error {
-	if ic, ok := cfg.(*itemConfig); ok {
-		return o(ic)
-	}
-
-	return errs.New(
-		errs.M("not itemConfig: %s", reflect.TypeOf(cfg).String()),
-		errs.C(errorClass, errs.TypeCastingError))
-}
+// Option marks itemOption as an options.Option; NewItemDefinition applies it by
+// calling the func directly after its type-switch matches.
+func (itemOption) Option() {}
 
 // ------------------- options.Configurator interface -------------------------
 func (ic *itemConfig) Validate() error {
@@ -165,14 +156,9 @@ func WithIDef(iDef *ItemDefinition) IAEOption {
 
 // ------------------- options.Option interface -------------------------------
 
-// Apply runs IAEOption on given cfg if its cast to iaeConfig.
-func (iaeO IAEOption) Apply(cfg options.Configurator) error {
-	if iaeC, ok := cfg.(*iaeConfig); ok {
-		return iaeO(iaeC)
-	}
-
-	return fmt.Errorf("not IEA config (%s)", reflect.TypeOf(cfg).String())
-}
+// Option marks IAEOption as an options.Option; NewIAE applies it by calling the
+// func directly after its type-switch matches.
+func (IAEOption) Option() {}
 
 // ------------------ options.Configurator interface --------------------------
 
@@ -234,16 +220,8 @@ func WithIAE(opts ...options.Option) IAEAdderOption {
 
 // ---------------------- options.Option interface ----------------------------
 
-// Apply applies the IAEAdderOption to the provided configurator.
-func (iaeO IAEAdderOption) Apply(cfg options.Configurator) error {
-	if iaeC, ok := cfg.(IAEAdder); ok {
-		return iaeO(iaeC)
-	}
-
-	return errs.New(
-		errs.M("invlaid configuration type"),
-		errs.C(errorClass, errs.TypeCastingError),
-		errs.D("config_type", reflect.TypeOf(cfg).String()))
-}
+// Option marks IAEAdderOption as an options.Option; the constructor applies it
+// by calling the func with a config that implements IAEAdder.
+func (IAEAdderOption) Option() {}
 
 // ----------------------------------------------------------------------------

--- a/pkg/model/data/property.go
+++ b/pkg/model/data/property.go
@@ -102,7 +102,7 @@ func NewProp(name string, iaeOpt IAEAdderOption) (*Property, error) {
 		name: name,
 	}
 
-	if err := iaeOpt.Apply(&cfg); err != nil {
+	if err := iaeOpt(&cfg); err != nil {
 		return nil,
 			fmt.Errorf("property option applying error: %w", err)
 	}

--- a/pkg/model/data/property_option.go
+++ b/pkg/model/data/property_option.go
@@ -3,10 +3,8 @@ package data
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"strings"
 
-	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/options"
 )
 
@@ -68,16 +66,8 @@ func WithProperty(name string, iaeOpt IAEAdderOption) PropertyOption {
 	return PropertyOption(f)
 }
 
-// Apply applies propertyOption on to PropertyAdder configuration.
-func (po PropertyOption) Apply(cfg options.Configurator) error {
-	if pc, ok := cfg.(PropertyAdder); ok {
-		return po(pc)
-	}
-
-	return errs.New(
-		errs.M("config doesn't suppurt PropertyConfigurator"),
-		errs.C(errorClass, errs.TypeCastingError),
-		errs.D("config_type", reflect.TypeOf(cfg).String()))
-}
+// Option marks PropertyOption as an options.Option; the dispatching constructor
+// applies it by calling the func with a config that implements PropertyAdder.
+func (PropertyOption) Option() {}
 
 // -----------------------------------------------------------------------------

--- a/pkg/model/data/property_test.go
+++ b/pkg/model/data/property_test.go
@@ -42,12 +42,6 @@ func TestPropertyCloneIsDeepCopy(t *testing.T) {
 	require.Error(t, err)
 }
 
-type invldPA struct{}
-
-func (ipa *invldPA) Validate() error {
-	return nil
-}
-
 func TestProperty(t *testing.T) {
 	t.Run("errors",
 		func(t *testing.T) {
@@ -84,12 +78,9 @@ func TestProperty(t *testing.T) {
 			// invalid params
 			mpac := mockdata.NewMockPropertyAdder(t)
 			po := data.WithProperty("", nil)
-			require.Error(t, po.Apply(mpac))
+			require.Error(t, po(mpac))
 			po = data.WithProperty("no iae", nil)
-			require.Error(t, po.Apply(mpac))
-
-			var ipac invldPA
-			require.Error(t, po.Apply(&ipac))
+			require.Error(t, po(mpac))
 		})
 
 	t.Run("normal",
@@ -116,7 +107,7 @@ func TestProperty(t *testing.T) {
 					data.ReadyDataState),
 			)
 
-			err := pa.Apply(mpac)
+			err := pa(mpac)
 			require.NoError(t, err)
 			require.Contains(t, pNames, "name")
 			require.Contains(t, pNames, "age")
@@ -125,7 +116,7 @@ func TestProperty(t *testing.T) {
 			pa = data.WithProperty("sex", data.WithIAE(
 				data.WithIDefinition(values.NewVariable("male"))))
 
-			err = pa.Apply(mpac)
+			err = pa(mpac)
 			require.NoError(t, err)
 			require.Contains(t, pNames, "sex")
 		})

--- a/pkg/model/data_objects/update_test.go
+++ b/pkg/model/data_objects/update_test.go
@@ -1,0 +1,29 @@
+package dataobjects_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	dataobjects "github.com/dr-dobermann/gobpm/pkg/model/data_objects"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDataObjectUpdateNotReady covers Update's readiness guard: a DataObject
+// with no incoming association keeps its initial (non-Ready) state, so Update
+// — which would otherwise flow the value to outgoing associations — refuses
+// because the object's value was never made Ready.
+func TestDataObjectUpdateNotReady(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	do, err := dataobjects.New(
+		"not-ready-do",
+		data.MustItemDefinition(values.NewVariable(1), foundation.WithID("nr")),
+		data.UndefinedSrcState,
+		foundation.WithID("notReadyDO"))
+	require.NoError(t, err)
+
+	require.Error(t, do.Update(context.Background()))
+}

--- a/pkg/model/events/end.go
+++ b/pkg/model/events/end.go
@@ -64,8 +64,18 @@ func NewEndEvent(
 		case foundation.BaseOption:
 			ec.baseOpts = append(ec.baseOpts, opt)
 
-		case endOption, EventOption, data.PropertyOption:
-			if err := so.Apply(&ec); err != nil {
+		case endOption:
+			if err := so(&ec); err != nil {
+				ee = append(ee, err)
+			}
+
+		case EventOption: // *endConfig implements eventConfig
+			if err := so(&ec); err != nil {
+				ee = append(ee, err)
+			}
+
+		case data.PropertyOption: // *endConfig implements data.PropertyAdder
+			if err := so(&ec); err != nil {
 				ee = append(ee, err)
 			}
 

--- a/pkg/model/events/end_options.go
+++ b/pkg/model/events/end_options.go
@@ -3,7 +3,6 @@ package events
 import (
 	"errors"
 	"fmt"
-	"reflect"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
@@ -32,16 +31,9 @@ func (ec *endConfig) eventType() eventConfigType {
 
 // -------------------- options.Option interface -------------------------------
 
-// Apply implements options.Option interface for endOption.
-func (eo endOption) Apply(cfg options.Configurator) error {
-	if ec, ok := cfg.(*endConfig); ok {
-		return eo(ec)
-	}
-
-	return errs.New(
-		errs.M("not an endConfig: %s", reflect.TypeOf(cfg).String()),
-		errs.C(errorClass, errs.TypeCastingError))
-}
+// Option marks endOption as an options.Option; newEndEvent applies it by
+// calling the func directly after its type-switch matches.
+func (endOption) Option() {}
 
 // ------------------------ options.Configurator interface ---------------------
 

--- a/pkg/model/events/event.go
+++ b/pkg/model/events/event.go
@@ -168,7 +168,7 @@ func newEvent(
 
 	for _, o := range baseOpts {
 		if po, ok := o.(data.PropertyOption); ok {
-			if err := po.Apply(&pc); err != nil {
+			if err := po(&pc); err != nil {
 				return nil, errs.New(
 					errs.M("newEvent: couldn't apply a property option to "+
 						"event %q", name),

--- a/pkg/model/events/event_options.go
+++ b/pkg/model/events/event_options.go
@@ -1,8 +1,6 @@
 package events
 
 import (
-	"reflect"
-
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/options"
 )
@@ -44,16 +42,9 @@ type (
 	EventOption func(cfg eventConfig) error
 )
 
-// Apply implements options.Option interface for the EventOption.
-func (eo EventOption) Apply(cfg options.Configurator) error {
-	if ec, ok := cfg.(eventConfig); ok {
-		return eo(ec)
-	}
-
-	return errs.New(
-		errs.M("cfg isn't eventConfig: %s", reflect.TypeOf(cfg).String()),
-		errs.C(errorClass, errs.TypeCastingError))
-}
+// Option marks EventOption as an options.Option; the event constructors apply
+// it by calling the func with a config that implements eventConfig.
+func (EventOption) Option() {}
 
 // WithCancelTrigger adds a CancelEventDefinition into eventConfig.
 func WithCancelTrigger(ced *CancelEventDefinition) EventOption {

--- a/pkg/model/events/start.go
+++ b/pkg/model/events/start.go
@@ -69,8 +69,18 @@ func NewStartEvent(
 		case foundation.BaseOption:
 			sc.baseOpts = append(sc.baseOpts, opt)
 
-		case startOption, EventOption, data.PropertyOption:
-			if err := so.Apply(&sc); err != nil {
+		case startOption:
+			if err := so(&sc); err != nil {
+				ee = append(ee, err)
+			}
+
+		case EventOption: // *startConfig implements eventConfig
+			if err := so(&sc); err != nil {
+				ee = append(ee, err)
+			}
+
+		case data.PropertyOption: // *startConfig implements data.PropertyAdder
+			if err := so(&sc); err != nil {
 				ee = append(ee, err)
 			}
 

--- a/pkg/model/events/start_options.go
+++ b/pkg/model/events/start_options.go
@@ -3,7 +3,6 @@ package events
 import (
 	"errors"
 	"fmt"
-	"reflect"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
@@ -52,16 +51,9 @@ func (sc *startConfig) eventType() eventConfigType {
 
 // ------------------- options.Option interface --------------------------------
 
-// Apply implements options.Option interface for startOption.
-func (so startOption) Apply(cfg options.Configurator) error {
-	if sc, ok := cfg.(*startConfig); ok {
-		return so(sc)
-	}
-
-	return errs.New(
-		errs.M("not an startConfig: %s", reflect.TypeOf(cfg).String()),
-		errs.C(errorClass, errs.TypeCastingError))
-}
+// Option marks startOption as an options.Option; newStartEvent applies it by
+// calling the func directly after its type-switch matches.
+func (startOption) Option() {}
 
 // ------------------ data.PropertyConfigurator interface ----------------------
 

--- a/pkg/model/flow/sequenceflow.go
+++ b/pkg/model/flow/sequenceflow.go
@@ -98,17 +98,19 @@ func newSequenceFlow(
 
 	ee := []error{}
 
+	addErr := func(err error) {
+		if err != nil {
+			ee = append(ee, err)
+		}
+	}
+
 	for _, opt := range opts {
 		switch o := opt.(type) {
 		case options.NameOption: // *sflowConfig implements options.NameConfigurator
-			if err := o(&fc); err != nil {
-				ee = append(ee, err)
-			}
+			addErr(o(&fc))
 
 		case sflowOption:
-			if err := o(&fc); err != nil {
-				ee = append(ee, err)
-			}
+			addErr(o(&fc))
 
 		case foundation.BaseOption:
 			fc.baseOpts = append(fc.baseOpts, o)

--- a/pkg/model/flow/sequenceflow.go
+++ b/pkg/model/flow/sequenceflow.go
@@ -100,8 +100,13 @@ func newSequenceFlow(
 
 	for _, opt := range opts {
 		switch o := opt.(type) {
-		case options.NameOption, sflowOption:
-			if err := o.Apply(&fc); err != nil {
+		case options.NameOption: // *sflowConfig implements options.NameConfigurator
+			if err := o(&fc); err != nil {
+				ee = append(ee, err)
+			}
+
+		case sflowOption:
+			if err := o(&fc); err != nil {
 				ee = append(ee, err)
 			}
 

--- a/pkg/model/flow/sequenceflow_options.go
+++ b/pkg/model/flow/sequenceflow_options.go
@@ -1,8 +1,6 @@
 package flow
 
 import (
-	"reflect"
-
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/options"
@@ -20,16 +18,10 @@ type sflowConfig struct {
 type sflowOption func(cfg *sflowConfig) error
 
 // ---------------- options.Option interface -----------------------------------
-func (so sflowOption) Apply(cfg options.Configurator) error {
-	if fc, ok := cfg.(*sflowConfig); ok {
-		return so(fc)
-	}
 
-	return errs.New(
-		errs.M("config doesn't suppurt figurator"),
-		errs.C(errorClass, errs.TypeCastingError),
-		errs.D("config_type", reflect.TypeOf(cfg).String()))
-}
+// Option marks sflowOption as an options.Option; newSequenceFlow applies it by
+// calling the func directly after its type-switch matches.
+func (sflowOption) Option() {}
 
 // --------------- options.Configureator interface -----------------------------
 

--- a/pkg/model/flow/sequenceflow_options_internal_test.go
+++ b/pkg/model/flow/sequenceflow_options_internal_test.go
@@ -6,20 +6,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// foreignConfig is an options.Configurator that is not *sflowConfig, used to
-// drive sflowOption.Apply down its type-casting error branch.
-type foreignConfig struct{}
-
-func (foreignConfig) Validate() error { return nil }
-
 func TestSflowOptionApply(t *testing.T) {
 	var opt sflowOption = func(*sflowConfig) error { return nil }
 
-	// the matching configurator runs the closure.
-	require.NoError(t, opt.Apply(&sflowConfig{}))
-
-	// a foreign configurator is rejected with a type-casting error.
-	require.Error(t, opt.Apply(foreignConfig{}))
+	// the option func runs against its config.
+	require.NoError(t, opt(&sflowConfig{}))
 }
 
 func TestSflowConfigValidate(t *testing.T) {

--- a/pkg/model/foundation/base.go
+++ b/pkg/model/foundation/base.go
@@ -2,6 +2,7 @@
 package foundation
 
 import (
+	"reflect"
 	"strings"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
@@ -102,8 +103,20 @@ func NewBaseElement(opts ...options.Option) (*BaseElement, error) {
 	}
 
 	for _, opt := range opts {
-		if err := opt.Apply(&bc); err != nil {
-			return nil, err
+		switch o := opt.(type) {
+		case BaseOption:
+			if err := o(&bc); err != nil {
+				return nil, err
+			}
+
+		default:
+			// Base-layer catch-all: an option that leaked past a
+			// constructor without a category-(b) guard is rejected here
+			// (replaces the type-assertion BaseOption.Apply used to make).
+			return nil, errs.New(
+				errs.M("invalid base option type"),
+				errs.C(errorClass, errs.InvalidParameter, errs.TypeCastingError),
+				errs.D("option_type", reflect.TypeOf(o).String()))
 		}
 	}
 

--- a/pkg/model/foundation/base_test.go
+++ b/pkg/model/foundation/base_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/options"
 	"github.com/stretchr/testify/require"
 )
 
@@ -41,12 +42,6 @@ func TestBaseElement(t *testing.T) {
 		})
 }
 
-// foreignConfig is an options.Configurator that is not *baseConfig, used to
-// drive BaseOption.Apply down its type-casting error branch.
-type foreignConfig struct{}
-
-func (foreignConfig) Validate() error { return nil }
-
 func TestMustBaseElementPanics(t *testing.T) {
 	// a failing option (blank explicit id) makes the Must form panic.
 	require.Panics(t, func() {
@@ -54,8 +49,10 @@ func TestMustBaseElementPanics(t *testing.T) {
 	})
 }
 
-func TestBaseOptionApplyForeignConfig(t *testing.T) {
-	bo, ok := foundation.WithID("x").(foundation.BaseOption)
-	require.True(t, ok)
-	require.Error(t, bo.Apply(foreignConfig{}))
+func TestNewBaseElementRejectsForeignOption(t *testing.T) {
+	// an option that isn't a BaseOption is rejected by the base-layer
+	// catch-all (FIX-020 §6.1) — options.WithName yields an options.NameOption,
+	// not a foundation.BaseOption.
+	_, err := foundation.NewBaseElement(options.WithName("x"))
+	require.Error(t, err)
 }

--- a/pkg/model/foundation/options.go
+++ b/pkg/model/foundation/options.go
@@ -1,7 +1,6 @@
 package foundation
 
 import (
-	"reflect"
 	"strings"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
@@ -29,16 +28,9 @@ func (bc *baseConfig) Validate() error {
 	return nil
 }
 
-// Apply implements options.Option interface for BaseOption
-func (bo BaseOption) Apply(cfg options.Configurator) error {
-	if bc, ok := cfg.(*baseConfig); ok {
-		return bo(bc)
-	}
-
-	return errs.New(
-		errs.M("not BaseConfig: %s", reflect.TypeOf(cfg).String()),
-		errs.C(errorClass, errs.TypeCastingError))
-}
+// Option marks BaseOption as an options.Option; NewBaseElement applies it by
+// calling the func directly after its type-switch matches.
+func (BaseOption) Option() {}
 
 // WithID updates id field in BaseConfig.
 func WithID(id string) options.Option {

--- a/pkg/model/gateways/complex.go
+++ b/pkg/model/gateways/complex.go
@@ -124,16 +124,9 @@ func (cc *complexConfig) Validate() error {
 // options.Option so it can be passed alongside the base/gateway options.
 type ComplexOption func(*complexConfig) error
 
-// Apply implements options.Option against the complexConfig.
-func (o ComplexOption) Apply(cfg options.Configurator) error {
-	if cc, ok := cfg.(*complexConfig); ok {
-		return o(cc)
-	}
-
-	return errs.New(
-		errs.M("cfg isn't a complexConfig"),
-		errs.C(errorClass, errs.InvalidParameter, errs.TypeCastingError))
-}
+// Option marks ComplexOption as an options.Option; NewComplexGateway applies it
+// by calling the func directly after its type-assertion matches.
+func (ComplexOption) Option() {}
 
 // WithActivationThreshold sets a single guard-less threshold triple ("N of M").
 // Mutually exclusive with WithActivation.
@@ -207,7 +200,7 @@ func NewComplexGateway(opts ...options.Option) (*ComplexGateway, error) {
 
 	for _, opt := range opts {
 		if co, ok := opt.(ComplexOption); ok {
-			if err := co.Apply(&cc); err != nil {
+			if err := co(&cc); err != nil {
 				ee = append(ee, err)
 			}
 

--- a/pkg/model/gateways/complex.go
+++ b/pkg/model/gateways/complex.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"strconv"
 	"sync"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
@@ -48,7 +49,7 @@ func NewTriple(count int, opts ...TripleOption) (Triple, error) {
 			errs.New(
 				errs.M("NewTriple: count must be >= 1"),
 				errs.C(errorClass, errs.InvalidParameter),
-				errs.D("count", t.count))
+				errs.D("count", strconv.Itoa(t.count)))
 	}
 
 	if t.count < len(t.required) {
@@ -56,8 +57,8 @@ func NewTriple(count int, opts ...TripleOption) (Triple, error) {
 			errs.New(
 				errs.M("NewTriple: count must be >= the number of required flows"),
 				errs.C(errorClass, errs.InvalidParameter),
-				errs.D("count", t.count),
-				errs.D("required", len(t.required)))
+				errs.D("count", strconv.Itoa(t.count)),
+				errs.D("required", strconv.Itoa(len(t.required))))
 	}
 
 	return t, nil
@@ -438,9 +439,9 @@ func (cg *ComplexGateway) Validate() error {
 				errs.New(
 					errs.M("complex gateway triple count out of range [1, incoming]"),
 					errs.C(errorClass, errs.InvalidObject),
-					errs.D("triple", i),
-					errs.D("count", t.count),
-					errs.D("incoming", m)))
+					errs.D("triple", strconv.Itoa(i)),
+					errs.D("count", strconv.Itoa(t.count)),
+					errs.D("incoming", strconv.Itoa(m))))
 		}
 
 		// count >= len(required) is a build invariant (NewTriple), not re-checked here.
@@ -450,7 +451,7 @@ func (cg *ComplexGateway) Validate() error {
 					errs.New(
 						errs.M("complex gateway required flow is not an incoming flow"),
 						errs.C(errorClass, errs.InvalidObject),
-						errs.D("triple", i),
+						errs.D("triple", strconv.Itoa(i)),
 						errs.D("flow_id", req)))
 			}
 		}

--- a/pkg/model/gateways/complex_test.go
+++ b/pkg/model/gateways/complex_test.go
@@ -104,15 +104,6 @@ func TestNewComplexGateway(t *testing.T) {
 	require.Error(t, err)
 }
 
-// otherConfig is an options.Configurator that is not a complexConfig.
-type otherConfig struct{}
-
-func (otherConfig) Validate() error { return nil }
-
-func TestComplexOptionApplyWrongConfig(t *testing.T) {
-	require.Error(t, gateways.WithActivationThreshold(2).Apply(otherConfig{}))
-}
-
 func TestComplexIsActivationJoin(t *testing.T) {
 	cg, err := gateways.NewComplexGateway(gateways.WithActivationThreshold(1))
 	require.NoError(t, err)

--- a/pkg/model/gateways/event_based.go
+++ b/pkg/model/gateways/event_based.go
@@ -62,16 +62,9 @@ func (c *eventBasedConfig) Validate() error {
 // EventBasedOption configures an EventBasedGateway at construction.
 type EventBasedOption func(*eventBasedConfig) error
 
-// Apply implements options.Option against the eventBasedConfig.
-func (o EventBasedOption) Apply(cfg options.Configurator) error {
-	if ec, ok := cfg.(*eventBasedConfig); ok {
-		return o(ec)
-	}
-
-	return errs.New(
-		errs.M("cfg isn't an eventBasedConfig"),
-		errs.C(errorClass, errs.InvalidParameter, errs.TypeCastingError))
-}
+// Option marks EventBasedOption as an options.Option; NewEventBasedGateway
+// applies it by calling the func directly after its type-assertion matches.
+func (EventBasedOption) Option() {}
 
 // WithInstantiate marks the gate a process-start instantiator (no incoming flow): an
 // event fired at one of its arms starts a process instance (ADR-005 v.4 §2.12.4, BPMN
@@ -131,7 +124,7 @@ func NewEventBasedGateway(opts ...options.Option) (*EventBasedGateway, error) {
 
 	for _, opt := range opts {
 		if eo, ok := opt.(EventBasedOption); ok {
-			if err := eo.Apply(&ec); err != nil {
+			if err := eo(&ec); err != nil {
 				ee = append(ee, err)
 			}
 

--- a/pkg/model/gateways/event_based.go
+++ b/pkg/model/gateways/event_based.go
@@ -4,6 +4,7 @@ package gateways
 import (
 	"context"
 	"errors"
+	"strconv"
 	"strings"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
@@ -356,7 +357,7 @@ func (g *EventBasedGateway) Validate() error {
 			errs.M("event-based gateway needs at least two arms"),
 			errs.C(errorClass, errs.InvalidParameter),
 			errs.D("gateway_id", g.ID()),
-			errs.D("arms", len(out))))
+			errs.D("arms", strconv.Itoa(len(out)))))
 	}
 
 	msgCatch, recvTask := false, false
@@ -455,7 +456,7 @@ func (g *EventBasedGateway) validateArm(
 			errs.C(errorClass, errs.InvalidParameter),
 			errs.D("gateway_id", g.ID()),
 			errs.D("arm_id", arm.ID()),
-			errs.D("incoming", len(in))))
+			errs.D("incoming", strconv.Itoa(len(in)))))
 	}
 
 	if arm.NodeType() == flow.ActivityNodeType {
@@ -501,7 +502,7 @@ func (g *EventBasedGateway) validateStartGate() []error {
 				"incoming flow"),
 			errs.C(errorClass, errs.InvalidParameter),
 			errs.D("gateway_id", g.ID()),
-			errs.D("incoming", len(g.Incoming()))))
+			errs.D("incoming", strconv.Itoa(len(g.Incoming())))))
 	}
 
 	if g.gwType == ParallelEvents && !g.instantiate {

--- a/pkg/model/gateways/event_based_test.go
+++ b/pkg/model/gateways/event_based_test.go
@@ -224,11 +224,6 @@ func TestEventBasedGatewayCloneCarriesStart(t *testing.T) {
 	require.Equal(t, gateways.ParallelEvents, cg.EventGatewayType())
 }
 
-func TestEventBasedOptionApplyWrongConfig(t *testing.T) {
-	// Apply against a foreign configurator must fail the type assertion.
-	require.Error(t, gateways.WithInstantiate().Apply(otherConfig{}))
-}
-
 func TestEventBasedGatewayDefinitions(t *testing.T) {
 	g, err := gateways.NewEventBasedGateway()
 	require.NoError(t, err)

--- a/pkg/model/gateways/gateway.go
+++ b/pkg/model/gateways/gateway.go
@@ -116,8 +116,17 @@ func New(opts ...options.Option) (*Gateway, error) {
 		case foundation.BaseOption:
 			gc.baseOpts = append(gc.baseOpts, o)
 
-		case GatewayOption, options.NameOption:
-			if err := o.Apply(&gc); err != nil {
+		case GatewayOption:
+			if err := o(&gc); err != nil {
+				ee = append(ee,
+					errs.New(
+						errs.M("gateway option failed"),
+						errs.C(errorClass, errs.BulidingFailed),
+						errs.E(err)))
+			}
+
+		case options.NameOption: // *gatewayConfig implements options.NameConfigurator
+			if err := o(&gc); err != nil {
 				ee = append(ee,
 					errs.New(
 						errs.M("gateway option failed"),

--- a/pkg/model/gateways/gateway.go
+++ b/pkg/model/gateways/gateway.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strconv"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
@@ -332,8 +333,8 @@ func (g *Gateway) TestFlows() error {
 		return errs.New(
 			errs.M(errM),
 			errs.C(errorClass, errs.InvalidObject),
-			errs.D("incoming_count", inCount),
-			errs.D("outgoing_count", outCount))
+			errs.D("incoming_count", strconv.Itoa(inCount)),
+			errs.D("outgoing_count", strconv.Itoa(outCount)))
 	}
 
 	return nil

--- a/pkg/model/gateways/gateway_options.go
+++ b/pkg/model/gateways/gateway_options.go
@@ -2,7 +2,6 @@ package gateways
 
 import (
 	"fmt"
-	"reflect"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
@@ -56,17 +55,9 @@ func WithDirection(dir GDirection) GatewayOption {
 
 // --------------------- option.Option interface ------------------------------
 
-// Apply updates the gateway configuration by GatewayOption.
-func (gOpt GatewayOption) Apply(cfg options.Configurator) error {
-	if gc, ok := cfg.(*gatewayConfig); ok {
-		return gOpt(gc)
-	}
-
-	return errs.New(
-		errs.M("cfg isn't an gatewayConfig"),
-		errs.C(errorClass, errs.InvalidParameter, errs.TypeCastingError),
-		errs.D("cfg_type", reflect.TypeOf(cfg).String()))
-}
+// Option marks GatewayOption as an options.Option; New applies it by calling
+// the func directly after its type-switch matches.
+func (GatewayOption) Option() {}
 
 // -------------------- options.Configurator interface ------------------------
 

--- a/pkg/model/hinteraction/consinp/consinp.go
+++ b/pkg/model/hinteraction/consinp/consinp.go
@@ -79,7 +79,7 @@ func NewRenderer(
 	for _, opt := range opts {
 		switch o := opt.(type) {
 		case ciOption:
-			err := o.Apply(&cfg)
+			err := o(&cfg)
 			if err != nil {
 				return nil,
 					errs.New(

--- a/pkg/model/hinteraction/consinp/consinp_options.go
+++ b/pkg/model/hinteraction/consinp/consinp_options.go
@@ -3,7 +3,6 @@ package consinp
 import (
 	"fmt"
 	"io"
-	"reflect"
 	"slices"
 	"strings"
 
@@ -183,16 +182,8 @@ func (ciCfg *consInpConfig) Validate() error {
 
 // --------------- options.Option interface -----------------------------------
 
-// Apply adds option to the configuration cfg.
-func (cio ciOption) Apply(cfg options.Configurator) error {
-	if ciCfg, ok := cfg.(*consInpConfig); ok {
-		return cio(ciCfg)
-	}
-
-	return errs.New(
-		errs.M("not consInpConfig"),
-		errs.C(errorClass, errs.TypeCastingError),
-		errs.D("config_type", reflect.TypeOf(cfg).String()))
-}
+// Option marks ciOption as an options.Option; NewRenderer applies it by calling
+// the func directly after its type-switch matches.
+func (ciOption) Option() {}
 
 // -----------------------------------------------------------------------------

--- a/pkg/model/options/name_option.go
+++ b/pkg/model/options/name_option.go
@@ -2,10 +2,7 @@
 package options
 
 import (
-	"reflect"
 	"strings"
-
-	"github.com/dr-dobermann/gobpm/pkg/errs"
 )
 
 // NameConfigurator interface extends Configurator to support setting names.
@@ -18,17 +15,9 @@ type NameConfigurator interface {
 // NameOption is a function type for setting name configuration options.
 type NameOption func(cfg NameConfigurator) error
 
-// Apply implements the Option interface for NameOption.
-func (no NameOption) Apply(cfg Configurator) error {
-	if nc, ok := cfg.(NameConfigurator); ok {
-		return no(nc)
-	}
-
-	return errs.New(
-		errs.M("config doesn't implement NameConfigurator"),
-		errs.C(errorClass, errs.TypeCastingError),
-		errs.D("config_type", reflect.TypeOf(cfg).String()))
-}
+// Option marks NameOption as an Option; the dispatching constructor applies it
+// by calling the func with a config that implements NameConfigurator.
+func (NameOption) Option() {}
 
 // -----------------------------------------------------------------------------
 

--- a/pkg/model/options/option.go
+++ b/pkg/model/options/option.go
@@ -1,13 +1,15 @@
 package options
 
-const errorClass = "OPTIONS_ERRORS"
-
 // Configurator interface defines objects that can be configured and validated.
 type Configurator interface {
 	Validate() error
 }
 
-// Option interface defines configuration options that can be applied to Configurators.
+// Option is a compile-time marker for model configuration options. Options are
+// applied by each constructor's type-switch calling the option's concrete func
+// directly — there is no generic Apply. A new option type adds the marker method
+// (func (X) Option() {}) alongside its underlying func; a new constructor
+// dispatches by direct func call, never via an Apply(Configurator) round trip.
 type Option interface {
-	Apply(cfg Configurator) error
+	Option()
 }

--- a/pkg/model/options/options_test.go
+++ b/pkg/model/options/options_test.go
@@ -1,7 +1,6 @@
 package options_test
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
@@ -35,7 +34,6 @@ func (nc *nameCfg) SetName(name string) error {
 }
 
 func TestNameOption(t *testing.T) {
-	configurator := cfg{}
 	emptyNameCfg := nameCfg{
 		cfg:              cfg{},
 		emptyNameAllowed: true,
@@ -45,22 +43,14 @@ func TestNameOption(t *testing.T) {
 		cfg: cfg{},
 	}
 
-	var ae *errs.ApplicationError
-
-	// not a NameConfigurator error
-	err := options.WithName("test name").Apply(&configurator)
-	require.Error(t, err)
-	require.True(t, errors.As(err, &ae))
-	require.True(t, ae.HasClass(errs.TypeCastingError))
-
 	// empty name isn't allowed
-	require.Error(t, options.WithName("").Apply(&nonEmptyNameCfg))
+	require.Error(t, options.WithName("")(&nonEmptyNameCfg))
 
 	// empty name allowed
-	require.NoError(t, options.WithName("").Apply(&emptyNameCfg))
+	require.NoError(t, options.WithName("")(&emptyNameCfg))
 	require.Empty(t, emptyNameCfg.name)
 
 	// nonempty name
-	require.NoError(t, options.WithName("test name").Apply(&nonEmptyNameCfg))
+	require.NoError(t, options.WithName("test name")(&nonEmptyNameCfg))
 	require.Equal(t, "test name", nonEmptyNameCfg.name)
 }

--- a/pkg/model/process/process.go
+++ b/pkg/model/process/process.go
@@ -59,8 +59,13 @@ func New(
 
 	for _, po := range procOpts {
 		switch opt := po.(type) {
-		case activities.RoleOption, data.PropertyOption:
-			if err := opt.Apply(&pc); err != nil {
+		case activities.RoleOption: // *processConfig implements RoleConfigurator
+			if err := opt(&pc); err != nil {
+				ee = append(ee, err)
+			}
+
+		case data.PropertyOption: // *processConfig implements data.PropertyAdder
+			if err := opt(&pc); err != nil {
 				ee = append(ee, err)
 			}
 

--- a/pkg/model/process/process.go
+++ b/pkg/model/process/process.go
@@ -57,17 +57,19 @@ func New(
 
 	ee := []error{}
 
+	addErr := func(err error) {
+		if err != nil {
+			ee = append(ee, err)
+		}
+	}
+
 	for _, po := range procOpts {
 		switch opt := po.(type) {
 		case activities.RoleOption: // *processConfig implements RoleConfigurator
-			if err := opt(&pc); err != nil {
-				ee = append(ee, err)
-			}
+			addErr(opt(&pc))
 
 		case data.PropertyOption: // *processConfig implements data.PropertyAdder
-			if err := opt(&pc); err != nil {
-				ee = append(ee, err)
-			}
+			addErr(opt(&pc))
 
 		case foundation.BaseOption:
 			pc.baseOpts = append(pc.baseOpts, opt)

--- a/pkg/thresher/errpaths_internal_test.go
+++ b/pkg/thresher/errpaths_internal_test.go
@@ -1,0 +1,31 @@
+package thresher
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestThresherPropagateEventHubError covers Thresher.PropagateEvent's
+// hub-failure branch: a Started thresher forwards to its EventHub, and a hub
+// error is wrapped and returned.
+func TestThresherPropagateEventHubError(t *testing.T) {
+	th, err := New("propagate-hub-error")
+	require.NoError(t, err)
+
+	hub := mockeventproc.NewMockEventHub(t)
+	hub.EXPECT().PropagateEvent(mock.Anything, mock.Anything).
+		Return(errors.New("hub boom"))
+	th.eventHub = hub
+	th.state.Store(uint32(Started))
+
+	eDef, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	require.Error(t, th.PropagateEvent(context.Background(), eDef))
+}

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -520,7 +520,7 @@ func (t *Thresher) PropagateEvent(
 			errs.M("event propagation failed"),
 			errs.C(errorClass, errs.OperationFailed),
 			errs.D("event_definition_id", eDef.ID()),
-			errs.D("event_definition_type", eDef.Type()),
+			errs.D("event_definition_type", string(eDef.Type())),
 			errs.E(err))
 	}
 


### PR DESCRIPTION
## Summary

A core-hardening pass on the `errs` and `pkg/model/options` utilities, plus a
coverage sweep. Two one-shot FIX docs (both Accepted) anchor it.

## FIX-019 — reflection-free string-typed `errs` details
`errs` sits on error paths but stored details as `map[string]any`, forcing
boxing on every `D()`, reflective `%v` in `Error()`, and a reflective,
panic-on-failure `json.Marshal` in `JSON()`. Now: `map[string]string` /
`D(k, v string)`; `Error()` via `strings.Builder`; `JSON()` returns
`([]byte, error)` and *propagates* the marshal error. ~30 call sites migrated to
pre-stringified values (`strconv.Itoa` / `string(...)` / `.ID()`); the waiter
`reflect.TypeOf(eDefI)` diagnostics became `string(eDefI.Type())` — a method,
not reflection.

## FIX-020 — option-dispatch hardening (−179 lines)
21 option types implemented `options.Option.Apply` by type-asserting the generic
`Configurator` back to their concrete config — an unreachable branch (the
constructor always passes the right config) carrying `reflect.TypeOf(cfg)`.
`options.Option` is now a marker `interface { Option() }`; the 21 `Apply`
methods are deleted; constructors dispatch by type-switch calling the option
func directly. Category-(b) "invalid option type" misuse guards preserved.

## Coverage
- `pkg/model/data` 84.7% → 89.8% (real gaps + white-box defensive guards).
- `pkg/model/data_objects` 87.8% → 89.2% (Update readiness guard).
- `pkg/model/artifacts` 86.2% → **100%** (6 unreachable nil-map guards removed +
  Group tests).
- Deterministic unit tests for instance/thresher/eventhub error branches that
  were only flakily covered.
- `COVER_EXCLUDE` now also excludes the structurally-uncoverable `Option()`
  marker no-ops (alongside logger lines).

## Verification
`make ci` green on the committed branch — lint, `-race`, diff-coverage 97.2%,
govulncheck across all 22 modules.
