### PR TITLE
Feat/activity conditional flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the GoBPM project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Activity-outgoing conditional and default flows (SRD-046, closes #51).**
+  A task's completion now honors the BPMN sequence-flow rule: an
+  unconditional outgoing flow always fires, a **conditional** flow fires only
+  when its condition is true, and the activity's **default** flow fires only
+  when no conditional fired. Previously conditions and defaults on
+  task-outgoing flows were model-accepted but **silently ignored** (all flows
+  forked unconditionally); `SetDefaultFlow` now also rejects a flow carrying
+  a condition (the gateway rule), and a `DefaultFlow()` getter is added.
+  Selecting nothing (all conditions false, no default) faults the instance
+  with a classified error — an explicit engine choice mirroring the gateway
+  exception (Camunda-7-aligned). Single-outgoing-flow activities are
+  untouched (a short-circuit keeps the common case cost-free).
+
 ## [v0.8.1-rc.1] - 2026-07-15
 
 The **substrate** release: with the Core Task Types epic complete

--- a/docs/srd/SRD-046-activity-conditional-flows.md
+++ b/docs/srd/SRD-046-activity-conditional-flows.md
@@ -1,0 +1,300 @@
+# SRD-046 — Activity-outgoing conditional and default flows
+
+| Field | Value |
+|---|---|
+| Status | Draft v.1 |
+| Version | v.1 |
+| Date | 2026-07-15 |
+| Owner | Ruslan Gabitov |
+| Implements | BPMN 2.0 sequence-flow semantics at activity completion — the vendored extract `docs/bpmn-spec/semantics/token-flow.md` §"Multiple outgoing sequence flows on an activity" (GitHub issue #51) |
+| Upstream | [ADR-001 v.6](../design/ADR-001-execution-model.md) (the track/fork execution model — the consumer of the selected flows), [ADR-005 v.4](../design/ADR-005-gateways-and-joins.md) (the gateway condition-evaluation idiom this mirrors), [ADR-010 v.2](../design/ADR-010-process-data-model.md) (the data source conditions evaluate over) |
+| Refines | — |
+
+Today `flow.Condition()` is honored **only by gateways** (`gateway.go:221-302`,
+`exclusive.go:91`, `event_based.go:396`). Every activity's `Exec` returns
+`Outgoing()` unfiltered and the track forks **all** of them — while the model
+happily **accepts** what the engine ignores: `flow.WithCondition` attaches to
+any `flow.Link(...)` call regardless of source type, and
+`activity.SetDefaultFlow` exists (`activity.go:143`) but nothing reads it
+(dead today, grounding-verified). A modeller's condition or default on
+a task-outgoing flow is **silently dropped** — the silent-misbehavior class the
+engine's fail-fast posture forbids.
+
+The standard's rule (the vendored `token-flow.md`, quoted):
+
+> When an activity transitions to **Completed**, all of its outgoing sequence
+> flows receive a token. Behavior depends on the conditions:
+> | All outgoing unconditional | Parallel split — all branches activated. |
+> | All outgoing have `conditionExpression` | Inclusive split — each true condition produces a token. |
+> | Mix of unconditional + conditional | Combination — unconditional always fire, conditional fire when their condition is true. |
+
+## 1. Background
+
+- **The engine gap.** Activity `Exec`s return raw `Outgoing()` at 8 sites
+  across 5 files (`service_task.go:269,388,400,470`, `send_task.go:147`,
+  `user_task.go:210`, `receive_task.go:200`, `manual_task.go:72`); the track's
+  `checkFlows` forks exactly what `Exec` returned, no re-filtering
+  (`track.go:985-1056`) — so **activity-side selection needs zero engine
+  change**, the same locus gateways already use (nodes own their routing).
+- **The model half-exists.** `activity.defaultFlow` + `SetDefaultFlow`
+  (outgoing-membership validated, empty clears) are present but dead;
+  `SetDefaultFlow` misses the no-condition rule `gateways.UpdateDefaultFlow`
+  enforces (`gateway.go:182-186`).
+- **A clone hazard (grounding find).** `activity.clone` shares `defaultFlow`
+  **by reference** (`activity.go:120`) while instances clone their node graphs
+  — a pointer-identity default check would silently stop matching on a cloned
+  instance. Selection must compare **by flow ID**.
+- **The evaluation idiom exists.** `gateways.checkCondition`
+  (`gateway.go:221-248`): require `ResultType() == "bool"`, evaluate via
+  `re.ExpressionEngine().Evaluate(ctx, cond, re)` (the `re` is the
+  `data.Source`), classified errors carrying node/flow ids. Every activity
+  `Exec` already holds the same `ctx, re` pair.
+
+## 2. Requirements
+
+### Functional
+
+- **FR-1 — the selection rule at every activity completion.** A shared
+  `activity.selectOutgoing(ctx, re) ([]*flow.SequenceFlow, error)` implements
+  the standard's table:
+  - an **unconditional** non-default flow → always selected;
+  - a **conditional** flow → selected iff its condition evaluates `true`;
+  - the **default** flow → selected iff **no conditional flow** was selected
+    (with no conditional flows present, vacuously selected);
+  - a **single outgoing flow** (or none) short-circuits unfiltered — the
+    overwhelmingly common case pays nothing (the gateway pass-through
+    precedent, `gateway.go:258-260`).
+- **FR-2 — the evaluation idiom mirrors gateways.** Bool-typed conditions
+  only; a non-bool `ResultType` or a failed evaluation is a classified error
+  naming the activity and flow ids (the `checkCondition` shape).
+- **FR-3 — every Exec return site selects.** All 8 unfiltered
+  `return X.Outgoing(), nil` sites (§1) become
+  `return X.selectOutgoing(ctx, re)` — including the ServiceTask worker-resume
+  (`bindOutput`/`writeStatus`) and UserTask completion paths.
+- **FR-4 — zero-selected is a classified error (engine choice).** All-flows
+  conditional + all false + no default → a classified error (→ the track's
+  fault path). The extract prescribes this **for gateways only** and is
+  silent for activities — recorded as an engine choice: gateway parity
+  (`gateway.go:293-299`) and Camunda 7 alignment (it throws), consistent with
+  the no-hidden-dead-token posture. Unreachable when ≥1 unconditional flow
+  exists.
+- **FR-5 — default-flow hardening.** `SetDefaultFlow` additionally rejects a
+  flow **carrying a condition** (the BPMN rule `UpdateDefaultFlow` already
+  enforces for gateways); selection identifies the default **by ID** (the §1
+  clone hazard). A `DefaultFlow()` getter is added for symmetry with gateways.
+- **FR-6 — tests + changelog.** Unit tests on the selection rule (the
+  inclusive-gateway test harness shape), an engine e2e (a task's conditional
+  flows route a real instance), the changelog entry. No new example — the
+  behavior composes into existing ones; `docs/guides` is data-scoped.
+
+### Non-functional
+
+- **NFR-1 — zero engine change.** No edits in `internal/` or to gateways;
+  the track consumes the selected flows as today.
+- **NFR-2 — no behavior change for the plain case.** One outgoing
+  unconditional flow (virtually every existing model/test/example) takes the
+  short-circuit — byte-identical behavior, no evaluation cost.
+- **NFR-3 — events out of scope.** The extract's rule binds to *activity*
+  completion; it is silent on event-outgoing conditions. Events keep today's
+  behavior (conditions ignored); a registration-time rejection is a possible
+  follow-up, not S46.
+- **NFR-4 — `completionQuantity` out of scope.** The extract's "the number of
+  tokens placed on each outgoing flow is `completionQuantity` (default 1)"
+  rides the loop-characteristics/multi-instance model gobpm doesn't implement
+  yet (epic #88); S46 places one token per selected flow — the default-1
+  behavior, explicitly noted rather than silently narrowed.
+
+## 3. Models
+
+### 3.1 The selector (`pkg/model/activities/activity.go` + a new `flowselect.go`)
+
+```go
+// selectOutgoing applies the BPMN activity-completion rule to the activity's
+// outgoing flows (token-flow.md §"Multiple outgoing sequence flows"):
+// unconditional flows always fire; conditional flows fire when true; the
+// default fires only when no conditional fired. One (or no) outgoing flow
+// short-circuits unfiltered.
+func (a *activity) selectOutgoing(
+    ctx context.Context, re renv.RuntimeEnvironment,
+) ([]*flow.SequenceFlow, error) {
+    out := a.Outgoing()
+    if len(out) <= 1 {
+        return out, nil
+    }
+
+    selected := []*flow.SequenceFlow{}
+    conditionalFired := false
+
+    for _, of := range out {
+        if a.defaultFlow != nil && of.ID() == a.defaultFlow.ID() { // by ID — clone-robust
+            continue // decided after the loop
+        }
+
+        cond := of.Condition()
+        if cond == nil {
+            selected = append(selected, of) // unconditional → always
+            continue
+        }
+
+        ok, err := a.checkCondition(ctx, re, cond, of) // the gateway idiom
+        if err != nil {
+            return nil, err
+        }
+
+        if ok {
+            selected = append(selected, of)
+            conditionalFired = true
+        }
+    }
+
+    if a.defaultFlow != nil && !conditionalFired {
+        selected = append(selected, a.defaultFlow) // the activity's own object
+    }
+
+    if len(selected) == 0 {
+        return nil, errs.New(
+            errs.M("no outgoing flow selected: all conditions false and "+
+                "no default flow"),
+            errs.C(errorClass, errs.InvalidState),
+            errs.D("activity_id", a.ID()),
+            errs.D("activity_name", a.Name()))
+    }
+
+    return selected, nil
+}
+```
+
+`checkCondition` mirrors `gateways.checkCondition` (bool `ResultType`,
+`re.ExpressionEngine().Evaluate(ctx, cond, re)`, classified errors with
+activity/flow ids) — a deliberate ~25-line cross-package duplication; hoisting
+a shared evaluator would create a new common home for two callers (§4.3).
+
+### 3.2 Default-flow hardening (`activity.go`)
+
+`SetDefaultFlow(flowID)` gains (after the existing outgoing-membership check):
+
+```go
+if o.Condition() != nil {
+    return errs.New(
+        errs.M("default flow %q must not carry a condition", flowID),
+        errs.C(errorClass, errs.InvalidParameter))
+}
+```
+
+plus `func (a *activity) DefaultFlow() *flow.SequenceFlow` (the gateway-getter
+symmetry). The pre-existing typo in the membership error (`"dosn't existed"`,
+`activity.go:161`) is fixed in the same touch — FR-5 makes that message live
+for the first time (the check-comment-vs-code rule).
+
+### 3.3 Worked example
+
+`quote` completes with four outgoing flows: `→ ship` (unconditional),
+`→ audit [total > 1000]`, `→ discount [total > 100]`, `→ review` (default).
+
+| `total` | Selected |
+|---|---|
+| 1500 | ship, audit, discount (conditionals true; default suppressed) |
+| 150 | ship, discount |
+| 50 | ship, **review** (no conditional fired → default) |
+
+With `ship` absent and `total = 50` and **no** default → the FR-4 classified
+error faults the track.
+
+## 4. Analysis & decisions
+
+### 4.1 Selection at the activity, not the track
+
+Gateways already own their routing (their `Exec` returns the *chosen* flows);
+activities join the same contract, and `checkFlows` stays untouched (NFR-1).
+*Alternative:* evaluate in `track.checkFlows` — rejected: it would re-filter
+gateway-returned flows (an exclusive gateway's chosen flow *carries* the very
+condition that selected it — double evaluation, possibly against changed data)
+and would put model semantics in the engine layer.
+
+### 4.2 Default selected by ID, not pointer
+
+`activity.clone` shares `defaultFlow` by reference while the instance's node
+graph is cloned — pointer identity would silently unmatch on clones (the §1
+hazard). Gateways carry the same latent pattern (`of == g.defaultFlow`,
+`gateway.go:269`, on cloned instances per ADR-009) — a named FIX candidate,
+out of S46's scope. ID comparison is clone-robust and costs one string
+compare. The *appended* object
+is the activity's own `defaultFlow` reference (the same object its `Outgoing()`
+holds on that clone — verified by the e2e).
+
+### 4.3 Duplicate the 25-line evaluator, don't hoist it
+
+`checkCondition` exists in `gateways`; activities get their own copy.
+*Alternative:* hoist into a shared package (`flow`? a new one) — rejected for
+S46: `flow` cannot import `renv` (cycle), a new package for one 25-line
+function serving two callers is speculative structure; noted as a by-need
+refactor if a third caller appears.
+
+### 4.4 Zero-selected errs — an engine choice, marked as such
+
+The extract's all-false-no-default **exception** clause exists for gateways
+only; for activities it is **silent** (verified). Choosing the error (over
+silently ending the track) is gateway parity + Camunda 7 alignment + the
+engine's no-hidden-outcomes posture: a token that silently vanishes on an
+activity with outgoing flows is undiagnosable. Recorded here, not claimed as
+a standard mandate.
+
+### 4.5 Events keep today's behavior
+
+The activity-completion rule binds to activities; the extract says nothing
+about conditions on event-outgoing flows. Start events return all outgoing
+(parallel), end events none — unchanged. Rejecting event-flow conditions at
+registration is a separate, smaller follow-up if wanted.
+
+## 5. API / contract
+
+- **Changed (additive)**: `activities` — every task's multi-flow completion
+  now honors conditions/default (previously silently ignored — a behavior
+  *fix*, not a break: any model relying on the old behavior was relying on a
+  standard violation); `SetDefaultFlow` rejects conditional flows (stricter —
+  previously accepted-and-ignored); new `DefaultFlow()` getter.
+- **Unchanged**: gateways, `internal/`, `flow.Link`/`WithCondition`, events.
+
+## 6. Test scenarios
+
+| # | Test | Covers |
+|---|---|---|
+| T-1 | `TestSelectOutgoing` (activities) | every §3.3 row: all-unconditional (parallel, incl. the ≤1 short-circuit), all-conditional (true subset), mix, default suppressed by a fired conditional, default fires on none, vacuous default, zero-selected → classified error, non-bool condition → error, failing evaluation → error |
+| T-2 | `TestSetDefaultFlowRejectsConditional` (activities) | the FR-5 hardening + `DefaultFlow()` getter; empty-clear and unknown-flow behaviors retained |
+| T-3 | `TestActivityConditionalFlowsE2E` (thresher) | a real instance: a task with conditional + default outgoing flows routes per §3.3 (incl. on a **cloned** instance — the by-ID robustness); the all-false-no-default case faults the instance |
+| T-4 | every existing test/example | unchanged (NFR-2) — `make ci` green is the proof |
+
+## 7. Milestones
+
+| # | Scope |
+|---|---|
+| **M1** | FR-1/2/4/5: `selectOutgoing` + `checkCondition` + `SetDefaultFlow` hardening + `DefaultFlow()`. T-1, T-2. |
+| **M2** | FR-3: the 8 Exec sites; the e2e (T-3). |
+| **M3** | Changelog; §10; `/check-srd`; Accepted; sync; the PR closes #51. |
+
+## 8. Cross-doc
+
+| Ref | Version | Direction | Role |
+|---|---|---|---|
+| ADR-001 | v.6 | up | the track/fork model consuming the selected flows |
+| ADR-005 | v.4 | up | the gateway condition idiom mirrored (gateways untouched) |
+| ADR-010 | v.2 | up | the data plane conditions evaluate over |
+
+## 9. Definition of Done
+
+- [ ] FR-1..FR-6 wired; every §6 test exists and is green.
+- [ ] Zero changes in `internal/` and `pkg/model/gateways` (NFR-1).
+- [ ] `make ci` green; diff-coverage ≥95% (aim 100%); full `-race`.
+- [ ] SRD-046 flipped to Accepted; changelog entry; issue #51 closed by the PR.
+- [ ] §10 filled with milestone SHAs and deltas.
+
+## 10. Implementation summary
+
+> ⚠️ TODO: filled after landing.
+
+## Open questions
+
+None. The selection locus (activity), the zero-selected engine choice, the
+by-ID default matching, the evaluator duplication, and the events non-goal are
+decided above. The gateway clone-pointer latency (§4.2) and event-flow
+condition rejection are named follow-ups, not S46 questions.

--- a/docs/srd/SRD-046-activity-conditional-flows.md
+++ b/docs/srd/SRD-046-activity-conditional-flows.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Draft v.1 |
+| Status | Accepted |
 | Version | v.1 |
 | Date | 2026-07-15 |
 | Owner | Ruslan Gabitov |
@@ -282,15 +282,38 @@ registration is a separate, smaller follow-up if wanted.
 
 ## 9. Definition of Done
 
-- [ ] FR-1..FR-6 wired; every §6 test exists and is green.
-- [ ] Zero changes in `internal/` and `pkg/model/gateways` (NFR-1).
-- [ ] `make ci` green; diff-coverage ≥95% (aim 100%); full `-race`.
-- [ ] SRD-046 flipped to Accepted; changelog entry; issue #51 closed by the PR.
-- [ ] §10 filled with milestone SHAs and deltas.
+- [x] FR-1..FR-6 wired; every §6 test exists and is green.
+- [x] Zero changes in `internal/` and `pkg/model/gateways` (NFR-1).
+- [x] `make ci` green; diff-coverage ≥95% (aim 100%); full `-race`.
+- [x] SRD-046 flipped to Accepted; changelog entry; issue #51 closed by the PR.
+- [x] §10 filled with milestone SHAs and deltas.
 
 ## 10. Implementation summary
 
-> ⚠️ TODO: filled after landing.
+Landed on `feat/activity-conditional-flows` in three milestones.
+
+### 10.1 Milestones
+
+| # | Commit | Scope | Tests |
+|---|---|---|---|
+| doc | `2f77a48` | this SRD | — |
+| M1 | `0065425` | `selectOutgoing` + `checkCondition` (`flowselect.go`), `SetDefaultFlow` hardening + typo fix + `DefaultFlow()` | `TestSelectOutgoing`, `TestSetDefaultFlowHardening` |
+| M2 | `bdb5aa0` | the 8 Exec sites wired; `bindOutput` gains `ctx`; ManualTask/UserTask discarded params named | `TestActivityConditionalFlowsE2E` |
+| M3 | (this) | changelog `[Unreleased]`; §10; Accepted flip | `make ci` (T-4) |
+
+All touched functions at 100% coverage; `make ci` green at each milestone
+(M2: diff-coverage 100% of 70 changed lines).
+
+### 10.2 Deltas vs the §3 draft
+
+- **`bindOutput` gained a `ctx` parameter.** The grounding said all 8 sites
+  had `ctx` in scope; `bindOutput(re, res)` itself did not — its caller
+  (`execWorkerOutcome`) did, so the context is threaded one level (an
+  internal-method signature change).
+- **Two discarded parameters became used.** `ManualTask.Exec(_, _)` and
+  `UserTask.Exec(_, re)` now name `ctx`/`re` — the selection needs them.
+- Everything else landed exactly per the §3 model (by-ID default, the
+  short-circuit, the classified errors, the gateway-idiom duplication).
 
 ## Open questions
 

--- a/pkg/model/activities/activity.go
+++ b/pkg/model/activities/activity.go
@@ -138,8 +138,11 @@ func (a *activity) Properties() []*data.Property {
 	return slices.Collect(maps.Values(a.properties))
 }
 
-// SetDefaultFlow sets default flow from the Activity.
-// If the flowId is empty, then default flow cleared for Activity.
+// SetDefaultFlow sets default flow from the Activity — the flow taken when no
+// conditional outgoing flow fires (SRD-046). The flow must be one of the
+// activity's outgoing flows and must NOT carry a condition (the BPMN rule the
+// gateway's UpdateDefaultFlow enforces too). If the flowId is empty, then
+// default flow cleared for Activity.
 func (a *activity) SetDefaultFlow(flowID string) error {
 	flowID = strings.TrimSpace(flowID)
 
@@ -150,16 +153,31 @@ func (a *activity) SetDefaultFlow(flowID string) error {
 	}
 
 	for _, o := range a.Outgoing() {
-		if o.ID() == flowID {
-			a.defaultFlow = o
-
-			return nil
+		if o.ID() != flowID {
+			continue
 		}
+
+		if o.Condition() != nil {
+			return errs.New(
+				errs.M("default flow %q must not carry a condition", flowID),
+				errs.C(errorClass, errs.InvalidParameter),
+				errs.D("activity_name", a.Name()))
+		}
+
+		a.defaultFlow = o
+
+		return nil
 	}
 
 	return errs.New(
-		errs.M("flow %q dosn't existed in activity %q", flowID, a.Name()),
+		errs.M("flow %q doesn't exist in activity %q", flowID, a.Name()),
 		errs.C(errorClass, errs.InvalidParameter))
+}
+
+// DefaultFlow returns the activity's default outgoing flow, or nil when none
+// is set (the gateway-getter symmetry, SRD-046).
+func (a *activity) DefaultFlow() *flow.SequenceFlow {
+	return a.defaultFlow
 }
 
 // BoundaryEvents returns list of events bounded to the acitvity.

--- a/pkg/model/activities/flowselect.go
+++ b/pkg/model/activities/flowselect.go
@@ -1,0 +1,104 @@
+package activities
+
+import (
+	"context"
+
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/renv"
+)
+
+// selectOutgoing applies the BPMN activity-completion rule to the activity's
+// outgoing flows (docs/bpmn-spec/semantics/token-flow.md, "Multiple outgoing
+// sequence flows on an activity"; SRD-046): an unconditional flow always
+// fires, a conditional flow fires when its condition is true, and the default
+// flow fires only when no conditional flow fired. A single (or no) outgoing
+// flow short-circuits unfiltered — the common case pays nothing. Selecting
+// nothing (all flows conditional, all false, no default) is a classified
+// error — an engine choice mirroring the gateway rule (the extract prescribes
+// the exception for gateways only).
+func (a *activity) selectOutgoing(
+	ctx context.Context,
+	re renv.RuntimeEnvironment,
+) ([]*flow.SequenceFlow, error) {
+	out := a.Outgoing()
+	if len(out) <= 1 {
+		return out, nil
+	}
+
+	selected := []*flow.SequenceFlow{}
+	conditionalFired := false
+
+	for _, of := range out {
+		// The default is matched BY ID, not pointer: clone shares defaultFlow
+		// by reference while an instance clones its node graph (SRD-046 §4.2).
+		if a.defaultFlow != nil && of.ID() == a.defaultFlow.ID() {
+			continue // decided after the loop
+		}
+
+		cond := of.Condition()
+		if cond == nil {
+			selected = append(selected, of) // unconditional → always fires
+
+			continue
+		}
+
+		ok, err := a.checkCondition(ctx, re, cond, of)
+		if err != nil {
+			return nil, err
+		}
+
+		if ok {
+			selected = append(selected, of)
+			conditionalFired = true
+		}
+	}
+
+	if a.defaultFlow != nil && !conditionalFired {
+		selected = append(selected, a.defaultFlow)
+	}
+
+	if len(selected) == 0 {
+		return nil, errs.New(
+			errs.M("no outgoing flow selected: all conditions false and "+
+				"no default flow"),
+			errs.C(errorClass, errs.InvalidState),
+			errs.D("activity_id", a.ID()),
+			errs.D("activity_name", a.Name()))
+	}
+
+	return selected, nil
+}
+
+// checkCondition evaluates a sequence flow's boolean condition through the
+// engine's ExpressionEngine (reached via the RuntimeEnvironment) — the
+// gateways.checkCondition idiom mirrored at the activity (SRD-046 §4.3). A
+// non-bool condition and a failed evaluation are classified errors naming the
+// activity and the flow.
+func (a *activity) checkCondition(
+	ctx context.Context,
+	re renv.RuntimeEnvironment,
+	cond data.FormalExpression,
+	of *flow.SequenceFlow,
+) (bool, error) {
+	if cond.ResultType() != "bool" {
+		return false, errs.New(
+			errs.M("invalid condition expression type"),
+			errs.C(errorClass, errs.TypeCastingError),
+			errs.D("outgoing_flow_id", of.ID()),
+			errs.D("activity_id", a.ID()))
+	}
+
+	res, err := re.ExpressionEngine().Evaluate(ctx, cond, re)
+	if err != nil {
+		return false, errs.New(
+			errs.M("flow condition evaluation failed"),
+			errs.C(errorClass, errs.OperationFailed),
+			errs.D("outgoing_flow_id", of.ID()),
+			errs.D("activity_id", a.ID()),
+			errs.E(err))
+	}
+
+	return res.Get(ctx).(bool), nil
+}

--- a/pkg/model/activities/flowselect_test.go
+++ b/pkg/model/activities/flowselect_test.go
@@ -1,0 +1,243 @@
+package activities
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/dr-dobermann/gobpm/generated/mockrenv"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	exprengine "github.com/dr-dobermann/gobpm/pkg/model/expression/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/options"
+	"github.com/stretchr/testify/require"
+)
+
+// selectRe builds a RuntimeEnvironment mock serving the Go expression engine.
+func selectRe(t *testing.T) *mockrenv.MockRuntimeEnvironment {
+	t.Helper()
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().ExpressionEngine().Return(exprengine.New()).Maybe()
+
+	return re
+}
+
+// constCond builds a bool-typed condition evaluating to v.
+func constCond(t *testing.T, v bool) data.FormalExpression {
+	t.Helper()
+
+	c, err := goexpr.New(nil,
+		data.MustItemDefinition(values.NewVariable(false)),
+		func(_ context.Context, _ data.Source) (data.Value, error) {
+			return values.NewVariable(v), nil
+		})
+	require.NoError(t, err)
+
+	return c
+}
+
+// failCond builds a bool-typed condition whose evaluation fails.
+func failCond(t *testing.T) data.FormalExpression {
+	t.Helper()
+
+	c, err := goexpr.New(nil,
+		data.MustItemDefinition(values.NewVariable(false)),
+		func(ctx context.Context, ds data.Source) (data.Value, error) {
+			_, err := ds.Find(ctx, "missing")
+
+			return nil, err
+		})
+	require.NoError(t, err)
+
+	return c
+}
+
+// intCond builds a NON-bool condition (the type-rejection case).
+func intCond(t *testing.T) data.FormalExpression {
+	t.Helper()
+
+	c, err := goexpr.New(nil,
+		data.MustItemDefinition(values.NewVariable(0)),
+		func(_ context.Context, _ data.Source) (data.Value, error) {
+			return values.NewVariable(1), nil
+		})
+	require.NoError(t, err)
+
+	return c
+}
+
+// linked builds a source activity with one outgoing flow per option applied
+// in order, returning the source and its flows.
+func linked(
+	t *testing.T, conds ...data.FormalExpression,
+) (*activity, []*flow.SequenceFlow) {
+	t.Helper()
+
+	src, err := newActivity("src", WithoutParams())
+	require.NoError(t, err)
+
+	flows := make([]*flow.SequenceFlow, 0, len(conds))
+
+	for i, c := range conds {
+		trg, err := newActivity("trg", WithoutParams())
+		require.NoError(t, err)
+
+		opts := []options.Option{}
+		if c != nil {
+			opts = append(opts, flow.WithCondition(c))
+		}
+
+		sf, err := flow.Link(src, trg, opts...)
+		require.NoError(t, err, "link %d", i)
+
+		flows = append(flows, sf)
+	}
+
+	return src, flows
+}
+
+// ids maps flows to their ID set for order-free comparison.
+func ids(flows []*flow.SequenceFlow) map[string]bool {
+	out := map[string]bool{}
+	for _, f := range flows {
+		out[f.ID()] = true
+	}
+
+	return out
+}
+
+// TestSelectOutgoing (SRD-046 T-1): every row of the activity-completion rule
+// (token-flow.md) plus the classified error branches.
+func TestSelectOutgoing(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("no flows — short-circuit", func(t *testing.T) {
+		a, _ := linked(t)
+		got, err := a.selectOutgoing(ctx, selectRe(t))
+		require.NoError(t, err)
+		require.Empty(t, got)
+	})
+
+	t.Run("single flow — short-circuit, no evaluation", func(t *testing.T) {
+		a, fl := linked(t, constCond(t, false)) // even a false condition
+		got, err := a.selectOutgoing(ctx, selectRe(t))
+		require.NoError(t, err)
+		require.Equal(t, ids(fl), ids(got))
+	})
+
+	t.Run("all unconditional — parallel split", func(t *testing.T) {
+		a, fl := linked(t, nil, nil, nil)
+		got, err := a.selectOutgoing(ctx, selectRe(t))
+		require.NoError(t, err)
+		require.Equal(t, ids(fl), ids(got))
+	})
+
+	t.Run("all conditional — true subset", func(t *testing.T) {
+		a, fl := linked(t,
+			constCond(t, true), constCond(t, false), constCond(t, true))
+		got, err := a.selectOutgoing(ctx, selectRe(t))
+		require.NoError(t, err)
+		require.Equal(t,
+			map[string]bool{fl[0].ID(): true, fl[2].ID(): true}, ids(got))
+	})
+
+	t.Run("mix — unconditional always, conditional when true", func(t *testing.T) {
+		a, fl := linked(t, nil, constCond(t, false), constCond(t, true))
+		got, err := a.selectOutgoing(ctx, selectRe(t))
+		require.NoError(t, err)
+		require.Equal(t,
+			map[string]bool{fl[0].ID(): true, fl[2].ID(): true}, ids(got))
+	})
+
+	t.Run("default suppressed by a fired conditional", func(t *testing.T) {
+		a, fl := linked(t, constCond(t, true), nil)
+		require.NoError(t, a.SetDefaultFlow(fl[1].ID()))
+
+		got, err := a.selectOutgoing(ctx, selectRe(t))
+		require.NoError(t, err)
+		require.Equal(t, map[string]bool{fl[0].ID(): true}, ids(got))
+	})
+
+	t.Run("default fires when no conditional fired", func(t *testing.T) {
+		a, fl := linked(t, constCond(t, false), nil)
+		require.NoError(t, a.SetDefaultFlow(fl[1].ID()))
+
+		got, err := a.selectOutgoing(ctx, selectRe(t))
+		require.NoError(t, err)
+		require.Equal(t, map[string]bool{fl[1].ID(): true}, ids(got))
+	})
+
+	t.Run("default alongside unconditional, false conditional", func(t *testing.T) {
+		// spec-literal: the default fires iff no CONDITIONAL fired —
+		// unconditional flows don't suppress it (SRD-046 FR-1).
+		a, fl := linked(t, nil, constCond(t, false), nil)
+		require.NoError(t, a.SetDefaultFlow(fl[2].ID()))
+
+		got, err := a.selectOutgoing(ctx, selectRe(t))
+		require.NoError(t, err)
+		require.Equal(t,
+			map[string]bool{fl[0].ID(): true, fl[2].ID(): true}, ids(got))
+	})
+
+	t.Run("vacuous default — no conditionals at all", func(t *testing.T) {
+		a, fl := linked(t, nil, nil)
+		require.NoError(t, a.SetDefaultFlow(fl[1].ID()))
+
+		got, err := a.selectOutgoing(ctx, selectRe(t))
+		require.NoError(t, err)
+		require.Equal(t, ids(fl), ids(got))
+	})
+
+	t.Run("zero selected — classified error", func(t *testing.T) {
+		a, _ := linked(t, constCond(t, false), constCond(t, false))
+		_, err := a.selectOutgoing(ctx, selectRe(t))
+		require.ErrorContains(t, err, "no outgoing flow selected")
+	})
+
+	t.Run("non-bool condition — classified error", func(t *testing.T) {
+		a, _ := linked(t, intCond(t), nil)
+		_, err := a.selectOutgoing(ctx, selectRe(t))
+		require.ErrorContains(t, err, "invalid condition expression type")
+	})
+
+	t.Run("failing evaluation — classified error", func(t *testing.T) {
+		re := selectRe(t)
+		re.EXPECT().Find(context.Background(), "missing").
+			Return(nil, errFind).Maybe()
+
+		a, _ := linked(t, failCond(t), nil)
+		_, err := a.selectOutgoing(ctx, re)
+		require.ErrorContains(t, err, "condition evaluation failed")
+	})
+}
+
+// errFind is the stub error the failing-evaluation case returns.
+var errFind = errors.New("missing datum")
+
+// TestSetDefaultFlowHardening (SRD-046 T-2): the conditional-default
+// rejection, the DefaultFlow getter, and the retained clear/unknown rules.
+func TestSetDefaultFlowHardening(t *testing.T) {
+	a, fl := linked(t, constCond(t, true), nil)
+
+	t.Run("conditional default rejected", func(t *testing.T) {
+		require.ErrorContains(t, a.SetDefaultFlow(fl[0].ID()),
+			"must not carry a condition")
+	})
+
+	t.Run("unconditional default accepted + getter", func(t *testing.T) {
+		require.NoError(t, a.SetDefaultFlow(fl[1].ID()))
+		require.Equal(t, fl[1].ID(), a.DefaultFlow().ID())
+	})
+
+	t.Run("empty clears", func(t *testing.T) {
+		require.NoError(t, a.SetDefaultFlow(""))
+		require.Nil(t, a.DefaultFlow())
+	})
+
+	t.Run("unknown flow rejected", func(t *testing.T) {
+		require.ErrorContains(t, a.SetDefaultFlow("nope"), "doesn't exist")
+	})
+}

--- a/pkg/model/activities/manual_task.go
+++ b/pkg/model/activities/manual_task.go
@@ -66,10 +66,10 @@ func (mt *ManualTask) TaskType() flow.TaskType {
 // Exec is a no-op pass-through: a Manual Task is never executed by an IT system
 // (BPMN §13.1), so it binds nothing and advances straight to its outgoing flows.
 func (mt *ManualTask) Exec(
-	_ context.Context,
-	_ renv.RuntimeEnvironment,
+	ctx context.Context,
+	re renv.RuntimeEnvironment,
 ) ([]*flow.SequenceFlow, error) {
-	return mt.Outgoing(), nil
+	return mt.selectOutgoing(ctx, re)
 }
 
 // ----------------------------------------------------------------------------

--- a/pkg/model/activities/receive_task.go
+++ b/pkg/model/activities/receive_task.go
@@ -197,7 +197,7 @@ func (rt *ReceiveTask) Exec(
 				errs.D("receive_task_id", rt.ID()))
 	}
 
-	return rt.Outgoing(), nil
+	return rt.selectOutgoing(ctx, re)
 }
 
 var (

--- a/pkg/model/activities/send_task.go
+++ b/pkg/model/activities/send_task.go
@@ -144,7 +144,7 @@ func (st *SendTask) Exec(
 				errs.D("send_task_id", st.ID()))
 	}
 
-	return st.Outgoing(), nil
+	return st.selectOutgoing(ctx, re)
 }
 
 var (

--- a/pkg/model/activities/service_task.go
+++ b/pkg/model/activities/service_task.go
@@ -266,7 +266,7 @@ func (st *ServiceTask) Exec(
 		}
 	}
 
-	return st.Outgoing(), nil
+	return st.selectOutgoing(ctx, re)
 }
 
 // execOperation runs op honoring st.timeout. With no timeout (the default) the
@@ -372,7 +372,7 @@ func (st *ServiceTask) execWorkerOutcome(
 		return nil, st.technicalFault(wo.Fault())
 
 	default: // OutcomeComplete
-		return st.bindOutput(re, wo.Output())
+		return st.bindOutput(ctx, re, wo.Output())
 	}
 }
 
@@ -381,11 +381,12 @@ func (st *ServiceTask) execWorkerOutcome(
 // the worker under WorkerTrusted) before it reached the track (SRD-039 M8), so the
 // track only commits it — no WithOutputMapping runs here anymore.
 func (st *ServiceTask) bindOutput(
+	ctx context.Context,
 	re renv.RuntimeEnvironment,
 	res []data.Data,
 ) ([]*flow.SequenceFlow, error) {
 	if len(res) == 0 {
-		return st.Outgoing(), nil
+		return st.selectOutgoing(ctx, re)
 	}
 
 	if err := re.Put(res...); err != nil {
@@ -397,7 +398,7 @@ func (st *ServiceTask) bindOutput(
 				errs.D("service_task_id", st.ID()))
 	}
 
-	return st.Outgoing(), nil
+	return st.selectOutgoing(ctx, re)
 }
 
 // raiseBpmnError returns a *events.BpmnError as the resume error, so the track
@@ -467,7 +468,7 @@ func (st *ServiceTask) writeStatus(
 				errs.D("service_task_id", st.ID()))
 	}
 
-	return st.Outgoing(), nil
+	return st.selectOutgoing(ctx, re)
 }
 
 // technicalFault wraps a raw fault as the terminal ServiceTask failure — the

--- a/pkg/model/activities/user_task.go
+++ b/pkg/model/activities/user_task.go
@@ -193,7 +193,7 @@ func (ut *UserTask) TaskType() flow.TaskType {
 // and resumed only on an authorized, validated Complete (ADR-020 §2.1, §2.4). So
 // Exec is reached exactly once, after acceptance; it never blocks.
 func (ut *UserTask) Exec(
-	_ context.Context,
+	ctx context.Context,
 	re renv.RuntimeEnvironment,
 ) ([]*flow.SequenceFlow, error) {
 	if len(ut.completedOutputs) > 0 {
@@ -207,7 +207,7 @@ func (ut *UserTask) Exec(
 		}
 	}
 
-	return ut.Outgoing(), nil
+	return ut.selectOutgoing(ctx, re)
 }
 
 // ------------------ eventproc.EventProcessor interface ----------------------

--- a/pkg/thresher/activity_flows_test.go
+++ b/pkg/thresher/activity_flows_test.go
@@ -1,0 +1,228 @@
+package thresher_test
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/model/service/gooper"
+	"github.com/dr-dobermann/gobpm/pkg/thresher"
+	"github.com/stretchr/testify/require"
+)
+
+// laneTask builds an in-process task flipping its flag when executed — the
+// probe for which conditional lanes fired.
+func laneTask(t *testing.T, name string, hit *atomic.Bool) *activities.ServiceTask {
+	t.Helper()
+
+	op, err := gooper.New(name,
+		func(_ context.Context, _ service.DataReader,
+			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			hit.Store(true)
+
+			return nil, nil
+		})
+	require.NoError(t, err)
+
+	st, err := activities.NewServiceTask(name, op, activities.WithoutParams())
+	require.NoError(t, err)
+
+	return st
+}
+
+// totalGt builds the condition "total > n" over the process property.
+func totalGt(t *testing.T, n int) data.FormalExpression {
+	t.Helper()
+
+	c, err := goexpr.New(nil,
+		data.MustItemDefinition(values.NewVariable(false)),
+		func(ctx context.Context, ds data.Source) (data.Value, error) {
+			d, err := ds.Find(ctx, "total")
+			if err != nil {
+				return nil, err
+			}
+
+			v, _ := d.Value().Get(ctx).(int)
+
+			return values.NewVariable(v > n), nil
+		})
+	require.NoError(t, err)
+
+	return c
+}
+
+// flowsProcess builds: start → route(no-op task) → {premium [total>100],
+// discount [total>50], review (default)} → ends.
+func flowsProcess(
+	t *testing.T, name string, total int,
+	premium, discount, review *atomic.Bool,
+) *process.Process {
+	t.Helper()
+
+	require.NoError(t, data.CreateDefaultStates())
+
+	proc, err := process.New(name,
+		data.WithProperties(
+			data.MustProperty("total",
+				data.MustItemDefinition(values.NewVariable(total),
+					foundation.WithID("total")),
+				data.ReadyDataState)))
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	route := laneTask(t, "route", &atomic.Bool{}) // the multi-flow source
+
+	pTask := laneTask(t, "premium", premium)
+	dTask := laneTask(t, "discount", discount)
+	rTask := laneTask(t, "review", review)
+
+	ends := make([]*events.EndEvent, 3)
+	for i, n := range []string{"end-p", "end-d", "end-r"} {
+		e, err := events.NewEndEvent(n)
+		require.NoError(t, err)
+		ends[i] = e
+	}
+
+	for _, e := range []flow.Element{
+		start, route, pTask, dTask, rTask, ends[0], ends[1], ends[2],
+	} {
+		require.NoError(t, proc.Add(e))
+	}
+
+	link(t, start, route)
+
+	_, err = flow.Link(route, pTask, flow.WithCondition(totalGt(t, 100)))
+	require.NoError(t, err)
+	_, err = flow.Link(route, dTask, flow.WithCondition(totalGt(t, 50)))
+	require.NoError(t, err)
+
+	rf, err := flow.Link(route, rTask)
+	require.NoError(t, err)
+	require.NoError(t, route.SetDefaultFlow(rf.ID()))
+
+	link(t, pTask, ends[0])
+	link(t, dTask, ends[1])
+	link(t, rTask, ends[2])
+
+	return proc
+}
+
+// flowsFaultProcess builds route with ONLY false-able conditional flows and no
+// default — the FR-4 zero-selected fault case.
+func flowsFaultProcess(t *testing.T, name string, total int) *process.Process {
+	t.Helper()
+
+	require.NoError(t, data.CreateDefaultStates())
+
+	proc, err := process.New(name,
+		data.WithProperties(
+			data.MustProperty("total",
+				data.MustItemDefinition(values.NewVariable(total),
+					foundation.WithID("total")),
+				data.ReadyDataState)))
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	route := laneTask(t, "route", &atomic.Bool{})
+	lane := laneTask(t, "lane", &atomic.Bool{})
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{start, route, lane, end} {
+		require.NoError(t, proc.Add(e))
+	}
+
+	link(t, start, route)
+
+	_, err = flow.Link(route, lane, flow.WithCondition(totalGt(t, 100)))
+	require.NoError(t, err)
+	_, err = flow.Link(route, end, flow.WithCondition(totalGt(t, 200)))
+	require.NoError(t, err)
+
+	link(t, lane, end)
+
+	return proc
+}
+
+// runFlows registers and runs proc to a terminal state, returning the
+// completion error.
+func runFlows(t *testing.T, proc *process.Process) error {
+	t.Helper()
+
+	th, err := thresher.New(proc.Name() + "-engine")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	require.NoError(t, th.Run(ctx))
+
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	h, err := th.StartLatest(proc.ID())
+	require.NoError(t, err)
+
+	wctx, wcancel := context.WithTimeout(ctx, 5*time.Second)
+	defer wcancel()
+
+	_, werr := h.WaitCompletion(wctx)
+
+	require.NoError(t, th.Shutdown(context.Background()))
+
+	return werr
+}
+
+// TestActivityConditionalFlowsE2E (SRD-046 T-3): a real instance routes a
+// task's conditional and default outgoing flows per the BPMN rule; the
+// zero-selected case faults the instance. Every instance runs a CLONED node
+// graph, so a firing default is the §4.2 by-ID robustness proof.
+func TestActivityConditionalFlowsE2E(t *testing.T) {
+	t.Run("total=150 — both conditionals, default suppressed", func(t *testing.T) {
+		var p, d, r atomic.Bool
+		require.NoError(t,
+			runFlows(t, flowsProcess(t, "flows-150", 150, &p, &d, &r)))
+		require.True(t, p.Load(), "premium must fire")
+		require.True(t, d.Load(), "discount must fire")
+		require.False(t, r.Load(), "default must be suppressed")
+	})
+
+	t.Run("total=75 — one conditional", func(t *testing.T) {
+		var p, d, r atomic.Bool
+		require.NoError(t,
+			runFlows(t, flowsProcess(t, "flows-75", 75, &p, &d, &r)))
+		require.False(t, p.Load())
+		require.True(t, d.Load())
+		require.False(t, r.Load())
+	})
+
+	t.Run("total=10 — default fires on a cloned instance", func(t *testing.T) {
+		var p, d, r atomic.Bool
+		require.NoError(t,
+			runFlows(t, flowsProcess(t, "flows-10", 10, &p, &d, &r)))
+		require.False(t, p.Load())
+		require.False(t, d.Load())
+		require.True(t, r.Load(), "the default lane must fire")
+	})
+
+	t.Run("all false, no default — the instance faults", func(t *testing.T) {
+		err := runFlows(t, flowsFaultProcess(t, "flows-fault", 10))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "no outgoing flow selected")
+	})
+}


### PR DESCRIPTION
# Activity-outgoing conditional and default flows (SRD-046) + issue triage

Closes #51.

A task's completion now honors the BPMN sequence-flow rule (the vendored
`docs/bpmn-spec/semantics/token-flow.md`, "Multiple outgoing sequence flows on
an activity"): an **unconditional** outgoing flow always fires, a
**conditional** flow fires only when its condition is true, and the activity's
**default** flow fires only when no conditional fired. Previously, conditions
and defaults on task-outgoing flows were model-accepted but **silently
ignored** — every flow forked unconditionally, the silent-misbehavior class
the engine's fail-fast posture forbids.

## What landed

- **`activity.selectOutgoing`** (`pkg/model/activities/flowselect.go`) — the
  selection rule applied at every task exit:
  - a single (or no) outgoing flow **short-circuits unfiltered** — the
    overwhelmingly common case pays nothing, byte-identical behavior;
  - unconditional flows always selected; conditional flows selected on a
    true condition; the default appended only when no conditional fired
    (vacuously when none exist);
  - the condition idiom mirrors `gateways.checkCondition` — bool-typed
    `ResultType`, evaluation via `re.ExpressionEngine().Evaluate`, classified
    errors naming the activity and the flow.
- **The default is matched by ID, not pointer** — `activity.clone` shares
  `defaultFlow` by reference while instances clone their node graphs, so
  pointer identity would silently unmatch on cloned instances (a grounding
  find). Gateways carry the same latent pattern (`gateway.go:269`) — a named
  FIX candidate, out of this PR's scope.
- **All 8 Exec sites wired** — the in-process ServiceTask path, the
  worker-resume paths (`bindOutput` gained the `ctx` its caller already held;
  `writeStatus`), SendTask, ReceiveTask, UserTask completion, and ManualTask
  (whose discarded `ctx`/`re` params are now used).
- **`SetDefaultFlow` hardened** — rejects a flow carrying a condition (the
  BPMN rule `UpdateDefaultFlow` already enforces for gateways); a
  `DefaultFlow()` getter added (gateway symmetry); the pre-existing
  `"dosn't existed"` typo fixed — FR-5 makes that message live for the first
  time.
- **Zero-selected faults the instance** — all flows conditional + all false +
  no default → a classified `InvalidState` error naming the activity, routed
  through the track's fault path. An explicit **engine choice**: the spec
  extract's exception clause binds to gateways only and is silent for
  activities — silence was not upgraded to a mandate; the choice is gateway
  parity + Camunda 7 alignment (no hidden dead tokens).
- **Zero engine change** — no `internal/` or `pkg/model/gateways` edits
  (verified via `git diff master`); the track forks exactly what `Exec`
  returns, as before.
- **Changelog** — the post-v0.8.1-rc.1 `[Unreleased]` section opens with this
  entry.

## Verification

- `make ci` green (diff-coverage **100% of 70 changed lines**, `-race`,
  lint 0, vuln 0); all touched functions at 100%.
- **Unit** (`TestSelectOutgoing`, `TestSetDefaultFlowHardening`): every rule
  row — short-circuits, parallel split, true subset, mix, default
  suppressed/fired/vacuous/alongside-unconditional — plus the three
  classified error branches and the hardening contract.
- **E2E** (`TestActivityConditionalFlowsE2E`): a real instance routes
  `{premium [total>100], discount [total>50], review (default)}` at
  150 → both conditionals + default suppressed; 75 → one; 10 → the default
  fires **on the instance's cloned node graph** (the by-ID robustness proof);
  and the all-false-no-default process faults with
  `"no outgoing flow selected"` surfacing through `WaitCompletion`.
- `/check-srd` PASS — FR-1..FR-6 wired (zero unfiltered `Outgoing()` returns
  remain), pins clean (ADR-001 v.6 / ADR-005 v.4 / ADR-010 v.2, 0 downward
  refs), SRD-046 Accepted.

## Issue triage (the same sweep that produced this PR)

An actuality pass over the open issues, done before this implementation:

- **#51** — confirmed **actual** and sharper than its 2024 body: the model
  *accepted* what the engine ignored (conditions on any `flow.Link`; the dead
  `SetDefaultFlow`). Implemented here; **this PR's merge closes it**.
- **#29 (role checking for tasks)** — **closed as superseded**: the
  ADR-020/SRD-034 Camunda-triad authorization
  (`assignee`/`candidateUsers`/`candidateGroups` via `Assignments()`, gating
  `Take`+`Complete`) delivered the framework; the old `Roles()` concept was
  explicitly replaced. Beyond-triad IAM stays in epic #73.
- **#76 (Event Core epic)** — **closed as superseded**: EventHub landed long
  ago; the lifecycle event types are the 13-kind `observability.Fact` catalog
  (ADR-013 v.2, all 13 emitting since SRD-041/044); audit/CQRS listeners are
  host-side plug-ins on the `Thresher.Observe` seam. The engine-side
  remainder (the ADR-013 control slice) is tracked in the roadmap.

## Out of scope (explicitly)

- Conditions on **event**-outgoing flows — the spec extract is silent; events
  keep today's behavior (a registration-time rejection is a possible
  follow-up).
- **`completionQuantity`** token multiplicity — rides the multi-instance
  model (epic #88); one token per selected flow (the default-1 behavior).
- The gateway **pointer-identity default** latent hazard — a named FIX
  candidate.

## Design note

No parent ADR — the standard fully prescribes the behavior (the SRD-030
precedent); SRD-046 pins ADR-001 v.6 (the fork model consuming the selection),
ADR-005 v.4 (the mirrored gateway idiom — gateways untouched), and ADR-010
v.2 (the data plane conditions evaluate over) as upstream context.
