### PR TITLE
ci: automate the go-install dev-tool pin updates (FIX-025)

### DIFF
--- a/.github/workflows/tool-pins.yml
+++ b/.github/workflows/tool-pins.yml
@@ -1,0 +1,42 @@
+name: Tool pin updates
+
+# Weekly (and on-demand) check for newer releases of the go-install dev-tool
+# pins that live in the Makefile + check.yml — the niche Dependabot can't cover
+# (FIX-025). On drift it opens a PR bumping both files, which then rides normal
+# CI so a breaking tool update surfaces in the PR, not on trunk.
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Mondays, 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Check for newer tool pins
+        id: check
+        run: bash scripts/check-tool-pins.sh
+
+      # Requires: Settings → Actions → General → "Allow GitHub Actions to create
+      # and approve pull requests" (see FIX-025 §3.3).
+      - name: Open a bump PR
+        if: steps.check.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          branch="chore/tool-pins-$(date +%Y%m%d%H%M)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git commit -am "chore: bump pinned dev-tool versions"
+          git push -u origin "$branch"
+          gh pr create \
+            --title "chore: bump pinned dev-tool versions" \
+            --body-file /tmp/pin-notes.md

--- a/docs/fix/FIX-025-automate-tool-pin-updates.md
+++ b/docs/fix/FIX-025-automate-tool-pin-updates.md
@@ -1,0 +1,104 @@
+# FIX-025 «Automate the go-install dev-tool pin updates»
+
+**Type:** FIX (one-shot; not rewritten after landing).
+**Status:** Draft v.1 (2026-07-18, branch `fix/automate-tool-pin-updates`, not yet implemented).
+**Date:** 2026-07-18.
+**Author:** Ruslan Gabitov.
+**Branch:** `fix/automate-tool-pin-updates`.
+**Paired doc:** closes the FIX-024 §8.3 backlog item.
+**Upstream:** self-contained (tooling/CI).
+
+**Grounded in (internal artifacts):**
+- `Makefile:50-53` (the four `*_VERSION` pins) + `62-64,121,131,193,231` (usage).
+- `.github/workflows/check.yml:40-48` (the same versions hardcoded independently).
+- `.github/dependabot.yml` (covers gomod + github-actions, NOT the go-install pins).
+
+---
+
+## §1 Symptoms
+
+The four go-install dev tools — **mockery**, **golangci-lint**, **govulncheck**,
+**covercheck** — are pinned to exact versions in **two** places (`Makefile`
+`*_VERSION` vars + the workflow's install step), but **nothing updates them**.
+Dependabot cannot: its `gomod`/`github-actions` ecosystems don't see version
+strings embedded in a Makefile or a `go install …@vX` line. So the pins silently
+age; a security fix in golangci-lint or govulncheck is picked up only when
+someone remembers to bump — by hand, in both files (the FIX-024 §8.3 backlog,
+and the recurring "two places must stay in sync" foot-gun).
+
+## §2 Root Cause Analysis
+
+The pins live **outside every dependency ecosystem** — they are tool versions in
+build tooling, not module requirements. Dependabot (native, kept for gomod +
+actions) has no custom/regex manager, so this niche needs its own mechanism. The
+options were Renovate (an external app / heavier self-hosted setup) or a
+self-contained in-repo Action; the latter fits gobpm's minimize-external-deps,
+in-repo-control posture (FIX-024) and keeps native Dependabot untouched.
+
+## §3 Solution
+
+### §3.1 Alternatives considered
+
+| Alternative | Decision |
+|---|---|
+| A. **Self-contained weekly Action + a check script** — reads the pins, queries the datasource, opens a PR bumping both files | ✅ chosen — no external app, all in-repo, native Dependabot kept |
+| B. Renovate (custom regex manager) — SaaS app or self-hosted | ❌ trades native for a third-party bot / heavier setup for four pins |
+| C. Notify-only (open an issue) | ❌ not an update; a PR is testable through CI |
+
+### §3.2 Changes by file
+
+#### §3.2.1 `scripts/check-tool-pins.sh` (new)
+For each tool: read the current pin from the `Makefile` `*_VERSION` var; resolve
+the latest release from `proxy.golang.org/<module>/@latest` — every tool is a Go
+module (mockery, `golangci-lint/v2`, `golang.org/x/vuln`, covercheck), so one
+datasource covers all four with no GitHub-API rate limits; if newer (semver
+`sort -V`), replace the exact old version string across **both** `Makefile` and
+the workflow (versions are unique per tool, so a global replace is
+collateral-free) and record it. Emits `changed=true|false` + a notes file for
+the PR body. No update ⇒ exit 0, no-op.
+
+#### §3.2.2 `.github/workflows/tool-pins.yml` (new)
+`schedule` (weekly) + `workflow_dispatch`; `permissions: contents: write,
+pull-requests: write`; SHA-pinned `checkout`. Runs the script; if it changed
+files, commits on a `chore/tool-pins-<date>` branch and opens a PR via the `gh`
+CLI (native to the runner — no third-party action). The bump then rides normal
+CI (`make ci`), so a breaking tool update is caught in the PR, not on trunk.
+
+### §3.3 Repo setting (operational note)
+Opening a PR from a workflow requires **Settings → Actions → General → "Allow
+GitHub Actions to create and approve pull requests"** to be enabled. Without it,
+`gh pr create` fails with a permissions error. (Owner action, one-time.)
+
+## §4 Verification
+
+- The script run against the current (fresh) pins reports "all current" OR
+  surfaces a genuinely newer version — either proves the query + compare path.
+- A forced-stale probe (temporarily lower a pin) makes the script detect + bump
+  it in both files (reverted after the check).
+- `bash -n` / shellcheck clean; the workflow YAML parses.
+- `make ci` unaffected (no Go/gate change).
+
+## §5 Prevention
+
+- The Action is the prevention — pins can't silently rot.
+- A `# tool-pin` comment marks the canonical `Makefile` lines the script reads.
+
+## §6 Regressions / side-effects
+
+- The bot opens PRs; a breaking tool bump surfaces as a **red PR**, never on
+  trunk. Rollback: delete the workflow + script.
+- Depends on the §3.3 repo setting; documented.
+
+## §7 Related
+
+- FIX-024 (merged) — pinned these versions; §8.3 named this follow-up.
+- [[project_ci_tool_versions_duplicated]] — the dual-file pin the script now
+  updates together.
+
+## §8 Implementation summary
+
+> ⚠️ TODO: fill AFTER landing.
+
+## Open questions
+
+None.

--- a/docs/fix/FIX-025-automate-tool-pin-updates.md
+++ b/docs/fix/FIX-025-automate-tool-pin-updates.md
@@ -1,7 +1,7 @@
 # FIX-025 «Automate the go-install dev-tool pin updates»
 
 **Type:** FIX (one-shot; not rewritten after landing).
-**Status:** Draft v.1 (2026-07-18, branch `fix/automate-tool-pin-updates`, not yet implemented).
+**Status:** Accepted v.1 (2026-07-18, branch `fix/automate-tool-pin-updates`, implemented — `make ci` green).
 **Date:** 2026-07-18.
 **Author:** Ruslan Gabitov.
 **Branch:** `fix/automate-tool-pin-updates`.
@@ -97,7 +97,30 @@ GitHub Actions to create and approve pull requests"** to be enabled. Without it,
 
 ## §8 Implementation summary
 
-> ⚠️ TODO: fill AFTER landing.
+### §8.1 Stages by commit (branch `fix/automate-tool-pin-updates`)
+| Stage | Commit | Scope |
+|---|---|---|
+| Doc | `0197fc7` | FIX-025 (this document) |
+| Impl | `f4ffcb7` | `scripts/check-tool-pins.sh` + `.github/workflows/tool-pins.yml` |
+
+`make ci` green (non-Go change; `diff-coverage 100% of 0 lines — PASS`).
+
+### §8.2 Empirical findings vs the §3 draft
+
+- **All four tools resolve via goproxy — no GitHub API.** The draft routed
+  golangci-lint through the GitHub releases API; in practice its module
+  `github.com/golangci/golangci-lint/v2` resolves on `proxy.golang.org/@latest`
+  like the rest, so all four use one datasource. The GitHub API also
+  pretty-prints JSON (`"tag_name": "…"` with a space) that a naive grep missed,
+  and is rate-limited unauthenticated — two reasons goproxy is cleaner.
+- **The check is already actionable.** Run against current pins it found
+  **mockery v3.5.0 → v3.7.1** and **golangci-lint v2.11.4 → v2.12.2** — so the
+  first post-merge run will open a real bump PR (govulncheck/covercheck current).
+  FIX-025 lands the *automation* only; the pins were reverted so the bumps ride
+  the Action, not this doc.
+
+### §8.3 Backlog
+- None.
 
 ## Open questions
 

--- a/scripts/check-tool-pins.sh
+++ b/scripts/check-tool-pins.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# check-tool-pins.sh (FIX-025) — detect newer releases of the pinned go-install
+# dev tools and, if any, bump them in BOTH the Makefile and the CI workflow
+# (Dependabot can't see version strings embedded in build tooling). Writes
+# `changed=true|false` to $GITHUB_OUTPUT and, when it bumped anything, the PR
+# body to /tmp/pin-notes.md. A no-op run exits 0. Run from the repo root.
+#
+# Every tool is a Go module, so `proxy.golang.org/<module>/@latest` (the highest
+# release, pre-releases excluded) is the one datasource — no GitHub API, no rate
+# limits.
+set -euo pipefail
+
+makefile="Makefile"
+workflow=".github/workflows/check.yml"
+notes="/tmp/pin-notes.md"
+
+# name | Makefile *_VERSION var | go module
+tools=(
+	"mockery|MOCKERY_VERSION|github.com/vektra/mockery/v3"
+	"golangci-lint|GOLANGCI_VERSION|github.com/golangci/golangci-lint/v2"
+	"govulncheck|GOVULNCHECK_VERSION|golang.org/x/vuln"
+	"covercheck|COVERCHECK_VERSION|github.com/dr-dobermann/covercheck"
+)
+
+latest_version() { # module
+	curl -fsSL "https://proxy.golang.org/${1}/@latest" |
+		grep -oE '"Version": *"[^"]*"' | head -1 | cut -d'"' -f4
+}
+
+current_pin() { # *_VERSION var
+	grep -oE "^${1}[[:space:]]*:=[[:space:]]*\S+" "$makefile" | awk '{print $NF}'
+}
+
+: >"$notes"
+changed=0
+
+for entry in "${tools[@]}"; do
+	IFS='|' read -r name var mod <<<"$entry"
+	cur="$(current_pin "$var")"
+	new="$(latest_version "$mod" || true)"
+
+	if [ -z "$new" ]; then
+		echo "WARN: could not resolve latest for $name ($mod)" >&2
+		continue
+	fi
+	if [ "$cur" = "$new" ]; then
+		echo "$name: $cur (current)"
+		continue
+	fi
+	# only ever bump forward (a pin ahead of the resolved latest is left alone)
+	if [ "$(printf '%s\n%s\n' "$cur" "$new" | sort -V | tail -1)" != "$new" ]; then
+		echo "$name: pinned $cur is ahead of resolved $new — skipping"
+		continue
+	fi
+
+	echo "$name: $cur -> $new (bumping)"
+	esc="$(printf '%s' "$cur" | sed 's/[.]/\\./g')" # each pin's version is unique
+	sed -i "s/${esc}/${new}/g" "$makefile" "$workflow"
+	echo "- \`$name\`: \`$cur\` → \`$new\`" >>"$notes"
+	changed=1
+done
+
+out="${GITHUB_OUTPUT:-/dev/stdout}"
+if [ "$changed" -eq 1 ]; then
+	echo "changed=true" >>"$out"
+	echo "--- pin updates ---"
+	cat "$notes"
+else
+	echo "changed=false" >>"$out"
+	echo "all tool pins current"
+fi


### PR DESCRIPTION
Closes the FIX-024 §8.3 backlog: the four go-install dev-tool pins (mockery, golangci-lint, govulncheck, covercheck) live in the Makefile + workflow but nothing updated them — Dependabot can't see version strings embedded in build tooling.

**Decision (owner):** keep native **Dependabot** for gomod + GitHub Actions; fill the niche with a **self-contained in-repo Action**, not Renovate (no external bot, consistent with the FIX-024 supply-chain hardening).

## What it does

- **`scripts/check-tool-pins.sh`** — reads each tool's `*_VERSION` pin from the Makefile, resolves the latest release from `proxy.golang.org/<module>/@latest` (every tool is a Go module → one datasource, no GitHub-API rate limits), and on a forward bump replaces the version across **both** the Makefile and `check.yml` (unique per tool → collateral-free). Emits the PR-body notes.
- **`.github/workflows/tool-pins.yml`** — weekly `cron` + `workflow_dispatch`; on drift it commits on a `chore/tool-pins-<date>` branch and opens a PR via the `gh` CLI (native to the runner). The bump rides normal CI, so a breaking tool update surfaces in the PR, never on trunk.

## Verified

The script run against current pins correctly resolves all four and detects the real updates available now — **mockery v3.5.0 → v3.7.1**, **golangci-lint v2.11.4 → v2.12.2** (govulncheck/covercheck current). It bumped both files correctly; reverted, since this PR lands the *automation* only — the first scheduled run will open that bump PR. `make ci` green.

## One repo setting needed

For the Action to open PRs, enable **Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"** (FIX-025 §3.3). Without it, `gh pr create` fails with a permissions error.
