### PR TITLE
feat: composite Standard Loop on the off-loop iteration decorator (ADR-025 v.2 §2.12, SRD-054)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Behavior events (`ComplexBehaviorDefinition`) follow (SRD-056.B). New
   `examples/multi-instance-parallel/`.
 
+### Changed
+
+- **Composite loop execution → off-loop iteration decorator (ADR-025 v.2 §2.12,
+  SRD-054).** Internal rework, behavior-preserving: a looped **composite**
+  activity (Sub-Process / Call Activity) now drives its own iteration from the
+  host's runner goroutine — requesting scope open/close from the single-writer
+  loop via a request/response protocol — instead of loop-goroutine-driven scope
+  re-entry. Standard Loop semantics are unchanged; the rework makes the
+  Multi-Instance behavior throw (§2.8) implementable with a deterministic
+  boundary catch (the loop-goroutine model self-deadlocked on it). Standard Loop
+  is re-landed on the decorator; sequential/parallel Multi-Instance follow.
+
 ## [v0.9.0] - 2026-07-18
 
 ### Added

--- a/docs/design/ADR-025-activity-iteration-loop-and-multi-instance.md
+++ b/docs/design/ADR-025-activity-iteration-loop-and-multi-instance.md
@@ -2,19 +2,29 @@
 
 | Field | Value |
 |---|---|
-| Status | Accepted |
-| Version | v.1 |
-| Date | 2026-07-18 |
+| Status | Draft |
+| Version | v.2 |
+| Date | 2026-07-21 |
 | Owner | Ruslan Gabitov |
-| Refines | [SAD-001 v.1](SAD-001-vision-and-architecture.md) §5 / §15.3, [ADR-023 v.2](ADR-023-sub-process-and-call-activity.md) (the execution-scope model this reuses), [ADR-018 v.1](ADR-018-boundary-events-and-activity-interruption.md) (boundary catch for thrown behavior events), [ADR-006 v.3](ADR-006-events-and-subscriptions.md) (event throwing/catching) |
+| Refines | [SAD-001 v.1](SAD-001-vision-and-architecture.md) §5 / §15.3, [ADR-023 v.2](ADR-023-sub-process-and-call-activity.md) (the execution-scope model this reuses), [ADR-018 v.1](ADR-018-boundary-events-and-activity-interruption.md) (boundary catch for thrown behavior events), [ADR-017 v.1](ADR-017-channel-based-event-processing.md) (the single-writer execution model §2.12 extends), [ADR-006 v.3](ADR-006-events-and-subscriptions.md) (event throwing/catching) |
 
-> **Accepted** — decides how an activity marked with *loop characteristics* runs
+> **Draft (v.2)** — decides how an activity marked with *loop characteristics* runs
 > **more than once**: BPMN's Standard Loop (a condition-driven sequential loop)
 > and Multi-Instance (a cardinality-driven fan-out, sequential or parallel, over
 > a data collection). It is prescriptive and grounded in the BPMN 2.0 object
 > model (§13.3.6–§13.3.7); the accompanying SRDs land it incrementally on the
 > existing execution-scope substrate. Names of code symbols are deliberately
 > absent — that grounding belongs to the SRDs.
+>
+> **v.2** adds §2.12: a **composite** looped activity iterates on the activity's
+> own (off-loop) execution — an *iteration decorator* — rather than under control
+> code run on the per-instance loop goroutine. This makes the §2.8 behavior throw
+> an ordinary off-loop emit with a deterministic boundary catch (the v.1 landing
+> could not implement it correctly), while keeping [ADR-017 v.1](ADR-017-channel-based-event-processing.md)'s
+> single-writer invariant intact. The §2.1–§2.11 semantics are unchanged; only
+> *who drives* composite iteration moves. The SRDs that landed the
+> loop-goroutine-driven composite model are superseded and deleted when the
+> decorator re-landing completes.
 
 ---
 
@@ -124,6 +134,10 @@ Isolation-by-frame for leaves and isolation-by-scope for composites is one
 uniform *principle* (per-iteration isolation) realized by two mechanisms, not two
 competing models.
 
+This subsection fixes the *mechanism*; **who drives it** for a composite activity
+— the activity's own off-loop execution, not the per-instance loop goroutine — is
+§2.12.
+
 ### 2.3 Standard Loop — a sequential condition-driven loop
 
 A Standard-Loop activity runs its inner activity repeatedly **in sequence**,
@@ -174,6 +188,10 @@ are alternative cardinality sources, not composable).
 
 Both shapes expose per-instance **`loopCounter`** (0-based ordinal) and the
 aggregate runtime attributes of §2.9 to the activity's expressions.
+
+For a composite activity these two shapes are the decorator's two driving
+strategies — await-each (sequential) and fan-out-then-await-all (parallel) — run
+on the activity's own execution (§2.12).
 
 ### 2.6 Data flow — split in, assemble out
 
@@ -245,6 +263,10 @@ The thrown events implicitly carry the Multi-Instance activity's runtime
 attributes (§2.9), so a boundary handler can read how far the activity has
 progressed.
 
+This subsection fixes *what* is thrown and *when*; the throw **executes** as an
+ordinary off-loop emit issued by the iteration decorator before it completes the
+activity (§2.12), which is what makes the boundary catch deterministic.
+
 ### 2.9 Instance runtime attributes (engine convention)
 
 The standard states that a Multi-Instance activity's *runtime attributes* are
@@ -290,6 +312,78 @@ extends this one.
   choice; the spec lists both attributes without forbidding both, but a
   well-formed MI activity uses exactly one source.
 - **Runtime-attribute set** (§2.9) is an engine convention pending a KB extension.
+
+### 2.12 Composite iteration runs off the loop — the iteration decorator (v.2)
+
+§2.2 fixes the *mechanism* (a composite activity re-opens its child scope per
+iteration); this subsection fixes *who drives it*. **A composite looped activity
+iterates on the activity's own execution — an off-loop *iteration decorator* —
+not under control code run on the per-instance loop goroutine.**
+
+**Why this is decided here.** The engine's execution model
+([ADR-017 v.1](ADR-017-channel-based-event-processing.md)) has a **single-writer
+loop goroutine** that owns all execution-lifecycle state (open scopes, token
+positions, the parallel instance barrier), while a node's *work* runs **off** it,
+on a per-token runner goroutine that reports state transitions back as events.
+The v.1 landing drove the iteration *control* — resolve the count, split data,
+evaluate the completion condition, decide re-entry, and (§2.8) **throw behavior
+events** — **on the loop goroutine**, splitting control and work across the
+goroutine boundary the wrong way. The §2.8 behavior throw is the proof: throwing
+an event means handing it to the loop's ordered inbound channel, but issued *from*
+the loop goroutine that hand-off self-deadlocks (the loop is the channel's only
+reader and is busy inside the throw); made fire-and-forget it instead drops the
+catch nondeterministically, because the throw and its boundary catch become
+separate loop steps the activity's own completion can race between. Both are
+symptoms of one structural fact: **the v.1 control was not the decorator BPMN
+describes** (§13.3.6–§13.3.7 frame loop characteristics as a wrapper *around the
+activity*, whose control belongs to the activity's execution).
+
+**The decision.**
+
+- **The activity's runner drives the iteration.** The composite host's own
+  (off-loop) execution resolves the count/condition, opens each instance, awaits
+  each completion, evaluates the completion condition, assembles output (§2.6),
+  throws behavior events (§2.8), and then completes the activity and follows its
+  outgoing flow. The host **no longer parks** while the loop drives iteration on
+  its behalf — its runner *is* the driver. Parking returns to its BPMN meaning
+  (waiting for an external event).
+- **The loop stays the single writer; the decorator *requests* scope
+  operations.** Running off-loop, the decorator must not mutate loop-owned state
+  directly (that would reintroduce the cross-goroutine races
+  [ADR-017 v.1](ADR-017-channel-based-event-processing.md) removed). It uses a
+  **request/response** protocol over the existing event channel: it requests an
+  operation (open an instance scope, close a drained one, bind a per-instance
+  datum), the loop performs the mutation on its own goroutine and acknowledges on
+  the decorator's inbound channel, and the decorator — blocked on that
+  acknowledgement — resumes. Strictly ordered, no shared mutable state, no lock:
+  the single-writer invariant is **preserved and extended**, not relaxed.
+- **Sequential and parallel are two driving strategies** (§2.5): await-each, or
+  fan-out-then-await-all with the N-of-N barrier — ordinary control flow on the
+  decorator's goroutine rather than callbacks re-entered by the loop.
+- **Behavior events become ordinary off-loop throws** (§2.8). The decorator emits
+  by the same path any activity uses, and can **block until the throw is
+  accepted** before completing the activity — so the boundary catch is ordered
+  *before* completion by construction, on a boundary that is still armed. The v.1
+  deadlock and nondeterministic drop are **structurally impossible** on this
+  model.
+
+**Scope.** This governs **composite** activities (Sub-Process, Call Activity) —
+the only activities that carry boundaries and throw behavior events. A **leaf-task
+loop already** runs in place on the task's own runner (§2.2); it is already off
+the loop goroutine and is **unchanged**.
+
+**Semantics are unchanged.** Everything §2.1–§2.11 decides — count fixed once
+(§2.4), split-in/assemble-out with the visibility barrier (§2.6), the completion
+condition (§2.7), the runtime attributes (§2.9) — is preserved verbatim. This
+subsection changes only **where that control runs** (on the decorator, off the
+loop), not **what it computes**. The re-open-a-child-scope mechanism of §2.2
+stands; the decorator merely *requests* each open/close rather than the loop
+performing it inline.
+
+**Engine note.** The request/response scope protocol is an engine mechanism, not
+a BPMN concept — BPMN is silent on the engine's goroutine model; the protocol
+exists solely to reconcile off-loop control with the single-writer invariant, and
+is invisible to a modeler.
 
 ---
 
@@ -337,6 +431,26 @@ engine convention explicitly rather than asserting a spec mandate.
   Rejected: it is a first-class BPMN marker in the conformance scope and changes
   the diagram's meaning (a marked activity vs. an explicit cycle).
 
+For the §2.12 execution model (v.2), the rejected alternatives were:
+
+- **Keep control on the loop; move only the behavior throw off-loop.** Special-case
+  the §2.8 throw onto a transient goroutine, or fire its boundary inline, leaving
+  iteration loop-driven. Rejected: it treats the symptom, not the structural
+  mismatch — control stays on the wrong goroutine — and it needs bespoke
+  inline-fire machinery to order the catch before completion. It does not
+  generalize: every future control-side emit re-hits the same wall.
+- **Relax the single-writer invariant.** Let the off-loop decorator open/close
+  scopes and update positions directly under a lock. Rejected: it reintroduces the
+  cross-goroutine mutation of lifecycle state that
+  [ADR-017 v.1](ADR-017-channel-based-event-processing.md) removed, and a lock over
+  the position/scope maps is a strictly worse synchronization than goroutine
+  confinement.
+- **Fire-and-forget async throw (keep the v.1 model).** Emit the behavior event
+  from a transient goroutine and let the catch land whenever. Rejected: empirically
+  nondeterministic — the catch is a later loop step that races the activity's
+  completion, dropping behavior events on both the sequential and parallel shapes.
+  A correctness gap, not a style choice.
+
 ---
 
 ## 5. Consequences
@@ -354,6 +468,19 @@ engine convention explicitly rather than asserting a spec mandate.
   the proven ADR-023 open/drain/close lifecycle rather than inventing new
   accounting. `Complex` behavior is the least-used, highest-complexity surface;
   it lands last, after the sequential and parallel cores are proven.
+- **v.2 rework (§2.12).** Moving composite iteration onto the off-loop decorator
+  **re-lands** the composite Standard Loop and Multi-Instance execution paths; the
+  element SRDs that landed the loop-goroutine-driven composite model are
+  **deleted and reused** — each is rewritten in place on the decorator (its old
+  content deleted, its number reused), rather than marked Obsolete or renumbered,
+  which keeps the element→SRD mapping stable and the doc-set consistent with the
+  code — and the conformance tracker is updated to the new landing. It adds one off-loop↔loop **coordination surface** (the scope
+  request/response protocol) — historically where races appear; mitigated by the
+  strict request/response discipline (the loop stays sole writer, no shared
+  state), by re-landing **incrementally** (Standard Loop, then sequential, then
+  parallel) with the existing loop / MI / boundary suites as the green-throughout
+  safety net, and by leaving **leaf-task loops untouched**, which bounds the blast
+  radius to composite iteration.
 
 ---
 
@@ -397,6 +524,25 @@ existing execution-scope substrate:
 Compensation (§2.10) is out of this rollout; it rides the future Transaction /
 compensation work.
 
+**v.2 re-landing (§2.12).** The three slices above landed on the
+loop-goroutine-driven composite model; v.2 re-lands them on the off-loop
+decorator, smallest-first, each its own SRD and PR:
+
+1. **Decorator engine + composite Standard Loop** — the request/response scope
+   protocol, proven by re-landing the simplest composite iteration, green against
+   the existing suites.
+2. **Sequential Multi-Instance** on the decorator.
+3. **Parallel Multi-Instance** on the decorator — the fan-out-then-await-all
+   strategy with the N-of-N barrier expressed as decorator control flow.
+4. **Multi-Instance behavior** (§2.8) on the decorator — a straightforward
+   off-loop throw with a deterministic boundary catch.
+5. **Retire the old seam** — remove the loop-goroutine-driven composite-iterator
+   seam and update the conformance tracker to the new landing.
+
+Each slice **deletes and reuses** its element's SRD — rewriting it in place on the
+decorator (old content deleted, its number reused) rather than marking it Obsolete
+or minting a new number — so the element→SRD mapping stays stable.
+
 ---
 
 ## 8. References
@@ -423,3 +569,4 @@ None.
 | Version | Date | Author | Change |
 |---|---|---|---|
 | v.1 | 2026-07-19 | Ruslan Gabitov | Initial draft — Standard Loop & Multi-Instance iteration model: per-iteration isolation by a mechanism fitting the activity kind (in-place fresh-frame for a leaf Task, per-iteration child scope for a composite, distinct per-instance scope for parallel MI), cardinality (expression \| collection), sequential/parallel sequencing, split/assemble data mediator with visibility barrier, completion condition, full `behavior` event-throwing (All/None/One/Complex), engine-convention runtime attributes; MI compensation deferred to the future Transaction work. |
+| v.2 | 2026-07-21 | Ruslan Gabitov | Added §2.12 — composite iteration runs on the activity's own off-loop execution (an *iteration decorator*), not under control code on the per-instance loop goroutine; the decorator requests scope operations from the single-writer loop via a request/response protocol (ADR-017 v.1 invariant preserved), sequential/parallel become its two driving strategies, and the §2.8 behavior throw becomes an ordinary off-loop emit with a deterministic boundary catch (unimplementable correctly on the v.1 model). Semantics §2.1–§2.11 unchanged; only *who drives* composite iteration moves. Forward-pointers added to §2.2/§2.5/§2.8; execution-model alternatives added to §4; v.2 rework consequences/rollout added to §5/§7. Leaf-task loops unchanged. The SRDs that landed the loop-goroutine-driven composite model are superseded and deleted when the re-landing completes. |

--- a/docs/srd/SRD-054-standard-loop.md
+++ b/docs/srd/SRD-054-standard-loop.md
@@ -2,380 +2,345 @@
 
 | Field | Value |
 |---|---|
-| Status | Accepted |
-| Version | v.1 |
-| Date | 2026-07-19 |
+| Status | Draft |
+| Date | 2026-07-21 |
 | Owner | Ruslan Gabitov |
-| Implements | [ADR-025 v.1](../design/ADR-025-activity-iteration-loop-and-multi-instance.md) §2.2–§2.3 (the Standard Loop slice of the activity-iteration model; epic #88) |
-| Upstream | [ADR-010 v.2](../design/ADR-010-process-data-model.md) (the execution frame = per-execution data boundary that isolates each iteration), [ADR-023 v.2](../design/ADR-023-sub-process-and-call-activity.md) (the composite child-scope re-entry seam), [ADR-018 v.1](../design/ADR-018-boundary-events-and-activity-interruption.md) (a boundary event arms once and guards the whole loop), [ADR-001 v.6](../design/ADR-001-execution-model.md) (the loop owns node execution) |
+| Implements | [ADR-025 v.2](../design/ADR-025-activity-iteration-loop-and-multi-instance.md) §2.2–§2.3 (the Standard Loop slice), §2.12 (composite iteration as an off-loop decorator); epic #88 |
+| Upstream | [ADR-017 v.1](../design/ADR-017-channel-based-event-processing.md) (the single-writer loop the decorator requests scope operations from), [ADR-010 v.2](../design/ADR-010-process-data-model.md) (the execution frame that isolates each leaf iteration), [ADR-023 v.2](../design/ADR-023-sub-process-and-call-activity.md) (the composite child-scope open/drain/close lifecycle), [ADR-018 v.1](../design/ADR-018-boundary-events-and-activity-interruption.md) (a boundary arms once and guards the whole loop), [ADR-001 v.6](../design/ADR-001-execution-model.md) (the loop owns node execution) |
 | Refines | — |
 
 ## §1 Background
 
-Every activity in gobpm runs **exactly once** per token that reaches it. BPMN
-2.0 §13.3.6 lets an activity carry `StandardLoopCharacteristics` — a structured
-`while`/`until` loop that re-runs the inner activity **sequentially** while a
-boolean `loopCondition` holds. ADR-025 §2.1–§2.3 decided the conception; this SRD
-lands the **first, smallest** slice of the epic (#88): Standard Loop, on both a
-leaf **Task** and a **composite** (Sub-Process / Call Activity), before the two
-Multi-Instance slices (SRD-055 sequential, SRD-056 parallel) follow.
+BPMN 2.0 §13.3.6 lets an activity carry `StandardLoopCharacteristics` — a
+structured `while`/`until` loop that re-runs the inner activity **sequentially**
+while a boolean `loopCondition` holds. This SRD lands Standard Loop on **both** a
+leaf **Task** and a **composite** (Sub-Process / Call Activity).
 
-The model already carries a **wired-but-empty** hook. Audit of every existing
-loop artifact: the empty `LoopCharacteristics` struct
-(`pkg/model/activities/loop.go:3-5`); its wiring — `WithLoop(lc
-*LoopCharacteristics)` (`activity_options.go:110-125`), `activityConfig.loop`
-(`:13`, `:61`), `activity.loopCharacteristics` (`activity.go:22`), the
-by-reference clone (`activity.go:117`); one test usage
-`WithLoop(&LoopCharacteristics{})` (`activity_test.go:49`); and doc-comment
-mentions of `WithLoop` in `service_task.go:71` / `user_task.go:80`. No execution
-consumes any of it today. **Decision: accommodate, not remove** — the wiring is
-exactly the seam this SRD builds on, so the empty struct becomes the sealed
-interface (FR-1) and the rest is reused unchanged; the only follow-on is updating
-the `activity_test.go:49` empty-struct usage to a real `StandardLoop` (M1).
+**This is the first slice of the ADR-025 v.2 decorator re-landing** (§2.12). The
+prior landing drove composite iteration *control* — resolve the continuation,
+re-open the scope — **on the per-instance loop goroutine**, via a
+loop-side `compositeIterator` seam (`firstOpen`/`afterDrain`) called from
+`onScopeOpen`/`resumeScopeHost`. ADR-025 v.2 §2.12 decided that control belongs on
+the **activity's own off-loop execution** — an *iteration decorator* — which
+**requests** scope operations from the single-writer loop rather than performing
+them. Standard Loop is the simplest composite iteration, so it is the slice that
+introduces the decorator engine (the request/response scope protocol); the
+sequential-MI, parallel-MI, and behavior slices re-land on it afterward.
 
-ADR-025 §2.2 (as amended) chose the iteration **mechanism by activity kind**:
+**The leaf-Task loop is unchanged** — it already runs in place on the task's own
+runner goroutine (a bounded `for` around `executeNode`), which is off the loop
+goroutine and needs no protocol. §2.12's scope is composite activities only.
 
-- a **leaf Task** iterates **in place** — re-executed once per pass, each pass in
-  a fresh execution frame (the frame is already the per-execution isolation
-  boundary, ADR-010);
-- a **composite** iterates by **re-opening its child scope per iteration** — the
-  ADR-023 nested-scope re-entry seam it already runs for its body.
+This SRD **deletes and reuses** the SRD-054 slot: its prior (loop-goroutine-driven
+composite) content is replaced in place with the decorator design; the model and
+leaf-Task requirements below are the landed reality, restated so the document is
+self-sufficient.
 
-Both follow the activity's single outgoing flow **once**, at loop exit, and both
-let a boundary event on the looped activity arm **once** and guard every
+ADR-025 §2.2 chose the iteration **mechanism by activity kind**: a leaf Task
+iterates **in place** (fresh frame per pass, ADR-010); a composite iterates by
+**re-opening its child scope per iteration** (the ADR-023 open/drain/close
+lifecycle). §2.12 fixes *who drives* the composite mechanism — the decorator, off
+the loop. Both kinds follow the activity's single outgoing flow **once**, at loop
+exit, and let a boundary event on the looped activity arm **once** and guard every
 iteration.
 
 ## §2 Requirements
 
-### Functional — the model
+### Functional — the model (landed, unchanged)
 
-- **FR-1 — `StandardLoopCharacteristics` type.** `LoopCharacteristics` becomes a
-  sealed marker interface; `StandardLoopCharacteristics` is a concrete
-  implementation carrying `loopCondition` (a `data.FormalExpression`, the same
-  boolean-expression type gateways evaluate — `gateway.go:224`), `testBefore`
-  (bool, default `false`), and an optional `loopMaximum` (`*int`, nil =
-  unbounded). It embeds `foundation.BaseElement` (§13.3.6 `→ BaseElement`).
-- **FR-2 — construction validates all inputs.** A `NewStandardLoop(loopCondition,
-  opts…)` constructor rejects a nil `loopCondition`, a `loopCondition` whose
-  `ResultType() != "bool"`, and a `loopMaximum ≤ 0` — at construction, with a
-  self-identifying error (per the validate-public-params rule). `WithLoop` accepts
-  any `LoopCharacteristics` (interface) and keeps its existing nil guard.
-- **FR-3 — `Activity.Validate` cross-check.** Validation rejects an activity
-  carrying **both** a Standard-Loop and a Multi-Instance characteristic
-  (ADR-025 §2.1 "at most one").
+- **FR-1 — `StandardLoopCharacteristics` type.** `LoopCharacteristics` is a sealed
+  marker interface; `StandardLoopCharacteristics` carries `loopCondition` (a
+  `data.FormalExpression`, bool), `testBefore` (bool, default `false`), and an
+  optional `loopMaximum` (`*int`, nil = unbounded); it embeds
+  `foundation.BaseElement`.
+- **FR-2 — construction validates all inputs.** `NewStandardLoop(loopCondition,
+  opts…)` rejects a nil `loopCondition`, a non-`bool` `ResultType()`, and a
+  `loopMaximum ≤ 0`, at construction, with a self-identifying error.
+- **FR-3 — `Activity.Validate` cross-check.** An activity carrying **both** a
+  Standard-Loop and a Multi-Instance characteristic is rejected (ADR-025 §2.1).
 - **FR-3a — an Event Sub-Process rejects iteration.** A `triggeredByEvent`
-  `SubProcess` carrying **any** `LoopCharacteristics` (Standard Loop or
-  Multi-Instance) fails validation. An Event Sub-Process is *instantiated by an
-  event, not by control flow* (`sub-processes.md §13.5.4`); it has no
-  token-driven activation to iterate, and its multiplicity already comes from its
-  trigger (a non-interrupting start fires multiple times). Because the marker
-  implements the shared `LoopCharacteristics` interface, this one guard covers
-  both Standard Loop (this SRD) and future Multi-Instance. **Engine
-  well-formedness rule** — the spec extract is *silent* on an explicit
-  prohibition (the object model places `loopCharacteristics` on `Activity`, so a
-  `SubProcess` may carry it in the schema); gobpm rejects it as semantically
-  meaningless for an event-instantiated handler.
+  `SubProcess` carrying any `LoopCharacteristics` fails validation (an
+  event-instantiated handler has no token-driven activation to iterate).
 
-### Functional — leaf-Task execution (in place)
+### Functional — leaf-Task execution, in place (landed, unchanged)
 
-- **FR-4 — in-place re-execution.** A leaf activity (a `NodeExecutor` that is not
-  a park-node — not a `scopeHost` / Call Activity / external worker / user task)
-  carrying `StandardLoopCharacteristics` is re-executed once per pass; each pass
-  opens a **fresh execution frame** (`executeNode` → `openFrameAt` +
-  `defer Discard`, `track.go:943-953`), so iterations are isolated with no new
-  construct.
-- **FR-5 — `testBefore` semantics.** `false` (default) → **post-tested**
-  (`do…while`): run once, then test `loopCondition`; loop continues while true.
-  `true` → **pre-tested** (`while`): test before each run, so **zero iterations**
-  are possible.
-- **FR-6 — `loopMaximum` cap.** When set, at most `loopMaximum` iterations run
-  regardless of the condition.
-- **FR-7 — single outgoing flow at exit.** The engine follows the activity's
-  outgoing sequence flow **once**, only after the loop terminates (`executeNode`
-  returns `nexts`; `checkFlows` follows them — `track.go:756-763` — is called once
-  after the loop breaks).
+- **FR-4 — in-place re-execution.** A leaf activity carrying
+  `StandardLoopCharacteristics` is re-executed once per pass; each pass opens a
+  **fresh execution frame**, so iterations are isolated with no new construct.
+- **FR-5 — `testBefore` semantics.** `false` (default) → post-tested (`do…while`);
+  `true` → pre-tested (`while`, zero iterations possible).
+- **FR-6 — `loopMaximum` cap.** At most `loopMaximum` iterations run when set.
+- **FR-7 — single outgoing flow at exit.** The activity's outgoing flow is
+  followed **once**, after the loop terminates.
 
-### Functional — composite execution (scope per iteration)
+### Functional — composite execution, the off-loop decorator (reworked)
 
-- **FR-8 — composite re-entry.** A composite (`scopeHost`) carrying
-  `StandardLoopCharacteristics` re-opens its child scope per iteration: on scope
-  drain, if `loopCondition` still holds and `loopMaximum` is not reached, the host
-  is re-queued for another open via the existing re-entry seam
-  (`resumeScopeHost` / `scopeEntry.queue`, `scope_runtime.go:287-313`) instead of
-  receiving its terminal `scopeDone`; when the loop finishes, `scopeDone` is
-  delivered as today so the composite follows its single outgoing flow once.
-- **FR-9 — boundary arms once.** A boundary event on the looped activity arms
-  once and guards all iterations (the host stays on the node across passes; no
-  `evMoved` is emitted until loop exit, so `armBoundaries` fires once —
-  `loop.go` boundary (dis)arm on `evMoved`).
+- **FR-8 — the composite host drives its own iteration off the loop.** A looped
+  composite activity iterates on its **own runner goroutine** (a new
+  `runCompositeLoop`, invoked from `executeStep` before the park path, mirroring
+  how `runStandardLoop` intercepts a leaf loop). Per pass the decorator: (a)
+  **requests** a scope-open and blocks for the loop's acknowledgement; (b) **parks
+  for drain** — the inner scope drains and the loop delivers `scopeDone` on the
+  host's `evtCh` (the existing mechanism); (c) evaluates the continuation
+  (`loopCounter`++, `loopMaximum`, `loopCondition` with `testBefore`) **off the
+  loop**; (d) repeats, or completes and follows the outgoing flow **once**. The
+  host no longer *parks for control* between passes — only for each pass's drain.
+- **FR-8a — the request/response scope protocol.** The decorator never mutates
+  loop-owned state (scopes, positions, arming) directly. It sends a `scopeRequest`
+  on a new loop-serviced `scopeReq` channel and blocks on a per-request buffered
+  reply channel; the loop performs the mutation on its own goroutine and replies.
+  For Standard Loop the only roundtrip is **`reqOpenScope`** (open the child scope,
+  seed the inner tracks, arm the scope handlers, reply with the opened path).
+  **Scope close stays on the existing drain path** (`completeScope`), so no
+  close-roundtrip is needed and there is no double-close. The protocol clones the
+  existing `taskReq`/`taskRoundtrip` (and `callReq`) pattern verbatim.
+- **FR-9 — boundary arms once.** A boundary event on the looped composite arms
+  **once** and guards every iteration: the host still **parks** between passes and
+  emits no `evMoved`/`evEnded` until loop exit, so `armBoundaries` fires once (on
+  arrival) and `disarmBoundaries` once (at exit) — unchanged from today.
 
-### Functional — `loopCounter`, observability & front door
+### Functional — `loopCounter`, observability & front door (landed, unchanged)
 
 - **FR-10 — `loopCounter`.** A 0-based per-iteration ordinal is published so the
-  `loopCondition` **and** the inner activity's expressions read it by name
-  (through `execEnv.Find` → frame-first resolution). It is read-only and
-  engine-maintained; each iteration sees its own value (never a stale sibling's).
-- **FR-11 — observability.** Emit an iteration Fact per pass (loop enter / each
-  iteration with `loopCounter` / loop exit) through the ADR-013 v.2 observability
-  reporter (observer-only; echo policy per the kind→level map).
-- **FR-12 — front door.** A runnable `examples/standard-loop/`, the composition/
-  iteration guide, `CHANGELOG.md`, the conformance tracker row, and the READMEs
-  (EN + RU) reflect the new capability.
+  `loopCondition` and the inner activity's expressions read it by name; read-only,
+  engine-maintained, each iteration sees its own value.
+- **FR-11 — observability.** An iteration Fact per pass (loop enter / each
+  iteration with `loopCounter` / loop exit) through the ADR-013 v.2 reporter.
+- **FR-12 — front door.** `examples/standard-loop/`, the iteration guide,
+  `CHANGELOG.md`, the conformance tracker row, and the READMEs (EN + RU) reflect
+  the capability (already landed; the decorator rework does not change the
+  user-visible behavior, so these need no user-facing change beyond a CHANGELOG
+  note).
 
 ### Non-functional
 
-- **NFR-1 — no new event kinds for the leaf path.** The leaf-Task loop is a
-  bounded `for` around `executeNode` in `run()`; it introduces no `trackEvent`
-  kind and no loop-goroutine round-trip.
-- **NFR-2 — reuse the expression mechanism.** `loopCondition` is evaluated
-  through the existing `ExpressionEngine().Evaluate(ctx, cond, env)` + `bool`
-  assertion path (`gateway.go:236-247`) — no new evaluator.
-- **NFR-3 — breaking-change budget.** Turning the empty `LoopCharacteristics`
-  struct into an interface is a public-API break, permitted pre-1.0 (v0.9.0): the
-  type is an unused stub with zero consumers. Recorded in `CHANGELOG.md` as a
-  breaking note.
-- **NFR-4 — coverage.** Every file this SRD creates/updates finishes at ≥95%
+- **NFR-1 — no new event kinds for the leaf path.** The leaf loop stays a bounded
+  `for` around `executeNode`; no `trackEvent` kind, no loop round-trip.
+- **NFR-2 — reuse the expression mechanism.** `loopCondition` is evaluated through
+  the existing `ExpressionEngine().Evaluate` + `bool` path via a transient frame
+  (`evalLoopCond`), which already runs **off** the loop goroutine — the decorator
+  needs no loop coordination to test the condition.
+- **NFR-3 — the single-writer invariant is preserved (ADR-017 v.1).** The loop
+  remains the sole writer of `ls.scopes`, the data plane, `ls.waiting`, positions,
+  and boundary/handler arming. The decorator only *requests* mutations; those
+  methods stay reachable only from loop-goroutine code. No lock, no shared mutable
+  state.
+- **NFR-4 — deadlock-free by construction.** The decorator blocks only on channels
+  the **loop** writes (the reply channel, `evtCh`), both buffered and both honoring
+  `ctx.Done()` / `inst.loopDone`; the loop never blocks on the decorator (the reply
+  send is to a cap-1 buffer). The wait graph is a DAG (decorator→loop), never a
+  cycle.
+- **NFR-5 — the existing suites are the safety net.** The landed Standard-Loop
+  tests (leaf + composite, unit + thresher e2e + the example smoke) stay **green
+  throughout** the rework; behavior is unchanged, only the composite execution
+  mechanism moves.
+- **NFR-6 — coverage.** Every file this SRD creates/updates finishes at ≥95%
   diff-coverage (aim 100%), delivered with the change; `make ci` green.
 
 ## §3 Models
 
-### §3.1 `pkg/model/activities/loop.go` — the type family
+### §3.1 Model type family (`pkg/model/activities/loop.go`) — landed, unchanged
 
-`LoopCharacteristics` turns from an empty struct into a sealed marker; the
-concrete Standard-Loop type + its constructor live here (one-entity-per-file: the
-MI type arrives in its own file under SRD-055/056):
+`LoopCharacteristics` is a sealed marker interface; `StandardLoopCharacteristics`
+(embedding `foundation.BaseElement`) carries `loopCondition` / `testBefore` /
+`loopMaximum`, built by `NewStandardLoop(loopCondition, opts…)` with the FR-2
+guards and the `WithTestBefore()` / `WithLoopMaximum(n)` options. Accessors
+`LoopCondition()` / `TestBefore()` / `LoopMaximum() (int, bool)` expose them to the
+runtime. `Activity.Validate` carries the loop⊕MI-exclusivity guard (FR-3);
+`subprocess.go`'s event-sub validator carries FR-3a. **No model change in this
+SRD** — the decorator rework is runtime-only.
 
-```go
-// LoopCharacteristics marks an activity as iterating; the concrete kind
-// (Standard Loop or Multi-Instance) selects the mechanism (ADR-025 §2.2).
-type LoopCharacteristics interface {
-    loopKind() loopKind // sealed discriminator — implemented only in this package
-}
+### §3.2 Runtime deltas (`internal/instance/`) — the decorator engine
 
-// StandardLoopCharacteristics is a sequential while/until loop (BPMN §13.3.6).
-type StandardLoopCharacteristics struct {
-    foundation.BaseElement
-    loopCondition data.FormalExpression // continue-while-true test (must be bool)
-    testBefore    bool                  // false = post-tested (do…while), true = pre-tested (while)
-    loopMaximum   *int                  // optional cap; nil = unbounded
-}
+- **`scope_decorator.go` (new) — the protocol types + the runner.**
+  ```go
+  type scopeRequest struct {
+      host  *track
+      node  flow.Node
+      n     int                // the pass ordinal — bound as loopCounter on open
+      reply chan scopeReply
+  }
+  type scopeReply struct {
+      scopePath scope.DataPath // opened child path
+      err       error
+  }
+  ```
+  A single request shape (open) is all Standard Loop needs — the scope close stays
+  on the drain path (§4.3), and there is no separate counter-bind roundtrip: the
+  loop binds `loopCounter = n` when it opens the scope (§4.6). No request-kind enum
+  is needed yet; the sequential/parallel-MI slices add kinds as they need them.
+  `(*track).runCompositeLoop(ctx, step, sl) ([]*flow.SequenceFlow, error)` — the
+  off-loop await-each driver (FR-8): the decorator tracks the pass in its own local
+  `pass` counter (no `host.loopCounter` mutation); for each pass, pre-test if
+  `testBefore` (reuse `evalLoopCond` + `loopMaximum`), `requestScope{n: pass}`
+  (**one** roundtrip — the loop opens the scope and binds `loopCounter = pass`),
+  then `awaitScopeDrained` (park on `evtCh` for `scopeDone`), then post-test; on
+  exit return the composite's outgoing flows once. `requestScope` clones
+  `taskRoundtrip` (send on `inst.scopeReq`, block on the cap-1 reply, select on
+  `ctx`/`loopDone`).
 
-func NewStandardLoop(
-    loopCondition data.FormalExpression, opts ...StandardLoopOption,
-) (*StandardLoopCharacteristics, error) { /* nil + bool-type + loopMaximum>0 guards */ }
-```
+- **`instance.go` — the request channel.** `scopeReq chan scopeRequest` added
+  beside `taskReq`/`jobReq`/`callReq` and initialized in the constructor.
 
-`StandardLoopOption` closures (project option style — the house `WithXxx`
-convention, self-naming, reject bad input): `WithTestBefore()`,
-`WithLoopMaximum(n int)`. Accessors `LoopCondition()`, `TestBefore()`,
-`LoopMaximum() (int, bool)` expose the fields to the runtime.
+- **`loop.go` — the loop-side handler.** A `case req := <-inst.scopeReq:` arm in
+  the loop `select`, dispatching to `handleScopeRequest` (loop goroutine), which
+  `OpenScope`s the child, records the `scopeEntry`, marks the host `waiting`,
+  **binds `loopCounter = req.n` at the host scope** (readable after the child
+  closes, §4.6), `seedScope`s the inner tracks, `armScopeHandlers`, and replies
+  with the opened path. This is the exact single-writer shape of
+  `handleTaskRequest`.
 
-### §3.2 `activity.go` / `activity_options.go` — field + validation deltas
+- **`scope_runtime.go` — the seam removals.** The looped-composite branches driven
+  from the loop are removed: the `firstOpen` short-circuit in `onScopeOpen` and the
+  `afterDrain`/reopen branch in `resumeScopeHost` (which always falls through to
+  `dispatchToParked(scopeDone)` now). `completeScope` still closes the drained scope
+  (the close stays here, FR-8a). A **plain** (non-looped) composite Sub-Process
+  keeps the current `evScopeOpen`→`onScopeOpen`→`resumeScopeHost` path unchanged.
 
-- `activity.loopCharacteristics` (`activity.go:22`) and the `WithLoop` parameter
-  (`activity_options.go:111`) change type `*LoopCharacteristics` →
-  `LoopCharacteristics` (interface). `WithLoop`'s nil guard
-  (`activity_options.go:113-117`) and the by-reference clone (`activity.go:117`)
-  are unchanged.
-- `activityConfig.Validate` / `Activity.Validate` gains the loop+MI-exclusivity
-  guard (FR-3). Field-level guards (nil condition, bool type, positive maximum)
-  live in `NewStandardLoop` (FR-2).
-- **`subprocess.go` — `validateEventSubShape`** (`subprocess.go:164`) gains the
-  FR-3a guard: a `triggeredByEvent` `SubProcess` (already the event-sub entry-shape
-  validator) rejects a non-nil `loopCharacteristics`. This is the natural home —
-  it already enforces the event-sub well-formedness rules (ADR-023 v.2 §2.10).
-
-### §3.3 Runtime deltas (`internal/instance/`)
-
-- **`track.go` — the leaf loop wrapper.** In `run()` around the `executeNode`
-  call (`track.go:756`), a bounded loop drives re-execution when `step.node`
-  carries `StandardLoopCharacteristics` and is not a park-node
-  (`checkNodeType` classes, `track.go:410-457`): pre-test (if `testBefore`),
-  publish `loopCounter` into the execution frame, `executeNode`, increment,
-  `loopMaximum` check, post-test (if not `testBefore`); `checkFlows(nexts)` runs
-  **once** after the loop.
-- **`scope_runtime.go` — the composite re-entry hook.** In `resumeScopeHost` /
-  `completeScope` (`scope_runtime.go:256-313`): if the drained host carries
-  `StandardLoopCharacteristics` and the loop continues, re-queue via
-  `entry.queue` → `onScopeOpen` and commit the next `loopCounter` into the fresh
-  child scope; otherwise deliver `scopeDone` as today.
-- **`loopCounter` datum** — built like a runtime variable
-  (`values.NewVariable(n)` → item definition → parameter `loopCounter`), published
-  **per iteration** into the leaf frame (`frame.Put`) or the composite child scope
-  (`Scope.Commit`); never routed through the instance-global `RuntimeVar` subtree
-  (siblings must not see a stale counter).
+- **`std_loop.go` — relocate, don't duplicate.** The Standard-Loop continuation
+  logic (`evalLoopCond`, `loopMaximum`, `testBefore`) is reused by
+  `runCompositeLoop`; the loop-side `standardLoopIterator.firstOpen`/`afterDrain`
+  callbacks are removed. **Leaf `runStandardLoop` is untouched.**
 
 ## §4 Analysis
 
-### §4.1 The hybrid mechanism realizes ADR-025 §2.2
+### §4.1 The decorator realizes ADR-025 v.2 §2.12
 
-The parent ADR §2.2 prescribes **isolation-by-frame for a leaf, isolation-by-scope
-for a composite**. Grounding confirms both are cheap:
+§2.12 prescribes that composite iteration control runs on the activity's own
+off-loop execution, requesting scope operations from the single-writer loop.
+`runCompositeLoop` runs on the host's runner goroutine (where every node's `Exec`
+already runs); it drives the loop with ordinary control flow (an await-each `for`)
+and touches loop-owned state only through `scopeReq`. This is the locus §2.12
+dictates — the SRD realizes the ADR, it does not deviate.
 
-- `executeNode` already opens a **fresh frame per call** and `defer f.Discard()`s
-  it (`track.go:943-953`), commits on success (`finalizeNodeExecution`,
-  `track.go:978`), and — crucially — **returns `nexts` without following them**
-  (the run loop's `checkFlows` follows them, `track.go:756-763`). So a `for`
-  around `executeNode` re-runs the same node N times, each pass isolated by its
-  own frame, and emits the outgoing flow exactly once. No new machinery (FR-4,
-  FR-7; NFR-1).
-- A composite is *not* run by `executeNode`; it **parks** as a `scopeHost` and
-  its body runs in a child scope drained through `resumeScopeHost`
-  (`scope_runtime.go:287-313`). The loop is a re-queue on that existing seam
-  (FR-8). Forcing a scope onto a leaf Task instead was rejected in ADR-025 §2.2
-  (a Task is not a scope container).
+### §4.2 The protocol clones an existing pattern (FR-8a)
 
-### §4.2 `loopCondition` reuses the existing evaluator (NFR-2)
+The engine already round-trips a runner→loop request and blocks for a
+single-writer reply: `taskReq`/`taskRoundtrip` (UserTask distribution) and
+`callReq`/`callRequest` (Call Activity completion). `scopeReq` is the same shape —
+a request channel serviced in the loop `select`, a per-request cap-1 reply channel,
+the caller selecting on `ctx.Done()`/`loopDone`. No new synchronization primitive
+is invented; the decorator reuses the proven roundtrip.
 
-The boolean test reuses the exact gateway path: `cond.ResultType() != "bool"`
-guard, `re.ExpressionEngine().Evaluate(ctx, cond, re)`, `res.Get(ctx).(bool)`
-(`gateway.go:227-247`). Standard Loop needs no new evaluator — only a
-`data.FormalExpression` field and a call to that same path at each pass/drain,
-against the iteration's frame/scope environment.
+### §4.3 Only `reqOpenScope`; the scope close stays on the drain path
 
-### §4.3 `loopCounter` publication (FR-10)
+A pass opens a scope, the inner graph runs, the scope drains (inner tracks
+`decScope` → `completeScope`), and the host resumes. The **drain and close already
+happen on the loop** in `completeScope`; the decorator learns of the drain via the
+existing `scopeDone` delivery. So the decorator needs no `reqCloseScope` — adding
+one would double-close (the drain path already closed the scope). The only
+mutation the decorator must *initiate* is the **open** (there is no drain-path
+trigger for it), hence a single `reqOpenScope` roundtrip (plus a `reqBindCounter`
+for the loop-owned counter write). This is the minimal correct protocol.
 
-Per-node execution data lives in the **frame** (frame-first resolution via
-`execEnv.Find`); scope-durable data is committed to the plane. For the leaf path
-`loopCounter` is `Put` into the per-iteration execution frame before
-`executeNodeCore`; for the composite path it is `Scope.Commit`ed into the fresh
-child scope at re-open (alongside how the existing scope seeds bind data). It is
-read-only and engine-maintained; publishing it per iteration (not once, globally)
-guarantees each iteration reads its own ordinal.
+### §4.4 Deadlock-freedom (NFR-4)
 
-### §4.4 Boundary events arm once across iterations (FR-9)
+The decorator waits on: (i) the reply channel — written only by the loop, cap-1
+buffered; (ii) `evtCh` for `scopeDone` — written only by the loop via
+`dispatchToParked` (the buffered slot guarantees the loop's send never blocks).
+Both waits select on `ctx.Done()` and `inst.loopDone`, so a terminate/interrupt
+unblocks the decorator. The loop, in `handleScopeRequest`, never blocks on the
+decorator (its reply send is non-blocking into the cap-1 buffer). The wait graph
+is therefore a DAG rooted at the decorator pointing to the loop — no cycle, no
+self-emit-on-the-loop-goroutine (the class of bug §2.12 removes). The loop's own
+`emit` into `inst.events` remains guarded by `<-inst.loopDone`.
 
-For the leaf path the track stays on the same `step.node` for every pass and
-emits no `evMoved` until the loop exits, so `armBoundaries` fires **once**; for
-the composite path the host parks once. Either way a boundary timer/message spans
-the whole loop — the desired BPMN semantics (a per-iteration re-arm would reset a
-timer every pass, which is wrong).
+### §4.5 Boundary arms once across iterations (FR-9)
 
-### §4.5 `testBefore` / `loopMaximum` edge cases
+A boundary arms on `evMoved` onto the composite and disarms on `evEnded`. Because
+the looped host **parks** on `evtCh` for each pass's drain and stays on the same
+step (no `evMoved`/`evEnded` mid-loop), `armBoundaries` fires once on arrival and
+`disarmBoundaries` once when `runCompositeLoop` returns the outgoing flows at loop
+exit — the desired BPMN semantic (a boundary timer spans the whole loop),
+unchanged from the prior landing.
 
-Pre-tested with an initially-false condition → **zero** executions, straight to
-the outgoing flow (FR-5). `loopMaximum` is checked after each pass, bounding even
-an always-true condition (FR-6); `loopMaximum ≤ 0` is rejected at construction
-(a zero/negative cap is a modelling error, not "run zero times" — use a
-pre-tested false condition for that).
+### §4.6 The continuation test runs off the loop; `loopCounter` binds at the host scope (NFR-2)
 
-### §4.6 An Event Sub-Process excludes iteration (FR-3a)
+`evalLoopCond` evaluates `loopCondition` against a transient read-only frame
+(`openFrameAt` + `Discard`); it performs no loop-owned mutation and already runs on
+the runner goroutine. The decorator calls it directly between passes — no protocol
+roundtrip for the test. `loopMaximum` and `testBefore` are plain arithmetic/branch
+on the decorator.
 
-`LoopCharacteristics` is placed on `Activity` in the BPMN object model, so a
-`SubProcess` may syntactically carry it. But an Event Sub-Process is defined by
-the standard as *event-instantiated, not control-flow-reached*
-(`sub-processes.md §13.5.4`), and iteration characteristics govern how a
-**token-activated** activity re-executes — a concept that does not apply to a
-handler fired by its trigger. An event sub-process that needs to run more than
-once uses a **non-interrupting** start (which fires multiple times, §13.5.4), not
-a loop marker. gobpm therefore rejects any `LoopCharacteristics` on a
-`triggeredByEvent` sub-process as a well-formedness rule. The rule is stated as
-an **engine choice**: the extract does not enumerate an explicit prohibition
-(silence is not a mandate), but the event-sub semantics make the marker
-meaningless, so validation surfaces it early rather than letting the runtime
-ignore it. Because the guard tests the shared `LoopCharacteristics` interface, it
-covers Multi-Instance for free when SRD-055/056 land.
+`loopCounter` must be bound at the **host** scope, not (only) the child: a
+post-tested loop evaluates `loopCondition` *after* the pass's child scope has
+drained and closed, so a counter bound only in the child would be gone by the test.
+The loop binds `loopCounter = req.n` at the host scope as part of `reqOpenScope`
+(§3.2) — the enclosing scope the child's inner tracks resolve by walk-up during the
+pass, and which survives the child close for the decorator's continuation test.
+This matches where the prior landing bound it; only the driver moves off the loop.
+
+### §4.7 Scope guard — Standard-Loop composite only
+
+`runCompositeLoop` is entered only for a **looped composite Standard Loop**
+(`standardLoopOf(node) != nil` and the node is a `scopeHost`). A **plain**
+(non-looped) composite keeps `parkScopeHost` → `onScopeOpen` → single resume; the
+**Multi-Instance** seam (`mi.go`, `mi_parallel.go`) is untouched by this SRD and
+re-lands on the decorator in the sequential/parallel slices. This bounds the blast
+radius to the one path the decorator proves.
 
 ## §6 Test scenarios
 
-| Test | Level | Asserts (FR) |
+| Test | Level | Covers |
 |---|---|---|
-| `TestStandardLoopBuildAndAccessors` | model | FR-1 fields/accessors + unset-option defaults |
-| `TestStandardLoopRejectsNilCondition` | model | FR-2 nil `loopCondition` rejected |
-| `TestStandardLoopRejectsNonBoolCondition` | model | FR-2 non-bool `ResultType` rejected |
-| `TestStandardLoopMaximumMustBePositive` | model | FR-2 `loopMaximum ≤ 0` rejected |
-| `TestActivityLoopMarkerIsSingle` | model | FR-3 one marker per activity — a later `WithLoop` replaces |
-| `TestEventSubProcessRejectsLoop` | model | FR-3a event sub-process rejects any loop/MI |
-| `TestStandardLoopRunsWhileConditionHolds` | instance | FR-4/FR-5/FR-10 post-tested runs while `loopCounter < 3` |
-| `TestStandardLoopPreTestedZeroIterations` | instance | FR-5/FR-7 pre-tested zero passes, flow proceeds once |
-| `TestStandardLoopMaximumCaps` | instance | FR-6 cap on an always-true condition |
-| `TestStandardLoopOf` | instance | loop capability detection (looped vs. plain node) |
-| `TestStandardLoopConditionErrorFaults` | instance | pre-tested condition error faults the instance |
-| `TestStandardLoopNonBoolConditionFaults` / `TestEvalLoopCondNonBool` | instance | non-bool runtime result rejected (via fault + direct) |
-| `TestStandardLoopBodyErrorFaults` | instance | a body error propagates out of the loop |
-| `TestEvalLoopCondFrameError` | instance | evalLoopCond frame-open guard |
-| `TestLoopedSubProcessReopensPerIteration` | instance | FR-8 composite re-opens its scope per pass |
-| `TestLoopedSubProcessPreTestedZero` | instance | FR-8 pre-tested composite zero iterations, host resumes |
-| `TestLoopedSubProcessMaximumCaps` | instance | FR-6 composite cap |
-| `TestLoopedSubProcessEmitsIterationFacts` | instance | FR-11 scope facts carry `loopCounter` (0/1/2) |
-| `TestLoopedSubProcessPreTestedConditionError` / `…ConditionErrorFaults` | instance | composite pre/post condition-error faults |
-| `TestStandardLoopLeafE2E` | thresher | FR-4–FR-7/FR-10 leaf loop end-to-end |
-| `TestStandardLoopSubProcessE2E` | thresher | FR-8 looped Sub-Process end-to-end |
+| `TestScopeRequestRoundtripOpens` | instance | FR-8a — `handleScopeRequest(reqOpenScope)` opens the scope, seeds tracks, arms handlers, replies with the path (mirrors the `handleTaskRequest` unit tests) |
+| `TestScopeRequestBindCounter` | instance | FR-8a — `reqBindCounter` binds `loopCounter` at the host path on the loop goroutine |
+| `TestScopeRequestUnblocksOnTerminate` | instance | NFR-4 — a pending roundtrip returns on `ctx`/`loopDone` cancel, no goroutine leak |
+| `TestLoopedSubProcessReopensPerIteration` | instance | FR-8 — the decorator re-opens the child scope N times (existing test, stays green) |
+| `TestLoopedSubProcessPreTestedZero` | instance | FR-5/FR-8 — a pre-tested false condition runs zero passes (existing, green) |
+| `TestLoopedSubProcessMaximumCaps` | instance | FR-6/FR-8 — `loopMaximum` caps composite passes (existing, green) |
+| `TestLoopedSubProcessEmitsIterationFacts` | instance | FR-11 — one iteration Fact per pass (existing, green) |
+| `TestLoopedSubProcessBoundarySpansIterations` | instance | FR-9 — a boundary on a looped composite arms once and fires across ≥2 passes |
+| `TestLoopedSubProcessInterruptMidIteration` | instance | NFR-4 — an interrupting boundary / terminate mid-pass unblocks the decorator and tears the inner scope down |
+| `TestStandardLoopSubProcessE2E` | thresher | FR-8/FR-10 end-to-end through the public engine (existing, green) |
+| `TestStandardLoopLeafE2E` | thresher | FR-4–FR-7 leaf loop unchanged (existing, green) |
+| `examples/standard-loop` smoke | example | FR-12 — runs to completion, exits 0 (existing) |
+
+The leaf-path unit tests (`TestStandardLoopRunsWhileConditionHolds`, …) must be
+**untouched** — the leaf path does not change.
 
 ## §7 Milestones
 
-| M | Scope | Files | Tests |
-|---|---|---|---|
-| **M1** | Model + validation | `activities/loop.go` (interface + `StandardLoopCharacteristics` + `NewStandardLoop` + options), `activity.go:22`, `activity_options.go` (`WithLoop` type, `Validate` exclusivity), `subprocess.go` (`validateEventSubShape` FR-3a guard), `activity_test.go:49` (empty-struct usage → real `StandardLoop`) | the 6 model tests |
-| **M2** | Leaf-Task in-place seam + `loopCounter` (leaf) | `internal/instance/track.go` (loop wrapper in `run()`, frame `Put`) | post/pre-tested, maximum, single-flow, fresh-frame, counter-visibility |
-| **M3** | Composite scope re-entry + `loopCounter` (scope) + observability | `internal/instance/scope_runtime.go` (re-entry hook, `Scope.Commit`), the iteration Fact | looped-subprocess re-open, boundary-armed-once, iteration facts |
-| **M4** | e2e + example + docs | `pkg/thresher/standard_loop_test.go`, `examples/standard-loop/`, guide, CHANGELOG, tracker, READMEs EN+RU | the two e2e tests |
+| # | Scope | Files |
+|---|---|---|
+| **M1** | The request/response scope protocol: `scopeReq` channel, `scopeRequest`/`scopeReply` types, the `scopeReq` `select` arm + `handleScopeRequest` (loop goroutine), unit-tested in isolation like `handleTaskRequest`. No behavior change yet (nothing calls it). | `scope_decorator.go` (new), `instance.go`, `loop.go` |
+| **M2** | `runCompositeLoop` + `requestScope`/`awaitScopeDrained`; wire the `executeStep` interception gated on a looped composite Standard Loop; reuse `evalLoopCond`/`loopMaximum`. The existing composite-loop tests + e2e go green on the decorator. | `scope_decorator.go`, `track.go`, `std_loop.go` |
+| **M3** | Remove the loop-side composite-loop seam (`onScopeOpen` `firstOpen` short-circuit, `resumeScopeHost` `afterDrain`/reopen branch, `standardLoopIterator` callbacks); confirm the whole suite + `examples/standard-loop` green; CHANGELOG note; update ADR-025 cross-refs / conformance tracker. | `scope_runtime.go`, `std_loop.go`, `composite_iter.go`, docs |
 
 ## §8 Cross-doc
 
-- **Implements** ADR-025 v.1 §2.2–§2.3 (upward; the Standard-Loop slice).
-- **Upstream** ADR-010 v.2 (frame isolation), ADR-023 v.2 (composite re-entry),
-  ADR-018 v.1 (boundary arming), ADR-001 v.6 (loop-owned execution) — all
-  up/sideways, version-pinned.
-- No downward references. This SRD is referenced by no higher-hierarchy doc.
+- **Implements** [ADR-025 v.2](../design/ADR-025-activity-iteration-loop-and-multi-instance.md) §2.2–§2.3 (Standard Loop), §2.12 (the off-loop decorator).
+- **Upstream** [ADR-017 v.1](../design/ADR-017-channel-based-event-processing.md) (single-writer loop), [ADR-023 v.2](../design/ADR-023-sub-process-and-call-activity.md) (scope lifecycle), [ADR-018 v.1](../design/ADR-018-boundary-events-and-activity-interruption.md) (boundary arm-once), [ADR-010 v.2](../design/ADR-010-process-data-model.md) (leaf frame), [ADR-001 v.6](../design/ADR-001-execution-model.md).
+- Direction: SRD → ADR only (up), all version-pinned. No downward reference.
 
 ## §9 Definition of Done
 
-- FR-1…FR-12 wired and covered by the §6 tests; the two e2e tests green.
-- `make ci` green (tidy, lint 0, `-race`, diff-coverage ≥95% on touched files
-  per NFR-4, govulncheck clean, all modules).
-- `examples/standard-loop/` runs to completion under a timeout (its built binary
-  gitignored, not staged).
-- ADR-025 flipped Draft → Accepted (the branch lands the conception + this first
-  slice, per the ADR-023/SRD-049 precedent) + its RU twin refreshed.
-- Conformance tracker row 4 (`StandardLoopCharacteristics`) advanced; CHANGELOG
-  `[Unreleased]` entry (with the breaking `LoopCharacteristics` note); README
-  EN+RU capability paragraph; iteration guide.
-- `/check-srd` PASS.
+- FR-1…FR-12 wired; FR-8/FR-8a via `runCompositeLoop` + the `scopeReq` protocol;
+  FR-4–FR-7 leaf path unchanged.
+- §6 tests exist and pass; the landed composite + leaf + e2e suites stay green
+  (NFR-5); `examples/standard-loop` runs and exits 0.
+- The loop-side composite-loop seam is removed (M3); a plain composite and the MI
+  seam are unaffected.
+- Single-writer invariant preserved (NFR-3): no decorator-side mutation of
+  loop-owned state; deadlock-freedom argued (NFR-4) and exercised by the
+  terminate/interrupt tests.
+- `make ci` green (tidy · lint · build · `-race` · diff-coverage ≥95% on touched
+  files · govulncheck); CHANGELOG `[Unreleased]` notes the internal rework.
+- `/check-srd` PASS before flipping status; ADR-025 v.2 stays Draft until the whole
+  re-landing completes (owner: flip after implementation).
 
 ## §10 Implementation summary
 
-### §10.1 Stages by commit (branch `feat/standard-loop`)
+> ⚠️ TODO: fill AFTER landing — stage commits + empirical findings vs this draft.
+
+### §10.1 Stages by commit (branch `feat/loop-mi-decorator-engine`)
 
 | Stage | Commit | Scope | Tests |
 |---|---|---|---|
-| M1 | `18393b0` | Model + validation: `LoopCharacteristics` interface, `StandardLoopCharacteristics`, `NewStandardLoop` + `WithTestBefore`/`WithLoopMaximum`, `activity` field/accessor, FR-3a event-sub guard | 6 model |
-| M2 | `c6bfe62` | Leaf in-place seam: `internal/instance/std_loop.go` (`executeStep`/`runStandardLoop`/`evalLoopCond`, `standardLoopOf`), `bindLoopCounterAt` | 9 instance + 1 thresher e2e |
-| M3 | `ffd78bc` | Composite scope re-entry: `resumeScopeHost` re-open + `onScopeOpen` pre-tested-zero, `track.loopCounter`, `bindLoopCounterOrFail`, `reportScope`+`AttrLoopCounter` | 7 instance |
-| M4 | `b75539f` | e2e, `examples/standard-loop/`, `docs/guides/iteration.md`, CHANGELOG, tracker, READMEs EN+RU | 1 thresher e2e |
 
 ### §10.2 Empirical findings vs the draft
 
-- **Leaf loop factored into its own file.** §3.3 sketched the wrapper inline in
-  `track.go` `run()`; it landed as `internal/instance/std_loop.go`
-  (`executeStep`/`runStandardLoop`) called from `run()` — same behaviour, cleaner
-  separation.
-- **Single test-site.** `runStandardLoop` uses one condition-test position
-  (`TestBefore() || loopCounter > 0`) for both pre- and post-tested loops, rather
-  than the two the §2.3 prose implies — fewer branches, one bind per pass.
-- **`loopCounter` binding.** Published to the enclosing scope via
-  `bindLoopCounterAt` (both condition and inner activity resolve it by walk-up),
-  not a frame `Put`; the composite's two bind sites were consolidated into
-  `bindLoopCounterOrFail`.
-- **Untriggerable defensive wraps.** `bindLoopCounterAt` → `plane.Commit` does
-  **not** fail on a non-existent path (it lazily accepts), so its error wrap is
-  dead-defensive (accepted, the `evalCondition` class). covercheck counts *source
-  lines* per uncovered block, which drove the single-bind + helper consolidation
-  to keep the diff-coverage gate green (95.2% of 229).
-- **Non-bool guard.** `evalLoopCond`'s non-boolean-result branch is unreachable
-  through `goexpr` (it enforces the declared result type at `Evaluate`), so it is
-  covered directly with a mock `FormalExpression`.
-- **FR-9 (boundary arms once)** has no dedicated named test — it rests on the
-  host-parks-once / leaf-stays-on-node structural argument; a dedicated
-  boundary-across-iterations test is a §10.3 follow-up.
-
 ### §10.3 Backlog
-
-- **Multi-Instance** — the rest of ADR-025: SRD-055 (sequential) and SRD-056
-  (parallel + `behavior`/`ComplexBehaviorDefinition`), which will exercise the
-  same scope substrate.
-- A **boundary-arms-once-across-iterations** regression test (FR-9), currently
-  covered only structurally.
 
 ## Open questions
 

--- a/docs/srd/SRD-054-standard-loop.md
+++ b/docs/srd/SRD-054-standard-loop.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Draft |
+| Status | Accepted |
 | Date | 2026-07-21 |
 | Owner | Ruslan Gabitov |
 | Implements | [ADR-025 v.2](../design/ADR-025-activity-iteration-loop-and-multi-instance.md) §2.2–§2.3 (the Standard Loop slice), §2.12 (composite iteration as an off-loop decorator); epic #88 |
@@ -351,16 +351,39 @@ The leaf-path unit tests (`TestStandardLoopRunsWhileConditionHolds`, …) must b
 
 ## §10 Implementation summary
 
-> ⚠️ TODO: fill AFTER landing — stage commits + empirical findings vs this draft.
-
 ### §10.1 Stages by commit (branch `feat/loop-mi-decorator-engine`)
 
 | Stage | Commit | Scope | Tests |
 |---|---|---|---|
+| M1+M2 (folded) | `13d4de4` | the scope protocol (`scopeReq` channel, `scopeRoundtrip`, `handleScopeRequest`) + the runner (`runCompositeLoop`, `awaitScopeDrained`); `checkNodeType` carve-out (a looped SL composite no longer parks); `executeStep` route; `resumeScopeHost` decorator-bypass | `TestLoopedSubProcess*` (integration), `scope_decorator_test.go` (roundtrip 4 paths / handler / runner-err / await-cancel), thresher `TestStandardLoopSubProcessE2E` |
+| M2 (seam removal) | `7d0d804` | remove `standardLoopIterator` + the SL branch of `compositeIteratorOf`; `scopeLoopCounter` recognizes the decorator-driven SL; CHANGELOG | full loop / MI / boundary suites + e2e stay green |
+
+Doc: ADR-025 v.2 `33e7913`, SRD-054 (this doc) `c495579`.
 
 ### §10.2 Empirical findings vs the draft
 
+- **M1/M2 fold.** The draft split M1 (protocol) / M2 (runner); the protocol has
+  **no production caller until the runner**, so an M1-only landing left the
+  `loop.go` `scopeReq` arm at 0 % coverage (measured 80.3 % FAIL). Folded into one
+  milestone; the old M3 (seam removal) became M2.
+- **Off-loop counter bind.** The draft had the loop bind `loopCounter` on
+  `reqOpenScope`; implementation moved it into `runCompositeLoop` (off the loop,
+  like the leaf `runStandardLoop`) because the pre-test eval must read `loopCounter`
+  **before** the open request, and `bindLoopCounterAt` is a plane-mutex-safe data
+  write, not a scope-lifecycle mutation. `scopeRequest.n` was dropped.
+- **`scopeLoopCounter` regression caught in M2.** Removing the SL branch from
+  `compositeIteratorOf` silently dropped `loopCounter` from SL iteration facts
+  (`scopeLoopCounter` gated on `compositeIteratorOf`); `TestLoopedSubProcessEmitsIterationFacts`
+  caught it, fixed to also recognize `standardLoopOf`.
+
 ### §10.3 Backlog
+
+- One defensive line uncovered (`runCompositeLoop`'s `awaitScopeDrained`-error
+  return — the mid-loop interrupt/terminate path); hard to trigger deterministically
+  without a racy interrupt, accepted at 98.4 % diff-coverage (the `awaitScopeDrained`
+  cancel/close branches themselves are covered white-box).
+- Sequential Multi-Instance still rides the `compositeIterator`/`afterDrain` seam;
+  it re-lands on the decorator in the next slice (SRD-055).
 
 ## Open questions
 

--- a/docs/srd/SRD-054-standard-loop.md
+++ b/docs/srd/SRD-054-standard-loop.md
@@ -157,27 +157,27 @@ SRD** — the decorator rework is runtime-only.
   type scopeRequest struct {
       host  *track
       node  flow.Node
-      n     int                // the pass ordinal — bound as loopCounter on open
       reply chan scopeReply
   }
   type scopeReply struct {
-      scopePath scope.DataPath // opened child path
       err       error
+      scopePath scope.DataPath // opened child path
   }
   ```
   A single request shape (open) is all Standard Loop needs — the scope close stays
-  on the drain path (§4.3), and there is no separate counter-bind roundtrip: the
-  loop binds `loopCounter = n` when it opens the scope (§4.6). No request-kind enum
-  is needed yet; the sequential/parallel-MI slices add kinds as they need them.
+  on the drain path (§4.3), and there is no counter-bind roundtrip: the decorator
+  binds `loopCounter` itself off the loop (§4.6). No request-kind enum is needed
+  yet; the sequential/parallel-MI slices add kinds as they need them.
   `(*track).runCompositeLoop(ctx, step, sl) ([]*flow.SequenceFlow, error)` — the
-  off-loop await-each driver (FR-8): the decorator tracks the pass in its own local
-  `pass` counter (no `host.loopCounter` mutation); for each pass, pre-test if
-  `testBefore` (reuse `evalLoopCond` + `loopMaximum`), `requestScope{n: pass}`
-  (**one** roundtrip — the loop opens the scope and binds `loopCounter = pass`),
-  then `awaitScopeDrained` (park on `evtCh` for `scopeDone`), then post-test; on
-  exit return the composite's outgoing flows once. `requestScope` clones
-  `taskRoundtrip` (send on `inst.scopeReq`, block on the cap-1 reply, select on
-  `ctx`/`loopDone`).
+  off-loop await-each driver (FR-8): for each pass it sets `t.loopCounter = pass`
+  and `bindLoopCounterAt(t.scopePath, pass)` (off the loop, like the leaf), pre-
+  tests if `testBefore` (reuse `evalLoopCond`), `requestScope{}` (**one**
+  open-roundtrip), `awaitScopeDrained` (park on `evtCh` for `scopeDone`), then the
+  `loopMaximum` cap; on exit it calls `executeNode` once so the composite selects
+  its single outgoing flow (`SubProcess.Exec` → `selectOutgoing`). `requestScope`
+  clones `taskRoundtrip` (send on `inst.scopeReq`, block on the cap-1 reply, select
+  on `ctx`/`loopDone`); `awaitScopeDrained` mirrors `run()`'s `evtCh` park (honors
+  `ctx`/channel-close for interrupt/terminate).
 
 - **`instance.go` — the request channel.** `scopeReq chan scopeRequest` added
   beside `taskReq`/`jobReq`/`callReq` and initialized in the constructor.
@@ -185,22 +185,31 @@ SRD** — the decorator rework is runtime-only.
 - **`loop.go` — the loop-side handler.** A `case req := <-inst.scopeReq:` arm in
   the loop `select`, dispatching to `handleScopeRequest` (loop goroutine), which
   `OpenScope`s the child, records the `scopeEntry`, marks the host `waiting`,
-  **binds `loopCounter = req.n` at the host scope** (readable after the child
-  closes, §4.6), `seedScope`s the inner tracks, `armScopeHandlers`, and replies
-  with the opened path. This is the exact single-writer shape of
-  `handleTaskRequest`.
+  `seedScope`s the inner tracks, `armScopeHandlers`, and replies with the opened
+  path — the exact single-writer shape of `handleTaskRequest`. (The counter is
+  already bound by the decorator, §4.6.)
 
-- **`scope_runtime.go` — the seam removals.** The looped-composite branches driven
-  from the loop are removed: the `firstOpen` short-circuit in `onScopeOpen` and the
-  `afterDrain`/reopen branch in `resumeScopeHost` (which always falls through to
-  `dispatchToParked(scopeDone)` now). `completeScope` still closes the drained scope
-  (the close stays here, FR-8a). A **plain** (non-looped) composite Sub-Process
-  keeps the current `evScopeOpen`→`onScopeOpen`→`resumeScopeHost` path unchanged.
+- **`track.go` — the interception (checkNodeType).** A `scopeHost` node that also
+  carries `standardLoopOf(node) != nil` **does not park** (`return nil`) — it
+  drives itself via `runCompositeLoop`. Every other composite (plain, Multi-
+  Instance) still `parkScopeHost`s for the loop-driven scope. Leaf loops and
+  non-composites are untouched.
 
-- **`std_loop.go` — relocate, don't duplicate.** The Standard-Loop continuation
+- **`std_loop.go` — the executeStep route.** `executeStep` routes a
+  `standardLoopOf(node) != nil` node that is a `scopeHost` to `runCompositeLoop`
+  and a leaf to `runStandardLoop` (unchanged). The Standard-Loop continuation
   logic (`evalLoopCond`, `loopMaximum`, `testBefore`) is reused by
-  `runCompositeLoop`; the loop-side `standardLoopIterator.firstOpen`/`afterDrain`
-  callbacks are removed. **Leaf `runStandardLoop` is untouched.**
+  `runCompositeLoop`. **Leaf `runStandardLoop` is untouched.**
+
+- **`scope_runtime.go` — the drain delivers to the decorator.** `resumeScopeHost`
+  gains a top guard: for a `standardLoopOf(entry.node) != nil` composite it just
+  `dispatchToParked(scopeDone)` (no `afterDrain` — the decorator drives re-entry),
+  before the Multi-Instance `compositeIterator`/`afterDrain` seam. `completeScope`
+  still closes the drained scope (FR-8a). The old-seam removal (the `onScopeOpen`
+  `firstOpen` short-circuit, the `standardLoopIterator` callbacks — now dead for a
+  Standard-Loop composite) is **M2** (kept live here only for sequential MI until
+  it re-lands). A **plain** (non-looped) composite keeps the current
+  `evScopeOpen`→`onScopeOpen`→`resumeScopeHost` path unchanged.
 
 ## §4 Analysis
 
@@ -265,10 +274,16 @@ on the decorator.
 `loopCounter` must be bound at the **host** scope, not (only) the child: a
 post-tested loop evaluates `loopCondition` *after* the pass's child scope has
 drained and closed, so a counter bound only in the child would be gone by the test.
-The loop binds `loopCounter = req.n` at the host scope as part of `reqOpenScope`
-(§3.2) — the enclosing scope the child's inner tracks resolve by walk-up during the
-pass, and which survives the child close for the decorator's continuation test.
-This matches where the prior landing bound it; only the driver moves off the loop.
+The **decorator binds it itself, off the loop** — `runCompositeLoop` calls
+`bindLoopCounterAt(host.scopePath, pass)` at the top of each pass, exactly as the
+leaf `runStandardLoop` does. This is a data-plane write (mutex-protected), not a
+scope-lifecycle mutation, so it is safe off the loop; and it *must* be off the loop
+because the continuation test reads `loopCounter` **before** the scope-open request
+(the bind→test→open order, matching `runStandardLoop`). Only the scope-lifecycle
+operations (open / seed / arm) go through the `reqOpenScope` roundtrip; the counter
+bind does not. This is where the design refined during implementation from "the
+loop binds on open" to "the decorator binds off-loop," keeping the leaf and
+composite loops symmetric.
 
 ### §4.7 Scope guard — Standard-Loop composite only
 
@@ -303,9 +318,14 @@ The leaf-path unit tests (`TestStandardLoopRunsWhileConditionHolds`, …) must b
 
 | # | Scope | Files |
 |---|---|---|
-| **M1** | The request/response scope protocol: `scopeReq` channel, `scopeRequest`/`scopeReply` types, the `scopeReq` `select` arm + `handleScopeRequest` (loop goroutine), unit-tested in isolation like `handleTaskRequest`. No behavior change yet (nothing calls it). | `scope_decorator.go` (new), `instance.go`, `loop.go` |
-| **M2** | `runCompositeLoop` + `requestScope`/`awaitScopeDrained`; wire the `executeStep` interception gated on a looped composite Standard Loop; reuse `evalLoopCond`/`loopMaximum`. The existing composite-loop tests + e2e go green on the decorator. | `scope_decorator.go`, `track.go`, `std_loop.go` |
-| **M3** | Remove the loop-side composite-loop seam (`onScopeOpen` `firstOpen` short-circuit, `resumeScopeHost` `afterDrain`/reopen branch, `standardLoopIterator` callbacks); confirm the whole suite + `examples/standard-loop` green; CHANGELOG note; update ADR-025 cross-refs / conformance tracker. | `scope_runtime.go`, `std_loop.go`, `composite_iter.go`, docs |
+| **M1** | The **protocol + the decorator runner, together** (folded — the protocol has no production caller until the runner, so landing it alone leaves the loop-side `scopeReq` arm uncoverable): the `scopeReq` channel, `scopeRequest`/`scopeReply` types, the `scopeReq` `select` arm + `handleScopeRequest` (loop goroutine); **plus** `runCompositeLoop` + `requestScope`/`awaitScopeDrained` on `track`, wiring the interception gated on a looped composite Standard Loop (reusing `evalLoopCond`/`loopMaximum`). The existing composite-loop tests + e2e go green on the decorator end-to-end, which exercises the whole protocol. | `scope_decorator.go` (new), `instance.go`, `loop.go`, `track.go`, `std_loop.go` |
+| **M2** | Remove the loop-side composite-loop seam (`onScopeOpen` `firstOpen` short-circuit, `resumeScopeHost` `afterDrain`/reopen branch, `standardLoopIterator` callbacks); confirm the whole suite + `examples/standard-loop` green; CHANGELOG note; update ADR-025 cross-refs / conformance tracker. | `scope_runtime.go`, `std_loop.go`, `composite_iter.go`, docs |
+
+> **Milestone fold note:** the original M1 (protocol only) / M2 (runner) split was
+> merged because the protocol plumbing has no production caller until the runner,
+> so an M1-only landing leaves the loop-side `scopeReq` arm at 0% coverage. Landing
+> them together lets the existing `TestLoopedSubProcess*` suite exercise the whole
+> protocol end-to-end. The old-seam removal (now M2) stays separate.
 
 ## §8 Cross-doc
 

--- a/internal/instance/composite_iter.go
+++ b/internal/instance/composite_iter.go
@@ -7,11 +7,13 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 )
 
-// compositeIterator drives a looped composite activity (a Sub-Process host) that
-// re-opens its child scope for each pass (ADR-025 §2.2). Standard Loop and
-// Multi-Instance are the two strategies over this one re-entry mechanism; the
-// re-entry seam (onScopeOpen / resumeScopeHost) calls the interface instead of
-// branching on the concrete iteration kind.
+// compositeIterator drives a loop-goroutine-driven composite activity (a
+// Sub-Process host) that re-opens its child scope for each pass (ADR-025 §2.2).
+// Since ADR-025 v.2 §2.12 only sequential Multi-Instance rides this seam —
+// Standard Loop drives itself off the loop through the iteration decorator
+// (runCompositeLoop), so it no longer needs the loop-side firstOpen/afterDrain
+// callbacks. The re-entry seam (onScopeOpen / resumeScopeHost) calls the interface
+// instead of branching on the concrete iteration kind.
 type compositeIterator interface {
 	// firstOpen prepares the first pass and reports whether the body scope
 	// opens at all. open=false means zero iterations — the host resumes without
@@ -20,8 +22,7 @@ type compositeIterator interface {
 
 	// beforeClose runs just before the drained child scope closes — the last
 	// point its data is readable. A Multi-Instance captures the per-instance
-	// output here; a Standard Loop does nothing. A non-nil error aborts the
-	// instance.
+	// output here. A non-nil error aborts the instance.
 	beforeClose(ctx context.Context, host *track, childPath scope.DataPath) error
 
 	// afterDrain runs when the child scope drains; reopen=true re-opens it for
@@ -30,20 +31,13 @@ type compositeIterator interface {
 	afterDrain(ctx context.Context, ls *loopState, host *track, node flow.Node) (reopen bool, err error)
 }
 
-// compositeIteratorOf returns the iteration strategy a composite host runs
-// under — Standard Loop or Multi-Instance — or nil when the host runs once. The
-// two markers are mutually exclusive by construction (§13.3.6 vs §13.3.7), so
-// the order of the checks is immaterial.
+// compositeIteratorOf returns the iteration strategy a loop-driven composite host
+// runs under, or nil when the host runs once or drives itself. Only a SEQUENTIAL
+// Multi-Instance rides the serial seam: a Standard Loop is decorator-driven
+// (§2.12) and a parallel MI has its own control flow (open N scopes, complete on
+// the last — SRD-056.A), so both return nil here, keeping every serial-seam site
+// (onScopeOpen / resumeScopeHost / scopeLoopCounter) clear of them.
 func compositeIteratorOf(node flow.Node) compositeIterator {
-	if sl := standardLoopOf(node); sl != nil {
-		return standardLoopIterator{sl: sl}
-	}
-
-	// only a SEQUENTIAL Multi-Instance rides the serial seam. A parallel MI has a
-	// different control flow (open N scopes, complete on the last) driven off this
-	// path entirely (SRD-056.A), so it returns nil here — keeping every
-	// serial-seam site (onScopeOpen / resumeScopeHost / scopeLoopCounter) clear of
-	// it.
 	if mi := multiInstanceOf(node); mi != nil && mi.IsSequential() {
 		return miIterator{mi: mi}
 	}

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -43,6 +43,7 @@ type Instance struct {
 	taskReq             chan taskRequest
 	jobReq              chan jobRequest
 	callReq             chan callRequest
+	scopeReq            chan scopeRequest
 	invoker             exec.ProcessInvoker
 	sc                  instanceScope
 	corr                correlator
@@ -217,6 +218,7 @@ func New(
 		taskReq:             make(chan taskRequest),
 		jobReq:              make(chan jobRequest),
 		callReq:             make(chan callRequest),
+		scopeReq:            make(chan scopeRequest),
 		invoker:             cfg.invoker,
 		loopDone:            make(chan struct{}),
 		parentEventProducer: ep,

--- a/internal/instance/loop.go
+++ b/internal/instance/loop.go
@@ -183,6 +183,12 @@ func (inst *Instance) loop(ctx context.Context, initial []*track) {
 			// Serviced on the loop goroutine so the output binding and the resume
 			// stay single-writer, mirroring jobReq (SRD-050 FR-7).
 			ls.handleCallCompletion(req)
+
+		case req := <-inst.scopeReq:
+			// A looped composite's off-loop iteration decorator asking to open the
+			// child scope for a pass; serviced on the loop goroutine so OpenScope /
+			// seed / arm stay single-writer, mirroring taskReq (SRD-054 FR-8a).
+			ls.handleScopeRequest(ctx, req)
 		}
 	}
 

--- a/internal/instance/mi_test.go
+++ b/internal/instance/mi_test.go
@@ -593,9 +593,10 @@ func TestMIResolveActivationFrameError(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestCompositeIteratorDispatch: compositeIteratorOf resolves the iteration
-// strategy by marker — Standard Loop, Multi-Instance, none (a non-looped
-// activity), or none (a node that carries no loop characteristics at all).
+// TestCompositeIteratorDispatch: compositeIteratorOf resolves the loop-driven
+// iteration strategy by marker — sequential Multi-Instance rides the seam;
+// Standard Loop is decorator-driven (§2.12) so it returns nil, as do a non-looped
+// activity and a node that carries no loop characteristics at all.
 func TestCompositeIteratorDispatch(t *testing.T) {
 	sl, err := activities.NewStandardLoop(loopCondLt(t, 1))
 	require.NoError(t, err)
@@ -615,7 +616,8 @@ func TestCompositeIteratorDispatch(t *testing.T) {
 	evNode, err := events.NewStartEvent("ev")
 	require.NoError(t, err)
 
-	require.IsType(t, standardLoopIterator{}, compositeIteratorOf(slNode))
+	require.Nil(t, compositeIteratorOf(slNode),
+		"a Standard Loop is decorator-driven, not on the serial seam")
 	require.IsType(t, miIterator{}, compositeIteratorOf(miNode))
 	require.Nil(t, compositeIteratorOf(plainNode))
 	require.Nil(t, compositeIteratorOf(evNode))

--- a/internal/instance/scope_decorator.go
+++ b/internal/instance/scope_decorator.go
@@ -1,0 +1,194 @@
+package instance
+
+import (
+	"context"
+
+	"github.com/dr-dobermann/gobpm/internal/scope"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
+)
+
+// scopeRequest is a looped composite's off-loop iteration decorator asking the
+// single-writer loop to open the child scope for one pass (SRD-054 §2.12 / FR-8a):
+// host is the composite host track, node is the composite node, and reply carries
+// the loop's verdict (the opened path) back to the decorator's runner goroutine.
+// The pass ordinal is bound as loopCounter by the decorator itself, off the loop
+// (§4.6) — a plane write, mutex-safe like the leaf loop's bind — so it is set
+// before the continuation test reads it and before the scope opens.
+type scopeRequest struct {
+	host  *track
+	node  flow.Node
+	reply chan scopeReply
+}
+
+// scopeReply is the loop's answer to a scopeRequest: the opened child path, or an
+// error the decorator faults on.
+type scopeReply struct {
+	err       error
+	scopePath scope.DataPath
+}
+
+// scopeRoundtrip hands req to the loop and blocks for the reply, honoring ctx and
+// instance shutdown — the runner-goroutine side of the scope protocol, cloned from
+// taskRoundtrip. The decorator never touches loop-owned state directly; it waits
+// only on channels the loop writes (scopeReq accept, then reply), so the wait graph
+// is a DAG (decorator → loop), never a cycle (SRD-054 NFR-3/NFR-4).
+func (inst *Instance) scopeRoundtrip(
+	ctx context.Context,
+	req scopeRequest,
+) (scope.DataPath, error) {
+	req.reply = make(chan scopeReply, 1)
+
+	select {
+	case inst.scopeReq <- req:
+	case <-inst.loopDone:
+		return "", errs.New(
+			errs.M("instance %q is not running", inst.ID()),
+			errs.C(errorClass, errs.InvalidState))
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+
+	select {
+	case r := <-req.reply:
+		return r.scopePath, r.err
+	case <-inst.loopDone:
+		return "", errs.New(
+			errs.M("instance %q stopped before scope reply", inst.ID()),
+			errs.C(errorClass, errs.InvalidState))
+	case <-ctx.Done():
+		return "", ctx.Err()
+	}
+}
+
+// handleScopeRequest opens one pass's child scope on the loop goroutine and replies
+// to the decorator (SRD-054 FR-8a). It is the loop-side half of the scope protocol,
+// mirroring handleTaskRequest: it performs the single-writer mutations the off-loop
+// decorator must not do — open the data-plane child scope, register the entry, mark
+// the host parked-for-drain, seed the inner tracks, and arm the scope handlers. The
+// pass ordinal is already bound as loopCounter by the decorator (off the loop, §4.6)
+// before this request, so the seeded body reads it by walk-up. Scope close stays on
+// the existing drain path (completeScope), so no close request is needed here (§4.3).
+func (ls *loopState) handleScopeRequest(ctx context.Context, req scopeRequest) {
+	sh, ok := req.node.(scopeHost)
+	if !ok {
+		// checkNodeType only routes scopeHost nodes to the decorator; a mismatch
+		// is a corrupt graph.
+		req.reply <- scopeReply{err: errs.New(
+			errs.M("scope open requested for a non-composite node %q",
+				req.node.ID()),
+			errs.C(errorClass, errs.TypeCastingError))}
+
+		return
+	}
+
+	child, err := req.host.scopePath.Append(scopeSegment(req.node))
+	if err != nil {
+		req.reply <- scopeReply{err: err}
+
+		return
+	}
+
+	if err := ls.inst.sc.plane.OpenScope(child); err != nil {
+		req.reply <- scopeReply{err: errs.New(
+			errs.M("couldn't open scope %q for composite %q",
+				string(child), req.node.ID()),
+			errs.C(errorClass, errs.OperationFailed),
+			errs.E(err))}
+
+		return
+	}
+
+	// the host parked on its evtCh for this pass's drain — record it
+	// parked-and-undelivered so the drain's synthetic completion can dispatch to
+	// it (the onScopeOpen discipline).
+	ls.waiting[req.host.ID()] = struct{}{}
+	ls.scopes[child] = &scopeEntry{
+		host:   req.host,
+		node:   req.node,
+		parent: req.host.scopePath,
+	}
+
+	ls.reportScope(observability.PhaseOpened, req.node, child,
+		scopeLoopCounter(req.node, req.host))
+	ls.seedScope(ctx, sh, child)
+	ls.armScopeHandlers(ctx, sh.Nodes(), child)
+
+	req.reply <- scopeReply{scopePath: child}
+}
+
+// runCompositeLoop drives a looped composite Standard Loop from the host's own
+// runner goroutine — the off-loop iteration decorator (SRD-054 FR-8, ADR-025 v.2
+// §2.12). Each pass it binds the ordinal (off the loop, like the leaf loop), tests
+// the continuation, requests the loop to open the child scope, and parks for the
+// drain; on exit it selects the composite's single outgoing flow once. This
+// replaces the loop-goroutine-driven firstOpen/afterDrain seam for a Standard-Loop
+// composite; the loop stays the sole writer of the scope (it only responds to the
+// open request and delivers the drain).
+func (t *track) runCompositeLoop(
+	ctx context.Context, step *stepInfo, sl standardLoop,
+) ([]*flow.SequenceFlow, error) {
+	for pass := 0; ; pass++ {
+		// publish the 0-based ordinal (track field + host-scope datum) so the
+		// condition and the body resolve it by name via walk-up, and it survives
+		// the child close for the next pass's test (§4.6). Off the loop — a
+		// plane write, mutex-safe, mirroring runStandardLoop's leaf bind.
+		t.loopCounter = pass
+		if err := t.instance.sc.bindLoopCounterAt(t.scopePath, pass); err != nil {
+			return nil, err
+		}
+
+		// pre-tested (while) tests every pass; post-tested (do-while) skips the
+		// first — one test site, matching runStandardLoop.
+		if sl.TestBefore() || pass > 0 {
+			cont, err := t.evalLoopCond(ctx, step.node, sl)
+			if err != nil {
+				return nil, err
+			}
+
+			if !cont {
+				break
+			}
+		}
+
+		// ask the loop to open the child scope for this pass and block for the
+		// acknowledgement (single-writer), then park for the scope's drain — the
+		// loop delivers scopeDone on evtCh, as for any composite host.
+		if _, err := t.instance.scopeRoundtrip(ctx,
+			scopeRequest{host: t, node: step.node}); err != nil {
+			return nil, err
+		}
+
+		if err := t.awaitScopeDrained(ctx); err != nil {
+			return nil, err
+		}
+
+		if m, ok := sl.LoopMaximum(); ok && pass+1 >= m {
+			break
+		}
+	}
+
+	// the loop finished — follow the composite's outgoing once (SubProcess.Exec
+	// selects it; the body already ran through the scope, so this only routes the
+	// token onward), mirroring runStandardLoop's single post-loop exit.
+	return t.executeNode(ctx, step)
+}
+
+// awaitScopeDrained parks the decorator's runner on evtCh for the pass's scope
+// drain — the loop delivers a scopeDone the same way it resumes any parked
+// composite host (dispatchToParked). It honors ctx cancellation and the loop
+// closing evtCh on stop, so a mid-pass interrupt/terminate unblocks the decorator
+// (SRD-054 NFR-4).
+func (t *track) awaitScopeDrained(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case _, ok := <-t.evtCh:
+		if !ok {
+			return context.Canceled
+		}
+
+		return nil
+	}
+}

--- a/internal/instance/scope_decorator_test.go
+++ b/internal/instance/scope_decorator_test.go
@@ -1,0 +1,220 @@
+package instance
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dr-dobermann/gobpm/internal/scope"
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+)
+
+// decoratorFixture builds a looped-composite instance and returns it with a fresh
+// loop state, the composite body node, and a host track positioned on it — the
+// white-box pieces the scope-protocol tests drive directly (the loop is NOT
+// running, so state is inspected on the test goroutine).
+func decoratorFixture(t *testing.T) (*Instance, *loopState, flow.Node, *track) {
+	t.Helper()
+
+	var count atomic.Int32
+
+	sl, err := activities.NewStandardLoop(loopCondLt(t, 3))
+	require.NoError(t, err)
+
+	inst := loopedSubProcessInstance(t, &count, sl)
+	inst.tracks = map[string]*track{}
+	ls := newLoopState(inst)
+	node := findNode(t, inst.s, "body")
+
+	host, err := newTrack(node, inst, nil)
+	require.NoError(t, err)
+
+	return inst, ls, node, host
+}
+
+// TestScopeRoundtripDelivers: scopeRoundtrip sends the request into the loop and
+// returns the reply's path (the happy path — a stand-in loop reads scopeReq and
+// answers).
+func TestScopeRoundtripDelivers(t *testing.T) {
+	inst, _, node, host := decoratorFixture(t)
+
+	want := scope.DataPath("/std-loop-sp/sp-body")
+	go func() {
+		req := <-inst.scopeReq
+		req.reply <- scopeReply{scopePath: want}
+	}()
+
+	got, err := inst.scopeRoundtrip(t.Context(),
+		scopeRequest{host: host, node: node})
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+}
+
+// TestScopeRoundtripSendUnblocks: while the request is still being handed to the
+// loop, a shutdown or a cancelled context unblocks the decorator (NFR-4) — no
+// hang if the loop is gone.
+func TestScopeRoundtripSendUnblocks(t *testing.T) {
+	t.Run("instance stopped", func(t *testing.T) {
+		inst, _, node, host := decoratorFixture(t)
+		close(inst.loopDone) // no reader on scopeReq → the send loses to loopDone
+
+		_, err := inst.scopeRoundtrip(t.Context(),
+			scopeRequest{host: host, node: node})
+		require.Error(t, err)
+	})
+
+	t.Run("context cancelled", func(t *testing.T) {
+		inst, _, node, host := decoratorFixture(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := inst.scopeRoundtrip(ctx, scopeRequest{host: host, node: node})
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// TestScopeRoundtripReplyUnblocks: after the loop accepts the request but before it
+// replies, a shutdown or a cancelled context unblocks the decorator (NFR-4).
+func TestScopeRoundtripReplyUnblocks(t *testing.T) {
+	t.Run("instance stopped", func(t *testing.T) {
+		inst, _, node, host := decoratorFixture(t)
+		go func() { <-inst.scopeReq; close(inst.loopDone) }() // accept, never reply
+
+		_, err := inst.scopeRoundtrip(t.Context(),
+			scopeRequest{host: host, node: node})
+		require.Error(t, err)
+	})
+
+	t.Run("context cancelled", func(t *testing.T) {
+		inst, _, node, host := decoratorFixture(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		go func() { <-inst.scopeReq; cancel() }() // accept, never reply
+
+		_, err := inst.scopeRoundtrip(ctx, scopeRequest{host: host, node: node})
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}
+
+// TestHandleScopeRequestOpens: the loop-side handler opens the child scope, records
+// the entry, parks the host for drain, and replies with the opened path (FR-8a).
+// The pass ordinal is bound by the decorator off the loop (runCompositeLoop), not
+// here. loopDone is closed first so the seeded inner tracks exit on emit rather
+// than blocking (no running loop reads inst.events).
+func TestHandleScopeRequestOpens(t *testing.T) {
+	inst, ls, node, host := decoratorFixture(t)
+	close(inst.loopDone)
+
+	reply := make(chan scopeReply, 1)
+	ls.handleScopeRequest(t.Context(),
+		scopeRequest{host: host, node: node, reply: reply})
+
+	r := <-reply
+	require.NoError(t, r.err)
+
+	child, err := host.scopePath.Append(scopeSegment(node))
+	require.NoError(t, err)
+	require.Equal(t, child, r.scopePath)
+	require.Contains(t, ls.scopes, child, "the entry is registered")
+	require.Contains(t, ls.waiting, host.ID(), "the host is parked for drain")
+}
+
+// TestRunCompositeLoopBindError: a loopCounter bind failure at an unopened host
+// scope faults out of the decorator's first pass (defensive, §4.6).
+func TestRunCompositeLoopBindError(t *testing.T) {
+	_, _, node, host := decoratorFixture(t)
+	host.scopePath = scope.DataPath("/nope") // unopened → the bind Commit fails
+
+	_, err := host.runCompositeLoop(
+		t.Context(), &stepInfo{node: node}, standardLoopOf(node))
+	require.Error(t, err)
+}
+
+// TestRunCompositeLoopRequestError: a scope-open request on a stopped instance
+// faults out (the roundtrip's loopDone path). The default post-tested loop skips
+// the pass-0 condition test, so the first thing that fails is the open request.
+func TestRunCompositeLoopRequestError(t *testing.T) {
+	inst, _, node, host := decoratorFixture(t)
+	close(inst.loopDone) // scopeRoundtrip returns the not-running error
+
+	_, err := host.runCompositeLoop(
+		t.Context(), &stepInfo{node: node}, standardLoopOf(node))
+	require.Error(t, err)
+}
+
+// TestAwaitScopeDrainedUnblocks: the decorator's per-pass drain wait unblocks on a
+// cancelled context and on the loop closing evtCh (a mid-pass interrupt / terminate),
+// so runCompositeLoop returns instead of hanging (NFR-4).
+func TestAwaitScopeDrainedUnblocks(t *testing.T) {
+	t.Run("context cancelled", func(t *testing.T) {
+		_, _, _, host := decoratorFixture(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		require.ErrorIs(t, host.awaitScopeDrained(ctx), context.Canceled)
+	})
+
+	t.Run("evtCh closed on stop", func(t *testing.T) {
+		_, _, _, host := decoratorFixture(t)
+		close(host.evtCh) // the loop closes evtCh on stop
+
+		require.Error(t, host.awaitScopeDrained(context.Background()))
+	})
+}
+
+// TestHandleScopeRequestNonComposite: a scope-open for a node that is not a
+// composite is a corrupt-graph error surfaced to the decorator.
+func TestHandleScopeRequestNonComposite(t *testing.T) {
+	inst, ls, _, host := decoratorFixture(t)
+	leaf := findNode(t, inst.s, "start") // a StartEvent is not a scopeHost
+
+	reply := make(chan scopeReply, 1)
+	ls.handleScopeRequest(t.Context(),
+		scopeRequest{host: host, node: leaf, reply: reply})
+
+	require.Error(t, (<-reply).err)
+}
+
+// TestHandleScopeRequestOpenScopeError: a data-plane open failure (the child path
+// already open) is surfaced to the decorator, before any seed or arm.
+func TestHandleScopeRequestOpenScopeError(t *testing.T) {
+	inst, ls, node, host := decoratorFixture(t)
+
+	child, err := host.scopePath.Append(scopeSegment(node))
+	require.NoError(t, err)
+	require.NoError(t, inst.sc.plane.OpenScope(child)) // pre-open → duplicate fails
+
+	reply := make(chan scopeReply, 1)
+	ls.handleScopeRequest(t.Context(),
+		scopeRequest{host: host, node: node, reply: reply})
+
+	require.Error(t, (<-reply).err)
+}
+
+// TestHandleScopeRequestAppendError: a host whose scope path is malformed fails at
+// the child-path derivation, surfaced to the decorator before any mutation.
+func TestHandleScopeRequestAppendError(t *testing.T) {
+	_, ls, node, host := decoratorFixture(t)
+	host.scopePath = scope.DataPath("no-leading-slash") // Validate rejects → Append fails
+
+	reply := make(chan scopeReply, 1)
+	ls.handleScopeRequest(t.Context(),
+		scopeRequest{host: host, node: node, reply: reply})
+
+	require.Error(t, (<-reply).err)
+}
+
+// TestHandleScopeRequestBindCounterError: binding loopCounter at a host scope that
+// is not open fails (the bind precedes OpenScope), surfaced to the decorator.
+func TestHandleScopeRequestBindCounterError(t *testing.T) {
+	_, ls, node, host := decoratorFixture(t)
+	host.scopePath = scope.DataPath("/does/not/exist") // well-formed but not open
+
+	reply := make(chan scopeReply, 1)
+	ls.handleScopeRequest(t.Context(),
+		scopeRequest{host: host, node: node, reply: reply})
+
+	require.Error(t, (<-reply).err)
+}

--- a/internal/instance/scope_runtime.go
+++ b/internal/instance/scope_runtime.go
@@ -377,12 +377,26 @@ func (ls *loopState) resumeScopeHost(
 	path scope.DataPath,
 	entry *scopeEntry,
 ) {
-	// SRD-054 / SRD-055: a looped composite re-opens its child scope for another
+	// SRD-054 §2.12: a looped Standard-Loop composite drives its own re-entry off
+	// the loop (the decorator). The loop does not decide reopen here — it just
+	// delivers the drain to the parked decorator (runCompositeLoop), which tests
+	// the condition and requests the next pass. Only the other composites
+	// (Multi-Instance) still use the loop-driven afterDrain seam below.
+	if standardLoopOf(entry.node) != nil {
+		ls.dispatchToParked(ctx, trackEvent{
+			kind:  evDeliver,
+			track: entry.host,
+			eDef:  newScopeDone(),
+		})
+
+		return
+	}
+
+	// SRD-055: a sequential Multi-Instance re-opens its child scope for another
 	// pass through the compositeIterator seam — the sequential re-entry the leaf
 	// loop performs in place — instead of resuming the host. afterDrain reports
-	// reopen=false when the iteration finishes (loop condition false / maximum
-	// reached, or the Multi-Instance count exhausted); then fall through to the
-	// normal resume.
+	// reopen=false when the iteration finishes (the Multi-Instance count
+	// exhausted); then fall through to the normal resume.
 	if it := compositeIteratorOf(entry.node); it != nil {
 		reopen, err := it.afterDrain(ctx, ls, entry.host, entry.node)
 		if err != nil {

--- a/internal/instance/scope_runtime.go
+++ b/internal/instance/scope_runtime.go
@@ -548,9 +548,10 @@ func (ls *loopState) reportScope(
 // looped composite, or -1 when the node is not looped (so its scope facts omit
 // the attribute).
 func scopeLoopCounter(node flow.Node, host *track) int {
-	// any composite iterator (Standard Loop or Multi-Instance) publishes its
-	// pass ordinal to the iteration scope facts (SRD-054 FR-11, SRD-055 FR-13).
-	if compositeIteratorOf(node) != nil {
+	// a looped composite publishes its pass ordinal to the iteration scope facts
+	// (SRD-054 FR-11, SRD-055 FR-13): a Standard Loop (decorator-driven, §2.12) or
+	// a sequential Multi-Instance (seam-driven, compositeIteratorOf).
+	if standardLoopOf(node) != nil || compositeIteratorOf(node) != nil {
 		return host.loopCounter
 	}
 

--- a/internal/instance/std_loop.go
+++ b/internal/instance/std_loop.go
@@ -3,7 +3,6 @@ package instance
 import (
 	"context"
 
-	"github.com/dr-dobermann/gobpm/internal/scope"
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/activities"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
@@ -123,78 +122,6 @@ func (t *track) runStandardLoop(
 	}
 
 	return nextFlows, nil
-}
-
-// standardLoopIterator is the composite-iteration strategy for a Standard Loop:
-// it re-opens the host's child scope while loopCondition holds and loopMaximum
-// is not reached (ADR-025 §2.2, composite mechanism). It wraps the same
-// bindLoopCounterAt / evalLoopCond / reachedMax logic the leaf loop runs in
-// place, behind the compositeIterator seam.
-type standardLoopIterator struct {
-	sl standardLoop
-}
-
-// firstOpen publishes the 0-based ordinal and, for a pre-tested (while) loop,
-// short-circuits to zero iterations when the condition is already false.
-func (it standardLoopIterator) firstOpen(
-	ctx context.Context, ls *loopState, host *track, node flow.Node,
-) (bool, error) {
-	if err := ls.inst.sc.bindLoopCounterAt(host.scopePath, 0); err != nil {
-		return false, err
-	}
-
-	if it.sl.TestBefore() {
-		cont, err := host.evalLoopCond(ctx, node, it.sl)
-		if err != nil {
-			return false, err
-		}
-
-		if !cont {
-			return false, nil
-		}
-	}
-
-	return true, nil
-}
-
-// beforeClose does nothing for a Standard Loop — it assembles no output.
-func (standardLoopIterator) beforeClose(
-	context.Context, *track, scope.DataPath,
-) error {
-	return nil
-}
-
-// afterDrain advances the ordinal and re-opens the scope while the loop maximum
-// is not reached and loopCondition still holds; otherwise the loop finishes and
-// the ordinal resets for a later re-entry of the same host.
-func (it standardLoopIterator) afterDrain(
-	ctx context.Context, ls *loopState, host *track, node flow.Node,
-) (bool, error) {
-	host.loopCounter++
-
-	if m, ok := it.sl.LoopMaximum(); ok && host.loopCounter >= m {
-		host.loopCounter = 0
-
-		return false, nil
-	}
-
-	if err := ls.inst.sc.bindLoopCounterAt(
-		host.scopePath, host.loopCounter); err != nil {
-		return false, err
-	}
-
-	cont, err := host.evalLoopCond(ctx, node, it.sl)
-	if err != nil {
-		return false, err
-	}
-
-	if cont {
-		return true, nil
-	}
-
-	host.loopCounter = 0
-
-	return false, nil
 }
 
 // evalLoopCond evaluates the loop's boolean loopCondition against a transient

--- a/internal/instance/std_loop.go
+++ b/internal/instance/std_loop.go
@@ -48,6 +48,12 @@ func (t *track) executeStep(
 	ctx context.Context, step *stepInfo,
 ) ([]*flow.SequenceFlow, error) {
 	if sl := standardLoopOf(step.node); sl != nil {
+		// a composite (scopeHost) Standard Loop iterates off the loop via the
+		// scope decorator (SRD-054 §2.12); a leaf Task iterates in place.
+		if _, ok := step.node.(scopeHost); ok {
+			return t.runCompositeLoop(ctx, step, sl)
+		}
+
 		return t.runStandardLoop(ctx, step, sl)
 	}
 

--- a/internal/instance/track.go
+++ b/internal/instance/track.go
@@ -377,16 +377,7 @@ func (t *track) checkNodeType(node flow.Node, atConstruction bool) error {
 	// host with a synthetic completion when the scope drains. Recognized by
 	// the container capability, keeping the runtime model-agnostic.
 	if _, ok := node.(scopeHost); ok {
-		// A looped Standard-Loop composite drives its own iteration off the loop
-		// (the decorator, SRD-054 §2.12): it must NOT park for loop-driven control
-		// — run() reaches it and executeStep routes it to runCompositeLoop. Every
-		// other composite (plain Sub-Process, Multi-Instance) still parks for the
-		// loop-driven scope re-entry.
-		if standardLoopOf(node) != nil {
-			return nil
-		}
-
-		return t.parkScopeHost(node, atConstruction)
+		return t.enterComposite(node, atConstruction)
 	}
 
 	// A Call Activity is a child-instance wait node (SRD-050): the host parks
@@ -485,6 +476,19 @@ func (t *track) checkNodeType(node flow.Node, atConstruction bool) error {
 	}
 
 	return nil
+}
+
+// enterComposite routes a composite host reached by a token: a looped
+// Standard-Loop composite drives its own iteration off the loop (the decorator,
+// SRD-054 §2.12) and must NOT park — run() reaches it and executeStep routes it to
+// runCompositeLoop; every other composite (plain Sub-Process, Multi-Instance)
+// parks for the loop-driven scope re-entry.
+func (t *track) enterComposite(node flow.Node, atConstruction bool) error {
+	if standardLoopOf(node) != nil {
+		return nil
+	}
+
+	return t.parkScopeHost(node, atConstruction)
 }
 
 // parkScopeHost parks the track on a composite node (SRD-049 FR-8): the

--- a/internal/instance/track.go
+++ b/internal/instance/track.go
@@ -377,6 +377,15 @@ func (t *track) checkNodeType(node flow.Node, atConstruction bool) error {
 	// host with a synthetic completion when the scope drains. Recognized by
 	// the container capability, keeping the runtime model-agnostic.
 	if _, ok := node.(scopeHost); ok {
+		// A looped Standard-Loop composite drives its own iteration off the loop
+		// (the decorator, SRD-054 §2.12): it must NOT park for loop-driven control
+		// — run() reaches it and executeStep routes it to runCompositeLoop. Every
+		// other composite (plain Sub-Process, Multi-Instance) still parks for the
+		// loop-driven scope re-entry.
+		if standardLoopOf(node) != nil {
+			return nil
+		}
+
 		return t.parkScopeHost(node, atConstruction)
 	}
 


### PR DESCRIPTION
## Summary

First slice of the **Loop/Multi-Instance decorator re-architecture** (ADR-025 v.2 §2.12): composite loop/MI iteration moves off the per-instance loop goroutine onto the activity's own execution — an **iteration decorator** — and composite **Standard Loop** is re-landed on it.

## Why

The Multi-Instance `behavior` throw (§2.8, throw an event as instances complete, caught on the MI activity's boundary) proved **unimplementable** on the loop-goroutine-driven model: throwing from the loop goroutine self-deadlocks on the loop's own unbuffered inbound channel, and a fire-and-forget throw drops the boundary catch nondeterministically (the catch is a later loop step the activity's completion races). Both are symptoms of one structural mismatch — iteration *control* ran on the loop goroutine while node *work* runs off it, which is **not** the decorator BPMN §13.3.6–§13.3.7 describes ("markers … wrap an inner Activity").

The decorator model dissolves the class of bug: a behavior throw becomes an ordinary off-loop emit caught by the same mechanism as any in-activity throw.

## What's in this PR

- **ADR-025 → v.2** (§2.12, Draft): the conception — a composite looped activity drives its own iteration from the host's runner goroutine, **requesting** scope operations from the single-writer loop via a request/response protocol (ADR-017 v.1's invariant preserved, not relaxed). Semantics §2.1–§2.11 unchanged; only *who drives* composite iteration moves.
- **SRD-054** (Accepted): composite Standard Loop re-landed on the decorator (delete-and-reuse of the SRD-054 slot).
- **Implementation** (`internal/instance`):
  - the scope protocol — a `scopeReq` channel + `handleScopeRequest` (loop goroutine), cloning the proven `taskReq`/`taskRoundtrip` pattern; opens the child scope / seeds / arms single-writer.
  - `runCompositeLoop` (host runner) — binds `loopCounter` off the loop (like the leaf loop), tests the continuation, requests the open, parks for the drain, repeats, selects the outgoing once. Deadlock-free by construction (the decorator waits only on loop-written, ctx/loopDone-aware channels).
  - `checkNodeType` stops parking a looped Standard-Loop composite; `executeStep` routes it to the decorator; `resumeScopeHost` delivers the drain to the decorator instead of the old `afterDrain`.
  - the now-dead `standardLoopIterator` seam is removed (sequential MI keeps `compositeIterator`/`afterDrain` until SRD-055 re-lands it).

**Behavior-preserving** — Standard Loop semantics are unchanged; leaf-task loops, plain composites, and the MI seam are untouched. Boundary arms-once is preserved (the host still parks per-pass drain).

## Verification

- `make ci` green (tidy · golangci-lint 0 · build · `-race` · **diff-coverage 98.4%** · govulncheck).
- Full `internal/instance` suite + thresher `TestStandardLoopSubProcessE2E` green under `-race`; the landed `TestLoopedSubProcess*` were the green-throughout safety net.

## Doc hierarchy

ADR-025 v.2 refines SAD-001 v.1 · ADR-017 v.1 (single-writer, extended) · ADR-023 v.2 · ADR-018 v.1. SRD-054 Implements ADR-025 v.2. All cross-refs up/sideways, version-pinned.

## What's next (out of scope here)

SRD-055 (sequential MI) → SRD-056.A (parallel MI) → SRD-056.B (behavior) re-land on the decorator on their own slices; **ADR-025 v.2 stays Draft and flips to Accepted** with the final slice.

Part of #88.
