### PR TITLE
Feat/bpmn converter

### DIFF
--- a/docs/design/ADR-024-process-interchange-converters.md
+++ b/docs/design/ADR-024-process-interchange-converters.md
@@ -1,0 +1,411 @@
+# ADR-024 — Process Interchange: pluggable import/export converters (BPMN 2.0 first)
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-07-17 |
+| Owner | Ruslan Gabitov |
+| Refines | [SAD-001 v.1](SAD-001-vision-and-architecture.md) §4 N7 / §5 / §9 / §14, [ADR-002 v.2 Extension Architecture](ADR-002-extension-architecture.md), [ADR-019 v.1 Definition Versioning](ADR-019-definition-versioning.md), [ADR-003 v.1 Module Layout](ADR-003-module-layout.md) |
+
+> **Draft** — decides how a process definition crosses the boundary between
+> an **external interchange format** and gobpm's **in-memory model**, in both
+> directions, without coupling either to the engine. The decision is a
+> **format-agnostic converter seam** — two small interfaces (`Importer`,
+> `Exporter`) plus a register-by-format-key registry in core — and a first
+> **batteries-included** implementation for **BPMN 2.0 XML**, shipped as the
+> separate module SAD-001 §9 already reserves (`doc-source/`), so core stays
+> dependency-clean and "accepts pre-built models" (SAD-001 §4 N7). Import
+> yields a `*process.Process`; the host registers it with the thresher itself
+> (ADR-019 versioning intact, because imported BPMN `id`s are preserved as the
+> definition's identity). Export walks the same model back to XML. The seam is
+> the extension point (ADR-002): a third party registers an `Importer`/`Exporter`
+> for XPDL, a JSON DSL, or a vendor dialect and the façade dispatches by
+> format. This ADR fixes the contract and the MVP element subset; the
+> accompanying SRD-051 lands BPMN import+export of that subset end-to-end.
+
+---
+
+## 1. Context & problem
+
+gobpm builds a process definition exactly one way today: **programmatically**,
+through `process.New(name, …opts)` + `p.Add(node)` + `flow.Link(src, trg)`
+(`pkg/model/process/process.go:47,175`, `pkg/model/flow/sequenceflow.go:62`).
+There is **no serialization layer of any kind** — a whole-repo search finds no
+`encoding/xml`, no `MarshalXML`/`UnmarshalXML`, and no `json:` tags on any model
+type. The engine "accepts pre-built models" and nothing else.
+
+That is a deliberate 0.1.0 shape, but it blocks adoption. The governing SAD
+names the gap in three places:
+
+- **[SAD-001 v.1 §4 N7](SAD-001-vision-and-architecture.md):** *"BPMN XML
+  parser … The parser will exist (it has to, for adoption), but it is a
+  **separate module** that constructs the in-memory model the engine consumes.
+  Core library accepts pre-built models."*
+- **[SAD-001 v.1 §5](SAD-001-vision-and-architecture.md):** the **BPMN modeler**
+  stakeholder authors *"BPMN 2.0 XML to be executed by goBpm"* and needs
+  *"strict spec conformance; clear feedback on unsupported elements."*
+- **[SAD-001 v.1 §9](SAD-001-vision-and-architecture.md):** the module layout
+  already reserves `doc-source/ ← FUTURE — BPMN XML parser (own go.mod)` as a
+  top-level module sibling to `runtime/` and `adapters/`.
+
+Two forces beyond the SAD shape this decision:
+
+1. **Bidirectional, not just a parser.** The requirement is import **and**
+   export — read a `.bpmn` into the model, and write the model back out. N7
+   speaks only of a "parser"; the seam must be symmetric.
+2. **Pluggable across formats, BPMN first.** BPMN 2.0 XML is the
+   batteries-included implementation, but the architecture must let a host or
+   a third party plug a different interchange format (XPDL, a JSON process DSL,
+   a vendor dialect) behind the same contract — matching the engine's whole
+   extension philosophy ([ADR-002 v.2](ADR-002-extension-architecture.md):
+   *"Users implement Go interfaces; pass impls to engine constructor"*).
+
+The problem this ADR solves: **define the converter contract and its home in
+the module graph, decide the BPMN 2.0 XML mapping and its conformance fence,
+and keep every choice consistent with SAD-001 §4/§9 (core stays clean) and
+ADR-019 (imported definitions must version correctly).**
+
+## 2. Decision
+
+### 2.1 A format-agnostic converter seam in core
+
+The seam is two interfaces and a registry, in a new core package `pkg/convert`.
+No XML, no format specifics, stdlib-only — so core keeps its "stdlib + uuid
+only" dependency budget ([SAD-001 v.1 §9.1](SAD-001-vision-and-architecture.md)).
+
+```go
+// package convert  (github.com/dr-dobermann/gobpm/pkg/convert)
+
+// Format identifies an interchange format in the registry.
+type Format string
+
+const BPMN Format = "bpmn"
+
+// Importer builds an in-memory process definition from an external
+// representation read off r.
+type Importer interface {
+	Import(ctx context.Context, r io.Reader) (*process.Process, error)
+}
+
+// Exporter serialises an in-memory process definition to w.
+type Exporter interface {
+	Export(ctx context.Context, w io.Writer, p *process.Process) error
+}
+```
+
+The interfaces are **split, not unified**: a format may support only one
+direction, they register independently, and the pair mirrors the
+`io.Reader`/`io.Writer` asymmetry the engine already speaks.
+
+### 2.2 A register-by-format-key registry
+
+The registry is Go's own `image.RegisterFormat` / `image.Decode` codec pattern —
+package-level maps keyed by `Format`, populated by each converter package's
+`init()`. The in-project precedent for package-global, swappable registration is
+`foundation.SetGenerator` / `GenerateID` — a package-global `IDGenerator` swapped
+under a mutex (`pkg/model/foundation/idgen.go:36,52`).
+
+This is a **deliberate deviation** from ADR-002 v.2's functional-options norm
+(engine-level extensions *"registered once at `Thresher` construction via
+functional options"*): a package-global registry is required because `convert`
+is engine-independent (§2.4) and has no `thresher.New` to hang a `WithConverter`
+option on. (`data.SourceProvider` is *not* the precedent — it is populated
+per-`Scope`-instance in `New` and never mutated, `internal/scope/scope.go:112`,
+so it models per-instance injection, not a global codec table.) A thin façade
+tops the maps:
+
+```go
+func RegisterImporter(f Format, imp Importer) error
+func RegisterExporter(f Format, exp Exporter) error
+
+// MustRegisterImporter / MustRegisterExporter panic on error — for use from
+// a converter package's init() (documented Must* panic, per the public-API
+// validation rule).
+
+func Import(ctx context.Context, f Format, r io.Reader) (*process.Process, error)
+func Export(ctx context.Context, f Format, w io.Writer, p *process.Process) error
+
+func Formats() []Format // registered formats, for diagnostics / feedback
+```
+
+Registration validates every argument on the public boundary — empty `Format`
+rejected, nil `Importer`/`Exporter` rejected, duplicate registration of the
+same `(Format, direction)` rejected — with a self-identifying error naming the
+function and the offending argument. `Import`/`Export` on an unregistered
+format return a clear *"unknown format %q (registered: …)"* error, listing
+`Formats()` so the caller sees what a blank import would have provided.
+
+### 2.3 The BPMN converter is a separate, batteries-included module
+
+Per SAD-001 §4 N7 and §9, the BPMN 2.0 XML converter ships as the reserved
+top-level module (`doc-source/`, own `go.mod`), **not** inside core. It imports
+core (`pkg/convert` for the interfaces, `pkg/model/*` to build/read the model),
+holds **all** `encoding/xml` code, and self-registers:
+
+```go
+// package bpmn  (the reserved doc-source/ module)
+func init() {
+	convert.MustRegisterImporter(convert.BPMN, importer{})
+	convert.MustRegisterExporter(convert.BPMN, exporter{})
+}
+```
+
+**"Batteries-included" means first-party, in-repo, zero-config after a blank
+import** — the `image`/`image/png` model: `_ "…/doc-source/bpmn"` registers
+both directions; `convert.Import(ctx, convert.BPMN, r)` then works. Core users
+who never import it get a clean *"unknown format"* error, never a hidden XML
+dependency. The examples and (future) `runtime/` blank-import it so the
+out-of-the-box experience is BPMN-ready.
+
+> This honours the dependency direction ([SAD-001 v.1 §9.1](SAD-001-vision-and-architecture.md):
+> the format module imports core, never the reverse) and N7's "core accepts
+> pre-built models". Whether BPMN should instead be a *true* core default
+> (no blank import) is deferred to Open Questions — it would require revising
+> SAD-001 N7 and is a SAD decision, not an ADR one. (N7 scopes only the import
+> *parser*; ADR-024 extends the seam to **export**, on which the SAD is silent —
+> a settled open point, not a contradiction.)
+
+### 2.4 No engine coupling; the host registers the result
+
+Import returns a `*process.Process`. The host then calls
+`thresher.RegisterProcess(p)` (`pkg/thresher/thresher.go:642`) itself — the
+converter never touches the engine. This keeps `convert` usable with no engine
+at all (tests, tooling, offline validation), consistent with ADR-002's
+two-layer model. The engine is deliberately kept free of any converter
+dependency; where a runnable service needs *"load a `.bpmn` and register it,"*
+that composition belongs to the **`runtime/` server layer** (its own
+workstream), which imports both core and the converter module — never the
+engine importing the converter. A `thresher.ImportAndRegister(format, r)`
+convenience is explicitly **out of scope** (Decisions §Q4).
+
+### 2.5 Imported identity feeds versioning
+
+The BPMN `id` attribute of `<bpmn:process>` and of every flow element is
+**preserved** as the model's foundation identity via
+`foundation.WithID(id)` (`pkg/model/foundation/options.go:36`). This is
+load-bearing: [ADR-019 v.1](ADR-019-definition-versioning.md) makes the
+**version key the process `id`** (*"Two registrations carrying the same id are
+two versions of one logical definition"*, ADR-019 §2). An importer that minted
+fresh auto-ids would make every import a singleton v1 and silently defeat
+versioning. Export writes `foundation.ID()` back to the `id` attribute and
+`Name()` to `name`, so a registered definition round-trips its identity.
+Missing/blank BPMN `id`s are an import error (BPMN requires `id` on flow
+elements), not a silent auto-id.
+
+### 2.6 MVP element subset and the conformance fence
+
+The MVP maps the **Common Executable Subclass** core
+([docs/bpmn-spec/conformance.md §2.1.3](../bpmn-spec/conformance.md)) — the
+same fence the engine's own conformance target already draws:
+
+| BPMN XML | Model target | Spec § |
+|---|---|---|
+| `<bpmn:definitions>` (root) | document envelope | §10 |
+| `<bpmn:process>` | `process.New(name, WithID(id))` | §10 |
+| `<bpmn:startEvent>` (none) | `events.NewStartEvent` | §13.5.1 |
+| `<bpmn:endEvent>` (none) | `events.NewEndEvent` | §13.5.6 |
+| `<bpmn:task>` / `<bpmn:manualTask>` | `activities.NewManualTask` (parse-but-no-op, §13.1) | §13.3.3 |
+| `<bpmn:userTask>` | `activities.NewUserTask` | §13.3.3 |
+| `<bpmn:sequenceFlow>` (`sourceRef`/`targetRef`, `conditionExpression`) | `flow.Link(src, trg, WithCondition)` | §13.2 / §13.3.1 |
+| `<bpmn:exclusiveGateway>` (`default`) | `gateways.NewExclusiveGateway` | §13.4.2 |
+| `<bpmn:parallelGateway>` | `gateways.NewParallelGateway` | §13.4.1 |
+
+**Explicitly out of MVP** (import must **tolerate and skip**, export must
+**omit**): all Diagram Interchange — `bpmndi:*`, `dc:*`, `di:*`,
+`BPMNShape`/`BPMNEdge` — which is *"not part of execution conformance"*
+([conformance.md](../bpmn-spec/conformance.md), [SAD-001 v.1 §4 N5](SAD-001-vision-and-architecture.md)).
+Also out of MVP and reported as **unsupported-element feedback** (SAD-001 §5),
+not silently dropped: **`serviceTask`** (it needs `operationRef` →
+`<bpmn:interface>`/`<bpmn:operation>` parsing and a `ServiceTask.Operation()`
+export getter that does not exist today — the first work of slice 2, per
+SRD-051 §4.6), inclusive/complex/event-based gateways, timer/message/signal/
+error events, boundary events, sub-processes, call activities, lanes,
+collaboration/choreography. Each lands in a later slice (§7).
+
+### 2.7 Namespaces and unsupported-element feedback
+
+The importer binds the `bpmn:` prefix to
+`http://www.omg.org/spec/BPMN/20100524/MODEL`
+(`docs/bpmn-spec/scripts/bpmn-moddle.json:2-4`) and matches on local name +
+namespace, not on a hard-coded prefix string (a file may bind the URI to any
+prefix). An in-scope-namespace element the MVP does not yet map produces an
+`UnsupportedElementError{Tag, ID, Section}` — the modeler's *"clear feedback"*
+requirement (SAD-001 §5). Foreign namespaces outside execution scope (DI/DC,
+vendor extension namespaces) are skipped silently.
+
+### 2.8 Round-trip is semantic, not byte-lossless
+
+MVP guarantees a **semantic** round-trip over the in-scope subset:
+`Import` then `Export` yields a process that is structurally and semantically
+equivalent (same nodes, ids, flows, conditions, gateway kinds) — **not**
+byte-identical XML. Formatting, attribute order, dropped DI, and namespace
+prefix normalisation legitimately differ. Byte-lossless or DI-preserving
+round-trip is a non-goal for MVP (§14.1-style deliberate deviation) and noted
+for future work. This is an **engine choice**, stated as such: the standard does
+not require a lossless textual round-trip for Process Execution Conformance.
+
+## 3. Standard grounding
+
+All claims cite the vendored KB ([docs/bpmn-spec/](../bpmn-spec/)), which carries
+the OMG §-refs.
+
+- **Conformance target.** *"Process Execution Conformance requires an engine to
+  implement the operational semantics defined in §13 for … the Common
+  Executable Subclass (§2.1.3)"* ([conformance.md:3-5](../bpmn-spec/conformance.md)).
+  The MVP element set is exactly the executable core of that subclass.
+- **`definitions`/`process` containment.** `Process` is a `rootElements` child
+  of `definitions`; flow elements are `flowElements` children of `process`
+  ([elements/foundation.md:21-24](../bpmn-spec/elements/foundation.md),
+  [elements/process.md:22-29](../bpmn-spec/elements/process.md)). `isExecutable`
+  is a 0..1 attribute — the "executable" requirement is a conformance
+  statement, not a schema cardinality.
+- **None start/end.** A start/end event with zero `eventDefinitions` is the
+  plain/none variant; none-start *"starts a new Process instance"* (§13.5.1),
+  none-end *"just consumes the token"* (§13.5.6)
+  ([semantics/events.md:7-9](../bpmn-spec/semantics/events.md),
+  [semantics/end-events.md:24](../bpmn-spec/semantics/end-events.md)).
+- **Tasks.** Abstract `task`/`manualTask` are non-operational — an engine *"MAY
+  treat it as a no-op pass-through"* (§13.1,
+  [semantics/tasks.md:51,72](../bpmn-spec/semantics/tasks.md)). `serviceTask`
+  resolves `operationRef`; `implementation` is a string hint
+  ([semantics/tasks.md:14](../bpmn-spec/semantics/tasks.md)).
+- **Sequence flow.** `sourceRef`/`targetRef` are ID references (attributes);
+  `conditionExpression` is a **child element**, an `Expression`
+  ([elements/flows.md:17-20](../bpmn-spec/elements/flows.md)). `isImmediate`
+  is non-operational and MAY be ignored
+  ([semantics/token-flow.md:19](../bpmn-spec/semantics/token-flow.md)).
+- **Gateways.** Exclusive: *"first condition that evaluates to true … else the
+  default sequence flow (referenced by the `default` attribute) … if all false
+  AND no default → engine throws"* (§13.4.2,
+  [semantics/gateways.md:28-48](../bpmn-spec/semantics/gateways.md)). Parallel:
+  one token from each incoming, one on each outgoing; *"cannot throw"* (§13.4.1),
+  and has **no** `default` attribute.
+- **DI/DC out of scope.** *"BPMNShape, BPMNEdge … all `bpmndi:*` and `dc:*`,
+  `di:*` | Visual layout metamodel; not part of execution conformance"*
+  ([conformance.md:155](../bpmn-spec/conformance.md)).
+
+**Engine notes (deliberate divergences):** semantic-only round-trip (§2.8);
+BPMN `id` treated as durable versioning identity (§2.5 — a gobpm/ADR-019 choice,
+the standard is silent on registry versioning); unsupported in-scope-namespace
+elements are a hard import error rather than a lenient skip (§2.7 — stricter
+than the standard requires, to serve the SAD-001 §5 feedback need).
+
+## 4. Alternatives considered
+
+| # | Decision point | Options | Chosen — why |
+|---|---|---|---|
+| A | Home of the BPMN parser | (a) in core; (b) separate module | **(b)** — SAD-001 §4 N7 + §9 mandate a separate module so core "accepts pre-built models" and keeps its stdlib+uuid budget. (a) would drag an XML/parser surface into core against N7. |
+| B | Seam wiring | (a) `thresher.WithConverter` single injected impl; (b) standalone register-by-key registry | **(b)** — the requirement is *multiple* pluggable formats; a single injected option (the `WithLogger` idiom) models one impl, not a keyed set. (b) matches `data.SourceProvider` and `image.RegisterFormat`, and keeps convert engine-independent. |
+| C | Interface shape | (a) unified `Converter{Import;Export}`; (b) split `Importer`/`Exporter` | **(b)** — a format may support one direction only; independent registration; mirrors `io.Reader`/`io.Writer`. A unified interface would force half-implementations to stub the other half. |
+| D | Parser implementation | (a) wrap a third-party Go BPMN lib; (b) hand-rolled `encoding/xml` | **(b)** — the MVP subset is small and stdlib `encoding/xml` covers it with zero deps; existing libs are DI/diagram-heavy and pull weight the module does not need. Revisitable per-format (the seam does not care). |
+| E | Imported ids | (a) auto-generate; (b) preserve BPMN `id` | **(b)** — ADR-019 keys versions on the process `id`; auto-ids would make every import a singleton v1 (§2.5). |
+| F | Round-trip fidelity | (a) byte-lossless / DI-preserving; (b) semantic-only | **(b)** for MVP — DI is out of execution scope; textual losslessness is not a conformance requirement and would balloon MVP scope (§2.8). |
+| G | "Batteries-included" delivery | (a) blank-import (image-style); (b) core-default (no import) | **(a)** for MVP — (b) contradicts SAD-001 N7 (BPMN in core) and would need a SAD revision. Surfaced in Open Questions. |
+
+## 5. Consequences
+
+**Positive**
+- Core stays dependency-clean; the XML surface is quarantined in one module
+  (SAD-001 §4/§9 upheld).
+- The seam is a genuine extension point: XPDL, a JSON DSL, or a vendor dialect
+  is a third-party `Importer`/`Exporter` registration — no core change.
+- `convert` works with no engine — offline validation, tooling, tests.
+- Imported definitions version correctly (§2.5), so import composes with the
+  Call Activity / registry line (ADR-019, ADR-023).
+- Unsupported-element errors give the modeler the SAD-001 §5 feedback loop.
+
+**Negative / costs**
+- BPMN is not a *literal* core default — a host must add the module dependency
+  and a blank import to get it (the image-model trade-off).
+- No DI round-trip — a file's diagram layout is lost on import→export. Acceptable
+  for an execution engine; called out for anyone expecting a modeler-grade
+  round-trip.
+- A new top-level module (`doc-source/`) enters CI's per-module matrix (tidy,
+  lint, race, coverage, govulncheck).
+
+## 6. Enterprise-readiness recommendations
+
+- **Conformance fixtures.** Wire the OMG **MIWG** import test set (SAD-001 §6
+  names MIWG fixtures as the P0 conformance tactic) as the converter's
+  acceptance corpus, growing per slice.
+- **Streaming.** `Import(io.Reader)` / `Export(io.Writer)` are already
+  stream-shaped; keep the BPMN impl streaming (`xml.Decoder` token stream) so
+  large definitions do not force whole-file buffering.
+- **XSD / schema validation.** Optional strict mode validating against the OMG
+  XSD before mapping — future, behind an option; MVP does structural validation
+  via `process.Validate()` post-build.
+- **Extension-element passthrough.** Preserve unknown in-`bpmn`-scope extension
+  elements (`extensionElements`) for lossless custom-namespace round-trip —
+  future, needs a model carrier.
+- **Dialect targeting on export.** MVP emits plain OMG BPMN; a future option can
+  target vendor dialects (Camunda/Zeebe namespaces).
+
+## 7. Rollout plan
+
+- **Slice 1 — SRD-051 (this ADR's landing).** `pkg/convert` seam + registry;
+  the `doc-source/` module scaffold (go.mod + doc.go, per SAD-001 §9.2
+  "scaffold upfront"); BPMN **import + export** of the §2.6 MVP subset;
+  unsupported-element feedback; semantic round-trip test corpus; a
+  `examples/bpmn-convert/` example; README/guide + changelog + CI per-module
+  wiring.
+- **Slice 2+ (own SRDs).** Gateways (inclusive/complex/event-based); events
+  (timer/message/signal/error) + boundary events; sub-process & call activity
+  (composes with ADR-023); lanes (parse-and-preserve); extension-element
+  passthrough; XSD strict mode; additional formats behind the same seam.
+- **Post-Slice-1:** `/check-srd`, SRD-051 → Accepted, ADR-024 → Accepted.
+
+## 8. References
+
+**Design (up / sideways, versioned):**
+- [SAD-001 v.1](SAD-001-vision-and-architecture.md) §4 N5/N7, §5, §9/§9.1/§9.2, §14 — parser-as-separate-module, modeler feedback, module layout, conformance scope.
+- [ADR-002 v.2](ADR-002-extension-architecture.md) — interfaces + compile-time wiring; the extension idiom the seam follows.
+- [ADR-019 v.1](ADR-019-definition-versioning.md) — version key = process id; the identity-preservation constraint (§2.5).
+- [ADR-003 v.1](ADR-003-module-layout.md) — module boundaries and import-direction rules for the new `doc-source/` module.
+
+> **Note — Draft parents.** SAD-001 v.1 and ADR-003 v.1 are themselves **Draft**;
+> their prescriptions may shift before Accepted, so these pins track a moving
+> baseline until both are ratified.
+
+**Standard (BPMN 2.0 KB):**
+- [docs/bpmn-spec/conformance.md](../bpmn-spec/conformance.md) — §2.1.3 Common Executable Subclass; DI/DC out of scope.
+- [docs/bpmn-spec/elements/](../bpmn-spec/elements/) — structural metamodel (foundation, process, events, activities, flows, gateways).
+- [docs/bpmn-spec/semantics/](../bpmn-spec/semantics/) — token-flow, tasks, gateways, events, end-events.
+
+**Code (grounding the model targets):**
+- `pkg/model/process/process.go:47,175` — `process.New`, `Add`.
+- `pkg/model/flow/sequenceflow.go:62` — `flow.Link`.
+- `pkg/model/foundation/options.go:36` — `foundation.WithID`.
+- `pkg/model/data/source.go:3` + `internal/scope/scope.go:111` — the register-by-key precedent.
+- `pkg/thresher/thresher.go:642` — `RegisterProcess` (the host-side consumer of an import).
+
+## Decisions (resolved open questions)
+
+- **Q1 — Module name: DECIDED (proposed, pending SAD-001 §9 ratification).**
+  Rename the reserved `doc-source/` module → **`convert/`** to reflect the now-
+  bidirectional seam (`io/` rejected — collides with the stdlib package;
+  `interchange/` longer, no gain). This is a SAD-001 §9 update (up-ref) for the
+  SAD owner to ratify; the ADR records it as **proposed** and refers to "the
+  converter module" until ratified.
+- **Q2 — Batteries-included: DECIDED.** Ship BPMN as **blank-import**
+  (`_ "…/convert/bpmn"`, image-style) — the only path that keeps core dependency-
+  clean (SAD-001 §9.1) without amending N7. A *true* core default is a clean
+  additive follow-up (revise N7 + a thin core default) if ever wanted; deferring
+  costs nothing now.
+- **Q3 — Format detection: DECIDED.** Keep an **explicit `Format` argument**; no
+  content sniffing for MVP (one format — nothing to disambiguate, and sniffing
+  can mis-fire on vendor dialects / BOM). A `convert.Detect` / `ImportAny`
+  sniffer is an additive follow-up once ≥2 formats exist.
+- **Q4 — Engine coupling: DECIDED.** **No** `thresher.ImportAndRegister`. The
+  engine stays decoupled from every non-runtime module; the *"import → register"*
+  composition is a **`runtime/` server concern** (§2.4), where the converter has
+  its first real consumer. The server is its **own workstream (own ADR/SRD)**,
+  not part of this landing — and it lives in the `runtime/` module
+  (`runtime/cmd/gobpm-server/`), never in core's `cmd/`, since core's dependency
+  budget is stdlib + uuid only (SAD-001 §9.1).
+
+## Document History
+
+| Version | Date | Change |
+|---|---|---|
+| v.1 | 2026-07-17 | Initial draft — converter seam (`pkg/convert`), BPMN as the batteries-included separate-module converter, MVP element subset, semantic round-trip. |

--- a/docs/srd/SRD-051-bpmn-converter.md
+++ b/docs/srd/SRD-051-bpmn-converter.md
@@ -1,0 +1,399 @@
+# SRD-051 — BPMN 2.0 converter: import & export of the MVP subset
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-07-17 |
+| Owner | Ruslan Gabitov |
+| Implements | [ADR-024 v.1](../design/ADR-024-process-interchange-converters.md) §2.1–§2.8 (the converter seam + the first BPMN slice) |
+| Upstream | [ADR-002 v.2](../design/ADR-002-extension-architecture.md) (extension interfaces live in `pkg/`; the seam follows it), [ADR-019 v.1](../design/ADR-019-definition-versioning.md) (version key = process id; the id-preservation constraint), [SAD-001 v.1](../design/SAD-001-vision-and-architecture.md) §4 N7 / §5 / §9 (parser as a separate module; modeler feedback; module layout), [docs/bpmn-spec/](../bpmn-spec/) (the BPMN 2.0 KB) |
+| Refines | — |
+
+## §1 Background
+
+gobpm builds a process definition exactly one way today — programmatically,
+via `process.New` + `Add` + `flow.Link` (`pkg/model/process/process.go:47,175`,
+`pkg/model/flow/sequenceflow.go:62`). There is **no serialization of any kind**:
+a whole-repo search finds no `encoding/xml`, no `Marshal/UnmarshalXML`, no
+`json:` tags on any model type. The engine "accepts pre-built models"
+([SAD-001 v.1 §4 N7](../design/SAD-001-vision-and-architecture.md)) and nothing
+else — which blocks the **BPMN modeler** persona
+([SAD-001 v.1 §5](../design/SAD-001-vision-and-architecture.md)) who authors
+`.bpmn` XML to be executed.
+
+[ADR-024 v.1](../design/ADR-024-process-interchange-converters.md) decides the
+answer: a **format-agnostic converter seam** in core (`pkg/convert` —
+`Importer`/`Exporter` + a register-by-format-key registry), and a first
+**batteries-included** BPMN 2.0 XML converter shipped as the reserved separate
+module (SAD-001 §9). This SRD lands **slice 1**: the seam, plus BPMN **import and
+export** of the executable-core MVP subset, engine-independent, with a semantic
+round-trip and unsupported-element feedback.
+
+The seams this lands on already exist:
+
+- **The model target** — every MVP node has an exported constructor
+  (`events.NewStartEvent`/`NewEndEvent` `pkg/model/events/{start,end}.go:54,48`;
+  `activities.NewManualTask`/`NewUserTask` `activities/{manual_task,user_task}.go:24,88`;
+  `gateways.NewExclusiveGateway`/`NewParallelGateway`
+  `gateways/{exclusive,parallel}.go:26,31`; `flow.Link`
+  `flow/sequenceflow.go:62`). Identity is set with `foundation.WithID`
+  (`foundation/options.go:36`).
+- **The read-back for export** — `Process.Nodes()`/`Flows()`/`Name()`
+  (`process/process.go:120,161,95`); `SequenceFlow.Source()`/`Target()`/
+  `Condition()` (`flow/sequenceflow.go:299,304,309`); `Gateway.Direction()`/
+  `DefaultFlow()` (`gateways/gateway.go:213,165`); `BaseElement.ID()`/`Name()`
+  (`foundation/base.go:138`, `flow/element.go:109`); node discrimination via
+  `NodeType()`/`EType()` (`flow/node.go:193,210`).
+- **The registration consumer** — an import feeds `thresher.RegisterProcess`
+  (`thresher/thresher.go:642`), which keys the version on the process id
+  (ADR-019).
+
+## §2 Requirements
+
+### Functional — the seam (`pkg/convert`, core)
+
+- **§FR-1 — Format & interfaces.** A `Format` string type with a `BPMN` constant;
+  split `Importer`/`Exporter` interfaces over `io.Reader`/`io.Writer`,
+  producing/consuming `*process.Process`.
+- **§FR-2 — Registry.** `RegisterImporter`/`RegisterExporter` (+ `Must…`
+  variants for `init()`), the façade `Import`/`Export`, and `Formats()`. Every
+  public argument is validated on entry (empty `Format`, nil impl, duplicate
+  `(Format, direction)` → a self-identifying error naming the function and the
+  offending argument — the ADR-002 / project public-API rule). `Import`/`Export`
+  on an unregistered format return a *"unknown format %q (registered: …)"* error
+  enumerating `Formats()`.
+- **§FR-3 — Unsupported-element feedback.** An `UnsupportedElementError` carrying
+  the offending element's tag, id, and the spec § — the SAD-001 §5 *"clear
+  feedback on unsupported elements"* requirement, surfaced from `Import`.
+
+### Functional — the BPMN converter (the reserved separate module)
+
+- **§FR-4 — Module scaffold.** A new module (SAD-001 §9 reservation; name
+  proposed `convert/` per ADR-024 Q1, pending SAD ratification) with `go.mod` +
+  `doc.go`, importing core only (dependency direction inward, SAD-001 §9.1). It
+  **self-registers** both directions via `init()` (`MustRegisterImporter`/
+  `Exporter`) so a blank import `_ "…/convert/bpmn"` turns BPMN on.
+- **§FR-5 — Import.** Parse BPMN 2.0 XML (namespace
+  `http://www.omg.org/spec/BPMN/20100524/MODEL`) into a `*process.Process` over
+  the §FR-8 element set, via a **namespace-aware token-stream decoder**
+  (`xml.Decoder`). BPMN `id`s are **preserved** as foundation identity
+  (`foundation.WithID`) — never auto-generated (ADR-019; §4.4). A missing/blank
+  `id` on a flow element is an import error.
+- **§FR-6 — Export.** Serialize a `*process.Process` back to BPMN 2.0 XML over
+  the §FR-8 set, writing `ID()` → `id` and `Name()` → `name`, emitting the
+  `bpmn:` namespace. **No** Diagram Interchange is emitted.
+- **§FR-7 — Diagram-interchange tolerance.** Import **skips** `bpmndi:*` / `dc:*`
+  / `di:*` and other out-of-execution-scope foreign-namespace subtrees silently
+  (SAD-001 §4 N5); an **in-`bpmn`-namespace** element the slice does not map is
+  an `UnsupportedElementError` (§FR-3), not a silent drop.
+- **§FR-8 — Element mapping (MVP subset).** The executable-core subset
+  ([docs/bpmn-spec/conformance.md](../bpmn-spec/conformance.md) §2.1.3):
+
+  | BPMN XML | Model target | Spec § |
+  |---|---|---|
+  | `<bpmn:definitions>` / `<bpmn:process>` | document envelope / `process.New(name, WithID(id))` | §10 |
+  | `<bpmn:startEvent>` (none) | `events.NewStartEvent` | §13.5.1 |
+  | `<bpmn:endEvent>` (none) | `events.NewEndEvent` | §13.5.6 |
+  | `<bpmn:task>` / `<bpmn:manualTask>` | `activities.NewManualTask` (no-op, §13.1) | §13.3.3 |
+  | `<bpmn:userTask>` | `activities.NewUserTask` | §13.3.3 |
+  | `<bpmn:sequenceFlow>` (`sourceRef`/`targetRef`, `conditionExpression`) | `flow.Link(src, trg, WithCondition)` | §13.2 / §13.3.1 |
+  | `<bpmn:exclusiveGateway>` (`default`) | `gateways.NewExclusiveGateway` | §13.4.2 |
+  | `<bpmn:parallelGateway>` | `gateways.NewParallelGateway` | §13.4.1 |
+
+  **`serviceTask` is deferred to the next slice** (§4.6) — it requires
+  `operationRef` → `<bpmn:interface>`/`<bpmn:operation>` parsing and a new
+  `ServiceTask.Operation()` export getter, materially heavier than the
+  no-external-ref tasks above.
+
+### Functional — front door
+
+- **§FR-9 — Example.** `examples/bpmn-convert/` (own module): blank-import the
+  BPMN converter, `convert.Import` a bundled `.bpmn`, `RegisterProcess` + run it
+  to completion on a thresher, then `convert.Export` it back.
+- **§FR-10 — Docs.** A converter section in the user guide/README, a changelog
+  entry, and the tracking-issue link.
+
+### Non-functional
+
+- **§NFR-1 — Dependency budget.** `pkg/convert` is stdlib-only (no `xml`); the
+  BPMN module uses stdlib `encoding/xml` only — zero third-party deps
+  (SAD-001 §9.1).
+- **§NFR-2 — Streaming.** Import/export are `io.Reader`/`io.Writer`-shaped and
+  stream via `xml.Decoder`/`xml.Encoder` — no whole-file buffering mandated.
+- **§NFR-3 — Semantic round-trip.** `Import` then `Export` yields a
+  structurally/semantically equivalent process (same ids, nodes, flows,
+  conditions, gateway kinds) — **not** byte-identical XML (ADR-024 §2.8).
+- **§NFR-4 — Public-API validation.** Every exported constructor/registry
+  function validates all parameters with self-identifying errors.
+- **§NFR-5 — CI parity.** The new module joins the `make ci` per-module matrix
+  (tidy, lint, build, race, diff-coverage ≥ `COVER_MIN`, govulncheck); touched
+  files meet the diff-coverage gate.
+
+## §3 Models
+
+### §3.1 `pkg/convert` (core seam)
+
+```go
+package convert
+
+type Format string
+
+const BPMN Format = "bpmn"
+
+type Importer interface {
+	Import(ctx context.Context, r io.Reader) (*process.Process, error)
+}
+
+type Exporter interface {
+	Export(ctx context.Context, w io.Writer, p *process.Process) error
+}
+
+func RegisterImporter(f Format, imp Importer) error
+func RegisterExporter(f Format, exp Exporter) error
+func MustRegisterImporter(f Format, imp Importer) // panics on error (init use)
+func MustRegisterExporter(f Format, exp Exporter)
+
+func Import(ctx context.Context, f Format, r io.Reader) (*process.Process, error)
+func Export(ctx context.Context, f Format, w io.Writer, p *process.Process) error
+func Formats() []Format
+
+type UnsupportedElementError struct {
+	Tag     string // local element name, e.g. "inclusiveGateway"
+	ID      string // the element's id attr, if present
+	Section string // spec §, e.g. "§13.4.3"
+}
+
+func (e *UnsupportedElementError) Error() string
+```
+
+Registry state is package-global maps keyed by `Format`, mutated only by
+`Register…` (typically from a converter package's `init()`) — the
+`image.RegisterFormat` idiom (ADR-024 §2.2), a deliberate deviation from the
+functional-options norm because `convert` is engine-independent.
+
+### §3.2 `convert/bpmn` (the BPMN module)
+
+Import uses a **token-stream decoder** (not struct-unmarshal — §4.3). Export
+uses typed XML structs marshalled with `xml.Encoder`:
+
+```go
+type xmlDefinitions struct {
+	XMLName   xml.Name     `xml:"http://www.omg.org/spec/BPMN/20100524/MODEL definitions"`
+	Processes []xmlProcess `xml:"process"`
+}
+
+type xmlProcess struct {
+	ID            string            `xml:"id,attr"`
+	Name          string            `xml:"name,attr,omitempty"`
+	IsExecutable  bool              `xml:"isExecutable,attr"`
+	StartEvents   []xmlNode         `xml:"startEvent"`
+	EndEvents     []xmlNode         `xml:"endEvent"`
+	Tasks         []xmlNode         `xml:"task"`
+	ManualTasks   []xmlNode         `xml:"manualTask"`
+	UserTasks     []xmlNode         `xml:"userTask"`
+	ExclusiveGWs  []xmlGateway      `xml:"exclusiveGateway"`
+	ParallelGWs   []xmlNode         `xml:"parallelGateway"`
+	SequenceFlows []xmlSequenceFlow `xml:"sequenceFlow"`
+}
+
+type xmlSequenceFlow struct {
+	ID        string `xml:"id,attr"`
+	Name      string `xml:"name,attr,omitempty"`
+	SourceRef string `xml:"sourceRef,attr"`
+	TargetRef string `xml:"targetRef,attr"`
+	Condition string `xml:"conditionExpression,omitempty"`
+}
+
+type importer struct{}
+type exporter struct{}
+
+func init() {
+	convert.MustRegisterImporter(convert.BPMN, importer{})
+	convert.MustRegisterExporter(convert.BPMN, exporter{})
+}
+```
+
+### §3.3 Import algorithm (two-pass)
+
+1. **Decode** the token stream: collect nodes and flows; skip foreign-namespace
+   subtrees (`di`/`dc`); an unmapped `bpmn:`-namespace start element →
+   `UnsupportedElementError`.
+2. **Build nodes** first — every node constructor called with `WithID(id)` — so
+   the id→node table is complete before wiring.
+3. **Link flows** — `flow.Link(nodes[sourceRef], nodes[targetRef], …)`, attaching
+   `WithCondition` when `conditionExpression` is present; re-resolve each
+   exclusive gateway's `default` by flow id.
+4. **`process.Validate()`** the assembled graph before returning.
+
+## §4 Analysis
+
+### §4.1 Why a separate module, engine-independent
+Inherited from ADR-024 §2.1–§2.4: SAD-001 §4 N7 mandates the parser as a
+separate module so core "accepts pre-built models"; import returns a
+`*process.Process` and the host registers it — the engine never imports the
+converter.
+
+### §4.2 Why preserve BPMN ids
+ADR-019 keys the version lineage on the process **id**; auto-generating ids on
+import would make every import a singleton v1 and silently defeat versioning
+(ADR-024 §2.5). Hence `foundation.WithID` on every mapped element, and a
+missing flow-element `id` is a hard error.
+
+### §4.3 Why a token-stream decoder, not struct-unmarshal
+`encoding/xml` struct-unmarshal **silently ignores** any element it has no field
+for — which would make §FR-3/§FR-7 impossible (an unsupported `bpmn:` element
+would vanish instead of raising `UnsupportedElementError`). A namespace-aware
+`xml.Decoder` token loop dispatches on each start element by local-name +
+namespace, so it can (a) map known elements, (b) skip DI subtrees by namespace,
+and (c) **error** on an unknown `bpmn:`-namespace element. Export has no such
+problem — we control the output — so it uses struct marshalling.
+
+### §4.4 Two-pass import
+`sourceRef`/`targetRef` are id references and `flow.Link` needs both endpoint
+nodes to exist; a single forward pass would fail on a flow whose target appears
+later in the document. Nodes are built first, flows linked second (§3.3).
+
+### §4.5 DI skip vs unsupported-element error
+DI/DC (`bpmndi:*`, `dc:*`, `di:*`) is out of execution conformance
+([conformance.md:155](../bpmn-spec/conformance.md)) — **skipped silently**. An
+in-`bpmn`-scope element the slice hasn't mapped yet (inclusive gateway, timer
+event, boundary event, sub-process) is **reported**, so the modeler learns what
+the engine won't run (SAD-001 §5). The discriminator is the namespace.
+
+### §4.6 Why `serviceTask` is deferred
+`NewServiceTask` requires a non-nil `service.Operation`
+(`activities/service_task.go:84`), which in BPMN is an `operationRef` into an
+`<bpmn:interface>`/`<bpmn:operation>` under `<definitions>`. Faithful import
+therefore needs interface/operation parsing, and faithful export needs a
+`ServiceTask.Operation()` getter that **does not exist today** (the struct field
+`operation` has no exported accessor, `activities/service_task.go`). Both are the
+first work of slice 2; landing them half-done (a placeholder operation that
+can't execute) would ship a misleading feature. The no-external-ref tasks
+(`task`/`manualTask`/`userTask`) round-trip cleanly and carry the MVP.
+
+> **ADR reconciliation:** ADR-024 §2.6 lists `serviceTask` in the MVP table.
+> This SRD trims it (discovered during grounding). ADR-024 §2.6 is to be updated
+> to move `serviceTask` to "later slice" — a downstream-sync edit on the parent
+> ADR, to confirm with the owner.
+
+### §4.7 Rejected shapes
+- **Wrapping a third-party BPMN library** — pulls DI/diagram weight the module
+  doesn't need for the executable subset; stdlib `encoding/xml` suffices
+  (ADR-024 §4-D).
+- **Struct-unmarshal import** — silently drops unknowns (§4.3).
+- **Byte-lossless round-trip** — DI is out of scope and textual losslessness is
+  not a conformance requirement (ADR-024 §2.8 / §4-F).
+
+## §5 API surface
+
+**New (core):** `pkg/convert` — `Format`, `BPMN`, `Importer`, `Exporter`,
+`RegisterImporter`/`RegisterExporter`, `MustRegisterImporter`/
+`MustRegisterExporter`, `Import`, `Export`, `Formats`, `UnsupportedElementError`.
+
+**New (module):** `convert/bpmn` — no exported surface beyond the `init()`
+self-registration (consumers use the `convert` façade); blank-import to enable.
+
+**Unchanged:** the model constructors, `thresher.RegisterProcess`. No engine API
+change.
+
+## §6 Test scenarios
+
+- **`TestConvertRegistry`** (`pkg/convert`) — register/lookup happy path;
+  duplicate registration rejected; nil impl rejected; empty format rejected;
+  `Import`/`Export` on an unknown format returns the enumerating error;
+  `Formats()` lists registered.
+- **`TestBPMNImportMVP`** (`convert/bpmn`) — each §FR-8 element imports to the
+  right constructor with id/name preserved; conditional + default flows attach.
+- **`TestBPMNExportMVP`** — a programmatically built process exports to XML with
+  correct tags/attrs; no DI emitted.
+- **`TestBPMNRoundTrip`** — the §6 worked example: import → export → re-import →
+  structural equality (ids, node kinds, flows, conditions, gateway direction &
+  default). Semantic, not byte (NFR-3).
+- **`TestBPMNPreservesID`** — an imported process registered via
+  `RegisterProcess` carries the BPMN process id as its version key (ADR-019).
+- **`TestBPMNUnsupportedElement`** — an `<bpmn:inclusiveGateway>` yields
+  `UnsupportedElementError{Tag:"inclusiveGateway", …}`; a `<bpmndi:BPMNDiagram>`
+  is skipped silently (no error).
+- **`TestBPMNImportRegisterRun`** (e2e, `examples/bpmn-convert/` or
+  `pkg/thresher`) — import the bundled `.bpmn`, register, run to completion.
+
+**Worked example** (the round-trip fixture — start → userTask → exclusiveGateway
+with a conditional branch + a default branch → two ends):
+
+```xml
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="approval" name="Approval" isExecutable="true">
+    <bpmn:startEvent id="s1" name="start"/>
+    <bpmn:userTask id="u1" name="review"/>
+    <bpmn:exclusiveGateway id="g1" name="decide" default="f_no"/>
+    <bpmn:endEvent id="e_ok" name="approved"/>
+    <bpmn:endEvent id="e_no" name="rejected"/>
+    <bpmn:sequenceFlow id="f_su" sourceRef="s1" targetRef="u1"/>
+    <bpmn:sequenceFlow id="f_ug" sourceRef="u1" targetRef="g1"/>
+    <bpmn:sequenceFlow id="f_ok" sourceRef="g1" targetRef="e_ok">
+      <bpmn:conditionExpression>approved == true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="f_no" sourceRef="g1" targetRef="e_no"/>
+  </bpmn:process>
+</bpmn:definitions>
+```
+
+After `convert.Import(ctx, convert.BPMN, r)`: `p.Name() == "Approval"`,
+`p.ID() == "approval"`, `len(p.Nodes()) == 5`, `len(p.Flows()) == 4`, the flow
+`f_ok` carries a condition, and `g1.DefaultFlow().ID() == "f_no"`. Re-exporting
+and re-importing reproduces the same structure (NFR-3).
+
+## §7 Milestones
+
+| # | Scope |
+|---|---|
+| M1 | `pkg/convert` seam — Format, `Importer`/`Exporter`, registry (+`Must…`, façade, `Formats`), `UnsupportedElementError`; `TestConvertRegistry` (§FR-1..3) |
+| M2 | `convert/bpmn` module scaffold + **import** (token-stream, id-preservation, DI-skip, unsupported-element error) of §FR-8; import + preserve-id + unsupported tests (§FR-4/5/7/8) |
+| M3 | **export** (`xml.Encoder`) of §FR-8 + semantic **round-trip** tests; the worked-example fixture (§FR-6, NFR-3) |
+| M4 | `examples/bpmn-convert/` + guide/README + changelog + tracker + CI per-module wiring + e2e (§FR-9/10, NFR-5) |
+
+Post-M4: `/check-srd`, §10 fill, SRD-051 → Accepted, ADR-024 → Accepted, and the
+ADR-024 §2.6 reconciliation (§4.6).
+
+## §8 Cross-doc
+
+- **Implements** [ADR-024 v.1](../design/ADR-024-process-interchange-converters.md)
+  §2.1–§2.8 — the seam and the first BPMN slice.
+- **Upstream** [ADR-002 v.2](../design/ADR-002-extension-architecture.md) (seam
+  idiom), [ADR-019 v.1](../design/ADR-019-definition-versioning.md) (id =
+  version key), [SAD-001 v.1](../design/SAD-001-vision-and-architecture.md) §4
+  N7 / §5 / §9 (separate module, modeler feedback, layout).
+- **Standard** [docs/bpmn-spec/](../bpmn-spec/) — conformance §2.1.3, elements,
+  semantics (§ pins in §FR-8).
+- **Downstream sync (on landing):** ADR-024 §2.6 `serviceTask` trim (§4.6);
+  and — if the SAD owner ratifies Q1 — the module name rename in SAD-001 §9.
+- **Direction check:** SRD → ADR/SAD (up), all pins versioned. No downward ref.
+
+## §9 Definition of Done
+
+- Every §FR wired to real code; §6 tests present and green.
+- `make ci` green across all modules **including the new `convert/bpmn`
+  module** (tidy, lint, build, race, diff-coverage ≥ `COVER_MIN` on touched
+  files, govulncheck).
+- `TestBPMNRoundTrip` and `TestBPMNImportRegisterRun` green; unsupported-element
+  feedback and id→version tie demonstrated.
+- `examples/bpmn-convert/` runs to completion; guide/README + changelog updated.
+- Cross-doc pins consistent (§8); ADR-024 §2.6 reconciliation applied.
+
+## §10 Implementation summary
+
+_(placeholder — filled at landing: milestones-by-commit, deltas vs this draft,
+empirical findings, backlog.)_
+
+## Open questions
+
+1. **Worked-example fixture source.** Hand-authored (the §6 snippet) for MVP, or
+   vendor a small **MIWG** conformance fixture subset now (SAD-001 §6 names MIWG
+   as the P0 conformance tactic)? Recommend hand-authored for slice 1; MIWG as a
+   later corpus.
+2. **`conditionExpression` language.** MVP imports the expression **body** as a
+   `data.FormalExpression`; do we record the `language` attribute (XPath vs the
+   engine's expression language) now, or default it and defer language handling?
+3. **Module name (inherited ADR-024 Q1).** `convert/` pending SAD-001 §9
+   ratification; the SRD uses "the BPMN module" until then.


### PR DESCRIPTION
Summary

Design landing for process interchange — reading and writing a gobpm process definition in an external format. Introduces a pluggable, format-agnostic converter seam and a first BPMN 2.0 XML converter.

This PR is design only — two Draft documents, no implementation code. The code lands in follow-up commits on this branch (milestones M1–M4 in SRD-051 §7).

- docs/design/ADR-024-process-interchange-converters.md — the decision.
- docs/srd/SRD-051-bpmn-converter.md — the first-slice implementation spec.

Why

gobpm builds a process definition exactly one way today: programmatically, via process.New + Add + flow.Link. There is no serialization of any kind — no encoding/xml, no marshalling. That blocks the BPMN modeler persona (SAD-001 §5), who authors .bpmn XML to be executed, and it's the gap SAD-001 §4 N7 already reserved a module for.

The decision (ADR-024)

- A format-agnostic seam in core (pkg/convert): split Importer / Exporter interfaces over io.Reader / io.Writer, plus a register-by-format-key registry — the image.RegisterFormat idiom. A third party can register a converter for XPDL, a JSON DSL, or a vendor dialect behind the same façade.
- Engine-independent. Import returns a *process.Process; the host calls thresher.RegisterProcess itself. The engine never imports the converter.
- BPMN 2.0 XML as the batteries-included first converter, shipped as the separate module SAD-001 §9 reserves, so core keeps its stdlib+uuid dependency budget (N7: "core accepts pre-built models"). A blank import enables it (image/image/png model).
- Imported ids are preserved as foundation identity, so imports participate correctly in ADR-019 versioning (version key = process id).
- MVP fenced to the Common Executable Subclass; Diagram Interchange is tolerated on import and omitted on export; round-trip is semantic, not byte-identical.

The first slice (SRD-051)

The pkg/convert seam + BPMN import and export of the executable-core subset:

┌───────────────────────────────────────────────┬──────────────────────────────────────────┐
│                     BPMN                      │               Model target               │
├───────────────────────────────────────────────┼──────────────────────────────────────────┤
│ definitions / process                         │ process.New(name, WithID(id))            │
├───────────────────────────────────────────────┼──────────────────────────────────────────┤
│ startEvent / endEvent (none)                  │ NewStartEvent / NewEndEvent              │
├───────────────────────────────────────────────┼──────────────────────────────────────────┤
│ task / manualTask                             │ NewManualTask (no-op, §13.1)             │
├───────────────────────────────────────────────┼──────────────────────────────────────────┤
│ userTask                                      │ NewUserTask                              │
├───────────────────────────────────────────────┼──────────────────────────────────────────┤
│ sequenceFlow (+ conditionExpression, default) │ flow.Link(…, WithCondition)              │
├───────────────────────────────────────────────┼──────────────────────────────────────────┤
│ exclusiveGateway / parallelGateway            │ NewExclusiveGateway / NewParallelGateway │
└───────────────────────────────────────────────┴──────────────────────────────────────────┘

- Import uses a namespace-aware token-stream decoder so an unmapped bpmn:-namespace element raises UnsupportedElementError (modeler feedback, SAD-001 §5) instead of being silently dropped by struct-unmarshal. DI/DC subtrees are skipped by namespace.
- serviceTask is deferred to slice 2 — it requires operationRef → interface/operation parsing and a ServiceTask.Operation() export getter that does not exist yet. Landing it half-done would ship a non-executable placeholder. ADR-024 §2.6 is reconciled to match.

Not in this PR

- Implementation (M1 seam → M2 import → M3 export + round-trip → M4 example / docs / CI). Tracked in SRD-051 §7.
- serviceTask, and all elements beyond the MVP subset (inclusive/complex/event-based gateways, timer/message/signal events, boundary events, sub-process, call activity, lanes) — later slices.
- The runtime/ server that will consume the converter — its own ADR/SRD.

Cross-doc

- SRD-051 Implements ADR-024 v.1 §2.1–§2.8.
- ADR-024 Refines SAD-001 v.1 §4/§5/§9, ADR-002 v.2, ADR-019 v.1, ADR-003 v.1. All references are up/sideways and version-pinned; standard claims are pinned to docs/bpmn-spec/.
- Both docs are Draft — they flip to Accepted after implementation and the /check-srd landing gate.

Review focus

1. The seam shape — split Importer/Exporter + package-global registry (a deliberate deviation from ADR-002's functional-options norm, justified by engine-independence; ADR-024 §2.2).
2. The module boundary — BPMN as a separate blank-import module vs. a true core default (ADR-024 Open Q2; the latter would need a SAD-001 N7 revision).
3. The MVP cut — serviceTask deferral (SRD-051 §4.6).
4. Open questions — module rename doc-source/ → convert/ (needs SAD-001 §9 ratification), format auto-detection, conditionExpression language handling.
