### PR TITLE
SRD-038: Service Task dispatch reshape & dispatcher-owned retry policy

### DIFF
--- a/docs/srd/SRD-038-service-task-retry.md
+++ b/docs/srd/SRD-038-service-task-retry.md
@@ -1,0 +1,441 @@
+# SRD-038 — Service Task dispatch reshape & retry policy (M6, M7)
+
+| Field | Value |
+|---|---|
+| Status | Draft (pending impl) |
+| Version | v.1 |
+| Date | 2026-07-08 |
+| Owner | Ruslan Gabitov |
+| Implements | [ADR-021 v.1 Service Task Execution Model](../design/ADR-021-service-task-execution-model.md) §2.6–§2.8 |
+
+> **Draft** — fourth of five SRDs landing [ADR-021 v.1](../design/ADR-021-service-task-execution-model.md).
+> Builds on classification ([SRD-037](SRD-037-service-task-classification.md), Accepted). Two coupled changes:
+> **(1) Dispatch reshape** — move a worker fault's **classification** off the parked **track** and into the
+> **dispatcher**, so classification + retry happen **before** the instance loop and the track only **applies** a
+> pre-decided terminal outcome. This restores ADR-021 §2.7 ("only the terminal outcome reaches the loop"); SRD-037
+> (M4) drifted classification to track-resume. **(2) Retry policy** — an extendable, batteries-included, two-level
+> `RetryPolicy` (default 3× exponential-backoff+jitter). Retry is a **dispatcher-side delayed re-enqueue** (the
+> dispatcher re-arms the job with a clock-gated backoff, no sleeping goroutine, the track stays parked), and
+> retries-exhausted → an incident-like terminal `Failed` that reaches the **instance** (incident-ready). This is the
+> ADR-021 **`EngineAuthoritative`** mode: the engine (here, its default in-process dispatcher) owns the policy and
+> the worker returns raw `{code, body}`. **Out of scope, → SRD-039:** the `WithWorkerTrust` knob + the
+> **`WorkerTrusted`** protocol (the worker runs the shipped policy internally, retries in-process, reports a verdict)
+> + the worked example. Sibling: SRD-035 (M1), SRD-036 (M2/M3), SRD-037 (M4/M5), all Accepted.
+
+---
+
+## 1. Background (verified against the code)
+
+### 1.1 SRD-037 (M4) left classification on the track — a drift from the ADR (verified)
+
+Today a worker fault rides all the way to the parked track before it is classified. The dispatcher's `Fail` method
+delivers a raw `tasks.WorkerOutcome` (`OutcomeFault`) to the engine sink; `Instance.handleJobCompletion`
+(`internal/instance/jobs.go:59-90`) resolves `jobID → track` and **delivers straight to the track's `evtCh`**:
+
+```go
+// jobs.go:85-89 (current)
+flipNotParked(tr, waiting, msgIdx)
+delete(jobs, jobID)
+tr.evtCh <- req.outcome        // ← wakes the track for it to classify + apply
+req.reply <- nil
+```
+
+The woken track runs `ServiceTask.execWorkerOutcome` (`service_task.go:337-363`), whose `OutcomeFault` case calls
+`classifyFault` (`:478-519`) — running the two-level `ErrorMapper` at **resume, on the track**. But ADR-021 §2.7 is
+explicit that under `EngineAuthoritative` "**only the terminal outcome reaches the loop**", and §2.6 that "the
+**engine** runs the `ErrorMapper` (sole authority)". So classification is meant to happen **before** the instance
+loop; M4 drifted it onto the track (as its own §4.1 acknowledged, deferring the locus). SRD-038 moves it to where
+the ADR puts it — the **dispatcher** — and that move is exactly what retry needs.
+
+### 1.2 Why classification must precede the loop (the design driver)
+
+Retry applies to **technical faults only** (ADR-021 §2.7): a technical fault re-runs the worker with backoff, and
+the ServiceTask must **stay parked** across attempts. A raw fault is only known to be technical (vs a business
+`BpmnError`/`Status` the `ErrorMapper` extracts from `{code, body}`) **after** classification — so the retry
+decision **requires** classification first. If classification stayed on the track, every intermediate technical
+fault would have to wake the track and send it back to sleep per attempt ("re-park"), and the track would have to
+carry the retry-cycle count it should not own.
+
+The clean structure (and the ADR's): **the worker returns a raw fault; the dispatcher classifies it and decides —
+re-publish (retry) or escalate a terminal outcome to the instance; the instance loop receives only terminals; the
+track applies one terminal.** The engine holds no live call between attempts — a re-armed job plus a parked track
+are both persistable (§2.7).
+
+```mermaid
+flowchart LR
+    WK[local worker: fn err] -->|raw Fault| DISP[dispatcher]
+    DISP -->|classify + retry loop| DISP
+    DISP -->|terminal only| SINK[engine sink]
+    SINK --> LOOP[instance loop\nhandleJobCompletion]
+    LOOP -->|deliver terminal| TR[track: apply]
+```
+
+### 1.3 Incident-readiness — the terminal reaches the instance, not the dispatcher's edge (design intent)
+
+Retries-exhausted terminates the task `Failed` (§2.8), but the exhausted **terminal is delivered to the instance
+loop** (like every other terminal), not swallowed at the dispatcher's edge. This is deliberate: it keeps the
+**instance** the single owner of every ServiceTask terminal, which is what a future first-class **Incident**
+construct needs — on exhaustion the instance can hold the track **parked** (an incident awaiting operator
+resolution) instead of faulting it, and a parked-during-incident track is the same shape that **dehydrates**
+cleanly, unified with parked UserTasks (ADR-020) and long timer events. SRD-038 lands the terminal `Failed`; the
+incident-hold + dehydration is a **future ADR** (§2.8) the seam is built for.
+
+### 1.4 The reshape rails (verified)
+
+- **Classification needs only the fault + an expression engine — no process scope.**
+  `ErrorMapper.Classify(ctx, ee expression.Engine, f Fault)` (`pkg/tasks/errormapper.go:67`) takes the expression
+  engine **directly** and builds its transient source from the `Fault`'s `{code, body}` — it reads no frame. So the
+  dispatcher can classify a raw fault on the reporting goroutine given a bound expression engine, no frame, no
+  instance involvement.
+- **The dispatcher already has a per-job store to re-arm.** `localdispatcher.jobEntry`
+  (`localdispatcher.go:46-51`) holds each job's lock state keyed in `byID`/`byTopic`; `lockNext`
+  (`:181-214`) hands out an entry when `e.workerID == "" || now.After(e.deadline)`, over the injected
+  `clock.Clock`. A retry re-arms the **existing** entry (unlock + a `notBefore` gate + attempt++) — no re-enqueue
+  round-trip through the instance.
+- **The clock already supports a timed wake.** `clock.Clock` (`pkg/clock/clock.go:10-15`) is `Now()` +
+  `After(d time.Duration) <-chan time.Time`; `syscl` and the `clocktest` fake both implement `After`. So
+  `FetchAndLock` can wake at the nearest future `notBefore` with `clk.After(until)` — no timer per job, no clock
+  interface change.
+- **The binder seam exists to give the dispatcher the expression engine.** The engine already binds its sink and
+  logger onto the dispatcher at startup via `tasks.SinkBinder`/`tasks.LoggerBinder`
+  (`workerdispatcher.go:156-170`, called in `thresher.go:209-218`). SRD-038 mirrors it with a
+  `tasks.ExpressionEngineBinder`.
+- **`Job.Policy` is a ready placeholder.** `tasks.Policy` (`workerdispatcher.go:61-65`) is an empty `struct{}`
+  documented as the SRD-037/038 fill; `Job` carries `Policy *Policy` (`:69-74`, the field at `:71`), populated
+  nowhere yet (`enqueueJob`, `jobs.go:155-156`, sets only `{ID, Topic, Input}`). SRD-038 fills `Policy` with the
+  resolved `{ErrorMapper, RetryPolicy}` and populates it at enqueue.
+
+## 2. Requirements
+
+### Functional — dispatch reshape (M6)
+
+- **FR-1 — Classification moves to the dispatcher.** A raw worker fault (`Fail`) is classified **in the dispatcher**,
+  on the reporting goroutine, via the resolved `Job.Policy.ErrorMapper` and a bound expression engine — **not** on
+  the track, **not** on the instance loop. This restores ADR-021 §2.7 ("only the terminal outcome reaches the
+  loop"). `ServiceTask.classifyFault` is removed from the track.
+- **FR-2 — `Job.Policy` carries the resolved outcome policy; the instance resolves it at enqueue.** The instance,
+  in `enqueueJob` (loop goroutine), resolves the **two-level** policy — per-service (a new `tasks.WorkerConfig`
+  exposed by the node) over engine-wide defaults — and populates `Job.Policy{ErrorMapper, RetryPolicy}`.
+  `tasks.WorkerConfig` (implemented by `ServiceTask`, `ok == false` for an in-process task) surfaces the node's
+  per-service `ErrorMapper`/`RetryPolicy`. `tasks.Policy` grows from the empty placeholder to
+  `{ErrorMapper, RetryPolicy}`.
+- **FR-3 — The dispatcher receives the expression engine via a binder seam.** A new `tasks.ExpressionEngineBinder`
+  (`BindExpressionEngine(expression.Engine)`), bound at engine startup exactly like `BindLogger`/`BindSink`, gives
+  the dispatcher the engine it needs to run the `ErrorMapper`. A dispatcher that reaches an engine another way
+  (a remote adapter) need not implement it.
+- **FR-4 — The track's apply shrinks to terminals only.** `execWorkerOutcome` receives only **terminal** outcomes:
+  `OutcomeComplete` → `bindOutput` (+ `WithOutputMapping`), `OutcomeBpmnError` → `raiseBpmnError`, `OutcomeStatus`
+  → `writeStatus`, `OutcomeFault` → `technicalFault` (the terminal, retries-exhausted case — **not** re-classified).
+  The track parks once and wakes once.
+
+### Functional — retry policy (M7)
+
+- **FR-5 — `RetryPolicy` abstraction + batteries.** `pkg/tasks.RetryPolicy` decides, given the attempt count and
+  the technical cause, whether to retry and the backoff before the next attempt. Batteries-included: `NoRetry`,
+  `FixedDelay(maxAttempts, delay)`, `ExponentialBackoff(maxAttempts, base, max, jitter)`. **Default — 3 attempts,
+  exponential backoff with jitter** (count 3 = Camunda `defaultNumberOfRetries`; backoff improves on Camunda's
+  zero-wait default, ADR-021 §2.7).
+- **FR-6 — Two-level config.** Engine-wide `WithWorkerRetryPolicy(p)` (on the thresher/enginert config +
+  `renv.EngineRuntime.WorkerRetryPolicy()` accessor) and per-service `activities.WithRetryPolicy(p)`; the
+  per-service policy overrides the engine-wide default; absent both, `DefaultRetryPolicy` applies. The instance
+  resolves the effective policy at enqueue into `Job.Policy` (so `Job.Policy.RetryPolicy` is always non-nil).
+  Mirrors `WorkerErrorMapper` (SRD-037 FR-3) exactly.
+- **FR-7 — Retry = dispatcher-side delayed re-enqueue (no sleeping goroutine).** On a **Technical** classification
+  the dispatcher consults `Job.Policy.RetryPolicy` against the entry's attempt count: if it retries, the dispatcher
+  **re-arms the existing store entry** — unlock it, set `notBefore = clk.Now() + backoff`, increment `attempt` —
+  **without delivering** (the track stays parked). `lockNext` skips a still-gated entry; `FetchAndLock` wakes at the
+  nearest `notBefore` via `clk.After`; a worker re-fetches after the backoff and the loop repeats. The engine holds
+  no live call (a re-armed job + a parked track are both persistable, §2.7).
+- **FR-8 — Retries-exhausted → incident-like `Failed`, delivered to the instance.** When the policy is exhausted,
+  the dispatcher delivers a **terminal** technical `OutcomeFault` to the sink; the instance loop routes it to the
+  track, which faults `Failing → Failed` with a diagnostic identifying the exhausted job (topic, attempts, last
+  error). It is **not** an auto-raised catchable BPMN Error (§2.8) — infrastructure exhaustion is operational, not
+  a model fault. The terminal reaching the **instance** (not the dispatcher's edge) is the incident-ready seam
+  (§1.3); the first-class Incident construct (parked-hold + operator surface + dehydration) is a **future ADR**.
+
+### Non-functional
+
+- **NFR-1 (park-once).** The track parks exactly once (`onJobWaiting`) and wakes exactly once (on the terminal
+  outcome). Intermediate retried faults never reach the instance loop or `evtCh` — no re-park.
+- **NFR-2 (only-terminal-to-loop).** `handleJobCompletion` receives only terminal outcomes; classification + the
+  retry loop run in the dispatcher, before the instance loop (ADR-021 §2.7). The instance's role in a retried job is
+  one enqueue (with the resolved policy) and one terminal.
+- **NFR-3 (dehydration-friendly / incident-ready).** Retry is a clock-gated re-arm — no per-job timer goroutine
+  (the fetch loop's single `clk.After` wait), no sleeping goroutine; a re-armed (waiting-for-`notBefore`) job plus a
+  parked track are both persistable (§2.7). The exhausted terminal reaches the instance (§1.3).
+- **NFR-4 (technical-only).** Only a Technical classification is retried; Success / Business Error / Business Status
+  are terminal on first report — never retried (§2.7).
+- **NFR-5 (single-writer preserved).** The instance loop stays the sole owner of the `jobs` registry and the sole
+  sender to `evtCh`. The dispatcher's classify+retry runs on the worker's reporting goroutine over the dispatcher's
+  own mutex-guarded store — it shares no state with the loop, and delivers terminals through the existing sink.
+- **NFR-6 (gate).** diff-coverage ≥95% on touched files; `make ci` green; the dispatcher classify/retry
+  (clock-driven re-arm + timed wake) is `-race` clean.
+
+## 3. Models
+
+### 3.1 `RetryPolicy` — `pkg/tasks/retrypolicy.go` (NEW)
+
+```go
+// RetryPolicy decides whether a technical fault is retried and the backoff before
+// the next attempt (ADR-021 §2.7). attempt is the 1-based number of the attempt
+// that just failed; cause is its technical error.
+type RetryPolicy interface {
+	Retry(attempt int, cause error) (backoff time.Duration, retry bool)
+}
+
+// Batteries: NoRetry (never), FixedDelay(maxAttempts, delay), and
+// ExponentialBackoff(maxAttempts, base, max, jitter). DefaultRetryPolicy is
+// ExponentialBackoff(3, base, max, jitter) — Camunda's count-of-3 with a
+// non-zero backoff.
+func NoRetry() RetryPolicy
+func FixedDelay(maxAttempts int, delay time.Duration) RetryPolicy
+func ExponentialBackoff(maxAttempts int, base, max time.Duration, jitter bool) RetryPolicy
+func DefaultRetryPolicy() RetryPolicy
+```
+
+### 3.2 `Policy` filled — `pkg/tasks/workerdispatcher.go` (EXTEND)
+
+The empty placeholder becomes the resolved outcome bundle the dispatcher consumes (and, under SRD-039
+`WorkerTrusted`, ships to the worker):
+
+```go
+// Policy is a worker-dispatched ServiceTask's resolved outcome policy. Under
+// EngineAuthoritative (SRD-038) the dispatcher uses it to classify a raw fault
+// (ErrorMapper) and drive retries (RetryPolicy); under WorkerTrusted (SRD-039) it
+// is shipped to the worker. The instance resolves it (two-level) at enqueue.
+type Policy struct {
+	ErrorMapper ErrorMapper // nil = raw faults fall through to the default Technical outcome
+	RetryPolicy RetryPolicy // always non-nil after resolution (DefaultRetryPolicy if unset)
+}
+```
+
+`OutputMapping`/`StatusVar` are **not** in `Policy` — the track applies them and it holds the `ServiceTask`
+directly (`execWorkerOutcome` is a `*ServiceTask` method), so they need no shipping. (SRD-039 revisits this if a
+`WorkerTrusted` worker maps its own output.)
+
+### 3.3 `WorkerConfig` — `pkg/tasks` (NEW), feeds enqueue
+
+```go
+// WorkerConfig is implemented by a node whose worker outcome the engine
+// classifies + retries. WorkerConfig returns the node's per-service policy
+// (either field nil = fall back to the engine-wide default at resolution).
+// ok == false for an in-process ServiceTask.
+type WorkerConfig interface {
+	WorkerConfig() (errorMapper ErrorMapper, retryPolicy RetryPolicy, ok bool)
+}
+```
+
+`ServiceTask` gains a `retryPolicy tasks.RetryPolicy` field (from `WithRetryPolicy`) and implements `WorkerConfig`
+(returning `st.errorMapper`, `st.retryPolicy`, `ok == workerTopic != ""`).
+
+### 3.4 Dispatcher classify + retry — `pkg/tasks/localdispatcher` (RESHAPE)
+
+`jobEntry` gains `attempt int` and `notBefore time.Time`; `Dispatcher` gains an `exprEngine expression.Engine`
+(bound). `Fail` becomes the classify+retry locus (the other report methods stay terminal-only):
+
+```mermaid
+flowchart TD
+    F[Fail: raw Fault on the reporting goroutine] --> V{lock held & unexpired?}
+    V -->|no| E[return lock error]
+    V -->|yes| CLS[Classify: Job.Policy.ErrorMapper + bound exprEngine\nnil mapper → Technical]
+    CLS -->|BpmnError| MB[terminal NewWorkerBpmnError]
+    CLS -->|Status| MS[terminal NewWorkerStatus]
+    CLS -->|Technical| RP{Job.Policy.RetryPolicy.Retry attempt+1}
+    RP -->|retry, backoff| RE[re-arm entry: workerID=; notBefore=now+backoff; attempt++; broadcast]
+    RP -->|exhausted| MF[terminal NewWorkerFault]
+    MB --> DEL[remove entry; sink.ReportJobCompletion terminal]
+    MS --> DEL
+    MF --> DEL
+    RE -. worker re-fetches after notBefore .-> F
+```
+
+Classification runs **outside** `d.mu` while the entry stays locked by the reporting worker (its lock is still
+valid, so no concurrent fetch); the decision (re-arm or remove) re-acquires `d.mu`. **On re-acquire, `Fail`
+re-validates the entry via the `heldEntry` invariant** (still present, still held by the reporting worker) before
+re-arm/remove — a lock that expired *during* a long classification is dropped rather than stomping a new holder.
+That expiry is only reachable with **multiple workers per topic**; the shipped `localdispatcher` registers exactly
+one worker per topic (`RegisterWorker` rejects duplicates) and `runWorker` calls `Fail` synchronously before its
+next fetch, so no concurrent fetch can occur during the classify window in 0.1.x — the re-validation guards the
+general `Dispatcher` seam (its crash-recovery reclaim path). Because the retry path must **keep** the entry to
+re-arm it, `Fail` gets its own classify+retry path and **stops delegating to `report()`** (which removes the entry
+before delivery); `Complete`/`ReportBpmnError`/`ReportStatus` keep using `report()`. Only the **Fault** kind is
+classified — `Complete` is terminal as today; `ReportBpmnError`/`ReportStatus` (worker self-classified verdicts)
+stay terminal pass-throughs (the local pool emits only `Complete`/`Fail`, so they matter for SRD-039).
+
+### 3.5 `lockNext` gate + `FetchAndLock` timed wake — `pkg/tasks/localdispatcher` (EXTEND)
+
+`lockNext` grows its return from `(LockedJob, bool)` to `(LockedJob, time.Time, bool)` — the middle value is the
+earliest future gate across the scanned entries, captured under the same `d.mu` — so it can skip a re-armed entry
+while gated and hand the fetch loop a wake time:
+
+```go
+// in lockNext's per-entry scan, after the lock check:
+if !e.notBefore.IsZero() && now.Before(e.notBefore) {
+    // track the earliest future gate for the caller's timed wake
+    if next.IsZero() || e.notBefore.Before(next) {
+        next = e.notBefore
+    }
+    continue
+}
+
+// FetchAndLock: when nothing is immediately available, also wake at the nearest gate.
+var timer <-chan time.Time
+if !next.IsZero() {
+    timer = d.clk.After(next.Sub(d.clk.Now()))
+}
+select {
+case <-wake:  continue // a job was enqueued
+case <-timer: continue // a backoff gate elapsed (nil channel blocks forever)
+case <-ctx.Done(): return nil, ctx.Err()
+}
+```
+
+### 3.6 Instance enqueue resolves the policy — `internal/instance/jobs.go` (EXTEND)
+
+`enqueueJob` resolves the two-level policy and populates `Job.Policy`; `handleJobCompletion` is **unchanged** (it
+already delivers the — now always terminal — outcome to the track). The `jobs` registry stays `map[JobID]*track`.
+
+```go
+// enqueueJob, after binding input:
+em, rp := inst.resolveWorkerPolicy(ev.node) // per-service (WorkerConfig) over engine-wide over default
+return inst.WorkerDispatcher().Enqueue(ctx, tasks.Job{
+    ID: jobID, Topic: topic, Input: input,
+    Policy: &tasks.Policy{ErrorMapper: em, RetryPolicy: rp},
+})
+
+// resolveWorkerPolicy: em may stay nil (→ default Technical); rp is never nil.
+//   em: node.WorkerConfig().errorMapper  ?? inst.WorkerErrorMapper()
+//   rp: node.WorkerConfig().retryPolicy  ?? inst.WorkerRetryPolicy() ?? tasks.DefaultRetryPolicy()
+```
+
+### 3.7 Track apply — `activities.execWorkerOutcome` (SHRINK)
+
+The `OutcomeFault` case changes from `classifyFault(...)` to `st.technicalFault(fault)` (the terminal
+retries-exhausted case); `classifyFault` is **deleted** from the ServiceTask. `technicalFault`'s doc-comment
+(`service_task.go:521-522`, currently "retry arrives in SRD-038") is refreshed — it is now the terminal
+retries-exhausted apply, not a placeholder. `bindOutput` / `raiseBpmnError` / `writeStatus` / `ProcessEvent` are
+unchanged.
+
+## 4. Analysis
+
+### 4.1 Classify in the dispatcher, before the loop (FR-1, NFR-2)
+
+`ErrorMapper.Classify` reads the fault's `{code, body}` and takes the expression engine as a parameter, so it runs
+on the reporting goroutine with the dispatcher's bound engine — no frame, no instance involvement. Placing it in
+the dispatcher (not the instance loop) is the ADR's own wording ("only the terminal outcome reaches the loop",
+"the engine runs the ErrorMapper") and is what lets the retry loop stay entirely off the track. *Rejected:
+classify on the instance loop (an earlier SRD-038 sketch)* — it makes the instance run the dispatcher's
+retry-orchestration (re-enqueue, attempt counting) per attempt; the user's design correction is that retry is
+dispatcher work and the instance should see only terminals. *Rejected: keep classify on the track (SRD-037 status
+quo)* — forces re-park per attempt and track-held retry state, the exact coupling this SRD removes.
+
+### 4.2 The dispatcher owns classify+retry; ADR-004 remote is a later locus call (FR-1, scope)
+
+For the in-process `localdispatcher` — the default and only transport in 0.1.x — the dispatcher owns classify+retry
+directly: it already has the per-job store to re-arm, and gets the expression engine + resolved policy via the
+binder seam + `Job.Policy`. A **remote** dispatcher (ADR-004) under `EngineAuthoritative` would either implement
+the same behavior in its adapter or the engine grows a shared pre-loop classify locus — an ADR-004 transport
+decision, not this SRD's. SRD-038 scopes to the local transport, matching the user's model ("the worker sends raw
+data to the dispatcher, and the dispatcher decides re-publish vs escalate").
+
+### 4.3 Retry = re-arm the existing entry, attempt count in the store (FR-7, NFR-3)
+
+The backoff is a `notBefore` gate on the **existing** entry (unlock + gate + `attempt++`), not a re-enqueue round
+trip and not a timer — so no goroutine sleeps and a waiting-to-retry job is persistable (§2.7). The attempt count
+is retry state owned by the dispatcher's store (where the job already lives), not shipped to the worker and not held
+by the instance. The fetch loop wakes at the nearest gate via `clk.After` — one bounded wait shared by all gated
+jobs on a topic, not one timer per job. *Rejected: a per-retry timer/goroutine* — un-persistable, one goroutine per
+retried job. *Rejected: re-enqueue via `Enqueue` (remove + re-add)* — needless index churn and a duplicate-id
+window; re-arming the entry in place is simpler and keeps the job's identity and input.
+
+### 4.4 Exhaustion is `Failed` and reaches the instance (FR-8, §1.3)
+
+Exhausted retries are an **operational** condition (a stuck job), not a business fault, so they terminate the task
+`Failed` with a diagnostic rather than raising a catchable errorCode — Camunda's incident distinction (§2.8).
+Delivering that terminal **to the instance** (not resolving it at the dispatcher's edge) keeps the instance the
+single owner of every terminal, which is the seam a future Incident construct needs to hold the track parked
+(instead of faulting) and dehydrate it — unified with parked UserTasks and long timers. What lands here is the
+terminal, observable `Failed`.
+
+### 4.5 `EngineAuthoritative`; `WorkerTrusted` → SRD-039 (scope)
+
+With the engine (its dispatcher) owning classification + retry and the worker returning raw `{code, body}`, this
+**is** ADR-021 `EngineAuthoritative`. SRD-039 adds the `WithWorkerTrust` knob and the `WorkerTrusted` protocol (the
+worker runs the shipped `Job.Policy` internally — maps its output, self-classifies, retries in-process holding its
+lock — and reports a verdict the dispatcher forwards without re-classify/retry), plus the worked example. No ADR-004
+dependency: ADR-004 is the remote *transport* for the same two protocols. Until SRD-039 lands the knob,
+`EngineAuthoritative` is the implicit (only) mode.
+
+## 5. API / contract surface
+
+- **New (`pkg/tasks`):** `RetryPolicy` + `NoRetry`/`FixedDelay`/`ExponentialBackoff`/`DefaultRetryPolicy`;
+  `WorkerConfig` interface; `ExpressionEngineBinder` interface. **Filled:** `Policy{ErrorMapper, RetryPolicy}`.
+- **New (`activities`):** `WithRetryPolicy(p)` `SrvTaskOption`; `ServiceTask.WorkerConfig()`; `retryPolicy` field.
+  **Removed from the track:** `ServiceTask.classifyFault`.
+- **New (engine config):** `WithWorkerRetryPolicy` (thresher + enginert) + a `WorkerRetryPolicy()` method **added to
+  the `renv.EngineRuntime` interface** — forcing accessors on `enginert.Runtime` and `thresher.thresherConfig` (the
+  `WorkerErrorMapper()` mirror) and a **`mockrenv` regeneration** (`make gen_mock_files`).
+- **Reshaped (`localdispatcher`):** `Dispatcher.exprEngine` + `BindExpressionEngine`; `Fail` classify+retry;
+  `jobEntry.{attempt, notBefore}`; `lockNext` gate + `FetchAndLock` timed wake.
+- **Reshaped (`instance`):** `enqueueJob` resolves + populates `Job.Policy` (`handleJobCompletion` unchanged).
+- **New startup wiring (`thresher`):** `BindExpressionEngine(cfg.ExpressionEngine())` alongside the existing
+  `BindSink`/`BindLogger`.
+
+## 6. Test scenarios
+
+**Proposed** (to be implemented in M6/M7; §10 records the actual landed names).
+
+| Test | FR/NFR | Scenario |
+|---|---|---|
+| `TestDispatcherClassifiesFaultToBpmnError` | FR-1, FR-4 | a raw `Fail` classified **by the dispatcher** → the sink/loop receives a terminal BpmnError → the track raises it → boundary |
+| `TestDispatcherClassifiesFaultToStatus` | FR-1 | a raw `Fail` mapped to Status → terminal Status → the track writes the status var and completes |
+| `TestEnqueueResolvesTwoLevelPolicy` | FR-2, FR-6 | `enqueueJob` populates `Job.Policy` from per-service `WorkerConfig` over engine-wide over `DefaultRetryPolicy`; an in-process task enqueues nothing |
+| `TestBindExpressionEngineSeam` | FR-3 | the engine binds its expression engine onto the dispatcher at startup; a fault classifies with it |
+| `TestTrackAppliesTerminalOnly` | FR-4, NFR-1 | the track parks once / wakes once; a raw fault reaches the track **only** as a terminal (never re-classified there) |
+| `TestRetryPolicyBatteries` | FR-5 | `NoRetry` never retries; `FixedDelay`/`ExponentialBackoff` retry to `maxAttempts` with the expected backoff; `DefaultRetryPolicy` = 3 attempts |
+| `TestTechnicalFaultRetriesViaReArm` | FR-7, NFR-1/3 | a technical fault re-arms the entry with backoff; advancing the clock lets a worker re-fetch; the track stays parked across attempts; no delivery until terminal |
+| `TestLocalDispatcherNotBeforeGate` | FR-7 | a re-armed entry with a future `notBefore` is skipped by `FetchAndLock` until `clk.After` fires at the gate |
+| `TestRetryExhaustedFaultsWithDiagnostic` | FR-8 | after `maxAttempts` technical faults, the dispatcher delivers a terminal Fault; the task `Failed` with a topic/attempts/last-error diagnostic; not a catchable BpmnError |
+| `TestBusinessOutcomeNotRetried` | NFR-4 | a fault classified BpmnError / Status is terminal on first report (RetryPolicy not consulted) |
+
+## 7. Milestones
+
+1. **M6 — dispatch reshape.** Move classification into the dispatcher: `ExpressionEngineBinder` seam +
+   `Dispatcher.exprEngine` + startup wiring; fill `Policy{ErrorMapper, RetryPolicy}`; `WorkerConfig` + instance
+   `resolveWorkerPolicy`/`Job.Policy` population; classify in `Dispatcher.Fail` (Technical stays terminal for now);
+   shrink `execWorkerOutcome` (remove `classifyFault`; `OutcomeFault` → `technicalFault`). One commit.
+2. **M7 — retry policy.** `RetryPolicy` + batteries + default + two-level config (`WithRetryPolicy` /
+   `WithWorkerRetryPolicy` + `renv` accessor); the dispatcher re-arm loop (`jobEntry.{attempt, notBefore}`,
+   `lockNext` gate, `FetchAndLock` timed wake); retries-exhausted → terminal `Failed` with diagnostic. One commit.
+
+## 8. Cross-doc
+
+- **Implements:** [ADR-021 v.1](../design/ADR-021-service-task-execution-model.md) §2.6 (`EngineAuthoritative`:
+  the engine classifies, the worker returns raw), §2.7 (retry by re-enqueue; "only the terminal reaches the loop"),
+  §2.8 (retries-exhausted → incident-like Failed). The §2.10 sequence diagram places the retry loop in `JQ`
+  (job queue / dispatcher) — `W→JQ: Fail` → `JQ→JQ: re-enqueue with backoff until exhausted` → `JQ→IL: exhausted`
+  — with only the terminal crossing to `IL` (instance loop); SRD-038 realizes exactly that locus.
+- **References (up / sideways):** [ADR-018 v.1](../design/ADR-018-boundary-events-and-activity-interruption.md)
+  (Business Error boundary — the unchanged apply path), [ADR-017 v.1](../design/ADR-017-channel-based-event-processing.md)
+  §2 (loop delivery / single-writer — the instance side stays within it),
+  [ADR-011 v.5](../design/ADR-011-process-data-flow.md) (data / expression), [ADR-001 v.6](../design/ADR-001-execution-model.md)
+  (execution model), [SAD-001 v.1](../design/SAD-001-vision-and-architecture.md) §11, §13.2.
+- **Sibling SRDs:** SRD-035/036/037 (Accepted); **SRD-039** (`WithWorkerTrust` + `WorkerTrusted` protocol + worked
+  example) forthcoming — **ADR-021 flips Accepted after SRD-039**. SRD→SRD sideways; pins by number.
+- Direction: SRD → ADR / SAD (up), SRD → SRD (sideways); no downward reference.
+
+## 9. Definition of Done
+
+- FR-1…FR-8 implemented and wired; NFR-1…NFR-6 upheld.
+- Every FR covered by ≥1 named §6 test, all green under `-race` (per-package coverage for the `tasks` /
+  `activities` / `localdispatcher` / `instance` touched code — the SRD-036 per-package-gate lesson). NFR-1/3/4 have
+  dedicated rows; **NFR-2** (only-terminal-to-loop) is asserted by `TestTrackAppliesTerminalOnly`; **NFR-5**
+  (single-writer) is a structural invariant that rides the `-race` gate (NFR-6).
+- `ServiceTask.classifyFault` removed from the track with no stale callers; the dispatcher classifies every raw
+  fault before delivery; `handleJobCompletion` receives only terminal outcomes.
+- `make ci` green (tidy · lint · build · `-race` · diff-coverage ≥95% on touched files · govulncheck).
+- SRD-038 flips to Accepted. **ADR-021 stays Draft** until SRD-039.
+
+## 10. Implementation summary (stage-by-stage actual landings + deltas vs draft)
+
+> ⚠️ TODO: fill AFTER landing (§10.1 stage commit SHAs for M6/M7, §10.2 empirical findings vs this draft).

--- a/docs/srd/SRD-038-service-task-retry.md
+++ b/docs/srd/SRD-038-service-task-retry.md
@@ -2,13 +2,13 @@
 
 | Field | Value |
 |---|---|
-| Status | Draft (pending impl) |
+| Status | Accepted |
 | Version | v.1 |
 | Date | 2026-07-08 |
 | Owner | Ruslan Gabitov |
 | Implements | [ADR-021 v.1 Service Task Execution Model](../design/ADR-021-service-task-execution-model.md) §2.6–§2.8 |
 
-> **Draft** — fourth of five SRDs landing [ADR-021 v.1](../design/ADR-021-service-task-execution-model.md).
+> **Accepted** — fourth of five SRDs landing [ADR-021 v.1](../design/ADR-021-service-task-execution-model.md).
 > Builds on classification ([SRD-037](SRD-037-service-task-classification.md), Accepted). Two coupled changes:
 > **(1) Dispatch reshape** — move a worker fault's **classification** off the parked **track** and into the
 > **dispatcher**, so classification + retry happen **before** the instance loop and the track only **applies** a
@@ -438,4 +438,21 @@ dependency: ADR-004 is the remote *transport* for the same two protocols. Until 
 
 ## 10. Implementation summary (stage-by-stage actual landings + deltas vs draft)
 
-> ⚠️ TODO: fill AFTER landing (§10.1 stage commit SHAs for M6/M7, §10.2 empirical findings vs this draft).
+### 10.1 Stages by commit (branch `feat/service-task-retry`)
+
+| Stage | Commit | Scope | Tests |
+|---|---|---|---|
+| Doc | `4534255` | SRD-038 (this document) | — |
+| M6 | `d79208c` | Dispatch reshape: `classify` in `localdispatcher.Fail`; `ExpressionEngineBinder` + `BindExpressionEngine` + startup wiring; `Policy{ErrorMapper, RetryPolicy}`; `WorkerConfig` + `resolveWorkerPolicy` (ErrorMapper level) → `Job.Policy`; `classifyFault` deleted, `execWorkerOutcome` `OutcomeFault → technicalFault` | `TestDispatcherClassifiesFaultTo{BpmnError,Status}`, `TestDispatcher{UnmatchedFaultIsTechnical,FaultWithoutEngineDefaultsTechnical,FaultMapperErrorFallsBackTechnical}`, `TestBindExpressionEngineSeam`, `TestThresherBindsExpressionEngineToDispatcher`, `TestServiceTaskWorkerConfig`, `TestEnqueueResolves{PerServiceErrorMapper,FallsBackToEngineErrorMapper}`, `TestServiceTaskWorkerExecFaultsOnCause` (terminal-fault apply) |
+| M7 | `1367eee` | Retry policy: `RetryPolicy` batteries + `DefaultRetryPolicy`; two-level `WithRetryPolicy` / `WithWorkerRetryPolicy` (+ `renv.WorkerRetryPolicy()`); dispatcher re-arm loop (`retryOrExhaust`, `jobEntry.{attempt, notBefore}`, `lockNext` gate, `FetchAndLock` `clk.After` wake); exhaustion → terminal `Failed` | `TestRetryPolicy{NoRetry,FixedDelay,ExponentialBackoff,ExponentialCap,ExponentialJitter}`, `TestDefaultRetryPolicy`, `TestTechnicalFaultRetriesViaReArm`, `TestLocalDispatcherNotBeforeGate`, `TestRetryExhaustedFaultsWithDiagnostic`, `TestBusinessOutcomeNotRetried`, `TestRetryReValidatesExpiredLock`, `TestEnqueueResolves{PerServiceRetryPolicy,FallsBackToEngineRetryPolicy}`, `TestWith{RetryPolicy,WorkerRetryPolicy}RejectsNil` |
+
+`make ci` green at each milestone (tidy · lint 0 issues · build · `-race` · diff-coverage ≥95% on touched files · govulncheck); every new/changed function measured at 100% coverage.
+
+### 10.2 Empirical findings — deltas vs the §3 draft
+
+- **Classification locus landed exactly as designed** — in `localdispatcher.Fail` (the dispatcher), not the instance loop. `handleJobCompletion` is unchanged; the only instance-side addition is `resolveWorkerPolicy` at enqueue (populating `Job.Policy`). Confirms §1.1/§4.1.
+- **Interfaces reached final shape in M6, wiring in M7** — `RetryPolicy`, `WorkerConfig`, `ExpressionEngineBinder`, and both `Policy` fields were defined in M6 with the retry field inert, so M7 added no signature churn.
+- **`Fail` stopped delegating to `report()` for the retry branch** — the technical-retry path must keep the store entry to re-arm it, so it re-acquires `d.mu` and re-validates (`heldEntry`); the business-verdict and exhausted branches still deliver via `report()`.
+- **Re-validation guard is covered deterministically** — `TestRetryReValidatesExpiredLock` uses a clock-advancing `ErrorMapper` (`clockPokeMapper`) to expire the lock mid-classify, exercising the drop-the-re-arm path the shipped single-worker-per-topic pool never hits.
+- **SRD-037 track-side classification tests were relocated** — the M4 tests that drove `classifyFault` at the track were removed from `pkg/model/activities` (the logic moved) and re-established at the dispatcher (`classify_test.go`) and instance (`resolveWorkerPolicy`) layers.
+- **§6 test-name drift (all covered, no gaps):** the proposed `TestEnqueueResolvesTwoLevelPolicy` landed split per level (`…PerServiceErrorMapper` / `…PerServiceRetryPolicy` / `…FallsBackToEngine{ErrorMapper,RetryPolicy}`); `TestRetryPolicyBatteries` landed split per battery; `TestTrackAppliesTerminalOnly` is realized by `TestServiceTaskWorkerExecFaultsOnCause` plus the dispatcher classify tests.

--- a/internal/enginert/enginert.go
+++ b/internal/enginert/enginert.go
@@ -41,6 +41,10 @@ type Runtime struct {
 	// workerErrorMapper is the engine-wide default ErrorMapper (SRD-037 FR-3);
 	// nil by default (a per-service WithErrorMapper overrides it).
 	workerErrorMapper tasks.ErrorMapper
+	// workerRetryPolicy is the engine-wide default RetryPolicy (SRD-038 FR-6);
+	// nil by default (a per-service WithRetryPolicy overrides it; absent both,
+	// the resolver falls back to tasks.DefaultRetryPolicy).
+	workerRetryPolicy tasks.RetryPolicy
 }
 
 // Default returns a Runtime with every extension set to its bundled default.
@@ -140,6 +144,20 @@ func (r *Runtime) WorkerErrorMapper() tasks.ErrorMapper { return r.workerErrorMa
 func (r *Runtime) WithWorkerErrorMapper(m tasks.ErrorMapper) *Runtime {
 	if m != nil {
 		r.workerErrorMapper = m
+	}
+
+	return r
+}
+
+// WorkerRetryPolicy returns the engine-wide default RetryPolicy (nil = fall back
+// to tasks.DefaultRetryPolicy at resolution).
+func (r *Runtime) WorkerRetryPolicy() tasks.RetryPolicy { return r.workerRetryPolicy }
+
+// WithWorkerRetryPolicy overrides the engine-wide default RetryPolicy and returns
+// the Runtime. A nil policy is ignored (the current default is kept).
+func (r *Runtime) WithWorkerRetryPolicy(p tasks.RetryPolicy) *Runtime {
+	if p != nil {
+		r.workerRetryPolicy = p
 	}
 
 	return r

--- a/internal/enginert/enginert_test.go
+++ b/internal/enginert/enginert_test.go
@@ -77,3 +77,21 @@ func TestWithWorkerErrorMapper(t *testing.T) {
 		t.Fatal("a nil mapper should be ignored (default kept)")
 	}
 }
+
+// TestWithWorkerRetryPolicy covers SRD-038 FR-6: the engine-wide default
+// RetryPolicy is nil by default, set by WithWorkerRetryPolicy, nil ignored.
+func TestWithWorkerRetryPolicy(t *testing.T) {
+	p := tasks.NoRetry()
+
+	if Default().WorkerRetryPolicy() != nil {
+		t.Fatal("the default worker retry policy should be nil")
+	}
+
+	if Default().WithWorkerRetryPolicy(p).WorkerRetryPolicy() != p {
+		t.Fatal("WithWorkerRetryPolicy was not applied")
+	}
+
+	if Default().WithWorkerRetryPolicy(nil).WorkerRetryPolicy() != nil {
+		t.Fatal("a nil policy should be ignored (default kept)")
+	}
+}

--- a/internal/instance/jobs.go
+++ b/internal/instance/jobs.go
@@ -160,23 +160,35 @@ func (inst *Instance) enqueueJob(
 	})
 }
 
-// resolveWorkerPolicy resolves the enqueued job's outcome policy: the node's
-// per-service ErrorMapper (tasks.WorkerConfig) over the engine-wide default
-// (WorkerErrorMapper). The dispatcher classifies a raw fault with it engine-side
-// (SRD-038 §3.6); nil ErrorMapper = a raw fault falls through to the default
-// technical outcome. RetryPolicy resolution arrives in M7.
+// resolveWorkerPolicy resolves the enqueued job's outcome policy two-level
+// (SRD-038 §3.6): the node's per-service config (tasks.WorkerConfig) over the
+// engine-wide defaults. The ErrorMapper may stay nil (a raw fault then falls
+// through to the default technical outcome); the RetryPolicy is always non-nil
+// (tasks.DefaultRetryPolicy when neither level sets one). The dispatcher uses
+// both to classify and retry a raw fault engine-side.
 func (inst *Instance) resolveWorkerPolicy(ew tasks.ExternalWorker) *tasks.Policy {
-	var em tasks.ErrorMapper
+	var (
+		em tasks.ErrorMapper
+		rp tasks.RetryPolicy
+	)
 
 	if wc, ok := ew.(tasks.WorkerConfig); ok {
-		em, _, _ = wc.WorkerConfig()
+		em, rp, _ = wc.WorkerConfig()
 	}
 
 	if em == nil {
 		em = inst.WorkerErrorMapper()
 	}
 
-	return &tasks.Policy{ErrorMapper: em}
+	if rp == nil {
+		rp = inst.WorkerRetryPolicy()
+	}
+
+	if rp == nil {
+		rp = tasks.DefaultRetryPolicy()
+	}
+
+	return &tasks.Policy{ErrorMapper: em, RetryPolicy: rp}
 }
 
 // cleanupJob drops any job owned by a track that ended without completing it

--- a/internal/instance/jobs.go
+++ b/internal/instance/jobs.go
@@ -152,8 +152,31 @@ func (inst *Instance) enqueueJob(
 
 	topic, _ := ew.WorkerTopic()
 
-	return inst.WorkerDispatcher().Enqueue(ctx,
-		tasks.Job{ID: jobID, Topic: topic, Input: input})
+	return inst.WorkerDispatcher().Enqueue(ctx, tasks.Job{
+		ID:     jobID,
+		Topic:  topic,
+		Input:  input,
+		Policy: inst.resolveWorkerPolicy(ew),
+	})
+}
+
+// resolveWorkerPolicy resolves the enqueued job's outcome policy: the node's
+// per-service ErrorMapper (tasks.WorkerConfig) over the engine-wide default
+// (WorkerErrorMapper). The dispatcher classifies a raw fault with it engine-side
+// (SRD-038 §3.6); nil ErrorMapper = a raw fault falls through to the default
+// technical outcome. RetryPolicy resolution arrives in M7.
+func (inst *Instance) resolveWorkerPolicy(ew tasks.ExternalWorker) *tasks.Policy {
+	var em tasks.ErrorMapper
+
+	if wc, ok := ew.(tasks.WorkerConfig); ok {
+		em, _, _ = wc.WorkerConfig()
+	}
+
+	if em == nil {
+		em = inst.WorkerErrorMapper()
+	}
+
+	return &tasks.Policy{ErrorMapper: em}
 }
 
 // cleanupJob drops any job owned by a track that ended without completing it

--- a/internal/instance/service_task_worker_internal_test.go
+++ b/internal/instance/service_task_worker_internal_test.go
@@ -312,13 +312,14 @@ func mustMapper(t *testing.T, code string) tasks.ErrorMapper {
 	return m
 }
 
-// enqueuedWorkerPolicy builds and runs start → ServiceTask(WithWorker,
-// [WithErrorMapper(perSvc)]) → end on a runtime carrying engineWide as the
-// engine-wide default, and returns the enqueued job's resolved Policy (SRD-038
-// §3.6, two-level resolution at enqueue).
-func enqueuedWorkerPolicy(
+// enqueuedPolicy builds and runs start → ServiceTask(WithWorker, extra...) → end
+// on rt (whose dispatcher must be disp) and returns the enqueued job's resolved
+// Policy (SRD-038 §3.6, two-level resolution at enqueue).
+func enqueuedPolicy(
 	t *testing.T,
-	perSvc, engineWide tasks.ErrorMapper,
+	disp *capDispatcher,
+	rt *enginert.Runtime,
+	extra ...options.Option,
 ) *tasks.Policy {
 	t.Helper()
 	require.NoError(t, data.CreateDefaultStates())
@@ -329,11 +330,8 @@ func enqueuedWorkerPolicy(
 	start, err := events.NewStartEvent("start")
 	require.NoError(t, err)
 
-	stOpts := []options.Option{
-		activities.WithWorker("topic-x"), activities.WithoutParams()}
-	if perSvc != nil {
-		stOpts = append(stOpts, activities.WithErrorMapper(perSvc))
-	}
+	stOpts := append([]options.Option{
+		activities.WithWorker("topic-x"), activities.WithoutParams()}, extra...)
 
 	st, err := activities.NewServiceTask("svc",
 		service.MustOperation("op", nil, nil, nil), stOpts...)
@@ -353,13 +351,6 @@ func enqueuedWorkerPolicy(
 
 	s, err := snapshot.New(p)
 	require.NoError(t, err)
-
-	disp := &capDispatcher{}
-	rt := enginert.Default().WithWorkerDispatcher(disp)
-
-	if engineWide != nil {
-		rt = rt.WithWorkerErrorMapper(engineWide)
-	}
 
 	inst, err := New(s, scope.EmptyDataPath, rt,
 		mockeventproc.NewMockEventProducer(t), &failDist{})
@@ -381,10 +372,14 @@ func TestEnqueueResolvesPerServiceErrorMapper(t *testing.T) {
 	perSvc := mustMapper(t, "PerService")
 	engineWide := mustMapper(t, "EngineWide")
 
-	policy := enqueuedWorkerPolicy(t, perSvc, engineWide)
+	disp := &capDispatcher{}
+	rt := enginert.Default().WithWorkerDispatcher(disp).
+		WithWorkerErrorMapper(engineWide)
+
+	policy := enqueuedPolicy(t, disp, rt, activities.WithErrorMapper(perSvc))
 
 	require.Equal(t, perSvc, policy.ErrorMapper)
-	require.Nil(t, policy.RetryPolicy, "RetryPolicy resolution arrives in M7")
+	require.NotNil(t, policy.RetryPolicy, "the RetryPolicy is always resolved")
 }
 
 // TestEnqueueFallsBackToEngineErrorMapper covers FR-2/§3.6: absent a per-service
@@ -392,9 +387,43 @@ func TestEnqueueResolvesPerServiceErrorMapper(t *testing.T) {
 func TestEnqueueFallsBackToEngineErrorMapper(t *testing.T) {
 	engineWide := mustMapper(t, "EngineWide")
 
-	policy := enqueuedWorkerPolicy(t, nil, engineWide)
+	disp := &capDispatcher{}
+	rt := enginert.Default().WithWorkerDispatcher(disp).
+		WithWorkerErrorMapper(engineWide)
+
+	policy := enqueuedPolicy(t, disp, rt)
 
 	require.Equal(t, engineWide, policy.ErrorMapper)
+}
+
+// TestEnqueueResolvesPerServiceRetryPolicy covers FR-6/§3.6: a per-service
+// WithRetryPolicy wins over the engine-wide default in the enqueued Job.Policy.
+func TestEnqueueResolvesPerServiceRetryPolicy(t *testing.T) {
+	perSvc := tasks.FixedDelay(5, time.Second)
+	engineWide := tasks.NoRetry()
+
+	disp := &capDispatcher{}
+	rt := enginert.Default().WithWorkerDispatcher(disp).
+		WithWorkerRetryPolicy(engineWide)
+
+	policy := enqueuedPolicy(t, disp, rt, activities.WithRetryPolicy(perSvc))
+
+	require.Equal(t, perSvc, policy.RetryPolicy)
+}
+
+// TestEnqueueFallsBackToEngineRetryPolicy covers FR-6/§3.6: absent a per-service
+// policy, the engine-wide default populates the Job.Policy (not the built-in
+// DefaultRetryPolicy).
+func TestEnqueueFallsBackToEngineRetryPolicy(t *testing.T) {
+	engineWide := tasks.FixedDelay(7, 2*time.Second)
+
+	disp := &capDispatcher{}
+	rt := enginert.Default().WithWorkerDispatcher(disp).
+		WithWorkerRetryPolicy(engineWide)
+
+	policy := enqueuedPolicy(t, disp, rt)
+
+	require.Equal(t, engineWide, policy.RetryPolicy)
 }
 
 // guardedWorkerInstance builds start → host(ServiceTask, WithWorker) → normalEnd

--- a/internal/instance/service_task_worker_internal_test.go
+++ b/internal/instance/service_task_worker_internal_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
 	"github.com/dr-dobermann/gobpm/pkg/model/events"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/options"
 	"github.com/dr-dobermann/gobpm/pkg/model/process"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
 	"github.com/dr-dobermann/gobpm/pkg/tasks"
@@ -297,6 +298,103 @@ func TestServiceTaskWorkerEnqueueFailureFaults(t *testing.T) {
 	require.Eventually(t, func() bool { return inst.State() == Terminated },
 		2*time.Second, 5*time.Millisecond)
 	require.ErrorContains(t, inst.LastErr(), "worker reported a technical fault")
+}
+
+// mustMapper builds a rule mapper yielding a Business Error of code (keyed on
+// fault code "409"), used to tell per-service from engine-wide by its yield.
+func mustMapper(t *testing.T, code string) tasks.ErrorMapper {
+	t.Helper()
+
+	m, err := tasks.NewRuleMapper(
+		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: code}})
+	require.NoError(t, err)
+
+	return m
+}
+
+// enqueuedWorkerPolicy builds and runs start → ServiceTask(WithWorker,
+// [WithErrorMapper(perSvc)]) → end on a runtime carrying engineWide as the
+// engine-wide default, and returns the enqueued job's resolved Policy (SRD-038
+// §3.6, two-level resolution at enqueue).
+func enqueuedWorkerPolicy(
+	t *testing.T,
+	perSvc, engineWide tasks.ErrorMapper,
+) *tasks.Policy {
+	t.Helper()
+	require.NoError(t, data.CreateDefaultStates())
+
+	p, err := process.New("st-policy")
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	stOpts := []options.Option{
+		activities.WithWorker("topic-x"), activities.WithoutParams()}
+	if perSvc != nil {
+		stOpts = append(stOpts, activities.WithErrorMapper(perSvc))
+	}
+
+	st, err := activities.NewServiceTask("svc",
+		service.MustOperation("op", nil, nil, nil), stOpts...)
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{start, st, end} {
+		require.NoError(t, p.Add(e))
+	}
+
+	_, err = flow.Link(start, st)
+	require.NoError(t, err)
+	_, err = flow.Link(st, end)
+	require.NoError(t, err)
+
+	s, err := snapshot.New(p)
+	require.NoError(t, err)
+
+	disp := &capDispatcher{}
+	rt := enginert.Default().WithWorkerDispatcher(disp)
+
+	if engineWide != nil {
+		rt = rt.WithWorkerErrorMapper(engineWide)
+	}
+
+	inst, err := New(s, scope.EmptyDataPath, rt,
+		mockeventproc.NewMockEventProducer(t), &failDist{})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	require.NoError(t, inst.Run(ctx))
+
+	job := waitForJob(t, disp)
+	require.NotNil(t, job.Policy, "the enqueued job carries a resolved Policy")
+
+	return job.Policy
+}
+
+// TestEnqueueResolvesPerServiceErrorMapper covers FR-2/§3.6: a per-service
+// WithErrorMapper wins over the engine-wide default in the enqueued Job.Policy.
+func TestEnqueueResolvesPerServiceErrorMapper(t *testing.T) {
+	perSvc := mustMapper(t, "PerService")
+	engineWide := mustMapper(t, "EngineWide")
+
+	policy := enqueuedWorkerPolicy(t, perSvc, engineWide)
+
+	require.Equal(t, perSvc, policy.ErrorMapper)
+	require.Nil(t, policy.RetryPolicy, "RetryPolicy resolution arrives in M7")
+}
+
+// TestEnqueueFallsBackToEngineErrorMapper covers FR-2/§3.6: absent a per-service
+// mapper, the engine-wide default populates the Job.Policy.
+func TestEnqueueFallsBackToEngineErrorMapper(t *testing.T) {
+	engineWide := mustMapper(t, "EngineWide")
+
+	policy := enqueuedWorkerPolicy(t, nil, engineWide)
+
+	require.Equal(t, engineWide, policy.ErrorMapper)
 }
 
 // guardedWorkerInstance builds start → host(ServiceTask, WithWorker) → normalEnd

--- a/pkg/model/activities/service_task.go
+++ b/pkg/model/activities/service_task.go
@@ -41,6 +41,7 @@ import (
 type ServiceTask struct {
 	operation   service.Operation
 	errorMapper tasks.ErrorMapper
+	retryPolicy tasks.RetryPolicy
 	// outputMapping shapes a worker's raw Complete body into the output
 	// (WithOutputMapping, SRD-037 FR-7); empty = direct reconciliation.
 	outputMapping []tasks.OutputRule
@@ -334,11 +335,14 @@ func (st *ServiceTask) wrapOpErr(err error) error {
 		errs.D("operation_id", st.operation.ID()))
 }
 
-// execWorkerOutcome classifies + applies the worker's stashed outcome on resume
-// (SRD-037 §3.5): a completion binds the output; a Business Error raises a BPMN
-// error caught by a boundary; a Business Status writes the WithStatus variable and
-// completes; a raw fault is run through the ErrorMapper. Runs on the track resume
-// goroutine, so re's expression engine + scope are available (no goroutine, §4.1).
+// execWorkerOutcome applies the worker's stashed terminal outcome on resume
+// (SRD-037 §3.5, reshaped SRD-038 §3.7): a completion binds the output; a
+// Business Error raises a BPMN error caught by a boundary; a Business Status
+// writes the WithStatus variable and completes; a terminal fault (the
+// retries-exhausted case) fails the task. Classification now runs in the
+// dispatcher before the loop, so the track only applies — it never sees a raw,
+// unclassified fault. Runs on the track resume goroutine, so re's scope is
+// available for the output/status write (no goroutine, §4.1).
 func (st *ServiceTask) execWorkerOutcome(
 	ctx context.Context,
 	re renv.RuntimeEnvironment,
@@ -355,7 +359,7 @@ func (st *ServiceTask) execWorkerOutcome(
 		return st.writeStatus(ctx, re, wo.StatusValue())
 
 	case tasks.OutcomeFault:
-		return st.classifyFault(ctx, re, wo.Fault())
+		return nil, st.technicalFault(wo.Fault())
 
 	default: // OutcomeComplete
 		return st.bindOutput(ctx, re, wo.Output())
@@ -475,51 +479,11 @@ func (st *ServiceTask) writeStatus(
 	return st.Outgoing(), nil
 }
 
-// classifyFault runs the ServiceTask's ErrorMapper over a raw fault (no mapper →
-// default Technical) and applies the mapped outcome (SRD-037 FR-3).
-func (st *ServiceTask) classifyFault(
-	ctx context.Context,
-	re renv.RuntimeEnvironment,
-	fault tasks.Fault,
-) ([]*flow.SequenceFlow, error) {
-	// Two-level ErrorMapper (SRD-037 FR-3): the per-service WithErrorMapper
-	// overrides the engine-wide WithWorkerErrorMapper default; absent both, a raw
-	// fault falls through to the default technical outcome.
-	mapper := st.errorMapper
-	if mapper == nil {
-		mapper = re.WorkerErrorMapper()
-	}
-
-	var mapped tasks.MappedOutcome = tasks.Technical{}
-
-	if mapper != nil {
-		m, err := mapper.Classify(ctx, re.ExpressionEngine(), fault)
-		if err != nil {
-			return nil,
-				errs.New(
-					errs.M("service task %q: error-mapping failed", st.Name()),
-					errs.C(errorClass, errs.OperationFailed),
-					errs.E(err),
-					errs.D("service_task_id", st.ID()))
-		}
-
-		mapped = m
-	}
-
-	switch o := mapped.(type) {
-	case tasks.BpmnError:
-		return st.raiseBpmnError(o.Code, o.Message)
-
-	case tasks.Status:
-		return st.writeStatus(ctx, re, o.Value)
-
-	default: // tasks.Technical (sealed interface — the only remaining kind)
-		return nil, st.technicalFault(fault)
-	}
-}
-
-// technicalFault wraps a raw fault as the terminal ServiceTask failure (retry
-// arrives in SRD-038).
+// technicalFault wraps a raw fault as the terminal ServiceTask failure — the
+// retries-exhausted outcome the dispatcher escalates once its RetryPolicy is
+// spent (SRD-038). A fault reaches the track only as this terminal; the
+// technical-vs-business classification now runs in the dispatcher, before the
+// loop, so the track never re-classifies here.
 func (st *ServiceTask) technicalFault(fault tasks.Fault) error {
 	return errs.New(
 		errs.M("service task %q worker reported a technical fault", st.Name()),
@@ -545,6 +509,15 @@ func (st *ServiceTask) BindJobInput(
 	r service.DataReader,
 ) (*data.ItemDefinition, error) {
 	return st.operation.BindInputOnly(ctx, r)
+}
+
+// WorkerConfig reports the ServiceTask's per-service outcome policy — its
+// WithErrorMapper and WithRetryPolicy — for the engine to resolve (two-level,
+// over the engine-wide defaults) and ship in the enqueued Job.Policy so the
+// dispatcher can classify + retry a raw fault engine-side. ok == false for an
+// in-process task (tasks.WorkerConfig, SRD-038 §3.3).
+func (st *ServiceTask) WorkerConfig() (tasks.ErrorMapper, tasks.RetryPolicy, bool) {
+	return st.errorMapper, st.retryPolicy, st.workerTopic != ""
 }
 
 // ------------------ eventproc.EventProcessor interface -----------------------

--- a/pkg/model/activities/service_task.go
+++ b/pkg/model/activities/service_task.go
@@ -128,12 +128,13 @@ func NewServiceTask(
 	// WithErrorMapper / WithStatus / WithOutputMapping govern the worker outcome —
 	// meaningless on an in-process ServiceTask, so require WithWorker (SRD-037 §3.4).
 	if sc.workerTopic == "" &&
-		(sc.errorMapper != nil || sc.statusVar != "" ||
+		(sc.errorMapper != nil || sc.retryPolicy != nil || sc.statusVar != "" ||
 			len(sc.outputMapping) > 0) {
 		return nil,
 			errs.New(
-				errs.M("WithErrorMapper/WithStatus/WithOutputMapping require a "+
-					"worker-dispatched ServiceTask (WithWorker); %q has none", name),
+				errs.M("WithErrorMapper/WithRetryPolicy/WithStatus/WithOutputMapping "+
+					"require a worker-dispatched ServiceTask (WithWorker); %q has none",
+					name),
 				errs.C(errorClass, errs.InvalidParameter))
 	}
 
@@ -149,6 +150,7 @@ func NewServiceTask(
 			timeout:         sc.timeout,
 			workerTopic:     sc.workerTopic,
 			errorMapper:     sc.errorMapper,
+			retryPolicy:     sc.retryPolicy,
 			outputMapping:   sc.outputMapping,
 			statusVar:       sc.statusVar,
 			statusOverwrite: sc.statusOverwrite,
@@ -186,6 +188,7 @@ func (st *ServiceTask) Clone() (flow.Node, error) {
 		timeout:         st.timeout,
 		workerTopic:     st.workerTopic,
 		errorMapper:     st.errorMapper,
+		retryPolicy:     st.retryPolicy,
 		outputMapping:   st.outputMapping,
 		statusVar:       st.statusVar,
 		statusOverwrite: st.statusOverwrite,

--- a/pkg/model/activities/service_task_options.go
+++ b/pkg/model/activities/service_task_options.go
@@ -13,6 +13,7 @@ import (
 // external-worker options (SRD-036/037/038).
 type srvTaskConfig struct {
 	errorMapper     tasks.ErrorMapper
+	retryPolicy     tasks.RetryPolicy
 	workerTopic     tasks.Topic
 	statusVar       string
 	outputMapping   []tasks.OutputRule
@@ -79,6 +80,25 @@ func WithErrorMapper(m tasks.ErrorMapper) SrvTaskOption {
 		}
 
 		c.errorMapper = m
+
+		return nil
+	}
+}
+
+// WithRetryPolicy sets the per-service RetryPolicy that governs technical-fault
+// retries for the worker-dispatched task (ADR-021 §2.7, SRD-038). A nil policy is
+// rejected. Overrides the engine-wide WithWorkerRetryPolicy default; absent both,
+// the engine's DefaultRetryPolicy applies. Valid only on a worker-dispatched
+// ServiceTask (checked at NewServiceTask).
+func WithRetryPolicy(p tasks.RetryPolicy) SrvTaskOption {
+	return func(c *srvTaskConfig) error {
+		if p == nil {
+			return errs.New(
+				errs.M("WithRetryPolicy: a nil RetryPolicy isn't allowed"),
+				errs.C(errorClass, errs.EmptyNotAllowed))
+		}
+
+		c.retryPolicy = p
 
 		return nil
 	}

--- a/pkg/model/activities/service_task_worker_test.go
+++ b/pkg/model/activities/service_task_worker_test.go
@@ -61,16 +61,17 @@ func TestServiceTaskWorkerExecBindsCompletedOutput(t *testing.T) {
 	require.Equal(t, "res", put.ItemDefinition().ID())
 }
 
-// TestServiceTaskWorkerExecFaultsOnCause: a Fail outcome stashed by ProcessEvent
-// makes Exec return a wrapped fault (no output committed).
+// TestServiceTaskWorkerExecFaultsOnCause: a terminal Fault outcome (SRD-038: the
+// dispatcher already classified/exhausted it) makes Exec fail the task with a
+// technical fault — the track applies, it does not re-classify (no ErrorMapper
+// call, no Put).
 func TestServiceTaskWorkerExecFaultsOnCause(t *testing.T) {
 	st := workerTask(t)
 
 	require.NoError(t, st.ProcessEvent(context.Background(),
 		tasks.NewWorkerFault("job-1", tasks.Fault{Cause: errors.New("boom")})))
 
-	re := mockrenv.NewMockRuntimeEnvironment(t) // no Put expected
-	re.EXPECT().WorkerErrorMapper().Return(nil) // no engine-wide default
+	re := mockrenv.NewMockRuntimeEnvironment(t) // no ErrorMapper / Put expected
 	_, err := st.Exec(context.Background(), re)
 	require.ErrorContains(t, err, "worker reported a technical fault")
 }
@@ -222,28 +223,6 @@ func workerTaskOpts(
 	return st
 }
 
-// bodyClauseNeedingBody builds a body-clause that reads "body" — it errors when
-// the fault carries none, exercising the ErrorMapper evaluation-error path.
-func bodyClauseNeedingBody(t *testing.T) data.FormalExpression {
-	t.Helper()
-
-	fe, err := goexpr.New(nil,
-		data.MustItemDefinition(values.NewVariable(false)),
-		func(ctx context.Context, ds data.Source) (data.Value, error) {
-			b, err := ds.Find(ctx, "body")
-			if err != nil {
-				return nil, err
-			}
-
-			s, _ := b.Value().Get(ctx).(string)
-
-			return values.NewVariable(s == "x"), nil
-		})
-	require.NoError(t, err)
-
-	return fe
-}
-
 // TestServiceTaskWorkerExecRaisesBpmnError: a Business Error outcome makes Exec
 // return a *events.BpmnError (caught by a boundary at the instance level).
 func TestServiceTaskWorkerExecRaisesBpmnError(t *testing.T) {
@@ -333,47 +312,6 @@ func TestServiceTaskWorkerStatusWithoutWithStatusFaults(t *testing.T) {
 
 // TestServiceTaskWorkerFaultClassifiedByMapper: a raw fault is run through the
 // ErrorMapper, which yields a Business Error here.
-func TestServiceTaskWorkerFaultClassifiedByMapper(t *testing.T) {
-	mapper, err := tasks.NewRuleMapper(
-		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "Conflict"}})
-	require.NoError(t, err)
-
-	st := workerTaskOpts(t, activities.WithErrorMapper(mapper))
-
-	require.NoError(t, st.ProcessEvent(context.Background(),
-		tasks.NewWorkerFault("job-1", tasks.Fault{Code: "409"})))
-
-	re := mockrenv.NewMockRuntimeEnvironment(t)
-	re.EXPECT().ExpressionEngine().Return(exprengine.New())
-
-	_, err = st.Exec(context.Background(), re)
-
-	var be *events.BpmnError
-	require.True(t, errors.As(err, &be))
-	require.Equal(t, "Conflict", be.Code)
-}
-
-// TestServiceTaskWorkerFaultMapperError: an ErrorMapper whose evaluation errors
-// surfaces from Exec.
-func TestServiceTaskWorkerFaultMapperError(t *testing.T) {
-	mapper, err := tasks.NewRuleMapper(
-		tasks.Rule{Code: "404", BodyClause: bodyClauseNeedingBody(t),
-			Yield: tasks.Status{Value: values.NewVariable("x")}})
-	require.NoError(t, err)
-
-	st := workerTaskOpts(t, activities.WithErrorMapper(mapper))
-
-	// Fault has no body → the clause's Find("body") errors → classify errors.
-	require.NoError(t, st.ProcessEvent(context.Background(),
-		tasks.NewWorkerFault("job-1", tasks.Fault{Code: "404"})))
-
-	re := mockrenv.NewMockRuntimeEnvironment(t)
-	re.EXPECT().ExpressionEngine().Return(exprengine.New())
-
-	_, err = st.Exec(context.Background(), re)
-	require.ErrorContains(t, err, "error-mapping failed")
-}
-
 // TestWithErrorMapperRejectsNil: a nil ErrorMapper is rejected at construction.
 func TestWithErrorMapperRejectsNil(t *testing.T) {
 	_, err := activities.NewServiceTask("svc",
@@ -438,28 +376,6 @@ func TestServiceTaskWorkerStatusPutError(t *testing.T) {
 
 // TestServiceTaskWorkerFaultMappedToStatus: the ErrorMapper yields a Business
 // Status for a raw fault, which is written to the WithStatus variable.
-func TestServiceTaskWorkerFaultMappedToStatus(t *testing.T) {
-	mapper, err := tasks.NewRuleMapper(
-		tasks.Rule{Code: "404",
-			Yield: tasks.Status{Value: values.NewVariable("NOT_FOUND")}})
-	require.NoError(t, err)
-
-	st := workerTaskOpts(t,
-		activities.WithErrorMapper(mapper), activities.WithStatus("s", false))
-
-	require.NoError(t, st.ProcessEvent(context.Background(),
-		tasks.NewWorkerFault("job-1", tasks.Fault{Code: "404"})))
-
-	re := mockrenv.NewMockRuntimeEnvironment(t)
-	re.EXPECT().ExpressionEngine().Return(exprengine.New())
-	re.EXPECT().Find(mock.Anything, "s").Return(nil, errors.New("nf"))
-	re.EXPECT().Put(mock.Anything).Return(nil)
-
-	flows, err := st.Exec(context.Background(), re)
-	require.NoError(t, err)
-	require.Empty(t, flows)
-}
-
 // bodyValueExpr builds a FormalExpression that returns the body's value — the
 // shape a WithOutputMapping rule's Path takes.
 func bodyValueExpr(t *testing.T) data.FormalExpression {
@@ -595,48 +511,25 @@ func TestWorkerClassificationBeatsMapper(t *testing.T) {
 	require.Equal(t, "Conflict", be.Code)
 }
 
-// TestTwoLevelErrorMapperOverride covers FR-3: the per-service WithErrorMapper
-// overrides the engine-wide default (the engine default is not consulted).
-func TestTwoLevelErrorMapperOverride(t *testing.T) {
-	perService, err := tasks.NewRuleMapper(
-		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "PerService"}})
+// TestServiceTaskWorkerConfig covers the tasks.WorkerConfig surface (SRD-038
+// §3.3): a worker-dispatched task exposes its per-service ErrorMapper/RetryPolicy
+// with ok == true; an in-process task reports ok == false.
+func TestServiceTaskWorkerConfig(t *testing.T) {
+	mapper, err := tasks.NewRuleMapper(
+		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "Conflict"}})
 	require.NoError(t, err)
 
-	st := workerTaskOpts(t, activities.WithErrorMapper(perService))
+	st := workerTaskOpts(t, activities.WithErrorMapper(mapper))
 
-	require.NoError(t, st.ProcessEvent(context.Background(),
-		tasks.NewWorkerFault("job-1", tasks.Fault{Code: "409"})))
+	em, rp, ok := st.WorkerConfig()
+	require.True(t, ok)
+	require.Equal(t, mapper, em)
+	require.Nil(t, rp) // WithRetryPolicy arrives in M7
 
-	re := mockrenv.NewMockRuntimeEnvironment(t)
-	re.EXPECT().ExpressionEngine().Return(exprengine.New())
-	// WorkerErrorMapper NOT expected — per-service overrides, the fallback is skipped.
-
-	_, err = st.Exec(context.Background(), re)
-
-	var be *events.BpmnError
-	require.True(t, errors.As(err, &be))
-	require.Equal(t, "PerService", be.Code)
-}
-
-// TestEngineDefaultErrorMapperUsed covers FR-3: absent a per-service mapper, the
-// engine-wide WorkerErrorMapper default classifies the raw fault.
-func TestEngineDefaultErrorMapperUsed(t *testing.T) {
-	engineWide, err := tasks.NewRuleMapper(
-		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "EngineWide"}})
+	// an in-process ServiceTask (no WithWorker) reports ok == false.
+	in, err := activities.NewServiceTask("in",
+		service.MustOperation("op", nil, nil, nil))
 	require.NoError(t, err)
-
-	st := workerTask(t) // no per-service mapper
-
-	require.NoError(t, st.ProcessEvent(context.Background(),
-		tasks.NewWorkerFault("job-1", tasks.Fault{Code: "409"})))
-
-	re := mockrenv.NewMockRuntimeEnvironment(t)
-	re.EXPECT().WorkerErrorMapper().Return(engineWide)
-	re.EXPECT().ExpressionEngine().Return(exprengine.New())
-
-	_, err = st.Exec(context.Background(), re)
-
-	var be *events.BpmnError
-	require.True(t, errors.As(err, &be))
-	require.Equal(t, "EngineWide", be.Code)
+	_, _, ok = in.WorkerConfig()
+	require.False(t, ok)
 }

--- a/pkg/model/activities/service_task_worker_test.go
+++ b/pkg/model/activities/service_task_worker_test.go
@@ -320,6 +320,14 @@ func TestWithErrorMapperRejectsNil(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestWithRetryPolicyRejectsNil: a nil RetryPolicy is rejected at construction.
+func TestWithRetryPolicyRejectsNil(t *testing.T) {
+	_, err := activities.NewServiceTask("svc",
+		service.MustOperation("op", nil, nil, nil),
+		activities.WithWorker("t"), activities.WithRetryPolicy(nil))
+	require.Error(t, err)
+}
+
 // TestWithStatusRejectsEmpty: an empty status variable name is rejected.
 func TestWithStatusRejectsEmpty(t *testing.T) {
 	_, err := activities.NewServiceTask("svc",
@@ -519,12 +527,14 @@ func TestServiceTaskWorkerConfig(t *testing.T) {
 		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "Conflict"}})
 	require.NoError(t, err)
 
-	st := workerTaskOpts(t, activities.WithErrorMapper(mapper))
+	policy := tasks.NoRetry()
+	st := workerTaskOpts(t,
+		activities.WithErrorMapper(mapper), activities.WithRetryPolicy(policy))
 
 	em, rp, ok := st.WorkerConfig()
 	require.True(t, ok)
 	require.Equal(t, mapper, em)
-	require.Nil(t, rp) // WithRetryPolicy arrives in M7
+	require.Equal(t, policy, rp)
 
 	// an in-process ServiceTask (no WithWorker) reports ok == false.
 	in, err := activities.NewServiceTask("in",

--- a/pkg/renv/engineruntime.go
+++ b/pkg/renv/engineruntime.go
@@ -36,4 +36,10 @@ type EngineRuntime interface {
 	// per-service WithErrorMapper (SRD-037 FR-3, two-level config). nil = no
 	// default (a raw fault falls through to the default technical outcome).
 	WorkerErrorMapper() tasks.ErrorMapper
+
+	// WorkerRetryPolicy is the engine-wide default RetryPolicy applied to a
+	// worker-dispatched ServiceTask's technical fault when the task carries no
+	// per-service WithRetryPolicy (SRD-038 FR-6, two-level config). nil = fall
+	// back to tasks.DefaultRetryPolicy at resolution.
+	WorkerRetryPolicy() tasks.RetryPolicy
 }

--- a/pkg/tasks/localdispatcher/classify_test.go
+++ b/pkg/tasks/localdispatcher/classify_test.go
@@ -1,0 +1,173 @@
+package localdispatcher_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/clock/clocktest"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	dgoexpr "github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	expengine "github.com/dr-dobermann/gobpm/pkg/model/expression/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/tasks"
+	"github.com/dr-dobermann/gobpm/pkg/tasks/localdispatcher"
+	"github.com/stretchr/testify/require"
+)
+
+// mustRuleMapper builds a tasks.RuleMapper from rules or fails the test.
+func mustRuleMapper(t *testing.T, rules ...tasks.Rule) tasks.ErrorMapper {
+	t.Helper()
+
+	m, err := tasks.NewRuleMapper(rules...)
+	require.NoError(t, err)
+
+	return m
+}
+
+// enqueueAndLock enqueues job "j1" on topic "charge" carrying policy and locks it
+// to worker "w1", leaving the dispatcher ready for a Fail report.
+func enqueueAndLock(
+	t *testing.T, d *localdispatcher.Dispatcher, policy *tasks.Policy,
+) {
+	t.Helper()
+
+	ctx := context.Background()
+	require.NoError(t, d.Enqueue(ctx,
+		tasks.Job{ID: "j1", Topic: "charge", Policy: policy}))
+	_, err := d.FetchAndLock(ctx, "w1", topics("charge"), time.Minute)
+	require.NoError(t, err)
+}
+
+// bodyRequiringClause builds a body-clause that reads "body" — it errors when the
+// fault carries none, exercising the ErrorMapper evaluation-error path.
+func bodyRequiringClause(t *testing.T) data.FormalExpression {
+	t.Helper()
+
+	fe, err := dgoexpr.New(nil,
+		data.MustItemDefinition(values.NewVariable(false)),
+		func(ctx context.Context, ds data.Source) (data.Value, error) {
+			if _, err := ds.Find(ctx, "body"); err != nil {
+				return nil, err
+			}
+
+			return values.NewVariable(true), nil
+		})
+	require.NoError(t, err)
+
+	return fe
+}
+
+// TestDispatcherClassifiesFaultToBpmnError: a raw Fail is classified engine-side
+// by the job's Policy.ErrorMapper into a Business Error terminal (SRD-038 FR-1).
+func TestDispatcherClassifiesFaultToBpmnError(t *testing.T) {
+	sink := &recordSink{}
+	d := localdispatcher.New(clocktest.New(base), time.Minute)
+	d.BindSink(sink)
+	d.BindExpressionEngine(expengine.New())
+
+	enqueueAndLock(t, d, &tasks.Policy{ErrorMapper: mustRuleMapper(t,
+		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "Conflict", Message: "dup"}})})
+
+	require.NoError(t, d.Fail(context.Background(), "j1", "w1",
+		tasks.Fault{Code: "409"}))
+
+	out := sink.last()
+	require.Equal(t, tasks.OutcomeBpmnError, out.Kind())
+	code, msg := out.BpmnError()
+	require.Equal(t, "Conflict", code)
+	require.Equal(t, "dup", msg)
+}
+
+// TestDispatcherClassifiesFaultToStatus: a raw Fail mapped to a Business Status
+// terminal (SRD-038 FR-1).
+func TestDispatcherClassifiesFaultToStatus(t *testing.T) {
+	sink := &recordSink{}
+	d := localdispatcher.New(clocktest.New(base), time.Minute)
+	d.BindSink(sink)
+	d.BindExpressionEngine(expengine.New())
+
+	enqueueAndLock(t, d, &tasks.Policy{ErrorMapper: mustRuleMapper(t,
+		tasks.Rule{Code: "404", Yield: tasks.Status{Value: values.NewVariable("NOT_FOUND")}})})
+
+	require.NoError(t, d.Fail(context.Background(), "j1", "w1",
+		tasks.Fault{Code: "404"}))
+
+	out := sink.last()
+	require.Equal(t, tasks.OutcomeStatus, out.Kind())
+	require.NotNil(t, out.StatusValue())
+}
+
+// TestDispatcherUnmatchedFaultIsTechnical: a fault matching no rule falls through
+// to the default Technical outcome — a terminal raw fault (SRD-038 §3.4).
+func TestDispatcherUnmatchedFaultIsTechnical(t *testing.T) {
+	sink := &recordSink{}
+	d := localdispatcher.New(clocktest.New(base), time.Minute)
+	d.BindSink(sink)
+	d.BindExpressionEngine(expengine.New())
+
+	enqueueAndLock(t, d, &tasks.Policy{ErrorMapper: mustRuleMapper(t,
+		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "Conflict"}})})
+
+	require.NoError(t, d.Fail(context.Background(), "j1", "w1",
+		tasks.Fault{Code: "500", Cause: errors.New("boom")}))
+
+	require.Equal(t, tasks.OutcomeFault, sink.last().Kind())
+}
+
+// TestDispatcherFaultWithoutEngineDefaultsTechnical: a mapper is configured but no
+// expression engine is bound, so the dispatcher can't run it and falls through to
+// the technical outcome (SRD-038 §3.4, nil-engine guard).
+func TestDispatcherFaultWithoutEngineDefaultsTechnical(t *testing.T) {
+	sink := &recordSink{}
+	d := localdispatcher.New(clocktest.New(base), time.Minute)
+	d.BindSink(sink)
+	// no BindExpressionEngine.
+
+	enqueueAndLock(t, d, &tasks.Policy{ErrorMapper: mustRuleMapper(t,
+		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "Conflict"}})})
+
+	require.NoError(t, d.Fail(context.Background(), "j1", "w1",
+		tasks.Fault{Code: "409", Cause: errors.New("boom")}))
+
+	require.Equal(t, tasks.OutcomeFault, sink.last().Kind())
+}
+
+// TestDispatcherFaultMapperErrorFallsBackTechnical: an ErrorMapper whose
+// evaluation errors is treated as a technical fault, not a failed report (SRD-038
+// §3.4).
+func TestDispatcherFaultMapperErrorFallsBackTechnical(t *testing.T) {
+	sink := &recordSink{}
+	d := localdispatcher.New(clocktest.New(base), time.Minute)
+	d.BindSink(sink)
+	d.BindExpressionEngine(expengine.New())
+
+	enqueueAndLock(t, d, &tasks.Policy{ErrorMapper: mustRuleMapper(t,
+		tasks.Rule{Code: "404", BodyClause: bodyRequiringClause(t),
+			Yield: tasks.Status{Value: values.NewVariable("x")}})})
+
+	// the fault carries no body → the clause's Find errors → classify errors.
+	require.NoError(t, d.Fail(context.Background(), "j1", "w1",
+		tasks.Fault{Code: "404"}))
+
+	require.Equal(t, tasks.OutcomeFault, sink.last().Kind())
+}
+
+// TestBindExpressionEngineSeam: a nil engine bind is ignored (the previously bound
+// engine is kept), so classification still runs (SRD-038 §3.4).
+func TestBindExpressionEngineSeam(t *testing.T) {
+	sink := &recordSink{}
+	d := localdispatcher.New(clocktest.New(base), time.Minute)
+	d.BindSink(sink)
+	d.BindExpressionEngine(expengine.New())
+	d.BindExpressionEngine(nil) // ignored — the bound engine is kept
+
+	enqueueAndLock(t, d, &tasks.Policy{ErrorMapper: mustRuleMapper(t,
+		tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "Conflict"}})})
+
+	require.NoError(t, d.Fail(context.Background(), "j1", "w1",
+		tasks.Fault{Code: "409"}))
+
+	require.Equal(t, tasks.OutcomeBpmnError, sink.last().Kind())
+}

--- a/pkg/tasks/localdispatcher/localdispatcher.go
+++ b/pkg/tasks/localdispatcher/localdispatcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/clock"
 	"github.com/dr-dobermann/gobpm/pkg/clock/syscl"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/expression"
 	"github.com/dr-dobermann/gobpm/pkg/observability"
 	"github.com/dr-dobermann/gobpm/pkg/tasks"
 )
@@ -52,15 +53,16 @@ type jobEntry struct {
 
 // Dispatcher is the in-memory fetch-and-lock job store (ADR-021 §2.4).
 type Dispatcher struct {
-	clk     clock.Clock
-	sink    tasks.JobCompletionSink
-	logger  observability.Logger
-	byID    map[tasks.JobID]*jobEntry
-	byTopic map[tasks.Topic][]*jobEntry
-	workers map[tasks.Topic]WorkerFunc
-	wake    chan struct{}
-	maxLock time.Duration
-	mu      sync.Mutex
+	clk        clock.Clock
+	sink       tasks.JobCompletionSink
+	logger     observability.Logger
+	exprEngine expression.Engine // classifies a raw fault's ErrorMapper (SRD-038)
+	byID       map[tasks.JobID]*jobEntry
+	byTopic    map[tasks.Topic][]*jobEntry
+	workers    map[tasks.Topic]WorkerFunc
+	wake       chan struct{}
+	maxLock    time.Duration
+	mu         sync.Mutex
 }
 
 // New returns an in-memory dispatcher whose locks are capped at maxLock
@@ -109,6 +111,22 @@ func (d *Dispatcher) BindLogger(logger observability.Logger) {
 	defer d.mu.Unlock()
 
 	d.logger = logger
+}
+
+// BindExpressionEngine sets the engine the dispatcher uses to run a Job's
+// ErrorMapper when it classifies a raw fault engine-side (EngineAuthoritative,
+// SRD-038). Bound at startup (tasks.ExpressionEngineBinder). A nil engine is
+// ignored — a dispatcher with no bound engine treats every raw fault as the
+// default technical outcome (no mapper can run).
+func (d *Dispatcher) BindExpressionEngine(ee expression.Engine) {
+	if ee == nil {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.exprEngine = ee
 }
 
 // Enqueue adds a job to the queue and wakes any waiting fetcher.
@@ -276,15 +294,72 @@ func (d *Dispatcher) ReportStatus(
 	return d.report(ctx, jobID, workerID, tasks.NewWorkerStatus(jobID, value))
 }
 
-// Fail reports a raw fault (the engine ErrorMapper classifies it) and removes the
-// job from the store.
+// Fail reports a raw fault. The dispatcher classifies it engine-side via the
+// job's Policy.ErrorMapper (EngineAuthoritative, SRD-038 §3.4): a Business Error
+// or Status becomes a terminal verdict; a Technical fault is terminal for now
+// (retry arrives in M7). The classified terminal is delivered to the sink and
+// the job removed. Classification runs outside d.mu while the reporting worker
+// still holds the job's (unexpired) lock, so no concurrent fetch can take it.
 func (d *Dispatcher) Fail(
 	ctx context.Context,
 	jobID tasks.JobID,
 	workerID tasks.WorkerID,
 	fault tasks.Fault,
 ) error {
-	return d.report(ctx, jobID, workerID, tasks.NewWorkerFault(jobID, fault))
+	d.mu.Lock()
+
+	e, err := d.heldEntry(jobID, workerID)
+	if err != nil {
+		d.mu.Unlock()
+
+		return err
+	}
+
+	policy := e.job.Policy
+	ee := d.exprEngine
+	logger := d.logger
+	d.mu.Unlock()
+
+	terminal := classify(ctx, logger, jobID, policy, ee, fault)
+
+	return d.report(ctx, jobID, workerID, terminal)
+}
+
+// classify runs the job's ErrorMapper over a raw fault and returns the
+// classified terminal outcome (SRD-038 §3.4). A nil policy / nil mapper / nil
+// engine, or a mapper error, falls through to a raw (technical) fault outcome —
+// the track terminates it (M7 adds retry on the technical branch, before this
+// terminal is reached).
+func classify(
+	ctx context.Context,
+	logger observability.Logger,
+	jobID tasks.JobID,
+	policy *tasks.Policy,
+	ee expression.Engine,
+	fault tasks.Fault,
+) *tasks.WorkerOutcome {
+	if policy == nil || policy.ErrorMapper == nil || ee == nil {
+		return tasks.NewWorkerFault(jobID, fault)
+	}
+
+	mapped, err := policy.ErrorMapper.Classify(ctx, ee, fault)
+	if err != nil {
+		logger.Warn("error-mapping failed; treating as a technical fault",
+			"job_id", string(jobID), "error", err.Error())
+
+		return tasks.NewWorkerFault(jobID, fault)
+	}
+
+	switch o := mapped.(type) {
+	case tasks.BpmnError:
+		return tasks.NewWorkerBpmnError(jobID, o.Code, o.Message)
+
+	case tasks.Status:
+		return tasks.NewWorkerStatus(jobID, o.Value)
+
+	default: // tasks.Technical (sealed interface — the only remaining kind)
+		return tasks.NewWorkerFault(jobID, fault)
+	}
 }
 
 // report validates the lock, removes the job, and delivers the outcome to the
@@ -444,6 +519,8 @@ func (d *Dispatcher) broadcastLocked() {
 }
 
 var (
-	_ tasks.WorkerDispatcher = (*Dispatcher)(nil)
-	_ tasks.SinkBinder       = (*Dispatcher)(nil)
+	_ tasks.WorkerDispatcher       = (*Dispatcher)(nil)
+	_ tasks.SinkBinder             = (*Dispatcher)(nil)
+	_ tasks.LoggerBinder           = (*Dispatcher)(nil)
+	_ tasks.ExpressionEngineBinder = (*Dispatcher)(nil)
 )

--- a/pkg/tasks/localdispatcher/localdispatcher.go
+++ b/pkg/tasks/localdispatcher/localdispatcher.go
@@ -47,8 +47,10 @@ type WorkerFunc func(ctx context.Context, job tasks.LockedJob) (*data.ItemDefini
 type jobEntry struct {
 	firstLock time.Time // when this lock was acquired (for the maxLock cap)
 	deadline  time.Time // current lock expiry
+	notBefore time.Time // > now while gated for a retry backoff (zero = available)
 	job       tasks.Job
 	workerID  tasks.WorkerID // "" = unlocked
+	attempt   int            // executions run so far (retry count = attempt-1)
 }
 
 // Dispatcher is the in-memory fetch-and-lock job store (ADR-021 §2.4).
@@ -172,9 +174,10 @@ func (d *Dispatcher) FetchAndLock(
 ) ([]tasks.LockedJob, error) {
 	for {
 		d.mu.Lock()
-		lj, ok := d.lockNext(workerID, topics, lockDuration)
+		lj, gate, ok := d.lockNext(workerID, topics, lockDuration)
 		wake := d.wake
 		logger := d.logger
+		now := d.clk.Now()
 		d.mu.Unlock()
 
 		if ok {
@@ -185,28 +188,48 @@ func (d *Dispatcher) FetchAndLock(
 			return []tasks.LockedJob{lj}, nil
 		}
 
+		// Nothing available now; if a retry backoff gate is pending, also wake at
+		// the nearest one (a nil timer channel never fires — the wake-only case).
+		var timer <-chan time.Time
+		if !gate.IsZero() {
+			timer = d.clk.After(gate.Sub(now))
+		}
+
 		select {
 		case <-wake:
 			continue // a job was enqueued (broadcast) — re-scan.
+		case <-timer:
+			continue // a retry backoff gate elapsed — re-scan.
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
 	}
 }
 
-// lockNext locks and returns the first available entry for one of topics.
-// Caller holds d.mu.
+// lockNext locks and returns the first available entry for one of topics. When
+// nothing is available it also returns the earliest future retry-backoff gate
+// (zero if none) so the caller can wake for it. Caller holds d.mu.
 func (d *Dispatcher) lockNext(
 	workerID tasks.WorkerID,
 	topics []tasks.Topic,
 	lockDuration time.Duration,
-) (tasks.LockedJob, bool) {
+) (tasks.LockedJob, time.Time, bool) {
 	now := d.clk.Now()
+
+	var gate time.Time
 
 	for _, topic := range topics {
 		for _, e := range d.byTopic[topic] {
 			if e.workerID != "" && !now.After(e.deadline) {
 				continue // locked and not expired
+			}
+
+			if !e.notBefore.IsZero() && now.Before(e.notBefore) {
+				if gate.IsZero() || e.notBefore.Before(gate) {
+					gate = e.notBefore // track the nearest backoff gate
+				}
+
+				continue // gated for a retry backoff
 			}
 
 			if e.workerID != "" {
@@ -219,16 +242,17 @@ func (d *Dispatcher) lockNext(
 			e.workerID = workerID
 			e.firstLock = now
 			e.deadline = now.Add(lockDuration)
+			e.notBefore = time.Time{} // consumed — the gate is now handed out
 
 			return tasks.LockedJob{
 				Job:      e.job,
 				WorkerID: workerID,
 				Deadline: e.deadline,
-			}, true
+			}, time.Time{}, true
 		}
 	}
 
-	return tasks.LockedJob{}, false
+	return tasks.LockedJob{}, gate, false
 }
 
 // ExtendLock extends jobID's lock (held by workerID) by newDuration from now,
@@ -296,10 +320,12 @@ func (d *Dispatcher) ReportStatus(
 
 // Fail reports a raw fault. The dispatcher classifies it engine-side via the
 // job's Policy.ErrorMapper (EngineAuthoritative, SRD-038 §3.4): a Business Error
-// or Status becomes a terminal verdict; a Technical fault is terminal for now
-// (retry arrives in M7). The classified terminal is delivered to the sink and
-// the job removed. Classification runs outside d.mu while the reporting worker
-// still holds the job's (unexpired) lock, so no concurrent fetch can take it.
+// or Status is a terminal verdict delivered to the sink; a Technical fault is
+// run through the Policy.RetryPolicy — a retry re-arms the job for a later
+// re-fetch (no delivery, the track stays parked), an exhausted policy delivers
+// the terminal fault. Classification runs outside d.mu while the reporting
+// worker still holds the job's (unexpired) lock, so no concurrent fetch can take
+// it; the retry decision re-acquires d.mu and re-validates the entry.
 func (d *Dispatcher) Fail(
 	ctx context.Context,
 	jobID tasks.JobID,
@@ -320,16 +346,80 @@ func (d *Dispatcher) Fail(
 	logger := d.logger
 	d.mu.Unlock()
 
-	terminal := classify(ctx, logger, jobID, policy, ee, fault)
+	outcome := classify(ctx, logger, jobID, policy, ee, fault)
 
-	return d.report(ctx, jobID, workerID, terminal)
+	// A business verdict (BpmnError / Status) is never retried — deliver it.
+	if outcome.Kind() != tasks.OutcomeFault {
+		return d.report(ctx, jobID, workerID, outcome)
+	}
+
+	// Technical fault — consult the retry policy (SRD-038 §3.4, FR-7/FR-8).
+	return d.retryOrExhaust(ctx, jobID, workerID, policy, fault, logger)
 }
 
-// classify runs the job's ErrorMapper over a raw fault and returns the
-// classified terminal outcome (SRD-038 §3.4). A nil policy / nil mapper / nil
-// engine, or a mapper error, falls through to a raw (technical) fault outcome —
-// the track terminates it (M7 adds retry on the technical branch, before this
-// terminal is reached).
+// retryOrExhaust applies the job's RetryPolicy to a technical fault: while it
+// retries, the entry is re-armed (unlocked, gated by a notBefore backoff, and
+// its attempt count incremented) for a later re-fetch, with no delivery so the
+// track stays parked; once exhausted (or with no policy) the terminal technical
+// fault is delivered. Re-validates the entry under d.mu before acting.
+func (d *Dispatcher) retryOrExhaust(
+	ctx context.Context,
+	jobID tasks.JobID,
+	workerID tasks.WorkerID,
+	policy *tasks.Policy,
+	fault tasks.Fault,
+	logger observability.Logger,
+) error {
+	d.mu.Lock()
+
+	e, err := d.heldEntry(jobID, workerID)
+	if err != nil {
+		d.mu.Unlock()
+
+		return err
+	}
+
+	attempt := e.attempt + 1
+
+	if backoff, retry := retryDecision(policy, attempt, fault.Cause); retry {
+		e.workerID = ""
+		e.attempt = attempt
+		e.notBefore = d.clk.Now().Add(backoff)
+		d.broadcastLocked()
+		d.mu.Unlock()
+
+		logger.Debug("job retry scheduled",
+			"job_id", string(jobID), "attempt", attempt, "backoff", backoff)
+
+		return nil
+	}
+
+	topic := e.job.Topic
+	d.mu.Unlock()
+
+	logger.Warn("job retries exhausted",
+		"job_id", string(jobID), "topic", string(topic), "attempts", attempt)
+
+	return d.report(ctx, jobID, workerID, tasks.NewWorkerFault(jobID, fault))
+}
+
+// retryDecision consults policy's RetryPolicy for the just-failed attempt; a nil
+// policy or RetryPolicy is a no-retry (terminal on first technical fault).
+func retryDecision(
+	policy *tasks.Policy, attempt int, cause error,
+) (time.Duration, bool) {
+	if policy == nil || policy.RetryPolicy == nil {
+		return 0, false
+	}
+
+	return policy.RetryPolicy.Retry(attempt, cause)
+}
+
+// classify runs the job's ErrorMapper over a raw fault and returns the mapped
+// outcome (SRD-038 §3.4): a Business Error / Status verdict, or a technical
+// OutcomeFault. A nil policy / nil mapper / nil engine, or a mapper error, falls
+// through to the technical outcome. The caller retries a technical outcome (via
+// the RetryPolicy) before it becomes terminal; a verdict is delivered as-is.
 func classify(
 	ctx context.Context,
 	logger observability.Logger,

--- a/pkg/tasks/localdispatcher/localdispatcher_test.go
+++ b/pkg/tasks/localdispatcher/localdispatcher_test.go
@@ -233,6 +233,10 @@ func TestLocalDispatcherReportGuards(t *testing.T) {
 	require.ErrorIs(t, d.Complete(ctx, "j1", "wB", nil),
 		localdispatcher.ErrNotLockHolder)
 
+	// Fail runs the same lock guard before it classifies (SRD-038).
+	require.ErrorIs(t, d.Fail(ctx, "missing", "wA", tasks.Fault{}),
+		localdispatcher.ErrJobNotFound)
+
 	// past the lock, the holder can no longer complete.
 	clk.Advance(11 * time.Second)
 	require.ErrorIs(t, d.Complete(ctx, "j1", "wA", nil),

--- a/pkg/tasks/localdispatcher/retry_test.go
+++ b/pkg/tasks/localdispatcher/retry_test.go
@@ -1,0 +1,178 @@
+package localdispatcher_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/clock/clocktest"
+	"github.com/dr-dobermann/gobpm/pkg/model/expression"
+	expengine "github.com/dr-dobermann/gobpm/pkg/model/expression/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/tasks"
+	"github.com/dr-dobermann/gobpm/pkg/tasks/localdispatcher"
+	"github.com/stretchr/testify/require"
+)
+
+// clockPokeMapper is an ErrorMapper that advances a fake clock while classifying
+// (returning Technical). It lets a test expire the reporting worker's lock during
+// the classify window, exercising the retry re-validation guard.
+type clockPokeMapper struct {
+	clk *clocktest.Clock
+	by  time.Duration
+}
+
+func (m clockPokeMapper) Classify(
+	context.Context, expression.Engine, tasks.Fault,
+) (tasks.MappedOutcome, error) {
+	m.clk.Advance(m.by)
+
+	return tasks.Technical{}, nil
+}
+
+// TestTechnicalFaultRetriesViaReArm: a technical fault with retries left re-arms
+// the job (no delivery, the track stays parked); once the backoff elapses it is
+// re-fetchable, preserving the attempt count (SRD-038 FR-7).
+func TestTechnicalFaultRetriesViaReArm(t *testing.T) {
+	sink := &recordSink{}
+	clk := clocktest.New(base)
+	d := localdispatcher.New(clk, time.Hour)
+	d.BindSink(sink)
+
+	ctx := context.Background()
+	// no ErrorMapper → a raw Fail is Technical; FixedDelay(3, 1s) retries attempts 1, 2.
+	require.NoError(t, d.Enqueue(ctx, tasks.Job{ID: "j1", Topic: "charge",
+		Policy: &tasks.Policy{RetryPolicy: tasks.FixedDelay(3, time.Second)}}))
+
+	_, err := d.FetchAndLock(ctx, "w1", topics("charge"), time.Minute)
+	require.NoError(t, err)
+	require.NoError(t, d.Fail(ctx, "j1", "w1",
+		tasks.Fault{Cause: errors.New("boom")}))
+	require.Nil(t, sink.last(), "a retried fault is not delivered")
+
+	// after the backoff the job is fetchable again (its attempt count preserved).
+	clk.Advance(time.Second)
+	jobs, err := d.FetchAndLock(ctx, "w1", topics("charge"), time.Minute)
+	require.NoError(t, err)
+	require.Equal(t, tasks.JobID("j1"), jobs[0].ID)
+	require.Nil(t, sink.last(), "still no terminal delivered mid-retry")
+}
+
+// TestLocalDispatcherNotBeforeGate: a re-armed job is withheld until its backoff
+// elapses, then a blocked fetcher wakes on the clock's timed signal (SRD-038 §3.5).
+func TestLocalDispatcherNotBeforeGate(t *testing.T) {
+	sink := &recordSink{}
+	clk := clocktest.New(base)
+	d := localdispatcher.New(clk, time.Hour)
+	d.BindSink(sink)
+
+	ctx := t.Context()
+	require.NoError(t, d.Enqueue(ctx, tasks.Job{ID: "j1", Topic: "charge",
+		Policy: &tasks.Policy{RetryPolicy: tasks.FixedDelay(3, time.Second)}}))
+
+	_, err := d.FetchAndLock(ctx, "w1", topics("charge"), time.Minute)
+	require.NoError(t, err)
+	require.NoError(t, d.Fail(ctx, "j1", "w1",
+		tasks.Fault{Cause: errors.New("boom")}))
+
+	// a fetcher blocks on the backoff gate and wakes when the clock passes it.
+	got := make(chan tasks.LockedJob, 1)
+	errc := make(chan error, 1)
+
+	go func() {
+		jobs, e := d.FetchAndLock(ctx, "w2", topics("charge"), time.Minute)
+		if e != nil {
+			errc <- e
+
+			return
+		}
+
+		got <- jobs[0]
+	}()
+
+	time.Sleep(30 * time.Millisecond) // let the fetcher reach the timed wait
+	clk.Advance(time.Second)          // fire the backoff-gate timer
+
+	select {
+	case lj := <-got:
+		require.Equal(t, tasks.JobID("j1"), lj.ID)
+	case e := <-errc:
+		t.Fatalf("fetch errored: %v", e)
+	case <-time.After(2 * time.Second):
+		t.Fatal("the gated job wasn't handed out after the backoff elapsed")
+	}
+}
+
+// TestRetryExhaustedFaultsWithDiagnostic: once the RetryPolicy is exhausted, the
+// dispatcher delivers a terminal technical fault carrying the cause (SRD-038 FR-8).
+func TestRetryExhaustedFaultsWithDiagnostic(t *testing.T) {
+	sink := &recordSink{}
+	d := localdispatcher.New(clocktest.New(base), time.Hour)
+	d.BindSink(sink)
+
+	ctx := context.Background()
+	// NoRetry → the first technical fault is immediately exhausted.
+	require.NoError(t, d.Enqueue(ctx, tasks.Job{ID: "j1", Topic: "charge",
+		Policy: &tasks.Policy{RetryPolicy: tasks.NoRetry()}}))
+
+	_, err := d.FetchAndLock(ctx, "w1", topics("charge"), time.Minute)
+	require.NoError(t, err)
+
+	require.NoError(t, d.Fail(ctx, "j1", "w1",
+		tasks.Fault{Code: "503", Cause: errors.New("upstream down")}))
+
+	out := sink.last()
+	require.NotNil(t, out)
+	require.Equal(t, tasks.OutcomeFault, out.Kind())
+	require.ErrorContains(t, out.Fault().Cause, "upstream down")
+}
+
+// TestBusinessOutcomeNotRetried: a fault the ErrorMapper classifies as a Business
+// Error is delivered immediately — the RetryPolicy is never consulted, the job is
+// not re-armed (SRD-038 NFR-4).
+func TestBusinessOutcomeNotRetried(t *testing.T) {
+	sink := &recordSink{}
+	d := localdispatcher.New(clocktest.New(base), time.Hour)
+	d.BindSink(sink)
+	d.BindExpressionEngine(expengine.New())
+
+	ctx := context.Background()
+	require.NoError(t, d.Enqueue(ctx, tasks.Job{ID: "j1", Topic: "charge",
+		Policy: &tasks.Policy{
+			ErrorMapper: mustRuleMapper(t,
+				tasks.Rule{Code: "409", Yield: tasks.BpmnError{Code: "Conflict"}}),
+			RetryPolicy: tasks.FixedDelay(3, time.Second)}}))
+
+	_, err := d.FetchAndLock(ctx, "w1", topics("charge"), time.Minute)
+	require.NoError(t, err)
+
+	require.NoError(t, d.Fail(ctx, "j1", "w1", tasks.Fault{Code: "409"}))
+
+	out := sink.last()
+	require.NotNil(t, out, "a business verdict is delivered, not retried")
+	require.Equal(t, tasks.OutcomeBpmnError, out.Kind())
+}
+
+// TestRetryReValidatesExpiredLock: if the reporting worker's lock expires during
+// classification, the retry re-validation finds the lock expired and drops the
+// re-arm rather than stomping a new holder (SRD-038 §3.4).
+func TestRetryReValidatesExpiredLock(t *testing.T) {
+	sink := &recordSink{}
+	clk := clocktest.New(base)
+	d := localdispatcher.New(clk, 10*time.Second)
+	d.BindSink(sink)
+	d.BindExpressionEngine(expengine.New())
+
+	ctx := context.Background()
+	require.NoError(t, d.Enqueue(ctx, tasks.Job{ID: "j1", Topic: "charge",
+		Policy: &tasks.Policy{
+			// classifying advances the clock 20s > the 10s lock — expiring it.
+			ErrorMapper: clockPokeMapper{clk: clk, by: 20 * time.Second},
+			RetryPolicy: tasks.FixedDelay(3, time.Second)}}))
+
+	_, err := d.FetchAndLock(ctx, "w1", topics("charge"), 10*time.Second)
+	require.NoError(t, err)
+
+	err = d.Fail(ctx, "j1", "w1", tasks.Fault{Cause: errors.New("boom")})
+	require.ErrorIs(t, err, localdispatcher.ErrLockExpired)
+}

--- a/pkg/tasks/retrypolicy.go
+++ b/pkg/tasks/retrypolicy.go
@@ -1,14 +1,103 @@
 package tasks
 
-import "time"
+import (
+	"math/rand/v2"
+	"time"
+)
 
 // RetryPolicy decides whether a technical fault is retried and the backoff
 // before the next attempt (ADR-021 §2.7). attempt is the 1-based number of the
 // attempt that just failed; cause is its technical error.
-//
-// The batteries (NoRetry / FixedDelay / ExponentialBackoff / DefaultRetryPolicy)
-// and the dispatcher-side retry loop land in SRD-038 M7; the interface is
-// defined here (M6) so Policy and WorkerConfig carry their final shape.
 type RetryPolicy interface {
 	Retry(attempt int, cause error) (backoff time.Duration, retry bool)
+}
+
+// Default retry knobs (ADR-021 §2.7): 3 attempts total (Camunda's
+// defaultNumberOfRetries) with jittered exponential backoff from 500ms, capped.
+const (
+	defaultRetryAttempts = 3
+	defaultRetryBase     = 500 * time.Millisecond
+	defaultRetryMax      = 30 * time.Second
+)
+
+// noRetry never retries — the first technical fault is terminal.
+type noRetry struct{}
+
+func (noRetry) Retry(int, error) (time.Duration, bool) { return 0, false }
+
+// NoRetry returns a RetryPolicy that never retries: a technical fault is
+// terminal on first report (a fail-fast worker).
+func NoRetry() RetryPolicy { return noRetry{} }
+
+// fixedDelay retries up to maxAttempts total, waiting a constant delay.
+type fixedDelay struct {
+	delay       time.Duration
+	maxAttempts int
+}
+
+// FixedDelay returns a RetryPolicy that retries a technical fault until
+// maxAttempts executions have been made, waiting delay before each retry.
+func FixedDelay(maxAttempts int, delay time.Duration) RetryPolicy {
+	return fixedDelay{delay: delay, maxAttempts: maxAttempts}
+}
+
+// Retry retries while fewer than maxAttempts executions have run.
+func (f fixedDelay) Retry(attempt int, _ error) (time.Duration, bool) {
+	if attempt >= f.maxAttempts {
+		return 0, false
+	}
+
+	return f.delay, true
+}
+
+// exponentialBackoff retries up to maxAttempts total, doubling the backoff from
+// base (capped at maxBackoff), optionally jittered.
+type exponentialBackoff struct {
+	base        time.Duration
+	maxBackoff  time.Duration
+	maxAttempts int
+	jitter      bool
+}
+
+// ExponentialBackoff returns a RetryPolicy that retries until maxAttempts
+// executions have run, doubling the backoff (base, 2·base, 4·base, …) capped at
+// maxBackoff. With jitter, each backoff is randomized into [d/2, d] to spread
+// retries.
+func ExponentialBackoff(
+	maxAttempts int, base, maxBackoff time.Duration, jitter bool,
+) RetryPolicy {
+	return exponentialBackoff{
+		base: base, maxBackoff: maxBackoff, maxAttempts: maxAttempts, jitter: jitter,
+	}
+}
+
+// Retry computes the capped (optionally jittered) exponential backoff for the
+// next attempt, or (0, false) once maxAttempts executions have run.
+func (e exponentialBackoff) Retry(attempt int, _ error) (time.Duration, bool) {
+	if attempt >= e.maxAttempts {
+		return 0, false
+	}
+
+	// base · 2^(attempt-1), guarding overflow and the max cap.
+	d := e.base << (attempt - 1)
+	if d <= 0 || d > e.maxBackoff {
+		d = e.maxBackoff
+	}
+
+	if e.jitter {
+		// spread into [d/2, d]; Int64N's argument is always >= 1, so it is safe
+		// for any d >= 0.
+		d = d/2 + time.Duration(rand.Int64N(int64(d/2)+1)) //nolint:gosec // jitter, not security
+	}
+
+	return d, true
+}
+
+// DefaultRetryPolicy is the engine default when neither a per-service nor an
+// engine-wide RetryPolicy is set: 3 attempts with jittered exponential backoff
+// from 500ms capped at 30s — improving on Camunda's zero-wait default
+// (ADR-021 §2.7).
+func DefaultRetryPolicy() RetryPolicy {
+	return ExponentialBackoff(
+		defaultRetryAttempts, defaultRetryBase, defaultRetryMax, true)
 }

--- a/pkg/tasks/retrypolicy.go
+++ b/pkg/tasks/retrypolicy.go
@@ -1,0 +1,14 @@
+package tasks
+
+import "time"
+
+// RetryPolicy decides whether a technical fault is retried and the backoff
+// before the next attempt (ADR-021 §2.7). attempt is the 1-based number of the
+// attempt that just failed; cause is its technical error.
+//
+// The batteries (NoRetry / FixedDelay / ExponentialBackoff / DefaultRetryPolicy)
+// and the dispatcher-side retry loop land in SRD-038 M7; the interface is
+// defined here (M6) so Policy and WorkerConfig carry their final shape.
+type RetryPolicy interface {
+	Retry(attempt int, cause error) (backoff time.Duration, retry bool)
+}

--- a/pkg/tasks/retrypolicy_test.go
+++ b/pkg/tasks/retrypolicy_test.go
@@ -1,0 +1,90 @@
+package tasks_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/tasks"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRetryPolicyNoRetry: NoRetry never retries — a technical fault is terminal.
+func TestRetryPolicyNoRetry(t *testing.T) {
+	_, retry := tasks.NoRetry().Retry(1, errors.New("x"))
+	require.False(t, retry)
+}
+
+// TestRetryPolicyFixedDelay: FixedDelay retries with a constant delay until
+// maxAttempts executions have run.
+func TestRetryPolicyFixedDelay(t *testing.T) {
+	p := tasks.FixedDelay(3, 2*time.Second)
+
+	d, ok := p.Retry(1, nil)
+	require.True(t, ok)
+	require.Equal(t, 2*time.Second, d)
+
+	d, ok = p.Retry(2, nil)
+	require.True(t, ok)
+	require.Equal(t, 2*time.Second, d)
+
+	_, ok = p.Retry(3, nil) // the 3rd (last) execution failed — no more retries
+	require.False(t, ok)
+}
+
+// TestRetryPolicyExponentialBackoff: ExponentialBackoff doubles the backoff from
+// base each attempt until maxAttempts.
+func TestRetryPolicyExponentialBackoff(t *testing.T) {
+	p := tasks.ExponentialBackoff(4, 100*time.Millisecond, time.Second, false)
+
+	d, ok := p.Retry(1, nil)
+	require.True(t, ok)
+	require.Equal(t, 100*time.Millisecond, d) // base
+
+	d, _ = p.Retry(2, nil)
+	require.Equal(t, 200*time.Millisecond, d) // 2·base
+
+	d, _ = p.Retry(3, nil)
+	require.Equal(t, 400*time.Millisecond, d) // 4·base
+
+	_, ok = p.Retry(4, nil)
+	require.False(t, ok) // exhausted
+}
+
+// TestRetryPolicyExponentialCap: the backoff is capped at max.
+func TestRetryPolicyExponentialCap(t *testing.T) {
+	// base 1s, attempt 3 → 4·base = 4s, capped at 2s.
+	p := tasks.ExponentialBackoff(5, time.Second, 2*time.Second, false)
+
+	d, ok := p.Retry(3, nil)
+	require.True(t, ok)
+	require.Equal(t, 2*time.Second, d)
+}
+
+// TestRetryPolicyExponentialJitter: with jitter, the backoff is randomized into
+// [d/2, d] of the computed backoff.
+func TestRetryPolicyExponentialJitter(t *testing.T) {
+	p := tasks.ExponentialBackoff(3, time.Second, 10*time.Second, true)
+
+	for range 20 {
+		d, ok := p.Retry(1, nil) // base 1s → jittered into [500ms, 1s]
+		require.True(t, ok)
+		require.GreaterOrEqual(t, d, 500*time.Millisecond)
+		require.LessOrEqual(t, d, time.Second)
+	}
+}
+
+// TestDefaultRetryPolicy: the engine default is 3 attempts (attempts 1 and 2
+// retry, the 3rd is terminal).
+func TestDefaultRetryPolicy(t *testing.T) {
+	p := tasks.DefaultRetryPolicy()
+
+	_, ok := p.Retry(1, nil)
+	require.True(t, ok)
+
+	_, ok = p.Retry(2, nil)
+	require.True(t, ok)
+
+	_, ok = p.Retry(3, nil)
+	require.False(t, ok)
+}

--- a/pkg/tasks/workerdispatcher.go
+++ b/pkg/tasks/workerdispatcher.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/expression"
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
 	"github.com/dr-dobermann/gobpm/pkg/observability"
@@ -58,11 +59,20 @@ func (j JobID) InstanceID() string {
 	return instanceID
 }
 
-// Policy is the per-service execution bundle shipped to a WorkerTrusted worker
-// (SRD-038): output mapping, error mapping, and retry policy. It is nil under
-// EngineAuthoritative and throughout M2/M3 — a placeholder here that SRD-037/038
-// fill in.
-type Policy struct{}
+// Policy is a worker-dispatched ServiceTask's resolved outcome policy. Under
+// EngineAuthoritative (SRD-038) the dispatcher uses it to classify a raw fault
+// (ErrorMapper) and drive technical retries (RetryPolicy); under WorkerTrusted
+// (SRD-039) it is shipped to the worker. The instance resolves it (two-level:
+// per-service over engine-wide) at enqueue. A nil Policy = an in-process task or
+// a not-yet-populated job.
+type Policy struct {
+	// ErrorMapper classifies a raw fault; nil = raw faults fall through to the
+	// default Technical outcome.
+	ErrorMapper ErrorMapper
+	// RetryPolicy drives technical-fault retries; wired in SRD-038 M7 (nil when
+	// unset).
+	RetryPolicy RetryPolicy
+}
 
 // Job is the unit the engine Enqueues. Input is the single bound input-message
 // item (nil if the operation has no inMessage), per the operation contract.
@@ -167,6 +177,23 @@ type SinkBinder interface {
 // dispatcher that manages its own logging need not implement it.
 type LoggerBinder interface {
 	BindLogger(logger observability.Logger)
+}
+
+// ExpressionEngineBinder is an optional dispatcher capability: the engine binds
+// its expression engine at startup so the dispatcher can run a Job's ErrorMapper
+// (which evaluates FormalExpressions) when it classifies a raw fault engine-side
+// under EngineAuthoritative (SRD-038). A dispatcher that never classifies
+// engine-side (e.g. a WorkerTrusted-only remote adapter) need not implement it.
+type ExpressionEngineBinder interface {
+	BindExpressionEngine(ee expression.Engine)
+}
+
+// WorkerConfig is implemented by a node whose worker outcome the engine
+// classifies and retries. WorkerConfig returns the node's per-service policy —
+// either value nil means "fall back to the engine-wide default" resolved at
+// enqueue; ok == false for an in-process (non-worker) node.
+type WorkerConfig interface {
+	WorkerConfig() (errorMapper ErrorMapper, retryPolicy RetryPolicy, ok bool)
 }
 
 // ExternalWorker is implemented by a node whose work is dispatched to an

--- a/pkg/thresher/dispatcher_binding_test.go
+++ b/pkg/thresher/dispatcher_binding_test.go
@@ -1,0 +1,39 @@
+package thresher_test
+
+import (
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/expression"
+	"github.com/dr-dobermann/gobpm/pkg/tasks"
+	"github.com/dr-dobermann/gobpm/pkg/thresher"
+	"github.com/stretchr/testify/require"
+)
+
+// bindingDispatcher is a capDispatcher that also records the startup binder calls,
+// so a test can assert the engine wires the dispatcher (SRD-038 §3.4): the sink
+// (SinkBinder) and the expression engine (ExpressionEngineBinder).
+type bindingDispatcher struct {
+	capDispatcher
+	sink      tasks.JobCompletionSink
+	exprBound expression.Engine
+}
+
+func (d *bindingDispatcher) BindSink(s tasks.JobCompletionSink) { d.sink = s }
+
+func (d *bindingDispatcher) BindExpressionEngine(ee expression.Engine) {
+	d.exprBound = ee
+}
+
+// TestThresherBindsExpressionEngineToDispatcher covers §3.4: at startup the engine
+// binds its expression engine onto the dispatcher (ExpressionEngineBinder), so the
+// dispatcher can run a Job's ErrorMapper when it classifies a raw fault.
+func TestThresherBindsExpressionEngineToDispatcher(t *testing.T) {
+	disp := &bindingDispatcher{}
+
+	_, err := thresher.New("bind-test", thresher.WithWorkerDispatcher(disp))
+	require.NoError(t, err)
+
+	require.NotNil(t, disp.exprBound,
+		"the dispatcher received the engine's expression engine")
+	require.NotNil(t, disp.sink, "the dispatcher received the completion sink")
+}

--- a/pkg/thresher/options.go
+++ b/pkg/thresher/options.go
@@ -38,6 +38,10 @@ type thresherConfig struct {
 	// workerErrorMapper is the engine-wide default ErrorMapper (SRD-037 FR-3);
 	// nil by default, overridden per-service by activities.WithErrorMapper.
 	workerErrorMapper tasks.ErrorMapper
+	// workerRetryPolicy is the engine-wide default RetryPolicy (SRD-038 FR-6);
+	// nil by default, overridden per-service by activities.WithRetryPolicy;
+	// absent both, the resolver falls back to tasks.DefaultRetryPolicy.
+	workerRetryPolicy tasks.RetryPolicy
 	taskDist          interactor.TaskDistributor
 
 	// Startup-report suppression (ADR-002 v.2 §4.4.1). Both default to false —
@@ -220,6 +224,23 @@ func WithWorkerErrorMapper(m tasks.ErrorMapper) Option {
 	}
 }
 
+// WithWorkerRetryPolicy sets the engine-wide default RetryPolicy applied to a
+// worker-dispatched ServiceTask's technical fault when it carries no per-service
+// activities.WithRetryPolicy (SRD-038 FR-6, two-level config).
+func WithWorkerRetryPolicy(p tasks.RetryPolicy) Option {
+	return func(c *thresherConfig) error {
+		if p == nil {
+			return errs.New(
+				errs.M("WithWorkerRetryPolicy: a nil RetryPolicy isn't allowed"),
+				errs.C(errorClass, errs.EmptyNotAllowed))
+		}
+
+		c.workerRetryPolicy = p
+
+		return nil
+	}
+}
+
 // WithoutBanner suppresses the startup banner block — the ASCII wordmark, the
 // product tagline, and the version / last-commit lines (ADR-002 v.2 §4.4.1).
 // The configuration dump still prints unless WithoutStartupConfig is also given.
@@ -261,6 +282,8 @@ func (c *thresherConfig) AuthorizationProvider() auth.AuthorizationProvider {
 func (c *thresherConfig) WorkerDispatcher() tasks.WorkerDispatcher { return c.dispatcher }
 
 func (c *thresherConfig) WorkerErrorMapper() tasks.ErrorMapper { return c.workerErrorMapper }
+
+func (c *thresherConfig) WorkerRetryPolicy() tasks.RetryPolicy { return c.workerRetryPolicy }
 
 func (c *thresherConfig) TaskDistributor() interactor.TaskDistributor { return c.taskDist }
 

--- a/pkg/thresher/options_test.go
+++ b/pkg/thresher/options_test.go
@@ -59,11 +59,13 @@ func TestEveryOptionOverridesItsDefault(t *testing.T) {
 		t.Fatalf("building the error mapper: %v", werr)
 	}
 
+	wrp := tasks.NoRetry()
+
 	for _, o := range []Option{
 		WithLogger(lg), WithTracer(tr), WithMetricsRecorder(mr), WithClock(ck),
 		WithRepository(rp), WithMessageBroker(mb), WithExpressionEngine(ee),
 		WithAuthorizationProvider(az), WithWorkerDispatcher(wd),
-		WithWorkerErrorMapper(wem),
+		WithWorkerErrorMapper(wem), WithWorkerRetryPolicy(wrp),
 	} {
 		if err := o(&c); err != nil {
 			t.Fatalf("option returned an error: %v", err)
@@ -73,7 +75,7 @@ func TestEveryOptionOverridesItsDefault(t *testing.T) {
 	if c.logger != lg || c.tracer != tr || c.metrics != mr || c.clock != ck ||
 		c.repository != rp || c.msgBroker != mb || c.exprEngine != ee ||
 		c.authz != az || c.dispatcher != wd ||
-		c.WorkerErrorMapper() != wem {
+		c.WorkerErrorMapper() != wem || c.WorkerRetryPolicy() != wrp {
 		t.Fatal("a WithXxx option did not override its field")
 	}
 }
@@ -257,5 +259,13 @@ func TestWithWorkerErrorMapperRejectsNil(t *testing.T) {
 	c := defaultConfig()
 	if err := WithWorkerErrorMapper(nil)(&c); err == nil {
 		t.Fatal("a nil ErrorMapper should be rejected")
+	}
+}
+
+// TestWithWorkerRetryPolicyRejectsNil: a nil engine-wide RetryPolicy is rejected.
+func TestWithWorkerRetryPolicyRejectsNil(t *testing.T) {
+	c := defaultConfig()
+	if err := WithWorkerRetryPolicy(nil)(&c); err == nil {
+		t.Fatal("a nil RetryPolicy should be rejected")
 	}
 }

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -217,6 +217,14 @@ func New(id string, opts ...Option) (*Thresher, error) {
 		lb.BindLogger(cfg.Logger())
 	}
 
+	// Bind the engine's expression engine so the dispatcher can run a Job's
+	// ErrorMapper when it classifies a raw fault engine-side (EngineAuthoritative,
+	// SRD-038). A dispatcher that never classifies engine-side need not implement
+	// ExpressionEngineBinder.
+	if eb, ok := cfg.WorkerDispatcher().(tasks.ExpressionEngineBinder); ok {
+		eb.BindExpressionEngine(cfg.ExpressionEngine())
+	}
+
 	// The EventHub receives the engine's resolved runtime (&t.cfg implements
 	// renv.EngineRuntime) so the waiters it builds reach Clock / ExpressionEngine
 	// (ADR-002 §4.3, Solution B). Built after t so it shares t's cfg pointer.


### PR DESCRIPTION
Fourth of five SRDs landing ADR-021 (Service Task Execution Model). Moves worker-fault classification off the parked track into the dispatcher (ADR-021 §2.7 "only the terminal outcome reaches the
loop"), then adds a dispatcher-owned retry policy for technical faults. This is the EngineAuthoritative path; WithWorkerTrust + the WorkerTrusted protocol + a worked example are scoped to
SRD-039, so ADR-021 stays Draft until then.

What changed
- Classification → dispatcher. A raw Fail is classified via the job's shipped Policy.ErrorMapper and a bound expression engine (ExpressionEngineBinder, wired at startup); a business verdict
(BpmnError/Status) is delivered, a technical fault feeds retry. The track's execWorkerOutcome shrinks to apply-only (classifyFault removed); the Instance's handleJobCompletion is unchanged (only
resolveWorkerPolicy was added at enqueue).
- Retry policy. RetryPolicy interface + batteries (NoRetry/FixedDelay/ExponentialBackoff) + DefaultRetryPolicy (3 attempts, jittered exp-backoff). Two-level config: per-service WithRetryPolicy
over engine-wide WithWorkerRetryPolicy over the default. Retry re-arms the dispatcher's store entry in place (unlock + notBefore backoff gate + attempt++), clock-gated via clk.After — no sleeping
goroutine; a re-armed job + a parked track are both persistable. Exhaustion → terminal Failed delivered to the Instance (incident-ready).

Testing. make ci green (tidy · lint 0 · build · -race · diff-coverage ≥95% · govulncheck). New/changed functions at 100% coverage. /review-srd (pre-approval) and /check-srd (post-impl) both PASS.
