### PR TITLE
Feat/service task classification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ COVER_BASE ?= origin/master
 # Matches the two logger-access forms in the codebase: `.logger.LEVEL(` and
 # `.Logger().LEVEL(`.
 #
-# Second regex: the `func (X) Option() {}` marker methods (FIX-020). Options
-# are dispatched by the constructor calling the underlying func directly, so
-# Option() is never invoked — it only makes the type satisfy options.Option at
+# Second/third regexes: sealed-interface marker methods — `func (X) Option() {}`
+# (FIX-020) and `func (X) mappedOutcome() {}` (SRD-037 MappedOutcome). The marker
+# is never invoked — it only makes the type satisfy the sealed interface at
 # compile time. An empty, never-called marker body is structurally uncoverable.
-COVER_EXCLUDE ?= \.(logger|Logger\(\))\.(Debug|Info|Warn|Error)\(,func \(.*\) Option\(\) \{\}
+COVER_EXCLUDE ?= \.(logger|Logger\(\))\.(Debug|Info|Warn|Error)\(,func \(.*\) Option\(\) \{\},func \(.*\) mappedOutcome\(\) \{\}
 
 # All Go modules in the monorepo (each with its own go.mod).
 # Discovered dynamically so adding a new module needs no Makefile edit.

--- a/docs/srd/SRD-037-service-task-classification.md
+++ b/docs/srd/SRD-037-service-task-classification.md
@@ -2,13 +2,13 @@
 
 | Field | Value |
 |---|---|
-| Status | Draft (pending impl) |
+| Status | Accepted |
 | Version | v.1 |
 | Date | 2026-07-07 |
 | Owner | Ruslan Gabitov |
 | Implements | [ADR-021 v.1 Service Task Execution Model](../design/ADR-021-service-task-execution-model.md) §2.5–§2.6 |
 
-> **Draft** — third of four SRDs landing [ADR-021 v.1](../design/ADR-021-service-task-execution-model.md)
+> **Accepted** — third of four SRDs landing [ADR-021 v.1](../design/ADR-021-service-task-execution-model.md)
 > (**M4 + M5** of M1–M8). Builds on the external-worker foundation ([SRD-036](SRD-036-service-task-job-queue.md),
 > Accepted): a worker-dispatched ServiceTask parks, enqueues, and resumes on a **`Complete` / `Fail`** report.
 > **M4** adds **outcome classification** — a worker outcome resolves to one of four kinds (success, **Business
@@ -431,4 +431,27 @@ policy runs* (trust) and *what a technical outcome triggers* (retry) together, s
 
 ## 10. Implementation summary (stage-by-stage actual landings + deltas vs draft)
 
-> ⚠️ TODO: fill AFTER landing (§10.1 stage commit SHAs for M4/M5, §10.2 empirical findings vs this draft).
+### 10.1 Stage commits (branch `feat/service-task-classification`)
+
+| Stage | Commit | Scope | Key tests |
+|---|---|---|---|
+| M4 | `3972fd5` | classification model (`Fault`, sealed `MappedOutcome`, `RuleMapper` + `faultSource`, report surface `Fail(Fault)`/`ReportBpmnError`/`ReportStatus`, `WorkerOutcome` variants) + `execWorkerOutcome` dispatch (`raiseBpmnError`/`writeStatus`/`classifyFault`/`technicalFault`) + `WithErrorMapper`/`WithStatus` + build guards + the observability overhaul (§10.3) | `TestRuleMapper*` (7), `TestServiceTaskWorker{ExecBindsCompletedOutput, ExecFaultsOnCause, ExecRaisesBpmnError, ExecWritesStatus, StatusOverwriteCollision/True, StatusWithoutWithStatusFaults, FaultClassifiedByMapper, FaultMappedToStatus, FaultMapperError, BpmnErrorEmptyCodeFaults}`, `TestWorker{ReportBpmnErrorRaisesBoundary, BpmnErrorUnmatchedFaultsInstance, ReportStatusCompletes}`, `TestClassificationOptionsRejectNonWorker`, `TestLocalDispatcher{ReportBpmnError, ReportStatus, BindLogger}` |
+| M5 | `a14500b` | `OutputRule` + `ApplyOutputMapping` (`pkg/tasks/outputmapping.go`) + `WithOutputMapping` + `bindOutput` applies it (direct-reconciliation default; required-path fault) | `TestApplyOutputMapping*` (3), `TestServiceTaskWorkerOutputMapping{ShapesBody, RequiredFaults}`, `TestWithOutputMappingRejects{InvalidRule, NonWorker}` |
+| gate | `fbc2395` | FR-3 two-level closure (§10.2-e): engine-wide `WorkerErrorMapper` default | `TestWorkerClassificationBeatsMapper`, `TestTwoLevelErrorMapperOverride`, `TestEngineDefaultErrorMapperUsed`, `TestWithWorkerErrorMapper*` |
+
+`make ci` green — lint/vet/build/`-race` clean, govulncheck clean, diff-coverage 98.1% of 365 changed lines (min 95%).
+
+### 10.2 Empirical findings — where the implementation refined the §3/§4 draft
+
+All preserve the required invariants; recorded here rather than by rewriting §3/§4 (one-shot doc).
+
+- **Classification runs at resume in `execWorkerOutcome` (§4.1 confirmed).** The mapper + status write + output mapping all run on the track's resume `Exec` where `re`'s expression engine + scope exist — the direct, synchronous consequence of the report (no held goroutine, NFR-1). The raw outcome rides in the `WorkerOutcome` to the resume; the loop stays a pure router.
+- **Business Error reuses the existing raise→catch path (§4.2 confirmed).** `raiseBpmnError` builds `events.NewBpmnError(code, msg)` and returns the raw `*events.BpmnError`; the loop's `matchErrorBoundary` catches it via `errors.As(t.lastErr, &be)` (boundary_watch.go) — **zero new raise machinery**. `NewBpmnError` errors only on an empty code (a Business Error precludes it); that is propagated defensively as a technical fault.
+- **`SrvTaskOption` became error-returning.** To validate the new options (`WithErrorMapper` rejects nil, `WithStatus` rejects an empty name, `WithOutputMapping` rejects a nil Path / empty Var) the option type changed from `func(*srvTaskConfig)` to `func(*srvTaskConfig) error`; `WithTimeout`/`WithWorker` return nil. Public constructor signatures are unchanged.
+- **Test renames (§6 → code).** The `ErrorMapper*` §6 names landed as `RuleMapper*` (the declarative impl); `TestWithStatusOverwriteGuard` split into collision + upsert tests; `TestOutputMappingDirectReconciliationDefault` is covered by `TestServiceTaskWorkerExecBindsCompletedOutput` (no-mapping → direct bind); the worker-scoped tests carry a `ServiceTaskWorker` prefix. Intent preserved; §6 stays as authored, this table is the mapping.
+- **FR-3 two-level engine-wide default landed at the landing gate (`fbc2395`).** M4 landed only the per-service `WithErrorMapper`; `/check-srd` flagged the engine-wide `WithWorkerErrorMapper` (FR-3 / §3.4 / §5) as missing. Closed by adding `renv.EngineRuntime.WorkerErrorMapper()` (implemented by `enginert` + the thresher config; set by `thresher.WithWorkerErrorMapper` / `enginert.WithWorkerErrorMapper`) and making `classifyFault` two-level (per-service overrides engine-wide). The generated `RuntimeEnvironment` mock was regenerated.
+
+### 10.3 Out-of-scope hardening folded into M4
+
+- **Observability overhaul of `localdispatcher`** (surfaced at implementation review): the worker pool's `Complete`/`Fail` report errors are now **logged, not dropped**; logging is **on by default** (`slog.Default()`); **full lifecycle logging** was added (enqueue, fetch/lock, expired-lock reclaim, extend, the report funnel, worker registration); and the logger is taken **from the runtime config** via a new `tasks.LoggerBinder` seam bound in `Thresher.New` (the dispatcher analogue of `SinkBinder`). `OutcomeKind.String()` uses a constant-keyed array (project convention).
+- **Coverage gate:** the sealed `MappedOutcome` marker (`func (X) mappedOutcome() {}`) is structurally uncoverable (never called), so it was added to the Makefile `COVER_EXCLUDE` list alongside the existing `Option()` marker exclusion.

--- a/docs/srd/SRD-037-service-task-classification.md
+++ b/docs/srd/SRD-037-service-task-classification.md
@@ -1,0 +1,434 @@
+# SRD-037 — Service Task outcome classification & output mapping (M4, M5)
+
+| Field | Value |
+|---|---|
+| Status | Draft (pending impl) |
+| Version | v.1 |
+| Date | 2026-07-07 |
+| Owner | Ruslan Gabitov |
+| Implements | [ADR-021 v.1 Service Task Execution Model](../design/ADR-021-service-task-execution-model.md) §2.5–§2.6 |
+
+> **Draft** — third of four SRDs landing [ADR-021 v.1](../design/ADR-021-service-task-execution-model.md)
+> (**M4 + M5** of M1–M8). Builds on the external-worker foundation ([SRD-036](SRD-036-service-task-job-queue.md),
+> Accepted): a worker-dispatched ServiceTask parks, enqueues, and resumes on a **`Complete` / `Fail`** report.
+> **M4** adds **outcome classification** — a worker outcome resolves to one of four kinds (success, **Business
+> Error** → BPMN errorCode, **Business Status** → status variable, **technical** → terminal here) by **code +
+> body**, via worker self-classification **and** a first-class declarative **`ErrorMapper`**, with
+> **`WithStatus`**. **M5** adds **output mapping** — **`WithOutputMapping`** shapes a raw response body into the
+> `DataOutput`. **Out of scope, → [SRD-038](../design/ADR-021-service-task-execution-model.md) (M6–M8):** the
+> **`WithWorkerTrust`** knob (policy-bundle shipping + `EngineAuthoritative`), the **retry policy** (technical
+> faults stay **terminal** here; SRD-038 re-routes them through retry), and the worked example. Sibling:
+> **SRD-035** (M1, Accepted), **SRD-036** (M2/M3, Accepted).
+
+---
+
+## 1. Background (verified against the code)
+
+### 1.1 The decision this SRD lands ([ADR-021 v.1](../design/ADR-021-service-task-execution-model.md) §2.5–§2.6)
+
+A worker outcome is **not** a bare `Complete`/`Fail`. It resolves to **four kinds** (§2.6): **Success** (bind the
+output, complete); **Business Error** — an *interrupting*, model-relevant failure raised as a **BPMN Error**
+(errorCode) that an Error **boundary event** catches (ADR-018); **Business Status** — a *non-interrupting*
+outcome written to a **status variable** so the task **completes normally** and a downstream gateway branches (the
+Camunda-Connector idiom); **technical fault** — a transient infrastructure failure. Classification is decided
+**when the report arrives** (no goroutine) by the outcome's **code** (a protocol/domain status) and **body** (the
+payload): a worker may **self-classify**, or report a raw fault the engine classifies via a declarative
+**`ErrorMapper`** (`match(code, bodyClause?) → BpmnError | Status | Technical`, first match wins). Output mapping
+(§2.5) shapes a raw response **body** into the `DataOutput` via **`WithOutputMapping`** — the success-path twin of
+the `ErrorMapper`, both reading the body through the same **protocol-bound** path mechanism.
+
+### 1.2 The base this SRD extends — SRD-036 M2/M3 (verified, Accepted)
+
+The worker report surface today is two terminal kinds (`pkg/tasks/workerdispatcher.go:108-118`):
+
+```go
+Complete(ctx, jobID JobID, workerID WorkerID, output *data.ItemDefinition) error
+Fail(ctx, jobID JobID, workerID WorkerID, cause error) error   // ← reworked in M4 (structured fault)
+// "Report methods for the classified outcomes (business status, BPMN error) join in SRD-037." (:82-83)
+```
+
+The report rides back as a `tasks.WorkerOutcome` (`pkg/tasks/workeroutcome.go:21-45`: `{cause, output, jobID}`,
+`NewWorkerComplete` / `NewWorkerFail`), a synthetic `flow.EventDefinition` delivered to the parked track;
+`ServiceTask.ProcessEvent` (`pkg/model/activities/service_task.go:356-378`) type-asserts it and stashes
+`completedOutput` / `outcomeErr`; `execWorkerOutcome` (`:305-332`) binds the output (`re.Put`) **or** returns the
+fault on resume. M4/M5 extend exactly these three seams — the report surface, the `WorkerOutcome`, and
+`ProcessEvent`/`execWorkerOutcome`.
+
+### 1.3 The machinery M4/M5 reuse (verified — all present, nothing new at the foundation)
+
+- **Raise a BPMN Error caught by errorCode.** `events.BpmnError{Code string, Err error}` +
+  `events.NewBpmnError(code, cause)` (`pkg/model/events/bpmn_error.go:15-33`). The loop's
+  **`matchErrorBoundary`** (`internal/instance/boundary_watch.go:186-224`) does
+  `errors.As(t.lastErr, &be)` (`:194`) and matches `be.Code` against each Error boundary's
+  `ErrorEventDefinition.Error().ErrorCode()` (`:210-213`), spawning the boundary's exception flow on a match
+  (`:215-217`); no match → the instance faults (`applyFailed`, `instance.go:1138`). **So a Business Error is
+  raised by returning a `*events.BpmnError` from `execWorkerOutcome`** — the track fails with it as `lastErr`, and
+  the existing SRD-029 path catches it. No new raise mechanism.
+- **Write a named scope variable.** `renv.RuntimeEnvironment.Put(dd ...data.Data)`
+  (`pkg/renv/runtimeenvironment.go:39`) stores node-produced values that reach the container scope at frame
+  commit; `data.MustParameter(name, data.MustItemAwareElement(item, data.ReadyDataState))`
+  (`service_task.go:317-319`) is the exact shape `execWorkerOutcome` already uses to commit its output. **So
+  `WithStatus` writes a Parameter named by the option** — a downstream exclusive gateway reads it.
+- **Evaluate an expression over data (predicates + output mapping).** `expression.Engine.Evaluate(ctx, expr
+  data.FormalExpression, src data.Source) (data.Value, error)` (`pkg/model/expression/expression.go:21-24`),
+  Go-native default `goexpr` (`goexpr/goexpr.go:20-24`); the exclusive gateway evaluates its conditions this way —
+  `re.ExpressionEngine().Evaluate(ctx, cond, re)` (`pkg/model/gateways/gateway.go:236`). **So the in-process
+  `ErrorMapper` body-clause and `WithOutputMapping` reuse `re.ExpressionEngine()`** over a Source exposing the
+  outcome's `{code, body}`.
+- **Operation error classes.** `service.Operation.Errors() []string` (`operation.go:52`, from
+  `Implementor.ErrorClasses()`, `:114-116`) — string classes, **no explicit `errorRef` field**. The ADR's "the
+  mapped errorCode should correspond to a declared `errorRef`" is thus an **advisory convention** (name ↔ code),
+  not an enforced link.
+
+### 1.4 Scope boundary — **trusted-implicit**; trust knob & retry → SRD-038 (design choice, confirmed)
+
+0.1.x has only **in-process local Go workers** via the `localdispatcher` pool (SRD-036) — no remote or untrusted
+worker until ADR-004. Every worker is therefore effectively **trusted**, so M4/M5 land the outcome **model +
+engine-side application** on the `WorkerTrusted`-implicit path (worker self-classification honored; `ErrorMapper`
+as the fallback over a raw fault), **without** the explicit `WithWorkerTrust(mode)` knob. The knob (policy-bundle
+shipping + the `EngineAuthoritative` sole-authority path) and the **retry policy** move to **SRD-038** — where the
+two trust modes' only observable difference (retry **location**) becomes real. A **technical fault is terminal
+here** (`Failing → Failed`), exactly as `Fail` is in M3; SRD-038 re-routes it through retry — a change to *how the
+outcome is handled*, forward-compatible (no signature change on the report call).
+
+## 2. Requirements
+
+### Functional — M4 (classification)
+
+- **FR-1 — Structured fault `{code, body}`.** `Fail` is reworked to carry a **structured fault**, not a bare Go
+  `error`: `Fault{ Code string; Body *data.ItemDefinition; Cause error }` (`Cause` is the diagnostic Go error).
+  `WorkerDispatcher.Fail(ctx, jobID, workerID, Fault)`; the `WorkerOutcome` carries the raw fault so the engine
+  `ErrorMapper` can classify `{code, body}` at resume. A pure-technical fault is `Fault{Cause: err}` (empty code,
+  nil body) — no rule matches → default technical (§2.6).
+- **FR-2 — Worker self-classified reports.** Two report methods join `WorkerDispatcher` (SRD-036 forward note):
+  **`ReportBpmnError(ctx, jobID, workerID, code string, message string)`** (the worker declares a Business Error =
+  Camunda `handleBpmnError`) and **`ReportStatus(ctx, jobID, workerID, value *data.ItemDefinition)`** (the worker
+  declares a Business Status). Each becomes a classified `WorkerOutcome` variant. Explicit worker classification
+  **wins** over the `ErrorMapper` (precedence §2.6).
+- **FR-3 — Declarative `ErrorMapper` (engine-side).** An `ErrorMapper` is an **ordered rule list**,
+  `match(codeMatcher, bodyClause?) → BpmnError{code, message?} | Status{value} | Technical` (first match wins);
+  `bodyClause` is an optional `data.FormalExpression` evaluated over the fault's `{code, body}` (in-process
+  binding: gobpm expressions over Go values), `value` a literal or body-extracted. A **pluggable `ErrorMapper`
+  interface** covers imperative cases the rule list can't express. Configured **two-level**:
+  **`WithWorkerErrorMapper(m)`** (engine-wide default) and **`WithErrorMapper(m)`** (per-service override). The
+  engine applies it to a **raw `Fail`** only (an explicit `ReportBpmnError`/`ReportStatus` bypasses it); no rule
+  matches → **default technical**.
+- **FR-4 — Business Error application.** A `BpmnError{code, message?}` outcome (worker-reported or mapper-yielded)
+  makes `execWorkerOutcome` **return `events.NewBpmnError(code, message-as-cause)`** as the resume error; the track
+  fails with it and the existing `matchErrorBoundary` path (§1.3) routes it to a matching Error **boundary event**
+  (interrupting, `Failing → Failed` → exception flow) or, unmatched, faults the instance. The mapped `errorCode`
+  **should correspond** to one of the `Operation`'s declared error classes (advisory, §1.3). Never retried.
+- **FR-5 — Business Status application + `WithStatus`.** A `Status{value}` outcome writes `value` into a
+  task-scoped variable named by **`WithStatus(statusName string, overwrite bool)`** (via
+  `re.Put(data.MustParameter(statusName, …))`) and the task **completes normally** (tokens on the outgoing
+  flows). **`overwrite = false`** (default): a pre-existing `statusName` in scope is a **runtime fault** (no
+  silent clobber); **`overwrite = true`**: upsert. A `Status` outcome (worker-reported **or** an `ErrorMapper`
+  rule yielding `Status`) on a ServiceTask with **no `WithStatus`** is a **build-time error** where statically
+  detectable (a mapper rule) and a **runtime fault** otherwise (a worker report). Never retried.
+- **FR-6 — Technical fault is terminal (retry → SRD-038).** A `Technical` outcome (raw `Fail` unmatched by the
+  mapper, or `default technical`) faults the task `Failing → Failed` with the wrapped `Cause` — exactly as M3's
+  `Fail`. Retry (re-enqueue / worker-internal) is **out of scope** (SRD-038); the outcome handling is
+  forward-compatible (SRD-038 re-routes it, no report-surface change).
+
+### Functional — M5 (output mapping)
+
+- **FR-7 — `WithOutputMapping`.** An optional **`WithOutputMapping(rules)`** declares
+  `{ body-path → output variable }` rules that extract fields from a `Complete`'s raw response **body** into the
+  `Operation`'s `outMessage` / `DataOutput`, via `data.FormalExpression` over the body (in-process binding). Absent
+  a mapping, the `Complete` payload is taken as the `outMessage` **directly** (the existing M3 path — it must match
+  the shape). A **required** output path the response does not satisfy is a **technical fault** (the worker's
+  response violated the contract, §2.6). This is the success-path twin of the `ErrorMapper` (FR-3), sharing the
+  path mechanism.
+
+### Non-functional
+
+- **NFR-1 (no goroutine).** Classification + mapping run **at resume** in `execWorkerOutcome` (on the track's
+  resume, triggered by the report) using `re`'s expression engine + scope — synchronous, no held goroutine
+  (§2.6 "evaluated when the report arrives — no goroutine").
+- **NFR-2 (single-writer preserved).** The status write is a `re.Put` into the resume frame (committed on the
+  single-writer path); the Business Error reuses the loop-owned `matchErrorBoundary` (ADR-017/SRD-029). The
+  dispatcher only reports; it never classifies against instance scope.
+- **NFR-3 (protocol-bound mapper seam).** The mapper **abstraction** (rule = `code` + a predicate over `body`) is
+  fixed and **shared** by `ErrorMapper` and `WithOutputMapping`; the concrete **binding** is a seam — in-process =
+  gobpm `FormalExpression` over Go values (this SRD); JSON body + JSONPath + HTTP-status → ADR-004. An embedder can
+  supply a binding for any protocol.
+- **NFR-4 (trusted-implicit, forward-compatible).** No `WithWorkerTrust` knob (SRD-038); worker self-classification
+  is honored and the `ErrorMapper` is the fallback — the `WorkerTrusted` precedence (§2.6). SRD-038 adds the knob
+  + `EngineAuthoritative` (ignore worker self-classification) + policy shipping without changing these outcomes.
+- **NFR-5 (gate).** diff-coverage ≥95% on touched files; `make ci` green; the classification/mapping + the
+  Business-Error boundary path are `-race` clean.
+
+## 3. Models
+
+### 3.1 Report surface — `pkg/tasks/workerdispatcher.go` (EXTEND)
+
+```go
+// Fault is a worker's raw (unclassified) terminal fault. Code is a protocol/domain
+// status (e.g. an HTTP status once a remote transport exists, ADR-004); Body is the
+// response payload; Cause is the diagnostic Go error. The engine ErrorMapper
+// classifies {Code, Body}; an all-empty Fault (just Cause) → default technical.
+type Fault struct {
+	Body  *data.ItemDefinition
+	Cause error
+	Code  string
+}
+
+type WorkerDispatcher interface {
+	// ... Enqueue / FetchAndLock / ExtendLock unchanged (SRD-036) ...
+
+	// Complete reports success (unchanged).
+	Complete(ctx context.Context, jobID JobID, workerID WorkerID, output *data.ItemDefinition) error
+
+	// ReportBpmnError declares a Business Error (Camunda handleBpmnError): the engine
+	// raises errorCode, caught by a matching Error boundary event.
+	ReportBpmnError(ctx context.Context, jobID JobID, workerID WorkerID, code, message string) error
+
+	// ReportStatus declares a Business Status: the engine writes value to the
+	// WithStatus variable and the task completes normally.
+	ReportStatus(ctx context.Context, jobID JobID, workerID WorkerID, value *data.ItemDefinition) error
+
+	// Fail reports a raw fault; the engine ErrorMapper classifies it (REWORKED: Fault
+	// replaces the bare cause error).
+	Fail(ctx context.Context, jobID JobID, workerID WorkerID, fault Fault) error
+}
+```
+
+### 3.2 `WorkerOutcome` — the classified completion event (EXTEND)
+
+```go
+// WorkerOutcome now carries one of four classifications for job JobID. kind selects
+// which fields are meaningful; ServiceTask.Exec dispatches on it at resume.
+type WorkerOutcome struct {
+	output   *data.ItemDefinition // kindComplete
+	bpmnCode string               // kindBpmnError
+	bpmnMsg  string               // kindBpmnError
+	status   *data.ItemDefinition // kindStatus
+	fault    Fault                // kindFault (raw — engine classifies)
+	jobID    JobID
+	kind     outcomeKind
+	foundation.BaseElement
+}
+
+// Constructors: NewWorkerComplete(jobID, output) (existing), NewWorkerBpmnError(jobID,
+// code, msg), NewWorkerStatus(jobID, value), NewWorkerFault(jobID, Fault) (replaces
+// NewWorkerFail). Accessors expose kind + the active field.
+```
+
+### 3.3 The `ErrorMapper` rule model — `pkg/tasks` (NEW)
+
+```go
+// Outcome kinds a rule yields.
+type MappedOutcome interface{ mappedOutcome() }
+type BpmnError struct{ Code, Message string } // -> Business Error (interrupting, ADR-018)
+type Status    struct{ Value data.Value }     // -> Business Status (WithStatus var)
+type Technical struct{}                        // -> retry policy (SRD-038); terminal here
+
+// Rule matches on code and, optionally, a predicate over the body; first match wins.
+type Rule struct {
+	Code       string                // exact code match ("" = any)
+	BodyClause data.FormalExpression // optional predicate over {code, body}; nil = code-only
+	Yield      MappedOutcome
+}
+
+// ErrorMapper classifies a raw fault. The declarative implementation is an ordered
+// Rule list; a custom implementation covers imperative cases.
+type ErrorMapper interface {
+	Classify(ctx context.Context, ee expression.Engine, f Fault) (MappedOutcome, error)
+}
+```
+
+The declarative `ErrorMapper` evaluates each `Rule.BodyClause` (when present) with `ee.Evaluate` over a transient
+`data.Source` exposing the fault's `code` and `body`, returning the first rule's `Yield`; none match →
+`Technical{}`. The `data.Source` interface is just `Find(ctx, name string) (Data, error)`
+(`pkg/model/data/data.go:28-32`), so the binding is a **lightweight in-memory adapter** whose `Find` resolves
+`"code"` → a string datum and `"body"` → the fault body — the same shape a `FormalExpression` reads from `re`
+(the gateway-condition precedent, `gateway.go:236`). (Validating this adapter's ergonomics is the one open
+implementation detail M4 confirms first.)
+
+### 3.4 ServiceTask options + config (`activities`, EXTEND)
+
+`srvTaskConfig` (SRD-035/036) gains `errorMapper tasks.ErrorMapper`, `statusVar string` + `statusOverwrite bool`,
+and `outputMapping []tasks.OutputRule`. New `SrvTaskOption`s (same closure pattern as `WithTimeout`/`WithWorker`,
+[[feedback_option_constructors]] — self-naming, reject invalid input, never erase a default):
+
+```go
+func WithErrorMapper(m tasks.ErrorMapper) SrvTaskOption      // per-service; nil rejected
+func WithStatus(statusName string, overwrite bool) SrvTaskOption // empty name rejected
+func WithOutputMapping(rules ...tasks.OutputRule) SrvTaskOption
+// engine-wide default: WithWorkerErrorMapper(m) on the thresher/enginert config (two-level, §2.2)
+```
+
+Build-time guards (in `NewServiceTask`, beside the M3 `WithWorker`+goOperation guard): a declarative `ErrorMapper`
+rule that yields `Status` while `WithStatus` is unset → error; `WithStatus`/`WithErrorMapper`/`WithOutputMapping`
+on a **non-worker** ServiceTask → error (they govern the worker outcome only).
+
+### 3.5 Resume dispatch — `ServiceTask.ProcessEvent` / `execWorkerOutcome` (EXTEND)
+
+`ProcessEvent` stashes the whole `WorkerOutcome` (its kind + active field). `execWorkerOutcome` dispatches:
+
+```mermaid
+flowchart TD
+    R[WorkerOutcome at resume] --> K{kind}
+    K -->|Complete| OM[apply WithOutputMapping over body -> outMessage / DataOutput; re.Put; Outgoing]
+    K -->|BpmnError| BE[build events.NewBpmnError code+msg; return the BpmnError as error; track fails; matchErrorBoundary catches]
+    K -->|Status| ST[if overwrite false read scope for name and fault on collision; re.Put status var; Outgoing]
+    K -->|Fault raw| EM[ErrorMapper.Classify code+body]
+    EM -->|BpmnError| BE
+    EM -->|Status| ST
+    EM -->|Technical / no match| TF[wrapped fault -> Failing to Failed  retry in SRD-038]
+```
+
+### 3.6 Lifecycle (worker report → classified terminal)
+
+```mermaid
+sequenceDiagram
+    participant W as Worker (pull)
+    participant JQ as Job store (dispatcher)
+    participant IL as Instance loop
+    participant T as ServiceTask track (resume)
+    alt success
+        W->>JQ: Complete(jobID, output)
+        JQ->>IL: WorkerOutcome complete
+        IL->>T: resume -> Exec: WithOutputMapping -> DataOutput -> Completed
+    else worker self-classifies a business error
+        W->>JQ: ReportBpmnError(jobID, code, msg)
+        JQ->>IL: WorkerOutcome bpmnError
+        IL->>T: resume -> Exec returns BpmnError -> matchErrorBoundary -> exception flow
+    else worker self-classifies a business status
+        W->>JQ: ReportStatus(jobID, value)
+        JQ->>IL: WorkerOutcome status
+        IL->>T: resume -> Exec writes WithStatus var -> Completed -> gateway branches
+    else raw fault (engine classifies)
+        W->>JQ: Fail(jobID, Fault code body cause)
+        JQ->>IL: WorkerOutcome fault
+        IL->>T: resume -> Exec: ErrorMapper.Classify -> BpmnError / Status / Technical
+    end
+```
+
+## 4. Analysis
+
+### 4.1 Classify at **resume** (`execWorkerOutcome`), not at report time (FR-3, FR-4, NFR-1)
+
+The `ErrorMapper` needs both the ServiceTask's mapper config **and** an expression engine + data source; `re`
+(the `RuntimeEnvironment`) carries both, and it exists **only** on the track's resume `Exec`. Running the mapper
+there — the direct, synchronous consequence of the report arriving (report → `ReportJobCompletion` →
+`handleJobCompletion` → deliver → resume → `Exec`) — satisfies the ADR's "evaluated when the report arrives — no
+goroutine" while reusing the exact seam M3 already runs (`execWorkerOutcome`). *Rejected: classify on the loop in
+`handleJobCompletion`* — the loop would have to open a frame and run expression evaluation per report (heavier,
+and it duplicates the resume machinery); the raw `{code, body}` riding in the `WorkerOutcome` to the resume is
+cheaper and keeps the loop a pure router (NFR-2).
+
+### 4.2 Business Error reuses the existing raise→catch path (FR-4)
+
+`matchErrorBoundary` already does `errors.As(t.lastErr, &be)` against `*events.BpmnError` (§1.3). So a Business
+Error is raised by building `events.NewBpmnError(code, message)` and **returning the resulting `*events.BpmnError`
+as the resume error**; the track fails with it as `lastErr` and the SRD-029 boundary path catches it by `code`.
+`errors.As` traverses the chain (`errs.ApplicationError.Unwrap` links the cause, verified), so returning it raw
+is simplest and an `errs`-wrapped one would also match. `NewBpmnError` returns `(*BpmnError, error)` and errors
+**only** on an empty code — which a Business-Error outcome's non-empty code precludes; the construction error is
+propagated defensively as a technical fault. Zero new raise mechanism. *Rejected: a bespoke "throw error" call
+from Exec* — duplicates the fail→boundary path ADR-018/SRD-029 owns.
+
+### 4.3 Structured `Fault{code, body, cause}` over a bare error (FR-1)
+
+The declarative `ErrorMapper` (ADR §7 requires it functional in 0.1.x) needs a `{code, body}` to classify; a bare
+Go `error` carries neither. `Fault` gives the in-process worker a structured raw fault the mapper reads, and is
+the **ready seam** ADR-004 plugs HTTP `{status, JSON}` into. `Cause` is retained for the diagnostic (a
+pure-technical fault is `Fault{Cause: err}` → default technical). *Rejected: keep `Fail(cause error)` + a separate
+raw-fault method* — two fault-report methods for one concept; a single structured `Fault` is cleaner and matches
+the ADR's "a fault is a structured outcome carrying a code and a body".
+
+### 4.4 `WithStatus` writes a free-named scope variable (FR-5)
+
+`re.Put(data.MustParameter(statusName, …))` writes a named `Parameter` into the resume frame → the container
+scope at commit (§1.3), exactly the shape a downstream exclusive gateway reads via `re.ExpressionEngine()`. The
+`overwrite=false` collision guard reads scope for `statusName` before writing and faults on a hit — no silent
+clobber (§2.6). *Rejected: require a declared `DataOutput` for the status* — the status variable is an engine
+addition orthogonal to the Operation's `outMessage` contract; a free-named var matches the Camunda-Connector
+"response-mapping → variable → gateway" idiom the ADR cites.
+
+### 4.5 Mapper binding is a **protocol seam**, shared by both mappers (FR-3, FR-7, NFR-3)
+
+`ErrorMapper` (classify a fault) and `WithOutputMapping` (shape an output) read the body through the **same** path
+mechanism — a `(body format, path language)` binding. In-process that is gobpm `FormalExpression` over Go values
+(this SRD); JSONPath-over-JSON rides with the HTTP transport in ADR-004. Fixing the abstraction now and leaving
+the binding pluggable means ADR-004 adds a binding, not a redesign. *Rejected: a Go predicate `func(code, body)
+bool` for the in-process body-clause* — it bypasses the expression mechanism the ADR names and diverges from the
+`WithOutputMapping` path; the pluggable `ErrorMapper` interface already covers imperative cases.
+
+### 4.6 Trusted-implicit; trust knob + retry deferred (NFR-4, FR-6)
+
+See §1.4. 0.1.x workers are trusted local Go workers, so worker self-classification is honored and the
+`ErrorMapper` is the fallback (`WorkerTrusted` precedence) — the knob would be inert. Deferring `WithWorkerTrust`
+and retry to SRD-038 keeps this SRD to the **outcome model** and its **application**; SRD-038 adds *where the
+policy runs* (trust) and *what a technical outcome triggers* (retry) together, since that is their shared concern.
+
+## 5. API / contract surface
+
+- **Reworked:** `WorkerDispatcher.Fail` (`cause error` → `Fault`); `WorkerOutcome` (classified variants,
+  `NewWorkerFail` → `NewWorkerFault`); `localdispatcher` + the generated `WorkerDispatcher` mock update.
+- **New (`pkg/tasks`):** `Fault`, `ReportBpmnError` / `ReportStatus` (interface methods), `ErrorMapper` +
+  `Rule`/`MappedOutcome`/`BpmnError`/`Status`/`Technical`, `OutputRule`, `NewWorkerBpmnError`/`NewWorkerStatus`.
+- **New (`activities`):** `WithErrorMapper`, `WithStatus`, `WithOutputMapping` `SrvTaskOption`s + `srvTaskConfig`
+  fields + build guards; `execWorkerOutcome`/`ProcessEvent` classification dispatch.
+- **New (engine config):** `WithWorkerErrorMapper` (engine-wide default) on the thresher/enginert config +
+  `renv.EngineRuntime` accessor (two-level, §2.2).
+
+## 6. Test scenarios
+
+| Test | FR/NFR | Scenario |
+|---|---|---|
+| `TestWorkerReportBpmnErrorRaisesBoundary` | FR-2, FR-4 | `ReportBpmnError(code)` on a ServiceTask with a matching Error boundary → interrupts, resumes the exception flow |
+| `TestWorkerBpmnErrorUnmatchedFaultsInstance` | FR-4 | a Business Error with no matching boundary → instance faults (not silently completed) |
+| `TestWorkerReportStatusWritesVarAndCompletes` | FR-2, FR-5 | `ReportStatus(value)` writes the `WithStatus` variable and the task completes; a downstream gateway reads it |
+| `TestWithStatusOverwriteGuard` | FR-5 | `overwrite=false` + pre-existing var → runtime fault; `overwrite=true` → upsert |
+| `TestStatusWithoutWithStatusIsError` | FR-5 | a mapper rule yielding `Status` with no `WithStatus` → build error; a worker `ReportStatus` with none → runtime fault |
+| `TestErrorMapperCodeOnlyToBpmnError` | FR-3, FR-4 | a raw `Fail{code:"409"}`, mapper rule `code 409 → BpmnError` → boundary |
+| `TestErrorMapperBodyClauseToStatus` | FR-3, FR-5 | `Fail{code:"404", body}` + `bodyClause $.type=="NOT_FOUND"` → `Status` written |
+| `TestErrorMapperNoMatchIsTechnical` | FR-3, FR-6 | `Fail{code:"500"}` unmatched → default technical → `Failing → Failed` |
+| `TestWorkerClassificationBeatsMapper` | FR-2, FR-3 | an explicit `ReportBpmnError` is honored even when a mapper rule would classify differently (precedence) |
+| `TestTwoLevelErrorMapperOverride` | FR-3 | per-service `WithErrorMapper` overrides the engine-wide `WithWorkerErrorMapper` |
+| `TestWithOutputMappingShapesBody` | FR-7 | `Complete` with a raw body + `WithOutputMapping {$.data.id → orderId}` → `orderId` in `DataOutput` |
+| `TestOutputMappingDirectReconciliationDefault` | FR-7 | no `WithOutputMapping` → the `Complete` payload is the `outMessage` directly (M3 path) |
+| `TestRequiredOutputPathUnsatisfiedFaults` | FR-7 | a required output path the body lacks → technical fault |
+| `TestClassificationOptionsRejectNonWorker` | FR-5, §3.4 | `WithStatus`/`WithErrorMapper`/`WithOutputMapping` on a non-worker ServiceTask → build error |
+
+## 7. Milestones
+
+1. **M4** — structured `Fault` + classified report surface (`ReportBpmnError`/`ReportStatus`, `Fail(Fault)`) +
+   `WorkerOutcome` variants + the `ErrorMapper` rule model + `WithStatus`/`WithErrorMapper`/`WithWorkerErrorMapper`
+   + `execWorkerOutcome`/`ProcessEvent` classification dispatch (Business Error → boundary, Business Status →
+   var, technical → terminal) + build guards. `localdispatcher` + mock update. One commit.
+2. **M5** — `WithOutputMapping` + the shared body-path binding (in-process `FormalExpression`) applied on a
+   `Complete`; direct-reconciliation default; required-path fault. One commit.
+
+## 8. Cross-doc
+
+- **Implements:** [ADR-021 v.1](../design/ADR-021-service-task-execution-model.md) §2.5 (output mapping),
+  §2.6 (outcome classification).
+- **References (up / sideways):** [ADR-018 v.1](../design/ADR-018-boundary-events-and-activity-interruption.md)
+  (Business Error → Error boundary interruption + chain — the FR-4 application),
+  [ADR-011 v.5](../design/ADR-011-process-data-flow.md) (operation / data binding, expression mechanism),
+  [ADR-017 v.1](../design/ADR-017-channel-based-event-processing.md) §2 (loop delivery / single-writer),
+  [ADR-001 v.6](../design/ADR-001-execution-model.md) (execution model),
+  [SAD-001 v.1](../design/SAD-001-vision-and-architecture.md) §11, §13.2.
+- **Sibling SRDs:** SRD-035 (M1, Accepted), SRD-036 (M2/M3, Accepted); SRD-038 (M6–M8 — `WithWorkerTrust`,
+  retry, example) forthcoming. SRD→SRD sideways; pins by number.
+- **Backlog:** **AB-005** (structured `ItemDefinition` compose/spread) is the data-layer follow-up a rich
+  `WithOutputMapping` (multi-variable spread) will lean on; out of scope here.
+- Direction: SRD → ADR / SAD (up), SRD → SRD (sideways); no downward reference. **ADR-021 stays Draft** until
+  SRD-038 lands.
+
+## 9. Definition of Done
+
+- FR-1…FR-7 implemented and wired; NFR-1…NFR-5 upheld.
+- Every FR/NFR covered by ≥1 named §6 test, all green under `-race` (per-package coverage for the `activities` /
+  `service` / `tasks` worker methods — the [[SRD-036]] per-package-gate lesson).
+- The `Fail(cause error)` surface is reworked to `Fail(Fault)` with no stale callers; `WorkerOutcome` variants
+  wired; the generated mock regenerated.
+- `make ci` green (tidy · lint · build · `-race` · diff-coverage ≥95% on touched files · govulncheck).
+- SRD-037 flips to Accepted. **ADR-021 stays Draft** until SRD-038 is grounded.
+
+## 10. Implementation summary (stage-by-stage actual landings + deltas vs draft)
+
+> ⚠️ TODO: fill AFTER landing (§10.1 stage commit SHAs for M4/M5, §10.2 empirical findings vs this draft).

--- a/internal/enginert/enginert.go
+++ b/internal/enginert/enginert.go
@@ -38,6 +38,9 @@ type Runtime struct {
 	expr       expression.Engine
 	authz      auth.AuthorizationProvider
 	dispatcher tasks.WorkerDispatcher
+	// workerErrorMapper is the engine-wide default ErrorMapper (SRD-037 FR-3);
+	// nil by default (a per-service WithErrorMapper overrides it).
+	workerErrorMapper tasks.ErrorMapper
 }
 
 // Default returns a Runtime with every extension set to its bundled default.
@@ -128,5 +131,18 @@ func (r *Runtime) AuthorizationProvider() auth.AuthorizationProvider { return r.
 
 // WorkerDispatcher returns the configured worker dispatcher.
 func (r *Runtime) WorkerDispatcher() tasks.WorkerDispatcher { return r.dispatcher }
+
+// WorkerErrorMapper returns the engine-wide default ErrorMapper (nil = none).
+func (r *Runtime) WorkerErrorMapper() tasks.ErrorMapper { return r.workerErrorMapper }
+
+// WithWorkerErrorMapper overrides the engine-wide default ErrorMapper and returns
+// the Runtime. A nil mapper is ignored (the current default is kept).
+func (r *Runtime) WithWorkerErrorMapper(m tasks.ErrorMapper) *Runtime {
+	if m != nil {
+		r.workerErrorMapper = m
+	}
+
+	return r
+}
 
 var _ renv.EngineRuntime = (*Runtime)(nil)

--- a/internal/enginert/enginert_test.go
+++ b/internal/enginert/enginert_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dr-dobermann/gobpm/pkg/clock/clocktest"
 	"github.com/dr-dobermann/gobpm/pkg/model/expression/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/tasks"
 	"github.com/dr-dobermann/gobpm/pkg/tasks/localdispatcher"
 )
 
@@ -53,5 +54,26 @@ func TestOverrides(t *testing.T) {
 
 	if r.Logger() != l {
 		t.Fatal("WithLogger was not applied")
+	}
+}
+
+// TestWithWorkerErrorMapper covers SRD-037 FR-3: the engine-wide default
+// ErrorMapper is nil by default, set by WithWorkerErrorMapper, nil ignored.
+func TestWithWorkerErrorMapper(t *testing.T) {
+	m, err := tasks.NewRuleMapper(tasks.Rule{Code: "1", Yield: tasks.Technical{}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if Default().WorkerErrorMapper() != nil {
+		t.Fatal("the default worker error mapper should be nil")
+	}
+
+	if Default().WithWorkerErrorMapper(m).WorkerErrorMapper() != m {
+		t.Fatal("WithWorkerErrorMapper was not applied")
+	}
+
+	if Default().WithWorkerErrorMapper(nil).WorkerErrorMapper() != nil {
+		t.Fatal("a nil mapper should be ignored (default kept)")
 	}
 }

--- a/internal/instance/jobs.go
+++ b/internal/instance/jobs.go
@@ -116,7 +116,7 @@ func (inst *Instance) onJobWaiting(
 		// instance surfaces it instead of parking forever with no job. The track was
 		// never registered (below), so deliver straight to its buffered evtCh where
 		// the loop is the sole sender; the track wakes and Exec faults. SRD-036 §4.3.
-		ev.track.evtCh <- tasks.NewWorkerFail(jobID, err)
+		ev.track.evtCh <- tasks.NewWorkerFault(jobID, tasks.Fault{Cause: err})
 
 		return
 	}

--- a/internal/instance/service_task_worker_internal_test.go
+++ b/internal/instance/service_task_worker_internal_test.go
@@ -65,8 +65,20 @@ func (d *capDispatcher) Complete(
 	return nil
 }
 
+func (d *capDispatcher) ReportBpmnError(
+	context.Context, tasks.JobID, tasks.WorkerID, string, string,
+) error {
+	return nil
+}
+
+func (d *capDispatcher) ReportStatus(
+	context.Context, tasks.JobID, tasks.WorkerID, data.Value,
+) error {
+	return nil
+}
+
 func (d *capDispatcher) Fail(
-	context.Context, tasks.JobID, tasks.WorkerID, error,
+	context.Context, tasks.JobID, tasks.WorkerID, tasks.Fault,
 ) error {
 	return nil
 }
@@ -213,11 +225,11 @@ func TestServiceTaskWorkerFailFaults(t *testing.T) {
 	job := waitForJob(t, disp)
 
 	require.NoError(t, inst.ReportJobCompletion(context.Background(),
-		tasks.NewWorkerFail(job.ID, errors.New("boom"))))
+		tasks.NewWorkerFault(job.ID, tasks.Fault{Cause: errors.New("boom")})))
 
 	require.Eventually(t, func() bool { return inst.State() == Terminated },
 		2*time.Second, 5*time.Millisecond)
-	require.ErrorContains(t, inst.LastErr(), "worker reported a failure")
+	require.ErrorContains(t, inst.LastErr(), "worker reported a technical fault")
 }
 
 // TestServiceTaskWorkerExecutorIgnored covers §2.5: the operation's in-process
@@ -284,7 +296,7 @@ func TestServiceTaskWorkerEnqueueFailureFaults(t *testing.T) {
 
 	require.Eventually(t, func() bool { return inst.State() == Terminated },
 		2*time.Second, 5*time.Millisecond)
-	require.ErrorContains(t, inst.LastErr(), "worker reported a failure")
+	require.ErrorContains(t, inst.LastErr(), "worker reported a technical fault")
 }
 
 // guardedWorkerInstance builds start → host(ServiceTask, WithWorker) → normalEnd
@@ -425,7 +437,157 @@ func TestServiceTaskWorkerBindInputFailureFaults(t *testing.T) {
 
 	require.Eventually(t, func() bool { return inst.State() == Terminated },
 		2*time.Second, 5*time.Millisecond)
-	require.ErrorContains(t, inst.LastErr(), "worker reported a failure")
+	require.ErrorContains(t, inst.LastErr(), "worker reported a technical fault")
 	_, enqueued := disp.lastJob()
 	require.False(t, enqueued, "no job is enqueued when input binding fails")
+}
+
+// errorGuardedWorkerInstance builds start → host(ServiceTask, WithWorker) →
+// normalEnd with an interrupting Error boundary (errorRef boundaryCode) →
+// excEnd, backed by disp. A worker Business Error matching boundaryCode is caught
+// by the boundary (SRD-037 FR-4).
+func errorGuardedWorkerInstance(
+	t *testing.T,
+	disp tasks.WorkerDispatcher,
+	boundaryCode string,
+) (inst *Instance, normalEndID, excEndID string) {
+	t.Helper()
+	require.NoError(t, data.CreateDefaultStates())
+
+	p, err := process.New("st-worker-err")
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	host, err := activities.NewServiceTask("host",
+		service.MustOperation("op", nil, nil, nil),
+		activities.WithWorker("topic-x"), activities.WithoutParams())
+	require.NoError(t, err)
+
+	normalEnd, err := events.NewEndEvent("normal-end")
+	require.NoError(t, err)
+
+	bpErr, err := bpmncommon.NewError("boundary-error", boundaryCode, nil)
+	require.NoError(t, err)
+
+	eed, err := events.NewErrorEventDefinition(bpErr)
+	require.NoError(t, err)
+
+	be, err := events.NewBoundaryEvent("err-bnd", host, eed, true)
+	require.NoError(t, err)
+
+	excEnd, err := events.NewEndEvent("exc-end")
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{start, host, normalEnd, be, excEnd} {
+		require.NoError(t, p.Add(e))
+	}
+
+	_, err = flow.Link(start, host)
+	require.NoError(t, err)
+	_, err = flow.Link(host, normalEnd)
+	require.NoError(t, err)
+	_, err = flow.Link(be, excEnd)
+	require.NoError(t, err)
+
+	s, err := snapshot.New(p)
+	require.NoError(t, err)
+
+	rt := enginert.Default().WithWorkerDispatcher(disp)
+	inst, err = New(s, scope.EmptyDataPath, rt,
+		mockeventproc.NewMockEventProducer(t), &failDist{})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	require.NoError(t, inst.Run(ctx))
+
+	return inst, normalEnd.ID(), excEnd.ID()
+}
+
+// TestWorkerReportBpmnErrorRaisesBoundary covers FR-2/FR-4: a worker's Business
+// Error matching an Error boundary interrupts the task and runs the exception flow.
+func TestWorkerReportBpmnErrorRaisesBoundary(t *testing.T) {
+	disp := &capDispatcher{}
+	inst, _, excEndID := errorGuardedWorkerInstance(t, disp, "ResourceConflict")
+
+	job := waitForJob(t, disp)
+
+	require.NoError(t, inst.ReportJobCompletion(context.Background(),
+		tasks.NewWorkerBpmnError(job.ID, "ResourceConflict", "conflict")))
+
+	require.Eventually(t, func() bool { return inst.State() == Completed },
+		2*time.Second, 5*time.Millisecond)
+	require.True(t, reachedNode(inst, excEndID), "the exception flow ran")
+}
+
+// TestWorkerBpmnErrorUnmatchedFaultsInstance covers FR-4: a Business Error with no
+// matching boundary faults the instance (not silently completed).
+func TestWorkerBpmnErrorUnmatchedFaultsInstance(t *testing.T) {
+	disp := &capDispatcher{}
+	inst, _, excEndID := errorGuardedWorkerInstance(t, disp, "ResourceConflict")
+
+	job := waitForJob(t, disp)
+
+	require.NoError(t, inst.ReportJobCompletion(context.Background(),
+		tasks.NewWorkerBpmnError(job.ID, "OtherCode", "x")))
+
+	require.Eventually(t, func() bool { return inst.State() == Terminated },
+		2*time.Second, 5*time.Millisecond)
+	require.False(t, reachedNode(inst, excEndID),
+		"no exception flow runs on a no-match")
+}
+
+// TestWorkerReportStatusCompletes covers FR-2/FR-5 end-to-end: a worker Business
+// Status writes the WithStatus variable into the real instance scope and the task
+// completes normally (proving re.Find/Put for a free-named var).
+func TestWorkerReportStatusCompletes(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	p, err := process.New("st-worker-status")
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	host, err := activities.NewServiceTask("host",
+		service.MustOperation("op", nil, nil, nil),
+		activities.WithWorker("topic-x"),
+		activities.WithStatus("orderStatus", false),
+		activities.WithoutParams())
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{start, host, end} {
+		require.NoError(t, p.Add(e))
+	}
+
+	_, err = flow.Link(start, host)
+	require.NoError(t, err)
+	_, err = flow.Link(host, end)
+	require.NoError(t, err)
+
+	s, err := snapshot.New(p)
+	require.NoError(t, err)
+
+	disp := &capDispatcher{}
+	rt := enginert.Default().WithWorkerDispatcher(disp)
+	inst, err := New(s, scope.EmptyDataPath, rt,
+		mockeventproc.NewMockEventProducer(t), &failDist{})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, inst.Run(ctx))
+
+	job := waitForJob(t, disp)
+
+	require.NoError(t, inst.ReportJobCompletion(context.Background(),
+		tasks.NewWorkerStatus(job.ID, values.NewVariable("NOT_FOUND"))))
+
+	require.Eventually(t, func() bool { return inst.State() == Completed },
+		2*time.Second, 5*time.Millisecond)
 }

--- a/pkg/model/activities/service_task.go
+++ b/pkg/model/activities/service_task.go
@@ -2,6 +2,7 @@ package activities
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/eventproc"
 	"github.com/dr-dobermann/gobpm/pkg/exec"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/dr-dobermann/gobpm/pkg/model/options"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
@@ -37,13 +39,19 @@ import (
 // defined by Message referred to by the outMessageRef attribute of the
 // Operation.
 type ServiceTask struct {
-	operation       service.Operation
-	outcomeErr      error
-	completedOutput *data.ItemDefinition
-	implementation  string
-	workerTopic     tasks.Topic
+	operation   service.Operation
+	errorMapper tasks.ErrorMapper
+	// outcome stashes the worker's report (set by ProcessEvent, read by Exec on
+	// resume — same goroutine). Runtime-only; nil on a fresh Clone (SRD-037 §3.5).
+	outcome        *tasks.WorkerOutcome
+	implementation string
+	workerTopic    tasks.Topic
+	// statusVar / statusOverwrite are the WithStatus config: the task-scoped
+	// variable a Business Status writes, and whether it may overwrite (SRD-037 FR-5).
+	statusVar string
 	task
-	timeout time.Duration
+	timeout         time.Duration
+	statusOverwrite bool
 }
 
 // NewServiceTask creates a new service task named name and operation as
@@ -60,6 +68,8 @@ type ServiceTask struct {
 //   - activities.WithRoles
 //   - activities.WithTimeout
 //   - activities.WithWorker
+//   - activities.WithErrorMapper
+//   - activities.WithStatus
 //   - foundation.WithID
 //   - foundation.WithDoc
 func NewServiceTask(
@@ -89,7 +99,9 @@ func NewServiceTask(
 	baseOpts := make([]options.Option, 0, len(taskOpts))
 	for _, o := range taskOpts {
 		if sto, ok := o.(SrvTaskOption); ok {
-			sto(&sc)
+			if err := sto(&sc); err != nil {
+				return nil, err
+			}
 
 			continue
 		}
@@ -108,17 +120,30 @@ func NewServiceTask(
 				errs.D("worker_topic", string(sc.workerTopic)))
 	}
 
+	// WithErrorMapper / WithStatus govern the worker outcome — meaningless on an
+	// in-process ServiceTask, so require WithWorker (SRD-037 §3.4).
+	if sc.workerTopic == "" && (sc.errorMapper != nil || sc.statusVar != "") {
+		return nil,
+			errs.New(
+				errs.M("WithErrorMapper/WithStatus require a worker-dispatched "+
+					"ServiceTask (WithWorker); %q has none", name),
+				errs.C(errorClass, errs.InvalidParameter))
+	}
+
 	t, err := newTask(name, baseOpts...)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ServiceTask{
-			task:           *t,
-			implementation: operation.Type(),
-			operation:      operation,
-			timeout:        sc.timeout,
-			workerTopic:    sc.workerTopic,
+			task:            *t,
+			implementation:  operation.Type(),
+			operation:       operation,
+			timeout:         sc.timeout,
+			workerTopic:     sc.workerTopic,
+			errorMapper:     sc.errorMapper,
+			statusVar:       sc.statusVar,
+			statusOverwrite: sc.statusOverwrite,
 		},
 		nil
 }
@@ -147,11 +172,14 @@ func (st *ServiceTask) Clone() (flow.Node, error) {
 	}
 
 	return &ServiceTask{
-		task:           t,
-		implementation: st.implementation,
-		operation:      st.operation.Clone(),
-		timeout:        st.timeout,
-		workerTopic:    st.workerTopic,
+		task:            t,
+		implementation:  st.implementation,
+		operation:       st.operation.Clone(),
+		timeout:         st.timeout,
+		workerTopic:     st.workerTopic,
+		errorMapper:     st.errorMapper,
+		statusVar:       st.statusVar,
+		statusOverwrite: st.statusOverwrite,
 	}, nil
 }
 
@@ -185,9 +213,9 @@ func (st *ServiceTask) Exec(
 
 	// A worker-dispatched ServiceTask runs Exec only on RESUME — checkNodeType
 	// parks it (binding input + enqueuing a job) before the in-process path is
-	// ever reached, so here we bind the worker's reported outcome (SRD-036).
+	// ever reached, so here we classify + apply the worker's outcome (SRD-037).
 	if st.workerTopic != "" {
-		return st.execWorkerOutcome(re)
+		return st.execWorkerOutcome(ctx, re)
 	}
 
 	op := st.operation.Clone()
@@ -298,25 +326,43 @@ func (st *ServiceTask) wrapOpErr(err error) error {
 		errs.D("operation_id", st.operation.ID()))
 }
 
-// execWorkerOutcome finishes a worker-dispatched ServiceTask on resume: it binds
-// the worker's output (stashed by ProcessEvent) to the execution frame and
-// advances, or faults with the reported cause (SRD-036 §3.5). Retry of a
-// technical fault arrives in SRD-038; here a fault is terminal.
+// execWorkerOutcome classifies + applies the worker's stashed outcome on resume
+// (SRD-037 §3.5): a completion binds the output; a Business Error raises a BPMN
+// error caught by a boundary; a Business Status writes the WithStatus variable and
+// completes; a raw fault is run through the ErrorMapper. Runs on the track resume
+// goroutine, so re's expression engine + scope are available (no goroutine, §4.1).
 func (st *ServiceTask) execWorkerOutcome(
+	ctx context.Context,
 	re renv.RuntimeEnvironment,
 ) ([]*flow.SequenceFlow, error) {
-	if st.outcomeErr != nil {
-		return nil,
-			errs.New(
-				errs.M("service task %q worker reported a failure", st.Name()),
-				errs.C(errorClass, errs.OperationFailed),
-				errs.E(st.outcomeErr),
-				errs.D("service_task_id", st.ID()))
-	}
+	wo := st.outcome
 
-	if st.completedOutput != nil {
-		res := data.MustParameter(st.completedOutput.ID(),
-			data.MustItemAwareElement(st.completedOutput, data.ReadyDataState))
+	switch wo.Kind() {
+	case tasks.OutcomeBpmnError:
+		code, message := wo.BpmnError()
+
+		return st.raiseBpmnError(code, message)
+
+	case tasks.OutcomeStatus:
+		return st.writeStatus(ctx, re, wo.StatusValue())
+
+	case tasks.OutcomeFault:
+		return st.classifyFault(ctx, re, wo.Fault())
+
+	default: // OutcomeComplete
+		return st.bindOutput(re, wo.Output())
+	}
+}
+
+// bindOutput commits a completion's output item to the execution frame and
+// advances. (SRD-037 M5 inserts WithOutputMapping shaping before the bind.)
+func (st *ServiceTask) bindOutput(
+	re renv.RuntimeEnvironment,
+	output *data.ItemDefinition,
+) ([]*flow.SequenceFlow, error) {
+	if output != nil {
+		res := data.MustParameter(output.ID(),
+			data.MustItemAwareElement(output, data.ReadyDataState))
 
 		if err := re.Put(res); err != nil {
 			return nil,
@@ -329,6 +375,122 @@ func (st *ServiceTask) execWorkerOutcome(
 	}
 
 	return st.Outgoing(), nil
+}
+
+// raiseBpmnError returns a *events.BpmnError as the resume error, so the track
+// fails with it and the loop's matchErrorBoundary routes it to a matching Error
+// boundary by code (SRD-037 FR-4). NewBpmnError errors only on an empty code —
+// which a Business Error precludes — propagated defensively as a technical fault.
+func (st *ServiceTask) raiseBpmnError(
+	code, message string,
+) ([]*flow.SequenceFlow, error) {
+	var cause error
+	if message != "" {
+		cause = errors.New(message)
+	}
+
+	be, err := events.NewBpmnError(code, cause)
+	if err != nil {
+		return nil,
+			errs.New(
+				errs.M("service task %q: invalid business-error code", st.Name()),
+				errs.C(errorClass, errs.OperationFailed),
+				errs.E(err),
+				errs.D("service_task_id", st.ID()))
+	}
+
+	return nil, be
+}
+
+// writeStatus writes value to the WithStatus variable and completes normally. A
+// Status outcome with no WithStatus configured is a runtime fault; overwrite=false
+// with a pre-existing variable is a collision fault — never a silent clobber
+// (SRD-037 FR-5).
+func (st *ServiceTask) writeStatus(
+	ctx context.Context,
+	re renv.RuntimeEnvironment,
+	value data.Value,
+) ([]*flow.SequenceFlow, error) {
+	if st.statusVar == "" {
+		return nil,
+			errs.New(
+				errs.M("service task %q: a Status outcome needs WithStatus", st.Name()),
+				errs.C(errorClass, errs.InvalidState),
+				errs.D("service_task_id", st.ID()))
+	}
+
+	if !st.statusOverwrite {
+		if _, err := re.Find(ctx, st.statusVar); err == nil {
+			return nil,
+				errs.New(
+					errs.M("service task %q: status variable %q already exists "+
+						"(overwrite=false)", st.Name(), st.statusVar),
+					errs.C(errorClass, errs.InvalidState),
+					errs.D("service_task_id", st.ID()),
+					errs.D("status_var", st.statusVar))
+		}
+	}
+
+	res := data.MustParameter(st.statusVar,
+		data.MustItemAwareElement(
+			data.MustItemDefinition(value), data.ReadyDataState))
+
+	if err := re.Put(res); err != nil {
+		return nil,
+			errs.New(
+				errs.M("couldn't write status variable %q", st.statusVar),
+				errs.C(errorClass),
+				errs.E(err),
+				errs.D("service_task_id", st.ID()))
+	}
+
+	return st.Outgoing(), nil
+}
+
+// classifyFault runs the ServiceTask's ErrorMapper over a raw fault (no mapper →
+// default Technical) and applies the mapped outcome (SRD-037 FR-3).
+func (st *ServiceTask) classifyFault(
+	ctx context.Context,
+	re renv.RuntimeEnvironment,
+	fault tasks.Fault,
+) ([]*flow.SequenceFlow, error) {
+	var mapped tasks.MappedOutcome = tasks.Technical{}
+
+	if st.errorMapper != nil {
+		m, err := st.errorMapper.Classify(ctx, re.ExpressionEngine(), fault)
+		if err != nil {
+			return nil,
+				errs.New(
+					errs.M("service task %q: error-mapping failed", st.Name()),
+					errs.C(errorClass, errs.OperationFailed),
+					errs.E(err),
+					errs.D("service_task_id", st.ID()))
+		}
+
+		mapped = m
+	}
+
+	switch o := mapped.(type) {
+	case tasks.BpmnError:
+		return st.raiseBpmnError(o.Code, o.Message)
+
+	case tasks.Status:
+		return st.writeStatus(ctx, re, o.Value)
+
+	default: // tasks.Technical (sealed interface — the only remaining kind)
+		return nil, st.technicalFault(fault)
+	}
+}
+
+// technicalFault wraps a raw fault as the terminal ServiceTask failure (retry
+// arrives in SRD-038).
+func (st *ServiceTask) technicalFault(fault tasks.Fault) error {
+	return errs.New(
+		errs.M("service task %q worker reported a technical fault", st.Name()),
+		errs.C(errorClass, errs.OperationFailed),
+		errs.E(fault.Cause),
+		errs.D("service_task_id", st.ID()),
+		errs.D("fault_code", fault.Code))
 }
 
 // ------------------ tasks.ExternalWorker interface ---------------------------
@@ -351,8 +513,9 @@ func (st *ServiceTask) BindJobInput(
 
 // ------------------ eventproc.EventProcessor interface -----------------------
 
-// ProcessEvent receives the synthetic WorkerOutcome the instance loop delivers
-// to the parked track and stashes it for Exec to bind on resume (SRD-036 §3.5).
+// ProcessEvent receives the synthetic WorkerOutcome the instance loop delivers to
+// the parked track and stashes it for Exec to classify + apply on resume (SRD-036
+// §3.5, SRD-037 §3.5).
 func (st *ServiceTask) ProcessEvent(
 	_ context.Context,
 	eDef flow.EventDefinition,
@@ -366,13 +529,7 @@ func (st *ServiceTask) ProcessEvent(
 			errs.D("event_type", string(eDef.Type())))
 	}
 
-	if cause := wo.Cause(); cause != nil {
-		st.outcomeErr = cause
-
-		return nil
-	}
-
-	st.completedOutput = wo.Output()
+	st.outcome = wo
 
 	return nil
 }

--- a/pkg/model/activities/service_task.go
+++ b/pkg/model/activities/service_task.go
@@ -482,10 +482,18 @@ func (st *ServiceTask) classifyFault(
 	re renv.RuntimeEnvironment,
 	fault tasks.Fault,
 ) ([]*flow.SequenceFlow, error) {
+	// Two-level ErrorMapper (SRD-037 FR-3): the per-service WithErrorMapper
+	// overrides the engine-wide WithWorkerErrorMapper default; absent both, a raw
+	// fault falls through to the default technical outcome.
+	mapper := st.errorMapper
+	if mapper == nil {
+		mapper = re.WorkerErrorMapper()
+	}
+
 	var mapped tasks.MappedOutcome = tasks.Technical{}
 
-	if st.errorMapper != nil {
-		m, err := st.errorMapper.Classify(ctx, re.ExpressionEngine(), fault)
+	if mapper != nil {
+		m, err := mapper.Classify(ctx, re.ExpressionEngine(), fault)
 		if err != nil {
 			return nil,
 				errs.New(

--- a/pkg/model/activities/service_task.go
+++ b/pkg/model/activities/service_task.go
@@ -41,6 +41,9 @@ import (
 type ServiceTask struct {
 	operation   service.Operation
 	errorMapper tasks.ErrorMapper
+	// outputMapping shapes a worker's raw Complete body into the output
+	// (WithOutputMapping, SRD-037 FR-7); empty = direct reconciliation.
+	outputMapping []tasks.OutputRule
 	// outcome stashes the worker's report (set by ProcessEvent, read by Exec on
 	// resume — same goroutine). Runtime-only; nil on a fresh Clone (SRD-037 §3.5).
 	outcome        *tasks.WorkerOutcome
@@ -70,6 +73,7 @@ type ServiceTask struct {
 //   - activities.WithWorker
 //   - activities.WithErrorMapper
 //   - activities.WithStatus
+//   - activities.WithOutputMapping
 //   - foundation.WithID
 //   - foundation.WithDoc
 func NewServiceTask(
@@ -120,13 +124,15 @@ func NewServiceTask(
 				errs.D("worker_topic", string(sc.workerTopic)))
 	}
 
-	// WithErrorMapper / WithStatus govern the worker outcome — meaningless on an
-	// in-process ServiceTask, so require WithWorker (SRD-037 §3.4).
-	if sc.workerTopic == "" && (sc.errorMapper != nil || sc.statusVar != "") {
+	// WithErrorMapper / WithStatus / WithOutputMapping govern the worker outcome —
+	// meaningless on an in-process ServiceTask, so require WithWorker (SRD-037 §3.4).
+	if sc.workerTopic == "" &&
+		(sc.errorMapper != nil || sc.statusVar != "" ||
+			len(sc.outputMapping) > 0) {
 		return nil,
 			errs.New(
-				errs.M("WithErrorMapper/WithStatus require a worker-dispatched "+
-					"ServiceTask (WithWorker); %q has none", name),
+				errs.M("WithErrorMapper/WithStatus/WithOutputMapping require a "+
+					"worker-dispatched ServiceTask (WithWorker); %q has none", name),
 				errs.C(errorClass, errs.InvalidParameter))
 	}
 
@@ -142,6 +148,7 @@ func NewServiceTask(
 			timeout:         sc.timeout,
 			workerTopic:     sc.workerTopic,
 			errorMapper:     sc.errorMapper,
+			outputMapping:   sc.outputMapping,
 			statusVar:       sc.statusVar,
 			statusOverwrite: sc.statusOverwrite,
 		},
@@ -178,6 +185,7 @@ func (st *ServiceTask) Clone() (flow.Node, error) {
 		timeout:         st.timeout,
 		workerTopic:     st.workerTopic,
 		errorMapper:     st.errorMapper,
+		outputMapping:   st.outputMapping,
 		statusVar:       st.statusVar,
 		statusOverwrite: st.statusOverwrite,
 	}, nil
@@ -350,28 +358,48 @@ func (st *ServiceTask) execWorkerOutcome(
 		return st.classifyFault(ctx, re, wo.Fault())
 
 	default: // OutcomeComplete
-		return st.bindOutput(re, wo.Output())
+		return st.bindOutput(ctx, re, wo.Output())
 	}
 }
 
-// bindOutput commits a completion's output item to the execution frame and
-// advances. (SRD-037 M5 inserts WithOutputMapping shaping before the bind.)
+// bindOutput commits a completion's output and advances. With WithOutputMapping
+// (SRD-037 FR-7) the raw body is shaped into the declared output variables (a
+// required path the body doesn't satisfy faults the task); otherwise the output
+// item is committed directly (the M3 direct-reconciliation default).
 func (st *ServiceTask) bindOutput(
+	ctx context.Context,
 	re renv.RuntimeEnvironment,
 	output *data.ItemDefinition,
 ) ([]*flow.SequenceFlow, error) {
-	if output != nil {
-		res := data.MustParameter(output.ID(),
-			data.MustItemAwareElement(output, data.ReadyDataState))
+	if output == nil {
+		return st.Outgoing(), nil
+	}
 
-		if err := re.Put(res); err != nil {
+	res := []data.Data{data.MustParameter(output.ID(),
+		data.MustItemAwareElement(output, data.ReadyDataState))}
+
+	if len(st.outputMapping) > 0 {
+		mapped, err := tasks.ApplyOutputMapping(
+			ctx, re.ExpressionEngine(), st.outputMapping, output)
+		if err != nil {
 			return nil,
 				errs.New(
-					errs.M("couldn't commit worker result"),
-					errs.C(errorClass),
+					errs.M("service task %q output mapping failed", st.Name()),
+					errs.C(errorClass, errs.OperationFailed),
 					errs.E(err),
 					errs.D("service_task_id", st.ID()))
 		}
+
+		res = mapped
+	}
+
+	if err := re.Put(res...); err != nil {
+		return nil,
+			errs.New(
+				errs.M("couldn't commit worker result"),
+				errs.C(errorClass),
+				errs.E(err),
+				errs.D("service_task_id", st.ID()))
 	}
 
 	return st.Outgoing(), nil

--- a/pkg/model/activities/service_task_options.go
+++ b/pkg/model/activities/service_task_options.go
@@ -15,6 +15,7 @@ type srvTaskConfig struct {
 	errorMapper     tasks.ErrorMapper
 	workerTopic     tasks.Topic
 	statusVar       string
+	outputMapping   []tasks.OutputRule
 	timeout         time.Duration
 	statusOverwrite bool
 }
@@ -98,6 +99,33 @@ func WithStatus(statusName string, overwrite bool) SrvTaskOption {
 
 		c.statusVar = statusName
 		c.statusOverwrite = overwrite
+
+		return nil
+	}
+}
+
+// WithOutputMapping shapes a worker's raw Complete response body into the
+// ServiceTask's output via {body-path → output variable} rules (ADR-021 §2.5,
+// SRD-037 FR-7). Absent a mapping, the Complete payload is taken as the output
+// directly. Each rule needs a non-nil Path and a non-empty Var. Valid only on a
+// worker-dispatched ServiceTask (checked at NewServiceTask).
+func WithOutputMapping(rules ...tasks.OutputRule) SrvTaskOption {
+	return func(c *srvTaskConfig) error {
+		for i, r := range rules {
+			if r.Path == nil {
+				return errs.New(
+					errs.M("WithOutputMapping: rule %d has a nil Path", i),
+					errs.C(errorClass, errs.EmptyNotAllowed))
+			}
+
+			if strings.TrimSpace(r.Var) == "" {
+				return errs.New(
+					errs.M("WithOutputMapping: rule %d has an empty Var", i),
+					errs.C(errorClass, errs.EmptyNotAllowed))
+			}
+		}
+
+		c.outputMapping = rules
 
 		return nil
 	}

--- a/pkg/model/activities/service_task_options.go
+++ b/pkg/model/activities/service_task_options.go
@@ -1,23 +1,28 @@
 package activities
 
 import (
+	"strings"
 	"time"
 
+	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/tasks"
 )
 
 // srvTaskConfig collects the ServiceTask-specific options (those that don't
 // belong to the embedded task) applied at NewServiceTask. It is extended by the
-// external-worker options in later SRDs (SRD-037/038).
+// external-worker options (SRD-036/037/038).
 type srvTaskConfig struct {
-	workerTopic tasks.Topic
-	timeout     time.Duration
+	errorMapper     tasks.ErrorMapper
+	workerTopic     tasks.Topic
+	statusVar       string
+	timeout         time.Duration
+	statusOverwrite bool
 }
 
-// SrvTaskOption is a ServiceTask-specific construction option (e.g.
-// WithTimeout). NewServiceTask separates these from the embedded task's options
-// and applies them to the ServiceTask itself.
-type SrvTaskOption func(*srvTaskConfig)
+// SrvTaskOption is a ServiceTask-specific construction option (e.g. WithTimeout).
+// NewServiceTask separates these from the embedded task's options and applies
+// them to the ServiceTask itself; a bad option value is rejected with an error.
+type SrvTaskOption func(*srvTaskConfig) error
 
 // Option marks SrvTaskOption as an options.Option; NewServiceTask applies it by
 // calling the func directly.
@@ -38,8 +43,10 @@ func (SrvTaskOption) Option() {}
 // value (the engine binds only that), and honor the context for true
 // cancellation.
 func WithTimeout(d time.Duration) SrvTaskOption {
-	return func(c *srvTaskConfig) {
+	return func(c *srvTaskConfig) error {
 		c.timeout = d
+
+		return nil
 	}
 }
 
@@ -51,7 +58,47 @@ func WithTimeout(d time.Duration) SrvTaskOption {
 // with a Go operation is a build-time error (§2.3). An empty topic is a no-op
 // (the task stays in-process).
 func WithWorker(topic string) SrvTaskOption {
-	return func(c *srvTaskConfig) {
+	return func(c *srvTaskConfig) error {
 		c.workerTopic = tasks.Topic(topic)
+
+		return nil
+	}
+}
+
+// WithErrorMapper sets the per-service ErrorMapper that classifies a worker's raw
+// fault into a Business Error / Business Status / technical outcome (ADR-021 §2.6,
+// SRD-037). A nil mapper is rejected. Governs the worker outcome, so it is valid
+// only on a worker-dispatched ServiceTask (checked at NewServiceTask).
+func WithErrorMapper(m tasks.ErrorMapper) SrvTaskOption {
+	return func(c *srvTaskConfig) error {
+		if m == nil {
+			return errs.New(
+				errs.M("WithErrorMapper: a nil ErrorMapper isn't allowed"),
+				errs.C(errorClass, errs.EmptyNotAllowed))
+		}
+
+		c.errorMapper = m
+
+		return nil
+	}
+}
+
+// WithStatus names the task-scoped variable a Business Status outcome writes, and
+// whether it may overwrite an existing one (ADR-021 §2.6, SRD-037 FR-5). An empty
+// name is rejected. overwrite=false makes a pre-existing variable a runtime
+// collision fault (no silent clobber). Valid only on a worker-dispatched
+// ServiceTask (checked at NewServiceTask).
+func WithStatus(statusName string, overwrite bool) SrvTaskOption {
+	return func(c *srvTaskConfig) error {
+		if strings.TrimSpace(statusName) == "" {
+			return errs.New(
+				errs.M("WithStatus: an empty status variable name isn't allowed"),
+				errs.C(errorClass, errs.EmptyNotAllowed))
+		}
+
+		c.statusVar = statusName
+		c.statusOverwrite = overwrite
+
+		return nil
 	}
 }

--- a/pkg/model/activities/service_task_worker_test.go
+++ b/pkg/model/activities/service_task_worker_test.go
@@ -458,3 +458,114 @@ func TestServiceTaskWorkerFaultMappedToStatus(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, flows)
 }
+
+// bodyValueExpr builds a FormalExpression that returns the body's value — the
+// shape a WithOutputMapping rule's Path takes.
+func bodyValueExpr(t *testing.T) data.FormalExpression {
+	t.Helper()
+
+	fe, err := goexpr.New(nil,
+		data.MustItemDefinition(values.NewVariable("")),
+		func(ctx context.Context, ds data.Source) (data.Value, error) {
+			b, err := ds.Find(ctx, "body")
+			if err != nil {
+				return nil, err
+			}
+
+			return values.NewVariable(b.Value().Get(ctx)), nil
+		})
+	require.NoError(t, err)
+
+	return fe
+}
+
+// TestServiceTaskWorkerOutputMappingShapesBody covers FR-7: WithOutputMapping
+// extracts the raw body into a declared output variable.
+func TestServiceTaskWorkerOutputMappingShapesBody(t *testing.T) {
+	st := workerTaskOpts(t, activities.WithOutputMapping(
+		tasks.OutputRule{Path: bodyValueExpr(t), Var: "orderId"}))
+
+	body := data.MustItemDefinition(values.NewVariable("order-42"),
+		foundation.WithID("body"))
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerComplete("job-1", body)))
+
+	var put data.Data
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().ExpressionEngine().Return(exprengine.New())
+	re.EXPECT().Put(mock.Anything).RunAndReturn(func(dd ...data.Data) error {
+		put = dd[0]
+
+		return nil
+	})
+
+	flows, err := st.Exec(context.Background(), re)
+	require.NoError(t, err)
+	require.Empty(t, flows)
+	require.Equal(t, "orderId", put.Name())
+	require.Equal(t, "order-42", put.Value().Get(context.Background()))
+}
+
+// missingDatumExpr reads a datum the fault/body source never exposes, so its
+// evaluation always errors (used to force a required-path failure).
+func missingDatumExpr(t *testing.T) data.FormalExpression {
+	t.Helper()
+
+	fe, err := goexpr.New(nil,
+		data.MustItemDefinition(values.NewVariable("")),
+		func(ctx context.Context, ds data.Source) (data.Value, error) {
+			d, err := ds.Find(ctx, "nested")
+			if err != nil {
+				return nil, err
+			}
+
+			return values.NewVariable(d), nil
+		})
+	require.NoError(t, err)
+
+	return fe
+}
+
+// TestServiceTaskWorkerOutputMappingRequiredFaults covers FR-7: a required output
+// path the body doesn't satisfy faults the task.
+func TestServiceTaskWorkerOutputMappingRequiredFaults(t *testing.T) {
+	st := workerTaskOpts(t, activities.WithOutputMapping(
+		tasks.OutputRule{Path: missingDatumExpr(t), Var: "v", Required: true}))
+
+	// the required path reads a datum the body doesn't provide → unsatisfied.
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerComplete("job-1",
+			data.MustItemDefinition(values.NewVariable("x")))))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().ExpressionEngine().Return(exprengine.New())
+
+	_, err := st.Exec(context.Background(), re)
+	require.ErrorContains(t, err, "output mapping failed")
+}
+
+// TestWithOutputMappingRejectsInvalidRule: a nil Path or empty Var is rejected.
+func TestWithOutputMappingRejectsInvalidRule(t *testing.T) {
+	_, err := activities.NewServiceTask("svc",
+		service.MustOperation("op", nil, nil, nil),
+		activities.WithWorker("t"),
+		activities.WithOutputMapping(tasks.OutputRule{Var: "v"})) // nil Path
+	require.Error(t, err)
+
+	_, err = activities.NewServiceTask("svc",
+		service.MustOperation("op", nil, nil, nil),
+		activities.WithWorker("t"),
+		activities.WithOutputMapping(
+			tasks.OutputRule{Path: bodyValueExpr(t), Var: "  "})) // empty Var
+	require.Error(t, err)
+}
+
+// TestWithOutputMappingRejectsNonWorker: WithOutputMapping requires WithWorker.
+func TestWithOutputMappingRejectsNonWorker(t *testing.T) {
+	_, err := activities.NewServiceTask("svc",
+		service.MustOperation("op", nil, nil, nil),
+		activities.WithOutputMapping(
+			tasks.OutputRule{Path: bodyValueExpr(t), Var: "v"}))
+	require.ErrorContains(t, err, "require a")
+}

--- a/pkg/model/activities/service_task_worker_test.go
+++ b/pkg/model/activities/service_task_worker_test.go
@@ -9,9 +9,12 @@ import (
 	"github.com/dr-dobermann/gobpm/generated/mockrenv"
 	"github.com/dr-dobermann/gobpm/pkg/model/activities"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
 	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
 	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	exprengine "github.com/dr-dobermann/gobpm/pkg/model/expression/goexpr"
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/options"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
 	"github.com/dr-dobermann/gobpm/pkg/model/service/gooper"
 	"github.com/dr-dobermann/gobpm/pkg/tasks"
@@ -64,11 +67,11 @@ func TestServiceTaskWorkerExecFaultsOnCause(t *testing.T) {
 	st := workerTask(t)
 
 	require.NoError(t, st.ProcessEvent(context.Background(),
-		tasks.NewWorkerFail("job-1", errors.New("boom"))))
+		tasks.NewWorkerFault("job-1", tasks.Fault{Cause: errors.New("boom")})))
 
 	re := mockrenv.NewMockRuntimeEnvironment(t) // no Put expected
 	_, err := st.Exec(context.Background(), re)
-	require.ErrorContains(t, err, "worker reported a failure")
+	require.ErrorContains(t, err, "worker reported a technical fault")
 }
 
 // TestServiceTaskWorkerExecNoOutputAdvances: a Complete outcome with no output
@@ -193,4 +196,265 @@ func TestServiceTaskProcessEventRejectsNonOutcome(t *testing.T) {
 	err = st.ProcessEvent(context.Background(), def)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "worker-outcome")
+}
+
+// workerTaskOpts builds a WithWorker ServiceTask over a no-message operation with
+// extra worker options (WithStatus / WithErrorMapper).
+func workerTaskOpts(
+	t *testing.T,
+	opts ...activities.SrvTaskOption,
+) *activities.ServiceTask {
+	t.Helper()
+	require.NoError(t, data.CreateDefaultStates())
+
+	all := []options.Option{
+		activities.WithWorker("topic-x"), activities.WithoutParams(),
+	}
+	for _, o := range opts {
+		all = append(all, o)
+	}
+
+	st, err := activities.NewServiceTask("svc",
+		service.MustOperation("op", nil, nil, nil), all...)
+	require.NoError(t, err)
+
+	return st
+}
+
+// bodyClauseNeedingBody builds a body-clause that reads "body" — it errors when
+// the fault carries none, exercising the ErrorMapper evaluation-error path.
+func bodyClauseNeedingBody(t *testing.T) data.FormalExpression {
+	t.Helper()
+
+	fe, err := goexpr.New(nil,
+		data.MustItemDefinition(values.NewVariable(false)),
+		func(ctx context.Context, ds data.Source) (data.Value, error) {
+			b, err := ds.Find(ctx, "body")
+			if err != nil {
+				return nil, err
+			}
+
+			s, _ := b.Value().Get(ctx).(string)
+
+			return values.NewVariable(s == "x"), nil
+		})
+	require.NoError(t, err)
+
+	return fe
+}
+
+// TestServiceTaskWorkerExecRaisesBpmnError: a Business Error outcome makes Exec
+// return a *events.BpmnError (caught by a boundary at the instance level).
+func TestServiceTaskWorkerExecRaisesBpmnError(t *testing.T) {
+	st := workerTask(t)
+
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerBpmnError("job-1", "ResourceConflict", "already exists")))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	_, err := st.Exec(context.Background(), re)
+
+	var be *events.BpmnError
+	require.True(t, errors.As(err, &be))
+	require.Equal(t, "ResourceConflict", be.Code)
+}
+
+// TestServiceTaskWorkerExecWritesStatus: a Business Status outcome writes the
+// WithStatus variable (no collision) and completes.
+func TestServiceTaskWorkerExecWritesStatus(t *testing.T) {
+	st := workerTaskOpts(t, activities.WithStatus("orderStatus", false))
+
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerStatus("job-1", values.NewVariable("NOT_FOUND"))))
+
+	var put data.Data
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().Find(mock.Anything, "orderStatus").
+		Return(nil, errors.New("not found")) // no collision
+	re.EXPECT().Put(mock.Anything).RunAndReturn(func(dd ...data.Data) error {
+		put = dd[0]
+
+		return nil
+	})
+
+	flows, err := st.Exec(context.Background(), re)
+	require.NoError(t, err)
+	require.Empty(t, flows)
+	require.Equal(t, "orderStatus", put.Name())
+}
+
+// TestServiceTaskWorkerStatusOverwriteCollision: overwrite=false + a pre-existing
+// variable is a runtime fault (no silent clobber).
+func TestServiceTaskWorkerStatusOverwriteCollision(t *testing.T) {
+	st := workerTaskOpts(t, activities.WithStatus("s", false))
+
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerStatus("job-1", values.NewVariable("X"))))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().Find(mock.Anything, "s").Return(
+		data.MustParameter("s", data.MustItemAwareElement(
+			data.MustItemDefinition(values.NewVariable("old")),
+			data.ReadyDataState)), nil) // exists → collision
+
+	_, err := st.Exec(context.Background(), re)
+	require.ErrorContains(t, err, "already exists")
+}
+
+// TestServiceTaskWorkerStatusOverwriteTrue: overwrite=true upserts without the
+// collision check.
+func TestServiceTaskWorkerStatusOverwriteTrue(t *testing.T) {
+	st := workerTaskOpts(t, activities.WithStatus("s", true))
+
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerStatus("job-1", values.NewVariable("X"))))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().Put(mock.Anything).Return(nil) // no Find (overwrite skips the guard)
+
+	_, err := st.Exec(context.Background(), re)
+	require.NoError(t, err)
+}
+
+// TestServiceTaskWorkerStatusWithoutWithStatusFaults: a worker Status report on a
+// task with no WithStatus is a runtime fault.
+func TestServiceTaskWorkerStatusWithoutWithStatusFaults(t *testing.T) {
+	st := workerTask(t) // no WithStatus
+
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerStatus("job-1", values.NewVariable("X"))))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	_, err := st.Exec(context.Background(), re)
+	require.ErrorContains(t, err, "needs WithStatus")
+}
+
+// TestServiceTaskWorkerFaultClassifiedByMapper: a raw fault is run through the
+// ErrorMapper, which yields a Business Error here.
+func TestServiceTaskWorkerFaultClassifiedByMapper(t *testing.T) {
+	mapper, err := tasks.NewRuleMapper(
+		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "Conflict"}})
+	require.NoError(t, err)
+
+	st := workerTaskOpts(t, activities.WithErrorMapper(mapper))
+
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerFault("job-1", tasks.Fault{Code: "409"})))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().ExpressionEngine().Return(exprengine.New())
+
+	_, err = st.Exec(context.Background(), re)
+
+	var be *events.BpmnError
+	require.True(t, errors.As(err, &be))
+	require.Equal(t, "Conflict", be.Code)
+}
+
+// TestServiceTaskWorkerFaultMapperError: an ErrorMapper whose evaluation errors
+// surfaces from Exec.
+func TestServiceTaskWorkerFaultMapperError(t *testing.T) {
+	mapper, err := tasks.NewRuleMapper(
+		tasks.Rule{Code: "404", BodyClause: bodyClauseNeedingBody(t),
+			Yield: tasks.Status{Value: values.NewVariable("x")}})
+	require.NoError(t, err)
+
+	st := workerTaskOpts(t, activities.WithErrorMapper(mapper))
+
+	// Fault has no body → the clause's Find("body") errors → classify errors.
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerFault("job-1", tasks.Fault{Code: "404"})))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().ExpressionEngine().Return(exprengine.New())
+
+	_, err = st.Exec(context.Background(), re)
+	require.ErrorContains(t, err, "error-mapping failed")
+}
+
+// TestWithErrorMapperRejectsNil: a nil ErrorMapper is rejected at construction.
+func TestWithErrorMapperRejectsNil(t *testing.T) {
+	_, err := activities.NewServiceTask("svc",
+		service.MustOperation("op", nil, nil, nil),
+		activities.WithWorker("t"), activities.WithErrorMapper(nil))
+	require.Error(t, err)
+}
+
+// TestWithStatusRejectsEmpty: an empty status variable name is rejected.
+func TestWithStatusRejectsEmpty(t *testing.T) {
+	_, err := activities.NewServiceTask("svc",
+		service.MustOperation("op", nil, nil, nil),
+		activities.WithWorker("t"), activities.WithStatus("  ", false))
+	require.Error(t, err)
+}
+
+// TestClassificationOptionsRejectNonWorker: WithStatus/WithErrorMapper require a
+// worker-dispatched ServiceTask.
+func TestClassificationOptionsRejectNonWorker(t *testing.T) {
+	_, err := activities.NewServiceTask("svc",
+		service.MustOperation("op", nil, nil, nil),
+		activities.WithStatus("s", false))
+	require.ErrorContains(t, err, "require a worker-dispatched")
+
+	mapper, merr := tasks.NewRuleMapper(
+		tasks.Rule{Code: "1", Yield: tasks.Technical{}})
+	require.NoError(t, merr)
+
+	_, err = activities.NewServiceTask("svc",
+		service.MustOperation("op", nil, nil, nil),
+		activities.WithErrorMapper(mapper))
+	require.ErrorContains(t, err, "require a worker-dispatched")
+}
+
+// TestServiceTaskWorkerBpmnErrorEmptyCodeFaults: a Business Error with an empty
+// code can't be raised (NewBpmnError rejects it) — surfaced as a fault.
+func TestServiceTaskWorkerBpmnErrorEmptyCodeFaults(t *testing.T) {
+	st := workerTask(t)
+
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerBpmnError("job-1", "", "no code")))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	_, err := st.Exec(context.Background(), re)
+	require.ErrorContains(t, err, "invalid business-error code")
+}
+
+// TestServiceTaskWorkerStatusPutError: a failing commit of the status variable
+// surfaces a wrapped error.
+func TestServiceTaskWorkerStatusPutError(t *testing.T) {
+	st := workerTaskOpts(t, activities.WithStatus("s", true))
+
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerStatus("job-1", values.NewVariable("X"))))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().Put(mock.Anything).Return(fmt.Errorf("boom"))
+
+	_, err := st.Exec(context.Background(), re)
+	require.ErrorContains(t, err, "couldn't write status variable")
+}
+
+// TestServiceTaskWorkerFaultMappedToStatus: the ErrorMapper yields a Business
+// Status for a raw fault, which is written to the WithStatus variable.
+func TestServiceTaskWorkerFaultMappedToStatus(t *testing.T) {
+	mapper, err := tasks.NewRuleMapper(
+		tasks.Rule{Code: "404",
+			Yield: tasks.Status{Value: values.NewVariable("NOT_FOUND")}})
+	require.NoError(t, err)
+
+	st := workerTaskOpts(t,
+		activities.WithErrorMapper(mapper), activities.WithStatus("s", false))
+
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerFault("job-1", tasks.Fault{Code: "404"})))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().ExpressionEngine().Return(exprengine.New())
+	re.EXPECT().Find(mock.Anything, "s").Return(nil, errors.New("nf"))
+	re.EXPECT().Put(mock.Anything).Return(nil)
+
+	flows, err := st.Exec(context.Background(), re)
+	require.NoError(t, err)
+	require.Empty(t, flows)
 }

--- a/pkg/model/activities/service_task_worker_test.go
+++ b/pkg/model/activities/service_task_worker_test.go
@@ -70,6 +70,7 @@ func TestServiceTaskWorkerExecFaultsOnCause(t *testing.T) {
 		tasks.NewWorkerFault("job-1", tasks.Fault{Cause: errors.New("boom")})))
 
 	re := mockrenv.NewMockRuntimeEnvironment(t) // no Put expected
+	re.EXPECT().WorkerErrorMapper().Return(nil) // no engine-wide default
 	_, err := st.Exec(context.Background(), re)
 	require.ErrorContains(t, err, "worker reported a technical fault")
 }
@@ -568,4 +569,74 @@ func TestWithOutputMappingRejectsNonWorker(t *testing.T) {
 		activities.WithOutputMapping(
 			tasks.OutputRule{Path: bodyValueExpr(t), Var: "v"}))
 	require.ErrorContains(t, err, "require a")
+}
+
+// TestWorkerClassificationBeatsMapper covers the FR-2/FR-3 precedence: an explicit
+// worker classification (ReportBpmnError) is honored directly — the ErrorMapper is
+// not consulted (it would map differently).
+func TestWorkerClassificationBeatsMapper(t *testing.T) {
+	mapper, err := tasks.NewRuleMapper(
+		tasks.Rule{Yield: tasks.Status{Value: values.NewVariable("mapped")}})
+	require.NoError(t, err)
+
+	st := workerTaskOpts(t,
+		activities.WithErrorMapper(mapper), activities.WithStatus("s", false))
+
+	// the worker self-classifies a Business Error → the mapper is bypassed.
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerBpmnError("job-1", "Conflict", "dup")))
+
+	// no ExpressionEngine / Put expected — the mapper never runs.
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	_, err = st.Exec(context.Background(), re)
+
+	var be *events.BpmnError
+	require.True(t, errors.As(err, &be))
+	require.Equal(t, "Conflict", be.Code)
+}
+
+// TestTwoLevelErrorMapperOverride covers FR-3: the per-service WithErrorMapper
+// overrides the engine-wide default (the engine default is not consulted).
+func TestTwoLevelErrorMapperOverride(t *testing.T) {
+	perService, err := tasks.NewRuleMapper(
+		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "PerService"}})
+	require.NoError(t, err)
+
+	st := workerTaskOpts(t, activities.WithErrorMapper(perService))
+
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerFault("job-1", tasks.Fault{Code: "409"})))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().ExpressionEngine().Return(exprengine.New())
+	// WorkerErrorMapper NOT expected — per-service overrides, the fallback is skipped.
+
+	_, err = st.Exec(context.Background(), re)
+
+	var be *events.BpmnError
+	require.True(t, errors.As(err, &be))
+	require.Equal(t, "PerService", be.Code)
+}
+
+// TestEngineDefaultErrorMapperUsed covers FR-3: absent a per-service mapper, the
+// engine-wide WorkerErrorMapper default classifies the raw fault.
+func TestEngineDefaultErrorMapperUsed(t *testing.T) {
+	engineWide, err := tasks.NewRuleMapper(
+		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "EngineWide"}})
+	require.NoError(t, err)
+
+	st := workerTask(t) // no per-service mapper
+
+	require.NoError(t, st.ProcessEvent(context.Background(),
+		tasks.NewWorkerFault("job-1", tasks.Fault{Code: "409"})))
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().WorkerErrorMapper().Return(engineWide)
+	re.EXPECT().ExpressionEngine().Return(exprengine.New())
+
+	_, err = st.Exec(context.Background(), re)
+
+	var be *events.BpmnError
+	require.True(t, errors.As(err, &be))
+	require.Equal(t, "EngineWide", be.Code)
 }

--- a/pkg/renv/engineruntime.go
+++ b/pkg/renv/engineruntime.go
@@ -30,4 +30,10 @@ type EngineRuntime interface {
 	ExpressionEngine() expression.Engine
 	AuthorizationProvider() auth.AuthorizationProvider
 	WorkerDispatcher() tasks.WorkerDispatcher
+
+	// WorkerErrorMapper is the engine-wide default ErrorMapper applied to a
+	// worker-dispatched ServiceTask's raw fault when the task carries no
+	// per-service WithErrorMapper (SRD-037 FR-3, two-level config). nil = no
+	// default (a raw fault falls through to the default technical outcome).
+	WorkerErrorMapper() tasks.ErrorMapper
 }

--- a/pkg/tasks/errormapper.go
+++ b/pkg/tasks/errormapper.go
@@ -1,0 +1,161 @@
+package tasks
+
+import (
+	"context"
+
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/expression"
+)
+
+// Fault is a worker's raw (unclassified) terminal fault (ADR-021 §2.6, SRD-037).
+// Code is a protocol/domain status (an HTTP status once a remote transport
+// exists, ADR-004); Body is the response payload; Cause is the diagnostic Go
+// error. The engine ErrorMapper classifies {Code, Body}; an all-empty Fault
+// (only Cause) matches no rule and falls through to the default technical outcome.
+type Fault struct {
+	Body  *data.ItemDefinition
+	Cause error
+	Code  string
+}
+
+// MappedOutcome is the classification an ErrorMapper yields for a raw fault: one
+// of BpmnError (business, interrupting), Status (business, non-interrupting), or
+// Technical (retry/terminal). It is a sealed interface — an unexported marker,
+// mirroring options.Option — so the set of outcomes is closed to this package.
+type MappedOutcome interface {
+	mappedOutcome()
+}
+
+// BpmnError yields a Business Error: the engine raises Code as a BPMN error
+// (interrupting), caught by a matching Error boundary event (ADR-018). Message is
+// an optional diagnostic.
+type BpmnError struct {
+	Code    string
+	Message string
+}
+
+// Status yields a Business Status: the engine writes Value to the ServiceTask's
+// WithStatus variable and the task completes normally.
+type Status struct {
+	Value data.Value
+}
+
+// Technical yields a technical fault: it feeds the retry policy (SRD-038) and is
+// terminal for now (SRD-037). It is also the implicit default when no rule matches.
+type Technical struct{}
+
+func (BpmnError) mappedOutcome() {}
+func (Status) mappedOutcome()    {}
+func (Technical) mappedOutcome() {}
+
+// Rule is one ErrorMapper classification rule (first match wins). Code is an exact
+// code match ("" matches any code); BodyClause is an optional predicate over the
+// fault's {code, body} (nil = code-only); Yield is the outcome on a match.
+type Rule struct {
+	BodyClause data.FormalExpression
+	Yield      MappedOutcome
+	Code       string
+}
+
+// ErrorMapper classifies a raw worker Fault into a MappedOutcome. The declarative
+// RuleMapper covers the common cases; a custom implementation covers imperative
+// ones the rule list can't express (ADR-021 §2.6). It is evaluated at resume with
+// the execution's expression engine (SRD-037 §4.1).
+type ErrorMapper interface {
+	Classify(ctx context.Context, ee expression.Engine, f Fault) (MappedOutcome, error)
+}
+
+// RuleMapper is the declarative ErrorMapper: an ordered rule list, first match
+// wins, falling through to Technical when none match.
+type RuleMapper struct {
+	rules []Rule
+}
+
+// NewRuleMapper builds a declarative ErrorMapper from rules (evaluated in order). A
+// rule with a nil Yield is rejected — every rule must classify to some outcome.
+func NewRuleMapper(rules ...Rule) (*RuleMapper, error) {
+	for i, r := range rules {
+		if r.Yield == nil {
+			return nil, errs.New(
+				errs.M("NewRuleMapper: rule %d has a nil Yield", i),
+				errs.C(errorClass, errs.EmptyNotAllowed))
+		}
+	}
+
+	return &RuleMapper{rules: rules}, nil
+}
+
+// Classify returns the first rule's Yield whose code matches and whose BodyClause
+// (if any) evaluates true over the fault's {code, body}; no match → Technical.
+func (m *RuleMapper) Classify(
+	ctx context.Context,
+	ee expression.Engine,
+	f Fault,
+) (MappedOutcome, error) {
+	src := newFaultSource(f)
+
+	for _, r := range m.rules {
+		if r.Code != "" && r.Code != f.Code {
+			continue
+		}
+
+		if r.BodyClause != nil {
+			v, err := ee.Evaluate(ctx, r.BodyClause, src)
+			if err != nil {
+				return nil, errs.New(
+					errs.M("ErrorMapper: body clause evaluation failed"),
+					errs.C(errorClass, errs.OperationFailed),
+					errs.E(err))
+			}
+
+			if match, _ := v.Get(ctx).(bool); !match {
+				continue
+			}
+		}
+
+		return r.Yield, nil
+	}
+
+	return Technical{}, nil
+}
+
+// faultSource is the transient data.Source that exposes a Fault's code and body to
+// a Rule.BodyClause FormalExpression — the same shape a gateway condition reads
+// from the runtime environment (SRD-037 §3.3, §4.5; validated against goexpr).
+type faultSource struct {
+	body *data.ItemDefinition
+	code string
+}
+
+// newFaultSource wraps a Fault as a data.Source keyed by "code" and "body".
+func newFaultSource(f Fault) *faultSource {
+	return &faultSource{code: f.Code, body: f.Body}
+}
+
+// Find resolves "code" (the fault code as a string datum) and "body" (the fault
+// body item); any other name is an ObjectNotFound error.
+func (s *faultSource) Find(_ context.Context, name string) (data.Data, error) {
+	switch name {
+	case "code":
+		return data.MustParameter("code",
+			data.MustItemAwareElement(
+				data.MustItemDefinition(values.NewVariable(s.code)),
+				data.ReadyDataState)), nil
+
+	case "body":
+		if s.body == nil {
+			return nil, errs.New(
+				errs.M("faultSource: the fault carries no body"),
+				errs.C(errorClass, errs.ObjectNotFound))
+		}
+
+		return data.MustParameter("body",
+			data.MustItemAwareElement(s.body, data.ReadyDataState)), nil
+	}
+
+	return nil, errs.New(
+		errs.M("faultSource: no datum %q (only code, body)", name),
+		errs.C(errorClass, errs.ObjectNotFound))
+}

--- a/pkg/tasks/errormapper_test.go
+++ b/pkg/tasks/errormapper_test.go
@@ -1,0 +1,170 @@
+package tasks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	exprengine "github.com/dr-dobermann/gobpm/pkg/model/expression/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/tasks"
+	"github.com/stretchr/testify/require"
+)
+
+// readName builds a FormalExpression that reads name from the source and reports
+// whether its string value equals want — the shape an ErrorMapper body-clause
+// takes over the transient fault Source (SRD-037 §3.3).
+func readName(t *testing.T, name, want string) data.FormalExpression {
+	t.Helper()
+
+	fe, err := goexpr.New(nil,
+		data.MustItemDefinition(values.NewVariable(false)),
+		func(ctx context.Context, ds data.Source) (data.Value, error) {
+			d, err := ds.Find(ctx, name)
+			if err != nil {
+				return nil, err
+			}
+
+			s, _ := d.Value().Get(ctx).(string)
+
+			return values.NewVariable(s == want), nil
+		})
+	require.NoError(t, err)
+
+	return fe
+}
+
+func TestRuleMapperCodeOnlyToBpmnError(t *testing.T) {
+	m, err := tasks.NewRuleMapper(
+		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "ResourceConflict"}})
+	require.NoError(t, err)
+
+	out, err := m.Classify(context.Background(), exprengine.New(),
+		tasks.Fault{Code: "409"})
+	require.NoError(t, err)
+
+	be, ok := out.(tasks.BpmnError)
+	require.True(t, ok)
+	require.Equal(t, "ResourceConflict", be.Code)
+}
+
+func TestRuleMapperBodyClauseToStatus(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	body := data.MustItemDefinition(values.NewVariable("NOT_FOUND"),
+		foundation.WithID("body"))
+
+	m, err := tasks.NewRuleMapper(
+		tasks.Rule{
+			Code:       "404",
+			BodyClause: readName(t, "body", "NOT_FOUND"),
+			Yield:      tasks.Status{Value: values.NewVariable("NOT_FOUND")},
+		})
+	require.NoError(t, err)
+
+	out, err := m.Classify(context.Background(), exprengine.New(),
+		tasks.Fault{Code: "404", Body: body})
+	require.NoError(t, err)
+
+	st, ok := out.(tasks.Status)
+	require.True(t, ok)
+	require.Equal(t, "NOT_FOUND", st.Value.Get(context.Background()))
+}
+
+// TestRuleMapperCodeClauseMatches covers the faultSource "code" datum path: a
+// body-clause that reads the fault's code.
+func TestRuleMapperCodeClauseMatches(t *testing.T) {
+	m, err := tasks.NewRuleMapper(
+		tasks.Rule{
+			BodyClause: readName(t, "code", "418"),
+			Yield:      tasks.BpmnError{Code: "Teapot"},
+		})
+	require.NoError(t, err)
+
+	out, err := m.Classify(context.Background(), exprengine.New(),
+		tasks.Fault{Code: "418"})
+	require.NoError(t, err)
+	require.IsType(t, tasks.BpmnError{}, out)
+}
+
+func TestRuleMapperNoMatchIsTechnical(t *testing.T) {
+	m, err := tasks.NewRuleMapper(
+		tasks.Rule{Code: "404", Yield: tasks.BpmnError{Code: "X"}})
+	require.NoError(t, err)
+
+	out, err := m.Classify(context.Background(), exprengine.New(),
+		tasks.Fault{Code: "500"})
+	require.NoError(t, err)
+	require.IsType(t, tasks.Technical{}, out)
+}
+
+// TestRuleMapperBodyClauseFalseFallsThrough: a matching code but a false
+// body-clause skips the rule and falls through to technical.
+func TestRuleMapperBodyClauseFalseFallsThrough(t *testing.T) {
+	body := data.MustItemDefinition(values.NewVariable("OTHER"),
+		foundation.WithID("body"))
+
+	m, err := tasks.NewRuleMapper(
+		tasks.Rule{
+			Code:       "404",
+			BodyClause: readName(t, "body", "NOT_FOUND"),
+			Yield:      tasks.Status{Value: values.NewVariable("x")},
+		})
+	require.NoError(t, err)
+
+	out, err := m.Classify(context.Background(), exprengine.New(),
+		tasks.Fault{Code: "404", Body: body})
+	require.NoError(t, err)
+	require.IsType(t, tasks.Technical{}, out)
+}
+
+func TestRuleMapperFirstMatchWins(t *testing.T) {
+	m, err := tasks.NewRuleMapper(
+		tasks.Rule{Yield: tasks.BpmnError{Code: "First"}}, // "" matches any
+		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "Second"}})
+	require.NoError(t, err)
+
+	out, err := m.Classify(context.Background(), exprengine.New(),
+		tasks.Fault{Code: "409"})
+	require.NoError(t, err)
+	require.Equal(t, "First", out.(tasks.BpmnError).Code)
+}
+
+func TestNewRuleMapperRejectsNilYield(t *testing.T) {
+	_, err := tasks.NewRuleMapper(tasks.Rule{Code: "409"})
+	require.Error(t, err)
+}
+
+// TestRuleMapperBodyClauseError: a body-clause reading a datum the fault lacks
+// (nil body) surfaces the evaluation error from Classify.
+func TestRuleMapperBodyClauseError(t *testing.T) {
+	m, err := tasks.NewRuleMapper(
+		tasks.Rule{
+			Code:       "404",
+			BodyClause: readName(t, "body", "x"),
+			Yield:      tasks.Status{Value: values.NewVariable("x")},
+		})
+	require.NoError(t, err)
+
+	// Fault carries no body → faultSource.Find("body") errors → Classify errors.
+	_, err = m.Classify(context.Background(), exprengine.New(),
+		tasks.Fault{Code: "404"})
+	require.Error(t, err)
+}
+
+// TestRuleMapperUnknownDatumError: a body-clause reading an unknown datum name
+// surfaces the faultSource not-found error.
+func TestRuleMapperUnknownDatumError(t *testing.T) {
+	m, err := tasks.NewRuleMapper(
+		tasks.Rule{
+			BodyClause: readName(t, "nope", "x"),
+			Yield:      tasks.Technical{},
+		})
+	require.NoError(t, err)
+
+	_, err = m.Classify(context.Background(), exprengine.New(),
+		tasks.Fault{Code: "404"})
+	require.Error(t, err)
+}

--- a/pkg/tasks/localdispatcher/localdispatcher.go
+++ b/pkg/tasks/localdispatcher/localdispatcher.go
@@ -8,12 +8,14 @@ package localdispatcher
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/dr-dobermann/gobpm/pkg/clock"
 	"github.com/dr-dobermann/gobpm/pkg/clock/syscl"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
 	"github.com/dr-dobermann/gobpm/pkg/tasks"
 )
 
@@ -52,6 +54,7 @@ type jobEntry struct {
 type Dispatcher struct {
 	clk     clock.Clock
 	sink    tasks.JobCompletionSink
+	logger  observability.Logger
 	byID    map[tasks.JobID]*jobEntry
 	byTopic map[tasks.Topic][]*jobEntry
 	workers map[tasks.Topic]WorkerFunc
@@ -72,7 +75,10 @@ func New(clk clock.Clock, maxLock time.Duration) *Dispatcher {
 	}
 
 	return &Dispatcher{
-		clk:     clk,
+		clk: clk,
+		// Observability is visible by default (project policy: accidental silence
+		// is the worse bug); slog.Default() satisfies observability.Logger.
+		logger:  slog.Default(),
 		byID:    map[tasks.JobID]*jobEntry{},
 		byTopic: map[tasks.Topic][]*jobEntry{},
 		workers: map[tasks.Topic]WorkerFunc{},
@@ -88,6 +94,21 @@ func (d *Dispatcher) BindSink(sink tasks.JobCompletionSink) {
 	defer d.mu.Unlock()
 
 	d.sink = sink
+}
+
+// BindLogger sets the dispatcher's logger from the engine's runtime config at
+// startup (tasks.LoggerBinder), so the pool's lifecycle logs use the embedder's
+// configured logger. A nil logger is ignored — the slog.Default() set in New is
+// kept, never erased (logging is on by default; FIX-020 class).
+func (d *Dispatcher) BindLogger(logger observability.Logger) {
+	if logger == nil {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.logger = logger
 }
 
 // Enqueue adds a job to the queue and wakes any waiting fetcher.
@@ -113,7 +134,11 @@ func (d *Dispatcher) Enqueue(_ context.Context, job tasks.Job) error {
 	d.byTopic[job.Topic] = append(d.byTopic[job.Topic], e)
 	d.broadcastLocked()
 
+	logger := d.logger
 	d.mu.Unlock()
+
+	logger.Debug("job enqueued",
+		"job_id", string(job.ID), "topic", string(job.Topic))
 
 	return nil
 }
@@ -131,9 +156,14 @@ func (d *Dispatcher) FetchAndLock(
 		d.mu.Lock()
 		lj, ok := d.lockNext(workerID, topics, lockDuration)
 		wake := d.wake
+		logger := d.logger
 		d.mu.Unlock()
 
 		if ok {
+			logger.Debug("job fetched and locked",
+				"worker_id", string(workerID), "job_id", string(lj.ID),
+				"topic", string(lj.Topic), "deadline", lj.Deadline)
+
 			return []tasks.LockedJob{lj}, nil
 		}
 
@@ -159,6 +189,13 @@ func (d *Dispatcher) lockNext(
 		for _, e := range d.byTopic[topic] {
 			if e.workerID != "" && !now.After(e.deadline) {
 				continue // locked and not expired
+			}
+
+			if e.workerID != "" {
+				// reaching here with a holder means the lock expired (the guard
+				// above continued otherwise) — reclaim it for crash recovery.
+				d.logger.Debug("expired job lock reclaimed",
+					"job_id", string(e.job.ID), "prev_worker", string(e.workerID))
 			}
 
 			e.workerID = workerID
@@ -201,6 +238,10 @@ func (d *Dispatcher) ExtendLock(
 
 	e.deadline = newDeadline
 
+	d.logger.Debug("job lock extended",
+		"job_id", string(jobID), "worker_id", string(workerID),
+		"deadline", newDeadline)
+
 	return nil
 }
 
@@ -214,14 +255,36 @@ func (d *Dispatcher) Complete(
 	return d.report(ctx, jobID, workerID, tasks.NewWorkerComplete(jobID, output))
 }
 
-// Fail reports a technical fault and removes the job from the store.
+// ReportBpmnError reports a worker-declared Business Error and removes the job.
+func (d *Dispatcher) ReportBpmnError(
+	ctx context.Context,
+	jobID tasks.JobID,
+	workerID tasks.WorkerID,
+	code, message string,
+) error {
+	return d.report(ctx, jobID, workerID,
+		tasks.NewWorkerBpmnError(jobID, code, message))
+}
+
+// ReportStatus reports a worker-declared Business Status and removes the job.
+func (d *Dispatcher) ReportStatus(
+	ctx context.Context,
+	jobID tasks.JobID,
+	workerID tasks.WorkerID,
+	value data.Value,
+) error {
+	return d.report(ctx, jobID, workerID, tasks.NewWorkerStatus(jobID, value))
+}
+
+// Fail reports a raw fault (the engine ErrorMapper classifies it) and removes the
+// job from the store.
 func (d *Dispatcher) Fail(
 	ctx context.Context,
 	jobID tasks.JobID,
 	workerID tasks.WorkerID,
-	cause error,
+	fault tasks.Fault,
 ) error {
-	return d.report(ctx, jobID, workerID, tasks.NewWorkerFail(jobID, cause))
+	return d.report(ctx, jobID, workerID, tasks.NewWorkerFault(jobID, fault))
 }
 
 // report validates the lock, removes the job, and delivers the outcome to the
@@ -252,7 +315,12 @@ func (d *Dispatcher) report(
 
 	d.remove(e)
 
+	logger := d.logger
 	d.mu.Unlock()
+
+	logger.Debug("job outcome reported",
+		"job_id", string(jobID), "worker_id", string(workerID),
+		"kind", outcome.Kind().String())
 
 	return sink.ReportJobCompletion(ctx, outcome)
 }
@@ -319,7 +387,10 @@ func (d *Dispatcher) RegisterWorker(
 
 	d.workers[topic] = fn
 
+	logger := d.logger
 	d.mu.Unlock()
+
+	logger.Info("registered local worker", "topic", string(topic))
 
 	go d.runWorker(ctx, topic, fn)
 
@@ -344,12 +415,23 @@ func (d *Dispatcher) runWorker(
 		for _, lj := range jobs {
 			out, e := fn(ctx, lj)
 			if e != nil {
-				_ = d.Fail(ctx, lj.ID, workerID, e)
+				// a pooled worker's plain error is a raw technical fault (no
+				// code/body → the ErrorMapper falls through to default technical).
+				if rerr := d.Fail(ctx, lj.ID, workerID,
+					tasks.Fault{Cause: e}); rerr != nil {
+					d.logger.Warn("local worker failed to report a job fault",
+						"topic", topic, "job_id", string(lj.ID),
+						"fault", e.Error(), "report_error", rerr.Error())
+				}
 
 				continue
 			}
 
-			_ = d.Complete(ctx, lj.ID, workerID, out)
+			if rerr := d.Complete(ctx, lj.ID, workerID, out); rerr != nil {
+				d.logger.Warn("local worker failed to report a job completion",
+					"topic", topic, "job_id", string(lj.ID),
+					"report_error", rerr.Error())
+			}
 		}
 	}
 }

--- a/pkg/tasks/localdispatcher/localdispatcher_test.go
+++ b/pkg/tasks/localdispatcher/localdispatcher_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dr-dobermann/gobpm/pkg/clock/clocktest"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
 	"github.com/dr-dobermann/gobpm/pkg/tasks"
 	"github.com/dr-dobermann/gobpm/pkg/tasks/localdispatcher"
 	"github.com/stretchr/testify/require"
@@ -75,7 +76,7 @@ func TestLocalDispatcherEnqueueFetchComplete(t *testing.T) {
 	require.NoError(t, d.Complete(ctx, "j1", "w1", nil))
 	require.NotNil(t, sink.last())
 	require.Equal(t, tasks.JobID("j1"), sink.last().JobID())
-	require.NoError(t, sink.last().Cause())
+	require.Equal(t, tasks.OutcomeComplete, sink.last().Kind())
 }
 
 // TestLocalDispatcherFetchWakesOnEnqueue: a fetcher blocked on an empty topic
@@ -121,8 +122,9 @@ func TestLocalDispatcherFailDeliversCause(t *testing.T) {
 	_, err := d.FetchAndLock(ctx, "w1", topics("charge"), time.Minute)
 	require.NoError(t, err)
 
-	require.NoError(t, d.Fail(ctx, "j1", "w1", errors.New("upstream 503")))
-	require.ErrorContains(t, sink.last().Cause(), "upstream 503")
+	require.NoError(t, d.Fail(ctx, "j1", "w1",
+		tasks.Fault{Cause: errors.New("upstream 503")}))
+	require.ErrorContains(t, sink.last().Fault().Cause, "upstream 503")
 }
 
 // TestLocalDispatcherLockExpiryRefetch: a locked job whose lock expires becomes
@@ -309,5 +311,86 @@ func TestLocalDispatcherWorkerPoolReportsFail(t *testing.T) {
 
 	require.Eventually(t, func() bool { return sink.last() != nil },
 		2*time.Second, 5*time.Millisecond)
-	require.ErrorContains(t, sink.last().Cause(), "worker boom")
+	require.ErrorContains(t, sink.last().Fault().Cause, "worker boom")
+}
+
+// spyLogger records log messages to verify the dispatcher uses a bound logger.
+type spyLogger struct {
+	mu   sync.Mutex
+	msgs []string
+}
+
+func (l *spyLogger) record(msg string) {
+	l.mu.Lock()
+	l.msgs = append(l.msgs, msg)
+	l.mu.Unlock()
+}
+
+func (l *spyLogger) Debug(msg string, _ ...any) { l.record(msg) }
+func (l *spyLogger) Info(msg string, _ ...any)  { l.record(msg) }
+func (l *spyLogger) Warn(msg string, _ ...any)  { l.record(msg) }
+func (l *spyLogger) Error(msg string, _ ...any) { l.record(msg) }
+
+func (l *spyLogger) has(msg string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	for _, m := range l.msgs {
+		if m == msg {
+			return true
+		}
+	}
+
+	return false
+}
+
+// TestLocalDispatcherReportBpmnError: a worker's Business Error is delivered to
+// the sink as an OutcomeBpmnError (SRD-037 FR-2).
+func TestLocalDispatcherReportBpmnError(t *testing.T) {
+	sink := &recordSink{}
+	d := localdispatcher.New(clocktest.New(base), time.Minute)
+	d.BindSink(sink)
+
+	ctx := context.Background()
+	require.NoError(t, d.Enqueue(ctx, newJob("j1", "charge")))
+	_, err := d.FetchAndLock(ctx, "w1", topics("charge"), time.Minute)
+	require.NoError(t, err)
+
+	require.NoError(t, d.ReportBpmnError(ctx, "j1", "w1", "Conflict", "dup"))
+	require.Equal(t, tasks.OutcomeBpmnError, sink.last().Kind())
+
+	code, msg := sink.last().BpmnError()
+	require.Equal(t, "Conflict", code)
+	require.Equal(t, "dup", msg)
+}
+
+// TestLocalDispatcherReportStatus: a worker's Business Status is delivered to the
+// sink as an OutcomeStatus carrying the value (SRD-037 FR-2).
+func TestLocalDispatcherReportStatus(t *testing.T) {
+	sink := &recordSink{}
+	d := localdispatcher.New(clocktest.New(base), time.Minute)
+	d.BindSink(sink)
+
+	ctx := context.Background()
+	require.NoError(t, d.Enqueue(ctx, newJob("j1", "charge")))
+	_, err := d.FetchAndLock(ctx, "w1", topics("charge"), time.Minute)
+	require.NoError(t, err)
+
+	require.NoError(t, d.ReportStatus(ctx, "j1", "w1",
+		values.NewVariable("NOT_FOUND")))
+	require.Equal(t, tasks.OutcomeStatus, sink.last().Kind())
+	require.Equal(t, "NOT_FOUND", sink.last().StatusValue().Get(ctx))
+}
+
+// TestLocalDispatcherBindLogger: a bound logger is used for lifecycle logging; a
+// nil logger is ignored (the default is kept).
+func TestLocalDispatcherBindLogger(t *testing.T) {
+	lg := &spyLogger{}
+	d := localdispatcher.New(clocktest.New(base), time.Minute)
+	d.BindLogger(nil) // ignored — keeps the default
+	d.BindLogger(lg)  // now uses lg
+
+	require.NoError(t, d.Enqueue(context.Background(), newJob("j1", "charge")))
+	require.True(t, lg.has("job enqueued"),
+		"the bound logger receives the lifecycle log")
 }

--- a/pkg/tasks/outputmapping.go
+++ b/pkg/tasks/outputmapping.go
@@ -1,0 +1,58 @@
+package tasks
+
+import (
+	"context"
+
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/expression"
+)
+
+// OutputRule extracts a value from a Complete's raw response body into a named
+// output variable (ADR-021 §2.5, SRD-037 FR-7). Path is a body-path expression
+// (in-process binding: gobpm expressions over Go values, reading the body as the
+// "body" datum); Var is the output variable it fills; Required makes a path the
+// body doesn't satisfy a fault rather than a skipped mapping.
+type OutputRule struct {
+	Path     data.FormalExpression
+	Var      string
+	Required bool
+}
+
+// ApplyOutputMapping evaluates each rule's Path over body and returns the extracted
+// data to commit as the ServiceTask's output. A required path that fails to
+// evaluate is an error (a worker response that violates the contract → technical
+// fault); an optional one is skipped. It is the success-path twin of the
+// ErrorMapper (SRD-037 §4.5): the body is exposed to Path as the "body" datum
+// through the same transient Source the classifier uses.
+func ApplyOutputMapping(
+	ctx context.Context,
+	ee expression.Engine,
+	rules []OutputRule,
+	body *data.ItemDefinition,
+) ([]data.Data, error) {
+	src := newFaultSource(Fault{Body: body})
+
+	out := make([]data.Data, 0, len(rules))
+
+	for _, r := range rules {
+		v, err := ee.Evaluate(ctx, r.Path, src)
+		if err != nil {
+			if r.Required {
+				return nil, errs.New(
+					errs.M("output mapping: required path for %q not satisfied",
+						r.Var),
+					errs.C(errorClass, errs.OperationFailed),
+					errs.E(err))
+			}
+
+			continue
+		}
+
+		out = append(out, data.MustParameter(r.Var,
+			data.MustItemAwareElement(
+				data.MustItemDefinition(v), data.ReadyDataState)))
+	}
+
+	return out, nil
+}

--- a/pkg/tasks/outputmapping_test.go
+++ b/pkg/tasks/outputmapping_test.go
@@ -1,0 +1,67 @@
+package tasks_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	exprengine "github.com/dr-dobermann/gobpm/pkg/model/expression/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/tasks"
+	"github.com/stretchr/testify/require"
+)
+
+// bodyValue builds a FormalExpression that extracts the body's value — the shape
+// a WithOutputMapping rule's Path takes (SRD-037 FR-7).
+func bodyValue(t *testing.T) data.FormalExpression {
+	t.Helper()
+
+	fe, err := goexpr.New(nil,
+		data.MustItemDefinition(values.NewVariable("")),
+		func(ctx context.Context, ds data.Source) (data.Value, error) {
+			b, err := ds.Find(ctx, "body")
+			if err != nil {
+				return nil, err
+			}
+
+			return values.NewVariable(b.Value().Get(ctx)), nil
+		})
+	require.NoError(t, err)
+
+	return fe
+}
+
+func TestApplyOutputMappingExtracts(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	body := data.MustItemDefinition(values.NewVariable("order-42"),
+		foundation.WithID("body"))
+
+	out, err := tasks.ApplyOutputMapping(context.Background(), exprengine.New(),
+		[]tasks.OutputRule{{Path: bodyValue(t), Var: "orderId"}}, body)
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, "orderId", out[0].Name())
+	require.Equal(t, "order-42", out[0].Value().Get(context.Background()))
+}
+
+// TestApplyOutputMappingRequiredMissingFaults: a required path the body doesn't
+// satisfy (its evaluation errors) is a fault.
+func TestApplyOutputMappingRequiredMissingFaults(t *testing.T) {
+	_, err := tasks.ApplyOutputMapping(context.Background(), exprengine.New(),
+		[]tasks.OutputRule{
+			{Path: readName(t, "nope", "x"), Var: "v", Required: true}}, nil)
+	require.Error(t, err)
+}
+
+// TestApplyOutputMappingOptionalMissingSkips: an optional path that fails to
+// evaluate is skipped (no output, no error).
+func TestApplyOutputMappingOptionalMissingSkips(t *testing.T) {
+	out, err := tasks.ApplyOutputMapping(context.Background(), exprengine.New(),
+		[]tasks.OutputRule{
+			{Path: readName(t, "nope", "x"), Var: "v"}}, nil)
+	require.NoError(t, err)
+	require.Empty(t, out)
+}

--- a/pkg/tasks/workerdispatcher.go
+++ b/pkg/tasks/workerdispatcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
 )
 
 // Named identifiers keep the extendable interface mixing-proof at compile time:
@@ -31,6 +32,9 @@ type (
 	// WorkerID identifies the worker holding a job's lock.
 	WorkerID string
 )
+
+// errorClass tags errors raised by the tasks package (ErrorMapper, options).
+const errorClass = "TASKS"
 
 // jobIDSep separates the owning instance id from the unique suffix inside a
 // JobID. A worker treats the whole JobID as opaque; the engine splits on the
@@ -78,9 +82,11 @@ type LockedJob struct {
 }
 
 // WorkerDispatcher is an asynchronous fetch-and-lock job queue (ADR-021 §2.4).
-// Enqueue is engine-facing; FetchAndLock / ExtendLock / Complete / Fail are
-// worker-facing. Report methods for the classified outcomes (business status,
-// BPMN error) join in SRD-037.
+// Enqueue is engine-facing; FetchAndLock / ExtendLock and the four terminal
+// reports (Complete / ReportBpmnError / ReportStatus / Fail) are worker-facing.
+// The reports mirror the four outcome kinds (SRD-037 §2.6): a worker either
+// self-classifies (ReportBpmnError / ReportStatus) or reports a raw Fault the
+// engine ErrorMapper classifies.
 type WorkerDispatcher interface {
 	// Enqueue adds a job to the queue (non-blocking); the engine then parks the
 	// ServiceTask.
@@ -114,8 +120,29 @@ type WorkerDispatcher interface {
 		output *data.ItemDefinition,
 	) error
 
-	// Fail reports a technical fault; cause identifies it.
-	Fail(ctx context.Context, jobID JobID, workerID WorkerID, cause error) error
+	// ReportBpmnError reports a worker-declared Business Error (Camunda
+	// handleBpmnError): the engine raises code (message is an optional
+	// diagnostic), caught by a matching Error boundary event (interrupting).
+	ReportBpmnError(
+		ctx context.Context,
+		jobID JobID,
+		workerID WorkerID,
+		code, message string,
+	) error
+
+	// ReportStatus reports a worker-declared Business Status: the engine writes
+	// value to the ServiceTask's WithStatus variable and the task completes.
+	ReportStatus(
+		ctx context.Context,
+		jobID JobID,
+		workerID WorkerID,
+		value data.Value,
+	) error
+
+	// Fail reports a raw fault the engine ErrorMapper classifies (§2.6). A
+	// pure-technical fault carries only Fault.Cause (empty code, nil body) and
+	// falls through to the default technical outcome.
+	Fail(ctx context.Context, jobID JobID, workerID WorkerID, fault Fault) error
 }
 
 // JobCompletionSink routes a worker's terminal report to the owning instance.
@@ -132,6 +159,14 @@ type JobCompletionSink interface {
 // not implement it.
 type SinkBinder interface {
 	BindSink(sink JobCompletionSink)
+}
+
+// LoggerBinder is an optional dispatcher capability: the engine binds its
+// configured logger (from the runtime config) at startup, so a dispatcher's own
+// lifecycle logging uses the embedder's logger rather than a private default. A
+// dispatcher that manages its own logging need not implement it.
+type LoggerBinder interface {
+	BindLogger(logger observability.Logger)
 }
 
 // ExternalWorker is implemented by a node whose work is dispatched to an

--- a/pkg/tasks/workeroutcome.go
+++ b/pkg/tasks/workeroutcome.go
@@ -11,18 +11,57 @@ import (
 // parked ServiceTask track, bypassing the EventHub and correlation.
 const workerOutcomeTrigger flow.EventTrigger = "ServiceTaskWorkerOutcome"
 
+// OutcomeKind classifies a WorkerOutcome into one of the four ADR-021 §2.6 kinds.
+// The parked ServiceTask dispatches on it at resume (SRD-037 §3.5).
+type OutcomeKind uint8
+
+const (
+	// OutcomeComplete is a success — bind Output, complete.
+	OutcomeComplete OutcomeKind = iota
+	// OutcomeBpmnError is a worker-declared Business Error — raise BpmnCode, caught
+	// by an Error boundary (interrupting).
+	OutcomeBpmnError
+	// OutcomeStatus is a worker-declared Business Status — write StatusValue to the
+	// WithStatus variable, complete normally.
+	OutcomeStatus
+	// OutcomeFault is a raw fault — the engine ErrorMapper classifies Fault{code,body}
+	// at resume.
+	OutcomeFault
+)
+
+// outcomeKindNames is the kind→name table, keyed by the constant so it stays
+// correct if the iota block is reordered. Keep it in sync with that block.
+var outcomeKindNames = [...]string{
+	OutcomeComplete:  "complete",
+	OutcomeBpmnError: "bpmnError",
+	OutcomeStatus:    "status",
+	OutcomeFault:     "fault",
+}
+
+// String returns the outcome-kind name for logging.
+func (k OutcomeKind) String() string {
+	if int(k) >= len(outcomeKindNames) {
+		return "unknown"
+	}
+
+	return outcomeKindNames[k]
+}
+
 // WorkerOutcome is the synthetic event a worker's report rides back into the
 // instance loop: it implements flow.EventDefinition, so it flows through the
 // parked track's event channel exactly like a UserTask completion (ADR-021
-// §2.4, SRD-036 §3.2). Exactly one of cause / output is meaningful — a Complete
-// carries the output item, a Fail carries the cause. It never reaches the
-// EventHub or correlation, so its Type is an internal sentinel and it exposes no
-// ItemDefinitions.
+// §2.4, SRD-036 §3.2). Its Kind selects which field is meaningful. It never
+// reaches the EventHub or correlation, so its Type is an internal sentinel and it
+// exposes no ItemDefinitions.
 type WorkerOutcome struct {
-	cause  error
-	output *data.ItemDefinition
-	jobID  JobID
+	status   data.Value
+	output   *data.ItemDefinition
+	fault    Fault
+	bpmnCode string
+	bpmnMsg  string
+	jobID    JobID
 	foundation.BaseElement
+	kind OutcomeKind
 }
 
 // NewWorkerComplete builds a successful outcome for job jobID carrying output
@@ -31,34 +70,73 @@ func NewWorkerComplete(jobID JobID, output *data.ItemDefinition) *WorkerOutcome 
 	return &WorkerOutcome{
 		BaseElement: *foundation.MustBaseElement(),
 		jobID:       jobID,
+		kind:        OutcomeComplete,
 		output:      output,
 	}
 }
 
-// NewWorkerFail builds a technical-fault outcome for job jobID carrying cause.
-func NewWorkerFail(jobID JobID, cause error) *WorkerOutcome {
+// NewWorkerBpmnError builds a worker-declared Business Error outcome: the engine
+// raises code (message is an optional diagnostic), caught by an Error boundary.
+func NewWorkerBpmnError(jobID JobID, code, message string) *WorkerOutcome {
 	return &WorkerOutcome{
 		BaseElement: *foundation.MustBaseElement(),
 		jobID:       jobID,
-		cause:       cause,
+		kind:        OutcomeBpmnError,
+		bpmnCode:    code,
+		bpmnMsg:     message,
+	}
+}
+
+// NewWorkerStatus builds a worker-declared Business Status outcome carrying value
+// (written to the ServiceTask's WithStatus variable).
+func NewWorkerStatus(jobID JobID, value data.Value) *WorkerOutcome {
+	return &WorkerOutcome{
+		BaseElement: *foundation.MustBaseElement(),
+		jobID:       jobID,
+		kind:        OutcomeStatus,
+		status:      value,
+	}
+}
+
+// NewWorkerFault builds a raw-fault outcome for job jobID; the engine ErrorMapper
+// classifies fault's {code, body} at resume.
+func NewWorkerFault(jobID JobID, fault Fault) *WorkerOutcome {
+	return &WorkerOutcome{
+		BaseElement: *foundation.MustBaseElement(),
+		jobID:       jobID,
+		kind:        OutcomeFault,
+		fault:       fault,
 	}
 }
 
 // JobID returns the job this outcome reports.
 func (o *WorkerOutcome) JobID() JobID { return o.jobID }
 
-// Output returns the operation result item on a completion (nil on a fault, or
-// when the operation produced no output).
+// Kind returns the outcome's classification.
+func (o *WorkerOutcome) Kind() OutcomeKind { return o.kind }
+
+// Output returns the operation result item on a completion (nil otherwise).
 func (o *WorkerOutcome) Output() *data.ItemDefinition { return o.output }
 
-// Cause returns the technical-fault cause (nil on a completion).
-func (o *WorkerOutcome) Cause() error { return o.cause }
+// BpmnError returns the worker-declared business-error code and message (empty on
+// other kinds).
+func (o *WorkerOutcome) BpmnError() (code, message string) {
+	return o.bpmnCode, o.bpmnMsg
+}
+
+// StatusValue returns the worker-declared business-status value (nil on other
+// kinds).
+func (o *WorkerOutcome) StatusValue() data.Value { return o.status }
+
+// Fault returns the raw fault (zero on other kinds); the engine ErrorMapper
+// classifies its {code, body}.
+func (o *WorkerOutcome) Fault() Fault { return o.fault }
 
 // Type returns the internal worker-outcome sentinel.
 func (o *WorkerOutcome) Type() flow.EventTrigger { return workerOutcomeTrigger }
 
-// GetItemsList returns nil — a WorkerOutcome carries its data via Output, not
-// ItemDefinitions.
+// GetItemsList returns nil — a WorkerOutcome carries its data via its kind-specific
+// accessors, not ItemDefinitions.
 func (o *WorkerOutcome) GetItemsList() []*data.ItemDefinition { return nil }
 
 var _ flow.EventDefinition = (*WorkerOutcome)(nil)

--- a/pkg/tasks/workeroutcome_test.go
+++ b/pkg/tasks/workeroutcome_test.go
@@ -21,8 +21,8 @@ func TestWorkerCompleteOutcome(t *testing.T) {
 	o := tasks.NewWorkerComplete("j1", item)
 
 	require.Equal(t, tasks.JobID("j1"), o.JobID())
+	require.Equal(t, tasks.OutcomeComplete, o.Kind())
 	require.Equal(t, item, o.Output())
-	require.NoError(t, o.Cause())
 	require.Nil(t, o.GetItemsList())
 	require.NotEmpty(t, o.Type())
 	require.NotEmpty(t, o.ID())
@@ -30,14 +30,47 @@ func TestWorkerCompleteOutcome(t *testing.T) {
 	var _ flow.EventDefinition = o
 }
 
-// TestWorkerFailOutcome: a fault outcome carries the cause and no output.
-func TestWorkerFailOutcome(t *testing.T) {
+// TestWorkerFaultOutcome: a fault outcome carries the raw fault and no output.
+func TestWorkerFaultOutcome(t *testing.T) {
 	cause := errors.New("upstream 503")
 
-	o := tasks.NewWorkerFail("j2", cause)
+	o := tasks.NewWorkerFault("j2", tasks.Fault{Code: "503", Cause: cause})
 
 	require.Equal(t, tasks.JobID("j2"), o.JobID())
+	require.Equal(t, tasks.OutcomeFault, o.Kind())
 	require.Nil(t, o.Output())
-	require.ErrorIs(t, o.Cause(), cause)
+	require.Equal(t, "503", o.Fault().Code)
+	require.ErrorIs(t, o.Fault().Cause, cause)
 	require.Nil(t, o.GetItemsList())
+}
+
+// TestWorkerBpmnErrorOutcome: a worker-declared Business Error carries its code
+// and message.
+func TestWorkerBpmnErrorOutcome(t *testing.T) {
+	o := tasks.NewWorkerBpmnError("j3", "ResourceConflict", "already exists")
+
+	require.Equal(t, tasks.OutcomeBpmnError, o.Kind())
+
+	code, msg := o.BpmnError()
+	require.Equal(t, "ResourceConflict", code)
+	require.Equal(t, "already exists", msg)
+}
+
+// TestWorkerStatusOutcome: a worker-declared Business Status carries its value.
+func TestWorkerStatusOutcome(t *testing.T) {
+	v := values.NewVariable("NOT_FOUND")
+
+	o := tasks.NewWorkerStatus("j4", v)
+
+	require.Equal(t, tasks.OutcomeStatus, o.Kind())
+	require.Equal(t, v, o.StatusValue())
+}
+
+// TestOutcomeKindString covers the kind→name table used for logging.
+func TestOutcomeKindString(t *testing.T) {
+	require.Equal(t, "complete", tasks.OutcomeComplete.String())
+	require.Equal(t, "bpmnError", tasks.OutcomeBpmnError.String())
+	require.Equal(t, "status", tasks.OutcomeStatus.String())
+	require.Equal(t, "fault", tasks.OutcomeFault.String())
+	require.Equal(t, "unknown", tasks.OutcomeKind(99).String())
 }

--- a/pkg/thresher/jobs_test.go
+++ b/pkg/thresher/jobs_test.go
@@ -51,8 +51,20 @@ func (d *capDispatcher) Complete(
 	return nil
 }
 
+func (d *capDispatcher) ReportBpmnError(
+	context.Context, tasks.JobID, tasks.WorkerID, string, string,
+) error {
+	return nil
+}
+
+func (d *capDispatcher) ReportStatus(
+	context.Context, tasks.JobID, tasks.WorkerID, data.Value,
+) error {
+	return nil
+}
+
 func (d *capDispatcher) Fail(
-	context.Context, tasks.JobID, tasks.WorkerID, error,
+	context.Context, tasks.JobID, tasks.WorkerID, tasks.Fault,
 ) error {
 	return nil
 }

--- a/pkg/thresher/options.go
+++ b/pkg/thresher/options.go
@@ -35,7 +35,10 @@ type thresherConfig struct {
 	exprEngine expression.Engine
 	authz      auth.AuthorizationProvider
 	dispatcher tasks.WorkerDispatcher
-	taskDist   interactor.TaskDistributor
+	// workerErrorMapper is the engine-wide default ErrorMapper (SRD-037 FR-3);
+	// nil by default, overridden per-service by activities.WithErrorMapper.
+	workerErrorMapper tasks.ErrorMapper
+	taskDist          interactor.TaskDistributor
 
 	// Startup-report suppression (ADR-002 v.2 §4.4.1). Both default to false —
 	// the report is visible by default; each flag opts its block out.
@@ -200,6 +203,23 @@ func WithWorkerDispatcher(d tasks.WorkerDispatcher) Option {
 	}
 }
 
+// WithWorkerErrorMapper sets the engine-wide default ErrorMapper applied to a
+// worker-dispatched ServiceTask's raw fault when it carries no per-service
+// activities.WithErrorMapper (SRD-037 FR-3, two-level config).
+func WithWorkerErrorMapper(m tasks.ErrorMapper) Option {
+	return func(c *thresherConfig) error {
+		if m == nil {
+			return errs.New(
+				errs.M("WithWorkerErrorMapper: a nil ErrorMapper isn't allowed"),
+				errs.C(errorClass, errs.EmptyNotAllowed))
+		}
+
+		c.workerErrorMapper = m
+
+		return nil
+	}
+}
+
 // WithoutBanner suppresses the startup banner block — the ASCII wordmark, the
 // product tagline, and the version / last-commit lines (ADR-002 v.2 §4.4.1).
 // The configuration dump still prints unless WithoutStartupConfig is also given.
@@ -239,6 +259,8 @@ func (c *thresherConfig) AuthorizationProvider() auth.AuthorizationProvider {
 }
 
 func (c *thresherConfig) WorkerDispatcher() tasks.WorkerDispatcher { return c.dispatcher }
+
+func (c *thresherConfig) WorkerErrorMapper() tasks.ErrorMapper { return c.workerErrorMapper }
 
 func (c *thresherConfig) TaskDistributor() interactor.TaskDistributor { return c.taskDist }
 

--- a/pkg/thresher/options_test.go
+++ b/pkg/thresher/options_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/observability/noop"
 	"github.com/dr-dobermann/gobpm/pkg/renv"
 	"github.com/dr-dobermann/gobpm/pkg/repository/memrepo"
+	"github.com/dr-dobermann/gobpm/pkg/tasks"
 	"github.com/dr-dobermann/gobpm/pkg/tasks/localdispatcher"
 )
 
@@ -53,10 +54,16 @@ func TestEveryOptionOverridesItsDefault(t *testing.T) {
 	az := allowall.New()
 	wd := localdispatcher.New(nil, 0)
 
+	wem, werr := tasks.NewRuleMapper(tasks.Rule{Code: "1", Yield: tasks.Technical{}})
+	if werr != nil {
+		t.Fatalf("building the error mapper: %v", werr)
+	}
+
 	for _, o := range []Option{
 		WithLogger(lg), WithTracer(tr), WithMetricsRecorder(mr), WithClock(ck),
 		WithRepository(rp), WithMessageBroker(mb), WithExpressionEngine(ee),
 		WithAuthorizationProvider(az), WithWorkerDispatcher(wd),
+		WithWorkerErrorMapper(wem),
 	} {
 		if err := o(&c); err != nil {
 			t.Fatalf("option returned an error: %v", err)
@@ -65,7 +72,8 @@ func TestEveryOptionOverridesItsDefault(t *testing.T) {
 
 	if c.logger != lg || c.tracer != tr || c.metrics != mr || c.clock != ck ||
 		c.repository != rp || c.msgBroker != mb || c.exprEngine != ee ||
-		c.authz != az || c.dispatcher != wd {
+		c.authz != az || c.dispatcher != wd ||
+		c.WorkerErrorMapper() != wem {
 		t.Fatal("a WithXxx option did not override its field")
 	}
 }
@@ -241,5 +249,13 @@ func TestWithoutBannerIdempotent(t *testing.T) {
 
 	if !c.suppressBanner || c.suppressStartupConfig {
 		t.Fatalf("WithoutBanner not idempotent / leaked: %+v", c)
+	}
+}
+
+// TestWithWorkerErrorMapperRejectsNil: a nil engine-wide ErrorMapper is rejected.
+func TestWithWorkerErrorMapperRejectsNil(t *testing.T) {
+	c := defaultConfig()
+	if err := WithWorkerErrorMapper(nil)(&c); err == nil {
+		t.Fatal("a nil ErrorMapper should be rejected")
 	}
 }

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -210,6 +210,13 @@ func New(id string, opts ...Option) (*Thresher, error) {
 		binder.BindSink(t)
 	}
 
+	// Bind the engine's configured logger so the dispatcher's own lifecycle logging
+	// uses the embedder's logger rather than its private default (SRD-037). Done
+	// after all options are applied, so a WithLogger override is honored.
+	if lb, ok := cfg.WorkerDispatcher().(tasks.LoggerBinder); ok {
+		lb.BindLogger(cfg.Logger())
+	}
+
 	// The EventHub receives the engine's resolved runtime (&t.cfg implements
 	// renv.EngineRuntime) so the waiters it builds reach Clock / ExpressionEngine
 	// (ADR-002 §4.3, Solution B). Built after t so it shares t's cfg pointer.


### PR DESCRIPTION
## Service Task outcome classification & output mapping (SRD-037, M4 + M5)

Lands milestones M4–M5 of ADR-021: a worker-dispatched ServiceTask's outcome is
classified and applied. ADR-021 stays **Draft** until SRD-038 (M6–M8).

### What's in it
- **M4 — classification.** A worker outcome resolves to four kinds by **code + body**:
  success; **Business Error** → a BPMN errorCode raised and caught by an Error
  boundary (interrupting); **Business Status** → a status variable written, task
  completes; **technical** → terminal (retry is SRD-038). Via worker
  self-classification (`ReportBpmnError`/`ReportStatus`) **and** a first-class
  declarative two-level `ErrorMapper` (`WithErrorMapper` per-service /
  `WithWorkerErrorMapper` engine-wide), plus `WithStatus`.
- **M5 — output mapping.** `WithOutputMapping` shapes a worker's raw response body
  into the declared output variables; direct reconciliation is the default.

### Design notes
- Classification runs **at resume** (`execWorkerOutcome`), where the expression
  engine + scope are available — no held goroutine.
- A Business Error reuses the existing `matchErrorBoundary` catch — **zero new
  raise machinery**.
- The mapper body-binding is in-process gobpm expressions over Go values;
  JSONPath/HTTP rides with the transport in ADR-004.
- `SrvTaskOption` is now error-returning, validating every new option (nil mapper /
  empty status name / nil path).

### Also folded in
An observability pass on `localdispatcher`: the worker pool's report errors are
logged (not dropped), logging is on by default, full lifecycle logging was added,
and the logger is taken from the runtime config via a new `tasks.LoggerBinder` seam.

### Verification
`make ci` green — lint/vet/build/`-race`, diff-coverage 98.1% (min 95%),
govulncheck. Every FR/NFR covered by a named test; `/check-srd` landing gate PASS.

### Deferred → SRD-038
`WithWorkerTrust` (policy shipping + `EngineAuthoritative`), the retry policy, and
the worked example.