### PR TITLE
Parallel Multi-Instance on the off-loop iteration decorator (SRD-056.A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,16 +101,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Composite loop execution → off-loop iteration decorator (ADR-025 v.2 §2.12,
-  SRD-054 / SRD-055).** Internal rework, behavior-preserving: a looped
+  SRD-054 / SRD-055 / SRD-056.A).** Internal rework, behavior-preserving: a looped
   **composite** activity (Sub-Process / Call Activity) now drives its own
   iteration from the host's runner goroutine — requesting scope open/close from
   the single-writer loop via a request/response protocol — instead of
   loop-goroutine-driven scope re-entry. Semantics are unchanged; the rework makes
   the Multi-Instance behavior throw (§2.8) implementable with a deterministic
   boundary catch (the loop-goroutine model self-deadlocked on it). **Standard
-  Loop** and **sequential Multi-Instance** are re-landed on the decorator (the
-  latter keeps only its output capture loop-side, before the child scope closes);
-  parallel Multi-Instance follows. The old `compositeIterator` seam is removed.
+  Loop**, **sequential Multi-Instance**, and **parallel Multi-Instance** are all
+  re-landed on the decorator: sequential/parallel keep only their output capture
+  loop-side (before each child scope closes), and parallel drives its N-of-N
+  barrier through a per-drain re-arm handshake (the loop delivers the concurrent
+  drains one at a time onto the runner's cap-1 park). The old
+  `compositeIterator` / loop-side `parallelInstanceDrained` seams are removed.
 
 ## [v0.9.0] - 2026-07-18
 

--- a/docs/srd/SRD-056.A-multi-instance-parallel.md
+++ b/docs/srd/SRD-056.A-multi-instance-parallel.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Draft |
+| Status | Accepted |
 | Date | 2026-07-21 |
 | Owner | Ruslan Gabitov |
 | Implements | [ADR-025 v.2](../design/ADR-025-activity-iteration-loop-and-multi-instance.md) §2.5 (parallel execution), §2.6 (data mediator), §2.7 (completion-condition cancellation), §2.9 (runtime attributes), §2.12 (composite iteration as an off-loop decorator) — the **parallel** slice; §2.8 `behavior` → SRD-056.B; epic #88 |
@@ -402,9 +402,8 @@ cancel faults), mirroring SRD-055's `mi_decorator_test.go`.
 
 | # | Scope | Files |
 |---|---|---|
-| **M1** | The off-loop parallel driver — `runMIParallel`; the `scopeFanOut`/`scopeReArm`/`scopeComplete` protocol ops + handlers; the `completeScope` group-branch rewrite (capture + dispatch-or-queue); `drivesOwnIteration` covers parallel; `executeStep` routes it; remove the `onScopeOpen` fan-out dispatch; `bindParallelCounters` off-loop. Reuses `openParallelInstance`/`captureParallelOutput`/`cancelOpenInstances`. Existing parallel suite + e2e green. | `mi_parallel.go`, `scope_decorator.go`, `scope_runtime.go`, `mi.go`, `std_loop.go`, `track.go` |
-| **M2** | Remove the dead loop-side driving — `fanOutParallelMI`, `parallelInstanceDrained`, the loop-side `bindParallelCounters`, the `onScopeOpen` parallel branch. | `mi_parallel.go`, `scope_runtime.go` |
-| **M3** | CHANGELOG note; SRD-056.A §10; doc sync. | docs |
+| **M1** | The off-loop parallel driver, switch **and** seam removal in one commit (the driver cannot half-switch — the moment `drivesOwnIteration` covers parallel and `executeStep` routes it, the old `onScopeOpen` fan-out + `parallelInstanceDrained` become unreachable and the `unused` linter fails on them, so their deletion folds into the switch, as SRD-054's M1+M2 folded): `runMIParallel` + `parallelBarrierStep`; the `scopeFanOut`/`scopeReArm`/`scopeComplete` protocol ops + handlers (`scopeExchange` full-reply); the `completeScope` group-branch rewrite (capture + dispatch-or-queue); `drivesOwnIteration` covers parallel; `executeStep` routes it; remove the `onScopeOpen` fan-out dispatch; `cancelScope` fact ordinal (FR-14); `bindParallelCounters` → off-loop `bindMICounters`. **Delete** `fanOutParallelMI` / `parallelInstanceDrained` / the loop-side `bindParallelCounters`. Reuses `openParallelInstance`/`captureParallelOutput`/`cancelOpenInstances`/`cancelParallelGroup`. Existing parallel suite + e2e green under `-race`; new white-box tests cover the decorator error/guard branches. | `mi_parallel.go`, `scope_decorator.go`, `scope_runtime.go`, `mi.go`, `std_loop.go` |
+| **M2** | CHANGELOG note; SRD-056.A §10; doc sync; Accepted flip. | docs |
 
 ## §8 Cross-doc
 
@@ -429,16 +428,40 @@ cancel faults), mirroring SRD-055's `mi_decorator_test.go`.
 
 ## §10 Implementation summary
 
-> ⚠️ TODO: fill AFTER landing — stage commits + empirical findings vs this draft.
-
 ### §10.1 Stages by commit (branch `feat/mi-parallel-decorator`)
 
 | Stage | Commit | Scope | Tests |
 |---|---|---|---|
+| doc | `e21d7f9` | SRD-056.A rewritten (delete-and-reuse) for the off-loop decorator | — |
+| M1 | `14bdd10` | off-loop parallel driver — `runMIParallel` + `parallelBarrierStep`; `scopeOp` protocol (`scopeFanOut`/`scopeReArm`/`scopeComplete`) + handlers + `scopeExchange`; `completeScope` group-branch (capture + dispatch-or-queue); `drivesOwnIteration` covers parallel; `executeStep` routing; `cancelScope` fact ordinal (FR-14); off-loop `bindMICounters`. **Deleted** `fanOutParallelMI`/`parallelInstanceDrained`/loop-side `bindParallelCounters`. Switch + seam removal folded. | 5 new white-box + 2 re-pointed; landed suite + e2e green under `-race`; `make ci` diff-cov 100% |
 
 ### §10.2 Empirical findings vs the draft
 
+- **The cap-1 handshake held exactly as §4.2 predicted.** The per-drain
+  dispatch-or-queue + `scopeReArm` serialized N concurrent drains onto the runner's
+  single-slot park with no loop stall; `-race` on the concurrent voting e2e is clean.
+- **The switch could not half-land — M1+M2 folded.** The moment `drivesOwnIteration`
+  covered parallel and `executeStep` routed it, `fanOutParallelMI` / the `onScopeOpen`
+  branch / `parallelInstanceDrained` went unreachable, and the `unused` linter fails on
+  a dead unexported method — so the seam deletion had to land in the switch commit (the
+  same fold SRD-054 took). §7 M2 collapsed to docs.
+- **The reused primitives were not counted as changed.** Although `mi_parallel.go` was
+  rewritten wholesale, `git diff` recognized `openParallelInstance` / `captureParallelOutput`
+  / `cancelOpenInstances` / `cancelParallelGroup` as moved-identical, so covercheck scored
+  only the genuinely new driver/handler lines — reaching 100% needed 5 focused white-box
+  tests plus re-pointing the two old white-box tests (`PublishError` → `handleComplete`,
+  `OpenScopeError` → `handleFanOut`) at the new loci.
+- **`runMIParallel` split for cognitive complexity.** The inline barrier loop hit gocognit
+  32 (> 30); extracting `parallelBarrierStep` (one delivered drain: bind, eval, finalize
+  or re-arm) brought both functions under the bar and reads cleaner.
+
 ### §10.3 Backlog
+
+- **SRD-056.B — the Multi-Instance `behavior` throw** (the original trigger for the
+  decorator rework) is now an ordinary off-loop throw at `parallelBarrierStep`'s
+  completion point (and sequential MI's), deterministic and boundary-catchable.
+- ADR-025 v.2 flips **Accepted** once SRD-056.B lands — the whole §2.12 re-landing
+  complete.
 
 ## Open questions
 

--- a/docs/srd/SRD-056.A-multi-instance-parallel.md
+++ b/docs/srd/SRD-056.A-multi-instance-parallel.md
@@ -2,352 +2,443 @@
 
 | Field | Value |
 |---|---|
-| Status | Accepted |
-| Version | v.1 |
-| Date | 2026-07-20 |
+| Status | Draft |
+| Date | 2026-07-21 |
 | Owner | Ruslan Gabitov |
-| Implements | [ADR-025 v.1](../design/ADR-025-activity-iteration-loop-and-multi-instance.md) §2.5 (parallel execution), §2.6 (data mediator), §2.7 (completion-condition cancellation), §2.9 (runtime attributes) — the **parallel** slice; §2.8 `behavior` → SRD-056.B (SRD-057 is reserved for Link Events) |
-| Upstream | [ADR-023 v.2](../design/ADR-023-sub-process-and-call-activity.md) (the execution-scope re-entry + `cancelScope`), [ADR-018 v.1](../design/ADR-018-boundary-events-and-activity-interruption.md) (scoped interruption / boundary cancel this reuses per instance), [ADR-011 v.7](../design/ADR-011-process-data-flow.md) (the `data.Collection` split/assemble mediator), [ADR-010 v.2](../design/ADR-010-process-data-model.md) (name-based data resolution), [ADR-013 v.2](../design/ADR-013-instance-observability.md) (iteration facts), [ADR-001 v.6](../design/ADR-001-execution-model.md) (the loop owns node execution) |
+| Implements | [ADR-025 v.2](../design/ADR-025-activity-iteration-loop-and-multi-instance.md) §2.5 (parallel execution), §2.6 (data mediator), §2.7 (completion-condition cancellation), §2.9 (runtime attributes), §2.12 (composite iteration as an off-loop decorator) — the **parallel** slice; §2.8 `behavior` → SRD-056.B; epic #88 |
+| Upstream | [ADR-017 v.1](../design/ADR-017-channel-based-event-processing.md) (the single-writer loop the decorator requests scope operations from), [ADR-023 v.2](../design/ADR-023-sub-process-and-call-activity.md) (the execution-scope re-entry + `cancelScope`), [ADR-018 v.1](../design/ADR-018-boundary-events-and-activity-interruption.md) (scoped interruption / boundary cancel this reuses per instance), [ADR-011 v.7](../design/ADR-011-process-data-flow.md) (the `data.Collection` split/assemble mediator), [ADR-010 v.2](../design/ADR-010-process-data-model.md) (name-based data resolution), [ADR-013 v.2](../design/ADR-013-instance-observability.md) (iteration facts), [ADR-001 v.6](../design/ADR-001-execution-model.md) |
 | Refines | — |
-| Related | SRD-055 (the sequential Multi-Instance slice this parallels), SRD-053 (the unique per-instance scope segment + N-concurrent-scope precedent) |
+| Related | SRD-054 (the composite-iteration decorator engine — the `scopeRequest`/`scopeRoundtrip` protocol this extends), SRD-055 (the sequential Multi-Instance slice this parallels), SRD-053 (the unique per-instance scope segment + N-concurrent-scope precedent) |
 
 ## §1 Background
 
-[SRD-055](SRD-055-multi-instance-sequential.md) landed **sequential** Multi-Instance
-on the SRD-054 composite-iteration seam: the `compositeIterator` three-hook
-contract (`firstOpen` → `open bool`, `beforeClose`, `afterDrain` → `reopen bool`,
-`composite_iter.go`) opens **one** child scope and re-opens the next on drain —
-serialization is a consequence of "one scope open at a time, reopen-on-drain".
-The runtime **explicitly rejects** a parallel Multi-Instance today
-(`internal/instance/mi.go`, `firstOpen`: `"parallel Multi-Instance is not yet
-implemented (SRD-056)"`).
+BPMN 2.0 §13.3.7 lets a **parallel** Multi-Instance (`isSequential = false`, the
+model default) run its inner activity **N times concurrently** — all N instances
+start at activation, run in **distinct per-instance scopes**, split a collection
+element in per instance, assemble one out, and the activity **completes when the
+last drains**; a `completionCondition` **cancels** the still-running remainder.
 
-ADR-025 §2.5 decides the **parallel** shape (`isSequential = false`, the model
-default — already constructible, so **this SRD makes no model change**): all N
-instances **start at activation** and run **concurrently in distinct per-instance
-scopes** (§2.2 "the exception that always needs a distinct scope per instance");
-the activity **completes when the last drains**. §2.7 makes `completionCondition`
-a **real cancellation** of the remaining concurrent instances; §2.9 makes
-`numberOfActiveInstances` genuinely `> 1` and adds `numberOfTerminatedInstances`.
+**This is the third slice of the ADR-025 v.2 decorator re-landing** (§2.12, after
+SRD-054's composite Standard Loop and SRD-055's sequential MI). The prior landing
+drove the parallel fan-out and the N-of-N barrier **entirely on the loop
+goroutine**: `fanOutParallelMI` opened N scopes at the host's `onScopeOpen`, the
+host **parked once**, and `parallelInstanceDrained` (loop-side, from
+`completeScope`) counted each drain, evaluated the `completionCondition`, cancelled
+the remainder, published the output, and resumed the host at exhaustion. §2.12
+moves that **control** onto the activity's own **off-loop runner** — the iteration
+decorator — so §2.8's behavior throw (SRD-056.B) becomes an ordinary off-loop throw
+caught on the MI boundary, instead of a loop-goroutine throw that self-deadlocks on
+the loop's own inbound channel.
 
-The concurrent-scope substrate already exists: `loopState.scopes
-map[DataPath]*scopeEntry` holds N coexisting scopes, `incScope`/`decScope`
-(`scope_runtime.go`) do per-scope drain accounting, and SRD-053's
-non-interrupting handlers already open a **unique** child segment per fire
-(`scopeSegment(node)+"-"+seq`, the `host.scopeSeg` override in `onScopeOpen`).
-What is missing is a **parallel driver** (the serial three-hook seam cannot
-express "open N, complete on the last"), an **N-of-N completion barrier** (the
-current model is one scope ⇄ one host-resume), **per-instance data binding at each
-instance's own scope**, and **MI-aware host teardown**.
+This SRD **deletes and reuses** the SRD-056.A slot: its prior (loop-goroutine-driven)
+execution content is replaced with the decorator design. The **model, the
+per-instance data mediator, positional assembly, the completion semantics, and the
+runtime attributes are unchanged** — only *who drives* the fan-out and the barrier
+moves off the loop.
 
-**In scope:** parallel fan-out, the per-instance data mediator, `completionCondition`
-cancellation, the runtime attributes, and MI-aware `cancelHostScope`; the voting
-worked example. **Deferred:** `behavior`/`ComplexBehaviorDefinition`/`ImplicitThrowEvent`
-→ **SRD-056.B**; MI compensation → future Transaction work (ADR-025 §2.10).
-Multi-Instance stays **composite-host-only** (as SRD-055 — no leaf-Task MI path
-exists, and none is added here).
+### §1.1 The constraint that shapes the parallel barrier
+
+A composite host's off-loop runner parks on a **single, cap-1, waiting-gated**
+channel (`track.evtCh`, `eventBufferDepth == 1`; `dispatchToParked` flips the host
+out of `ls.waiting` and blocks on the send). Sequential MI (SRD-055) fits this
+perfectly — **one** instance scope is open at a time, so **one** `scopeDone`
+arrives per pass and `awaitScopeDrained` reads exactly one. Parallel has **N
+concurrent** instance scopes draining in **arbitrary order** at that
+single-goroutine, single-slot runner, so the loop **cannot** fire N `scopeDone`s at
+it — each delivery needs the runner re-armed first.
+
+The decorator therefore drives the barrier with a **per-drain handshake** (ADR-025
+v.2 §2.12 "fan-out-then-await-all"): the loop delivers instance drains to the runner
+**one at a time** through the cap-1 re-arm, queueing any that arrive while the runner
+is busy; the runner processes each off-loop (count, bind the §2.9 attributes,
+evaluate the `completionCondition`, and — in SRD-056.B — throw the behavior event)
+and re-arms for the next. All completion **policy** runs on the runner; the loop
+performs only the single-writer **mutations** it requests (open N, capture each
+output before its scope closes, cancel the remainder, publish).
+
+**In scope:** the off-loop parallel driver (`runMIParallel`), the fan-out +
+N-of-N handshake barrier, the per-instance data mediator (reused), positional
+assembly + the visibility barrier (reused), `completionCondition` cancellation,
+the runtime attributes, and MI-aware `cancelHostScope` (the interrupting-boundary
+teardown of all N). **Deferred:** `behavior`/`ComplexBehaviorDefinition` →
+SRD-056.B; MI compensation → future Transaction work (ADR-025 §2.10). Multi-Instance
+stays **composite-host-only** (as SRD-055 — no leaf-Task MI path).
 
 ## §2 Requirements
 
-### Functional — the parallel driver
+### Functional — the model (landed, unchanged)
 
-- **FR-1 — parallel path dispatched by `IsSequential()`.** The runtime detects a
-  parallel Multi-Instance host (`multiInstanceOf(node) != nil && !IsSequential()`)
-  and drives it through a **new parallel fan-out** — *not* the serial
-  `compositeIterator`. The sequential `miIterator` (SRD-055) is left untouched
-  (its tests re-verify it). The `firstOpen` parallel-reject guard in `mi.go` is
-  removed. **Mechanism — `compositeIteratorOf` becomes sequential-only:** today
-  `compositeIteratorOf` (`composite_iter.go`) returns the *sequential* `miIterator`
-  for **any** MI node (`multiInstanceOf` is sequential-agnostic), so a parallel MI
-  would wrongly hit the serial seam at all four of its call sites (`onScopeOpen`,
-  `resumeScopeHost` ×2, `scopeLoopCounter`). `compositeIteratorOf` is therefore
-  changed to return `nil` for a parallel MI (guard on `IsSequential()`) — so every
-  serial-seam site skips it, and the parallel path owns the fan-out, the drain
-  interception, and the per-instance fact ordinal (FR-11). This is the concrete
-  realization of "the serial seam is untouched".
-- **FR-2 — fan out N distinct instance scopes at activation.** At the host's
-  first (only) `onScopeOpen`, N is resolved **once** (`resolveActivation`, reused),
-  and the engine opens **N child scopes** — instance *i* at segment
-  `scopeSegment(node) + "-" + i` (`i` = 0-based ordinal, deterministic and
-  addressable, ADR-025 §2.2/§2.5) — seeding each with the body start track, all
-  before the host parks. N ≤ 0 completes the activity with zero instances. Note
-  the existing `host.scopeSeg` override holds **one** segment for **one** host
-  (SRD-053), so the fan-out passes each instance's segment **per-scope** at open
-  time rather than through the single per-host override.
+- **FR-1 — no model change.** `MultiInstanceLoopCharacteristics` already expresses
+  parallel (`isSequential = false`, the default), constructed under the SRD-055
+  FR-2 guards. This SRD is **runtime-only**.
 
-### Functional — completion coordination
+### Functional — the decorator drives parallel MI off the loop (reworked)
 
-- **FR-3 — N-of-N completion barrier.** A per-activity **MI-group** (new
-  loop-owned state: the host track, the set of still-open instance paths, the
-  frozen N, and the completed / terminated counts) tracks the fan-out. Each
-  instance scope drains through the **existing** `decScope` → `completeScope`; the
-  parallel path intercepts that per-scope completion to decrement the group and
-  resumes the **single** host only when the group is exhausted (all N completed or
-  terminated). No `scopeEntry` re-entry (`reopen`) occurs for a parallel instance.
-- **FR-4 — completion order is nondeterministic; the engine is ordered.**
-  Instances run concurrently, but each scope's `completeScope` runs on the **loop
-  goroutine**, one at a time — so output capture, `completionCondition` evaluation,
-  and the counters are single-writer and race-free without new locks.
+- **FR-2 — the host drives its own fan-out via `runMIParallel`.** A parallel-MI
+  composite iterates on its **own runner goroutine** (a new `runMIParallel`, routed
+  by `executeStep` before the park path, like `runMISequential`). It resolves N
+  once off the loop, requests the loop to fan out N instance scopes, then runs the
+  per-drain barrier and, on exit, follows the composite's single outgoing flow once.
+  The host **no longer parks for control** — `drivesOwnIteration(node)` now covers a
+  parallel-MI composite too (Standard-Loop **or any** Multi-Instance composite), so
+  `checkNodeType`/`enterComposite` do not park it and the old `onScopeOpen`
+  fan-out dispatch is removed.
+- **FR-3 — fan out N distinct instance scopes (loop-side, on request).** A
+  `scopeRequest{op: scopeFanOut, n, col}` roundtrip asks the loop to open **N child
+  scopes** — instance *i* at segment `scopeSegment(node) + "-" + i` (0-based,
+  deterministic, ADR-025 §2.2/§2.5) — binding each instance's `loopCounter` + input
+  item at its **own** scope and seeding + arming its body, all before the reply.
+  Because the handler runs to completion on the loop goroutine, every instance is
+  registered in the loop-owned group and the host is marked waiting **before** any
+  drain is processed. N ≤ 0 opens no scope, creates no group, and follows the
+  outgoing once.
+- **FR-4 — the loop owns a lean N-of-N group; the runner owns the policy.** A
+  loop-owned `miGroup` (the host, node, the still-open instance-path→ordinal set,
+  the pre-sized staging collection, the output names, N, and the undelivered-drain
+  count) is the barrier substrate the per-scope `scopeEntry` model cannot express.
+  The **counting, the `completionCondition`, the cancellation decision, and the
+  §2.9 attribute binds run on the runner** (off the loop); the loop only mutates the
+  group on request.
 
-### Functional — the data mediator (per-instance scope)
+### Functional — the per-drain handshake barrier
 
-- **FR-5 — split in, at each instance's own scope.** Before instance *i*'s body
-  runs, `inputDataItem` = element *i* of the `loopDataInputRef` collection is bound
-  **into instance *i*'s child scope** (not the host scope — SRD-055 binds at the
-  host scope, which is safe only because sequential runs one at a time; concurrent
-  instances would clobber a shared `loopCounter` / item). The body reads it by name
-  within its own scope.
-- **FR-6 — assemble out, keyed by the instance ordinal.** When instance *i*
-  drains, its `outputDataItem` is read from its child scope and written to slot *i*
-  of the **private staging** collection — keyed by the **ordinal carried by the
-  scope**, not the host's mutable `loopCounter` (which is meaningless across N
-  concurrent instances). Positional assembly (slot = input ordinal) is
-  deterministic despite nondeterministic completion order (ADR-025 §2.6).
-- **FR-7 — visibility barrier.** The staging collection is never scope-visible
-  during the run; it publishes under `loopDataOutputRef` at the host scope **once**,
-  at activity completion (ADR-025 §2.6) — reusing SRD-055's `publishOutput`.
+- **FR-5 — one drain, one delivery.** Each instance scope drains through the
+  **existing** `decScope` → `completeScope`, which (on the loop) captures the
+  instance's output before the scope closes (FR-8), removes it from the group's open
+  set, and then **delivers one `scopeDone` to the runner if it is waiting, else
+  queues it** (increments the undelivered count). The runner receives exactly one
+  `scopeDone` per completed instance, in the loop's completion order.
+- **FR-6 — re-arm delivers the next.** After processing a drain the runner issues a
+  `scopeRequest{op: scopeReArm}` roundtrip; the loop re-marks the host waiting and,
+  if a drain is queued, immediately delivers one (dequeues). The runner then
+  `awaitScopeDrained`s the next. The handshake makes the loop deliver concurrent
+  drains strictly one at a time — the cap-1 channel is never sent to while the
+  runner is busy, so the single-writer loop never blocks on it.
+- **FR-7 — completion order is nondeterministic; the engine is ordered.** Instances
+  run concurrently, but each scope's `completeScope` runs on the **loop goroutine**,
+  one at a time — so output capture and the group mutations are single-writer and
+  race-free; and the runner processes one delivered drain at a time, so the counters
+  and the `completionCondition` evaluation are single-reader without new locks.
+
+### Functional — the data mediator (per-instance scope; unchanged)
+
+- **FR-8 — split in / assemble out, at each instance's own scope.** Instance *i*'s
+  `inputDataItem` = element *i* of the `loopDataInputRef` collection is bound **into
+  instance *i*'s child scope** at fan-out (loop-side, reused `openParallelInstance`)
+  — not the host scope, which SRD-055 could use only because it runs one at a time;
+  concurrent instances would clobber a shared `loopCounter`/item. When instance *i*
+  drains, its `outputDataItem` is read from its child scope into slot *i* of the
+  **private staging** collection, keyed by the **ordinal the scope carries** (frozen
+  at fan-out), not the host's mutable `loopCounter` — the one loop-side capture,
+  `captureParallelOutput` in `completeScope` before `CloseScope` (reused). Positional
+  assembly (slot = input ordinal) is deterministic despite nondeterministic
+  completion order (ADR-025 §2.6).
+- **FR-9 — visibility barrier.** The staging collection is never scope-visible
+  during the run (pre-sized to N; `SetAt(ordinal)` replaces; a cancelled slot keeps
+  its pre-run nil). It publishes under `loopDataOutputRef` at the host scope
+  **once**, at activity completion — the loop performs the `bindValueAt` in the
+  terminal `scopeComplete` handler (the staging is loop-owned; publish is a plane
+  write, not a throw, so it stays loop-side, unlike sequential's off-loop publish).
 
 ### Functional — completion condition & cancellation
 
-- **FR-8 — `completionCondition` cancels the remainder.** Evaluated on each
-  instance completion (the ordered loop-goroutine path, `evalCompletion` reused):
-  `true` → the activity is **done now** — every **still-open** instance scope is
-  **cancelled as a unit** via `cancelScope(path, PhaseCanceled)` (ADR-018
-  mechanism, already per-path + idempotent), each counted in
-  `numberOfTerminatedInstances`; the output publishes and the host resumes.
-  Cancelled instances do **not** contribute their `outputDataItem` (their slot
-  stays at its pre-run value). `false` → the instance is counted; the rest continue.
+- **FR-10 — `completionCondition` cancels the remainder.** Evaluated **on the
+  runner**, off the loop, after each delivered drain (`evalCompletion` reused,
+  reading the §2.9 attributes the runner bound at the host scope): `true` → the
+  activity is **done now** — the runner issues `scopeRequest{op: scopeComplete,
+  cancel: true}`; the loop **cancels every still-open instance scope as a unit**
+  (`cancelScope(path, PhaseCanceled)`, ADR-018 mechanism, idempotent + per-path),
+  counts them in `numberOfTerminatedInstances`, publishes the assembled output over
+  the completed slots, drops the group, and replies with the terminated count.
+  Cancelled instances contribute no `outputDataItem` (their slot stays nil). `false`
+  → the instance is counted and the runner re-arms for the next.
+- **FR-11 — natural completion.** When the runner has received N drains with no
+  `completionCondition` firing, it issues `scopeRequest{op: scopeComplete, cancel:
+  false}`; the loop publishes the staging and drops the group.
 
 ### Functional — runtime attributes & host teardown
 
-- **FR-9 — runtime attributes (§2.9).** The MI-group publishes, where the
-  `completionCondition` (and the body) resolve them by name:
-  `numberOfInstances` (frozen N), `numberOfActiveInstances` (still-running count —
-  genuinely `> 1` for parallel, decremented as instances complete),
-  `numberOfCompletedInstances`, and `numberOfTerminatedInstances` (§2.7 cancelled
-  count). Each instance additionally sees its own 0-based `loopCounter` in its scope.
-- **FR-10 — MI-aware host teardown.** An interrupting boundary firing on the MI
-  activity (or a scoped Terminate reaching it) currently tears down only the
-  **default** `sp-<id>` child segment (`cancelHostScope` →
-  `hostChildScope`/`scopeSegment`, `boundary_watch.go`), which does **not** exist
-  for a parallel MI. `cancelHostScope` becomes **MI-aware**: for a parallel-MI
-  host it cancels **all N** instance scopes (the MI-group's open paths) as a unit,
-  and drops the group.
-- **FR-11 — observability.** Each instance scope's Opened/Completed facts carry
-  that instance's 0-based ordinal, so concurrent passes are individually
-  observable. Because `compositeIteratorOf` returns `nil` for a parallel MI
-  (FR-1), `scopeLoopCounter` returns `-1` for it — the shared `host.loopCounter`
-  is meaningless across N concurrent instances anyway. The parallel path therefore
-  publishes each instance's **own** ordinal to `reportScope` directly (the ordinal
-  frozen on the instance scope at fan-out), not via `host.loopCounter`.
-- **FR-12 — front door.** A runnable `examples/multi-instance-parallel/` (the
-  **voting** worked example — a parallel Multi-Instance over a candidate list with
-  a `completionCondition` quorum), the iteration guide, `CHANGELOG.md`, the
-  conformance tracker row 4, and the READMEs (EN + RU) reflect parallel MI.
+- **FR-12 — runtime attributes (§2.9).** After each delivered drain the runner binds
+  the §2.9 attributes at the host scope (off the loop, `bindDataItemAt`, mutex-safe),
+  where the `completionCondition` (and the body) resolve them by name:
+  `numberOfInstances` (frozen N), `numberOfActiveInstances` (still-running, genuinely
+  `> 1` for parallel), `numberOfCompletedInstances` (the delivered count — monotonic,
+  one per evaluation, matching sequential), and `numberOfTerminatedInstances` (§2.7).
+  Each instance additionally sees its own 0-based `loopCounter` in its own scope
+  (bound at fan-out).
+- **FR-13 — MI-aware host teardown.** An interrupting boundary firing on the MI
+  activity (or a scoped Terminate reaching it) tears down **all N** instance scopes:
+  `cancelHostScope` is MI-aware — for a parallel-MI host it cancels the group's open
+  paths as a unit and drops the group (reused `cancelParallelGroup`). The parked
+  runner unblocks through `awaitScopeDrained`'s `evtCh`-closed path (as SL / sequential
+  MI), and `runMIParallel` returns.
+- **FR-14 — observability.** Each instance scope's Opened/Completed/Canceled facts
+  carry that instance's **own** 0-based ordinal — `entry.ordinal`, frozen on the
+  instance scope at fan-out — not the shared `host.loopCounter`, so concurrent passes
+  are individually observable. The ordinal is applied by the `completeScope`
+  grouped-entry override (`if entry.group != nil { ordinal = entry.ordinal }`) and
+  `openParallelInstance`'s direct `i` — **not** by `scopeLoopCounter`, which returns
+  the meaningless `host.loopCounter` for a self-driving node. Because this SRD widens
+  `drivesOwnIteration` to include parallel MI, `scopeLoopCounter(parallel)` flips from
+  `-1` to `host.loopCounter`; M1 therefore **extends the same `entry.group` ordinal
+  override to the cancel-path fact** (`cancelScope`'s `reportScope`) so a cancelled
+  instance reports its ordinal, not the shared counter.
+
+### Functional — front door
+
+- **FR-15 — front door.** `examples/multi-instance-parallel/` (the **voting**
+  worked example — a parallel MI over a candidate list with a `completionCondition`
+  quorum), the iteration guide, `CHANGELOG.md`, the conformance tracker, and the
+  READMEs (EN + RU) already describe parallel MI (behavior unchanged); the rework
+  needs only a CHANGELOG note.
 
 ### Non-functional
 
-- **NFR-1 — reuse the concurrent-scope substrate.** No new scope open/seed/drain/
-  cancel primitives — the parallel path rides `OpenScope`/seed/`armScopeHandlers`,
-  `incScope`/`decScope`/`completeScope`, `cancelScope`, and the `scopeSegment+"-"+i`
-  segment mechanism. The genuinely new code is the parallel fan-out + the MI-group
-  barrier + per-instance data binding + the `cancelHostScope` MI-awareness.
-- **NFR-2 — the sequential seam is untouched.** SRD-055's `miIterator` and the
-  `compositeIterator` three-hook contract are not modified; parallel is a separate
-  dispatch. SRD-054 + SRD-055 suites re-verify.
-- **NFR-3 — single-writer, no new locks.** All group state is loop-goroutine-owned
-  (like `miState` / `loopState.scopes`); concurrency is only in the instance bodies,
-  which the existing scope isolation already separates.
+- **NFR-1 — reuse the decorator + the concurrent-scope substrate.** No new scope
+  open/seed/drain/cancel primitives — `runMIParallel` reuses the SRD-054
+  `scopeRoundtrip`/`awaitScopeDrained` protocol and the SRD-056.A-landed
+  `openParallelInstance` / `captureParallelOutput` / `cancelOpenInstances` /
+  `cancelParallelGroup`. The genuinely new code is `runMIParallel`, the three new
+  scope-protocol ops (`scopeFanOut` / `scopeReArm` / `scopeComplete`) and their
+  loop-side handlers, and the `completeScope` group-branch rewrite (capture +
+  dispatch-or-queue instead of the loop-side driving).
+- **NFR-2 — single-writer preserved (ADR-017 v.1).** The loop stays the sole writer
+  of scope lifecycle (`OpenScope`/`CloseScope`, `ls.scopes`, `ls.miGroups`, the group
+  fields) and performs the pre-close capture and the final publish. The runner does
+  only mutex-safe plane **writes** (`bindDataItemAt` for the §2.9 attributes) off the
+  loop, and never reads loop-owned group state mid-flight — it counts delivered
+  drains locally and learns the terminated count from the `scopeComplete` reply.
+- **NFR-3 — no new locks; the handshake is the fence.** All group state is
+  loop-goroutine-owned; concurrency lives only in the instance bodies, which scope
+  isolation already separates. The cap-1 re-arm handshake serializes drain delivery,
+  so the loop never blocks on the runner's channel. `-race` on the e2e guards it.
 - **NFR-4 — deferred surfaces stay out.** No `behavior`/`ComplexBehaviorDefinition`
   (SRD-056.B), no compensation, no leaf-Task MI.
-- **NFR-5 — coverage.** Every touched file ≥95% diff-coverage (aim 100%);
-  `make ci` green, `-race` clean (the concurrency path especially).
+- **NFR-5 — the existing suites are the safety net.** The landed
+  `TestParallelMultiInstance*` (`internal/instance/mi_parallel_test.go`) +
+  `pkg/thresher` e2e + the SRD-054/SRD-055 suites stay green throughout — behavior
+  is unchanged.
+- **NFR-6 — coverage.** Every touched file finishes ≥95% diff-coverage (aim 100%);
+  `make ci` green, `-race` clean.
 
 ## §3 Models
 
 ### §3.1 Runtime deltas (`internal/instance/`)
 
-- **`mi.go` (or a new `mi_parallel.go`)** — the parallel driver:
-  `fanOutParallelMI(host, node)` (resolve N, create the group, open N scopes with
-  per-instance segments + per-instance input binds), the per-instance
-  drain/complete handling (output capture keyed by ordinal, counter maintenance,
-  `completionCondition` + cancellation), and host resume on group exhaustion. The
-  parallel-reject guard is removed.
-- **`miGroup`** — a new loop-owned per-activity struct (frozen N, `host`, the
-  open-instance-path set, `numberOfCompletedInstances` / `numberOfTerminatedInstances`,
-  the private staging `values.Array`, the `outputRef`/`outputItem`, the
-  `completionCondition`). Registered in a new `loopState.miGroups map[…]` keyed so
-  a draining instance path resolves back to its group.
-- **`composite_iter.go`** — `compositeIteratorOf` gains an `IsSequential()` guard
-  so it returns `nil` for a parallel MI (FR-1): the four serial-seam sites
-  (`onScopeOpen`, `resumeScopeHost` ×2, `scopeLoopCounter`) then all skip a
-  parallel MI, leaving the parallel path in sole control.
-- **`scope_runtime.go`** — `onScopeOpen` dispatches a parallel-MI host to the
-  fan-out (before the `compositeIterator` path); `completeScope` intercepts a
-  parallel-MI instance drain (decrement the group / evaluate completion / resume
-  host at zero) instead of `resumeScopeHost`'s serial re-entry.
-- **`boundary_watch.go`** — `cancelHostScope` (and `hostChildScope`) made
-  MI-aware: a parallel-MI host cancels the group's N paths.
-- **`scope.go`** — the per-instance input bind reuses `bindDataItemAt`
-  (SRD-055) at the instance child path; the ordinal / `numberOf*` binds likewise.
+- **`mi_parallel.go` — `runMIParallel` (new, host runner) + the group relocation.**
+  ```
+  runMIParallel(ctx, step, mi):
+    n, col := resolveActivation(...)                    // off-loop; count once
+    if n <= 0 { return t.executeNode(ctx, step) }       // zero-instance
+    scopeRoundtrip{op:scopeFanOut, host:t, node, n, col} // loop opens N + group + marks waiting
+    for completed := 0; ; {
+       awaitScopeDrained(ctx)                           // one delivered drain
+       completed++
+       bindParallelCounters(t, n, completed, terminated=0) // off-loop (FR-12)
+       if completed < n && mi.CompletionCondition() != nil && evalCompletion(...) {
+          term := scopeRoundtrip{op:scopeComplete, cancel:true}  // loop cancels+publishes+drops
+          bindParallelCounters(t, n, completed, term)   // final off-loop
+          break                                          // (SRD-056.B: throw before this)
+       }
+       if completed == n {
+          scopeRoundtrip{op:scopeComplete, cancel:false} // loop publishes+drops
+          break
+       }
+       scopeRoundtrip{op:scopeReArm}                    // loop re-marks waiting + delivers next queued
+    }
+    return t.executeNode(ctx, step)                     // follow the composite's outgoing once
+  ```
+  `bindParallelCounters` moves off the loop (the runner calls `bindDataItemAt`);
+  `resolveActivation` / `evalCompletion` reused (`mi.go`).
 
-*No model change* — `MultiInstanceLoopCharacteristics` already expresses parallel
-(`isSequential = false`, the default). `behavior` fields land in SRD-056.B.
+- **`scope_decorator.go` — the protocol gains an op.** `scopeRequest` carries an
+  `op scopeOp` (`scopeOpen` — the existing sequential/SL open; `scopeFanOut`;
+  `scopeReArm`; `scopeComplete`) plus `n int` / `col data.Collection` (fanOut) /
+  `cancel bool` (complete); `scopeReply` gains `terminated int`. `handleScopeRequest`
+  dispatches on `op`:
+  - `scopeFanOut` → build the `miGroup`, `openParallelInstance` ×N (reused), mark
+    the host waiting, reply.
+  - `scopeReArm` → `ls.waiting[host] = {}`; if the group has a queued drain,
+    dispatch one `scopeDone`; reply.
+  - `scopeComplete` → if `cancel`, `cancelOpenInstances` (reused) counting
+    `terminated`; publish `grp.staging` at the host scope (`bindValueAt`); drop
+    `ls.miGroups[host]`; reply(`terminated`).
+
+- **`mi_parallel.go` — `miGroup`** keeps `host`/`node`/`open`/`staging`/`outputRef`/
+  `outputItem`/`n`, **adds** `pending int` (undelivered drains). The loop-side
+  driving fields (`completed`/`terminated`/`mi`/`collection`/`inputItem`) that only
+  the old `parallelInstanceDrained` used are dropped — the runner owns those counts;
+  the fan-out reads names/collection from the request + `multiInstanceOf(node)`.
+
+- **`scope_runtime.go` — `completeScope` group-branch rewrite.** Keep the
+  `captureParallelOutput` step (forced loop-side, FR-8). Replace the
+  `parallelInstanceDrained` call with: remove the path from `grp.open`; if
+  `ls.waiting[host]` — `dispatchToParked(scopeDone)`; else `grp.pending++`. Remove
+  the `onScopeOpen` parallel-MI fan-out dispatch (a parallel MI never parks now).
+  `resumeScopeHost`'s `drivesOwnIteration` guard is untouched (the group branch
+  returns before it).
+
+- **`track.go` / `std_loop.go` — routing.** `drivesOwnIteration(node)` becomes
+  Standard-Loop composite **or any** Multi-Instance composite (drop the
+  `IsSequential()` narrowing); `executeStep` routes a `scopeHost` parallel MI to
+  `runMIParallel`.
+
+- **Seam removal (M2).** `fanOutParallelMI`, `parallelInstanceDrained`, the loop-side
+  `bindParallelCounters`, and the `onScopeOpen` parallel branch are deleted (the old
+  loop-driven fan-out + barrier). `openParallelInstance`, `captureParallelOutput`,
+  `cancelOpenInstances`, `cancelParallelGroup`, `cancelHostScope`'s MI branch are
+  **kept** (reused by the new handlers / boundary teardown).
+
+*No model change* — `behavior` fields land in SRD-056.B.
 
 ## §4 Analysis
 
-### §4.1 The design fork: a separate parallel driver (FR-1)
+### §4.1 Why the barrier moves off the loop (FR-2, ADR-025 v.2 §2.12)
 
-The `compositeIterator` contract (`firstOpen → open bool`, `afterDrain → reopen
-bool`) is **intrinsically serial** — it encodes "one scope, reopen on drain". A
-parallel Multi-Instance is "open N, complete on the last", which no `reopen bool`
-can express; and its single-scope `beforeClose(childPath)` + host-scope
-`bindInstance` both break under concurrency (N instances clobbering one
-`loopCounter` at the shared host scope). ADR-025 §2.2/§4 already decided
-**scope-per-concurrent-instance**. So parallel is a **separate dispatch** —
-`onScopeOpen` routes a parallel-MI host to the fan-out and leaves the serial seam
-(Standard Loop + sequential MI) untouched. This is cleaner than widening the
-three-hook seam (which would ripple into the already-landed serial callers). The
-one edit the serial seam *does* take is defensive: `compositeIteratorOf` guards on
-`IsSequential()` so a parallel MI never reaches any of its four call sites (FR-1)
-— without it the sequential `miIterator` would run on parallel drains and
-`scopeLoopCounter` would emit the wrong ordinal.
+The v.1 parallel barrier lived in `parallelInstanceDrained` on the loop goroutine —
+it counted drains, evaluated the `completionCondition`, cancelled the remainder, and
+resumed the host. SRD-056.B must **throw a behavior event** at those exact points
+(per instance / on completion, §2.8). A throw hands the event to the loop's ordered
+inbound channel; issued *from* the loop goroutine (the channel's only reader, busy
+inside the throw) it self-deadlocks, and made fire-and-forget it drops the boundary
+catch nondeterministically (§2.12). Because the behavior decision depends on the
+**aggregate** group state (None/One/All/Complex over the completed count), it must
+run wherever the barrier is — so the barrier itself must move off the loop. This SRD
+does that now, so SRD-056.B adds only the throw at an already-off-loop decision
+point, with no barrier rework.
 
-### §4.2 The N-of-N barrier reuses per-scope drain (FR-3, FR-4)
+### §4.2 The per-drain handshake is forced by the cap-1 runner park (FR-5, FR-6)
 
-The substrate already fires `completeScope` when **one** scope drains
-(`decScope` at `active == 0`). The gap is only that each `scopeEntry` today
-resumes **its own** host — but N parallel instances share **one** host. The
-`miGroup` supplies the missing barrier: `completeScope`, seeing the draining path
-belongs to a group, decrements the group's open set instead of resuming, and
-resumes the host only at zero. Because `completeScope` runs on the loop goroutine
-one drain at a time, the counters and `completionCondition` evaluation are
-single-writer — the concurrency lives only inside the instance bodies, which
-scope isolation already separates. This is the same "loop-owned state, concurrency
-in the bodies" discipline as `loopState.scopes` itself.
+The naive "the runner awaits N drains" is impossible: the runner's `evtCh` is cap-1
+and waiting-gated, so the loop can deliver a `scopeDone` only when the host is
+waiting, and delivering flips it not-waiting. With N concurrent drains and a single
+busy runner, the loop would block on the second send (§1.1). The handshake resolves
+it: `completeScope` **delivers one drain if the host is waiting, else queues it**
+(`grp.pending`), and `scopeReArm` re-marks the host waiting and dequeues the next.
+Every loop-side step — capture, close, group mutation, dispatch/queue, re-arm — runs
+on the loop goroutine and is serialized, so there is no race between a concurrent
+drain's `completeScope` and a `scopeReArm` handler. The runner sees drains strictly
+one at a time; the concurrency is only in the instance bodies (unchanged).
 
-### §4.3 Per-instance data at the instance scope (FR-5, FR-6)
+### §4.3 The runner never reads loop-owned group state mid-flight (NFR-2)
 
-SRD-055 binds `inputDataItem` / `loopCounter` at the **host** scope, safe only
-because one instance runs at a time (the SRD-055 code comments this). Parallel
-must bind at **each instance's own** child scope — the body reads its item within
-its scope, and output staging keys off the **ordinal the scope carries** (frozen
-at fan-out) rather than the host's mutable `loopCounter`. Positional assembly
-(slot = ordinal) keeps the output deterministic regardless of completion order
-(ADR-025 §2.6) — the property that motivated positional assembly in the first place.
+Delivery is **1:1 with completion, in order**, so the runner's local `completed`
+count (number of `scopeDone`s received) equals the group's authoritative completed
+count for every instance it has been told about — it never reads `grp.completed`.
+`numberOfCompletedInstances` as the `completionCondition` sees it is the **delivered**
+count (monotonic, one increment per evaluation) — the same "the condition sees each
+completion once, in order" contract as sequential MI, and a cleaner definition than
+the v.1 loop-side `grp.completed` (which could jump ahead of the evaluated drain when
+siblings drained into the queue). The `terminated` count comes back in the
+`scopeComplete` reply; `grp.staging` is read only at publish, which the **loop**
+performs (FR-9), after the last capture — no cross-goroutine read of loop state. The
+existing `TestParallelMultiInstanceRuntimeAttributes` asserts only completion (a
+never-true `numberOfInstances >= 100` condition, all N run), not mid-run active
+counts, so the delivered-count definition is behavior-preserving against the suite.
 
-### §4.4 Cancellation is real now (FR-8, FR-10)
+### §4.4 Publish and capture stay loop-side; only policy is off-loop (FR-8, FR-9)
 
-For sequential MI, "cancel remaining" reduced to "stop launching" (SRD-055 §4.4 —
-≤ 1 open scope). Parallel has N concurrent open scopes, so `completionCondition =
-true` performs a **real** teardown: `cancelScope(path, PhaseCanceled)` per
-still-open instance path (ADR-018 mechanism, already idempotent + per-path),
-counted in `numberOfTerminatedInstances`; the output publishes atomically over the
-completed slots. The **same** N-path set drives the `cancelHostScope`
-MI-awareness (FR-10): an interrupting boundary / scoped Terminate on the MI
-activity tears down all N via the group, closing the gap that today's
-default-segment resolution (`hostChildScope` → `scopeSegment` = `sp-<id>`) leaves
-open for a fanned-out activity.
+`grp.staging` is loop-owned: `captureParallelOutput` writes it on each drain (before
+`CloseScope` — the one window only the loop observes, as for sequential MI), and the
+final `bindValueAt` publishes it. Both are plane operations, not event throws, so
+keeping them on the loop introduces no deadlock and avoids sharing the group pointer
+with the runner. What genuinely must be off-loop is the **policy** — count, attribute
+binds, `completionCondition`, cancellation decision, and (SRD-056.B) the throw — and
+that is exactly what `runMIParallel` owns. This is the parallel counterpart of
+sequential's `captureSequentialOutput` staying loop-side (SRD-055 §4.2); parallel
+additionally keeps the publish loop-side because its staging is group-owned, not
+host-owned. This sequential/parallel **asymmetry** is deliberate and both conform to
+§2.12 ("the loop performs the mutation on request"): sequential publishes off-loop
+(`publishOutput`) because its staging is host-owned; parallel routes publish through
+the `scopeComplete` request because its staging is group-owned.
 
-### §4.5 Ordering of completion vs. host resume
+### §4.5 Cancellation is a single ordered step (FR-10, FR-13)
 
-`completeScope` is loop-serialized, so the last instance's drain, the final
-`completionCondition` evaluation, the output publish, and the host resume happen
-in one uninterrupted loop step — there is no window where the host resumes before
-the output is published or a concurrent instance's slot is captured.
+`completionCondition = true` → `scopeComplete{cancel:true}` runs one loop step:
+`cancelOpenInstances` tears down every still-open instance path (`cancelScope`,
+idempotent + per-path), counts them terminated, then publishes over the completed
+slots and drops the group — no window where the host resumes before the output is
+published or a sibling's slot is captured. The **same** open-path set drives
+`cancelHostScope`'s MI-awareness (FR-13): an interrupting boundary / scoped Terminate
+on the MI activity tears down all N via the loop-owned group, closing the gap the
+default-segment resolution (`sp-<id>`) leaves for a fanned-out activity. A queued
+(undelivered) drain at cancellation time is already out of `grp.open` (removed at its
+`completeScope`), so it counts as completed and keeps its captured slot — cancellation
+touches only the truly still-open instances.
+
+### §4.6 Zero-instance and the fan-out race
+
+`n ≤ 0` opens no scope, creates no group, and follows the composite's outgoing once
+(`executeNode`) — no publish (no staging). For `n > 0`, `scopeFanOut` runs to
+completion on the loop goroutine (opening all N, populating `grp.open`, marking the
+host waiting) **before** the loop processes any instance drain, so a fast instance
+cannot resume the host before the group is fully populated — the same "single loop
+goroutine removes the fan-out race" property the v.1 landing relied on, now reached
+through the request handler instead of `onScopeOpen`.
 
 ## §6 Test scenarios
 
-Landed test names (reconciled to the implementation at Accepted).
+The landed `internal/instance/mi_parallel_test.go` + `pkg/thresher` e2e are the
+behavior-preserving safety net (names reconciled at Accepted). New white-box tests
+cover the decorator's off-loop error paths (`runMIParallel`'s roundtrip / drain /
+cancel faults), mirroring SRD-055's `mi_decorator_test.go`.
 
-| Test | Level | Asserts (FR) |
+| Test | Level | Covers |
 |---|---|---|
-| `TestParallelMultiInstanceRunsAll` | instance | FR-1/FR-2/FR-3 N instances all run + completes when the last drains |
-| `TestParallelMultiInstanceDistinctScopes` | instance | FR-2 N distinct `-i` segments + FR-11 each Opened fact carries its ordinal |
-| `TestParallelMultiInstanceZeroCardinality` | instance | FR-2 N ≤ 0 → zero instances, completes |
-| `TestParallelMultiInstanceInputItemPerScope` | instance | FR-5 each instance sees its own element (set, order-independent) |
-| `TestParallelMultiInstanceAssemblesOutput` / `…OutputItemMissing` | instance | FR-6/FR-7 positional output, published once (+ missing-item fault) |
-| `TestParallelMultiInstanceCompletionCancelsRemainder` | instance | FR-8 `true` cancels still-open instances (gated bodies), `numberOfTerminatedInstances` |
-| `TestParallelMultiInstanceRuntimeAttributes` / `…NonBoolCompletion` | instance | FR-9 `numberOf*` readable by the condition (+ non-bool fault) |
-| `TestParallelMultiInstanceBoundaryInterruptsAll` | instance | FR-10 interrupting boundary tears down all N |
-| `TestParallelMultiInstanceCardinalityError` / `…InputGetAtError` / `…OpenScopeError` / `…PublishError` | instance | error paths (white-box for the defensive branches) |
-| `TestParallelMultiInstanceSequentialStillWorks` | instance | NFR-2 sequential MI + Standard Loop still pass (suite) |
-| `TestParallelMultiInstanceE2E` | thresher | FR-2–FR-9 end-to-end (the voting quorum) |
+| `TestParallelMultiInstanceRunsAll` | instance | FR-2/FR-3/FR-5 — N instances all run, complete when the last drains (existing) |
+| `TestParallelMultiInstanceDistinctScopes` | instance | FR-3/FR-14 — N distinct `-i` segments, each fact carries its ordinal (existing) |
+| `TestParallelMultiInstanceZeroCardinality` | instance | FR-3 — N ≤ 0, no scope, follow outgoing (existing) |
+| `TestParallelMultiInstanceInputItemPerScope` | instance | FR-8 — each instance sees its own element (existing) |
+| `TestParallelMultiInstanceAssemblesOutput` / `…OutputItemMissing` | instance | FR-8/FR-9 — positional output, published once (+ missing-item fault) (existing) |
+| `TestParallelMultiInstanceCompletionCancelsRemainder` | instance | FR-10 — `true` cancels still-open instances, `numberOfTerminatedInstances` (existing) |
+| `TestParallelMultiInstanceRuntimeAttributes` / `…NonBoolCompletion` | instance | FR-12 — `numberOf*` readable by the condition (+ non-bool fault) (existing) |
+| `TestParallelMultiInstanceBoundaryInterruptsAll` | instance | FR-13 — interrupting boundary tears down all N (existing) |
+| `TestParallelMultiInstance{CardinalityError,InputGetAtError,OpenScopeError,PublishError}` | instance | error paths — white-box (existing, re-pointed at the new loci) |
+| `TestRunMIParallel{RequestError,DrainError}` | instance | FR-2/FR-6 — fan-out roundtrip on a stopped instance faults; a mid-barrier `evtCh` close unblocks the runner (new white-box) |
+| `TestDrivesOwnIteration` | instance | FR-2 — parallel MI now self-drives (update: parallel → true) |
+| `TestParallelMultiInstanceE2E` | thresher | FR-2–FR-12 end-to-end, the voting quorum (existing) |
 
 ## §7 Milestones
 
-| M | Scope | Files |
+| # | Scope | Files |
 |---|---|---|
-| **M1** | Parallel fan-out + N-of-N barrier (open N scopes, resume host on last drain) | `internal/instance/mi.go` (+`mi_parallel.go`), `scope_runtime.go`, `loop.go` |
-| **M2** | Per-instance data mediator (input bind at instance scope, ordinal-keyed output assembly + barrier publish) | `mi.go`/`mi_parallel.go`, `scope.go` |
-| **M3** | `completionCondition` cancellation + runtime attributes (`numberOfActiveInstances`/`numberOfTerminatedInstances`) | `mi.go`/`mi_parallel.go` |
-| **M4** | MI-aware `cancelHostScope` (interrupting boundary / Terminate tears down all N) | `boundary_watch.go`, `scope_runtime.go` |
-| **M5** | e2e + `examples/multi-instance-parallel/` (voting) + docs (guide/CHANGELOG/tracker/READMEs) | `pkg/thresher/…`, `examples/…`, docs |
+| **M1** | The off-loop parallel driver — `runMIParallel`; the `scopeFanOut`/`scopeReArm`/`scopeComplete` protocol ops + handlers; the `completeScope` group-branch rewrite (capture + dispatch-or-queue); `drivesOwnIteration` covers parallel; `executeStep` routes it; remove the `onScopeOpen` fan-out dispatch; `bindParallelCounters` off-loop. Reuses `openParallelInstance`/`captureParallelOutput`/`cancelOpenInstances`. Existing parallel suite + e2e green. | `mi_parallel.go`, `scope_decorator.go`, `scope_runtime.go`, `mi.go`, `std_loop.go`, `track.go` |
+| **M2** | Remove the dead loop-side driving — `fanOutParallelMI`, `parallelInstanceDrained`, the loop-side `bindParallelCounters`, the `onScopeOpen` parallel branch. | `mi_parallel.go`, `scope_runtime.go` |
+| **M3** | CHANGELOG note; SRD-056.A §10; doc sync. | docs |
 
 ## §8 Cross-doc
 
-- **Implements** ADR-025 v.1 §2.5–§2.7, §2.9 (upward; the parallel slice — §2.8
-  `behavior` is SRD-056.B, so not claimed here).
-- **Upstream** ADR-023 v.2 (scope re-entry + `cancelScope`), ADR-018 v.1 (scoped
-  interruption reused per instance + the MI-aware boundary fix), ADR-011 v.7
-  (Collection mediator), ADR-010 v.2 (name resolution), ADR-013 v.2 (facts),
-  ADR-001 v.6 (loop execution) — all up/sideways, version-pinned.
-- **Related** SRD-055, SRD-053 (sideways, number-only per the one-shot rule).
-- No downward references. SRD-057 is reserved for Link Events (not referenced here).
+- **Implements** [ADR-025 v.2](../design/ADR-025-activity-iteration-loop-and-multi-instance.md) §2.5–§2.7, §2.9, §2.12.
+- **Upstream** [ADR-017 v.1](../design/ADR-017-channel-based-event-processing.md), [ADR-023 v.2](../design/ADR-023-sub-process-and-call-activity.md), [ADR-018 v.1](../design/ADR-018-boundary-events-and-activity-interruption.md), [ADR-011 v.7](../design/ADR-011-process-data-flow.md), [ADR-010 v.2](../design/ADR-010-process-data-model.md), [ADR-013 v.2](../design/ADR-013-instance-observability.md), [ADR-001 v.6](../design/ADR-001-execution-model.md).
+- **Related** SRD-054, SRD-055, SRD-053 (sideways, number-only per the one-shot rule). Direction: SRD → ADR / SRD only (up/sideways), version-pinned; no downward reference.
 
 ## §9 Definition of Done
 
-- FR-1…FR-12 wired and covered by the §6 tests; the e2e green; the SRD-054 +
-  SRD-055 suites still pass (NFR-2).
-- `make ci` green (diff-coverage ≥95% touched; `-race`; govulncheck; all modules).
-- `examples/multi-instance-parallel/` runs to completion (built binary gitignored).
-- Conformance tracker row 4 advanced (sequential ✅ + **parallel ✅**; `behavior`/
-  `ComplexBehaviorDefinition` / `completionQuantity` remain → SRD-056.B); CHANGELOG
-  `[Unreleased]`; iteration guide parallel note; README EN+RU.
-- `/check-srd` PASS. ADR-025 stays Accepted (this SRD implements it — no change).
+- FR-1…FR-15 wired; FR-2/FR-3 via `runMIParallel` + `scopeFanOut`, FR-5/FR-6 via the
+  handshake, FR-10/FR-11 via `scopeComplete`, FR-8 via the reused loop-side capture.
+- §6 tests exist and pass; the landed parallel suite + e2e + the SRD-054/SRD-055
+  suites stay green (NFR-5); `examples/multi-instance-parallel/` runs and exits 0.
+- The old loop-side fan-out + barrier is removed (M2); sequential MI + Standard Loop
+  are unaffected.
+- Single-writer preserved (NFR-2); the handshake fence documented (NFR-3) and
+  `-race` green on the concurrent e2e.
+- `make ci` green (verify the gate's own completion markers, not a wrapper exit);
+  CHANGELOG `[Unreleased]` notes the internal rework.
+- `/check-srd` PASS before flipping status; ADR-025 v.2 stays Draft until the whole
+  re-landing (SRD-056.B behavior) completes.
 
 ## §10 Implementation summary
 
-Landed on branch `feat/mi-parallel`; `make ci` green at every milestone (lint 0,
-`-race`, govulncheck clean, all modules), diff-coverage ≥95% touched.
+> ⚠️ TODO: fill AFTER landing — stage commits + empirical findings vs this draft.
 
-### §10.1 Stages by commit (branch `feat/mi-parallel`)
+### §10.1 Stages by commit (branch `feat/mi-parallel-decorator`)
 
 | Stage | Commit | Scope | Tests |
 |---|---|---|---|
-| SRD | `ed796e7` | this document (Draft) | — |
-| M1 | `6c39dd0` | parallel fan-out + N-of-N barrier (`mi_parallel.go`: `miGroup`, `fanOutParallelMI`, `openParallelInstance`, `parallelInstanceDrained`; `composite_iter.go` `IsSequential()` guard; `scope_runtime.go` dispatch + intercept; `loop.go` `miGroups`) | 4 + 2 white-box |
-| M2 | `23bcc72` | per-instance data mediator (per-instance-scope bind, pre-sized ordinal-keyed staging, `captureParallelOutput`, barrier publish) | +3 + 1 white-box |
-| M3 | `bd7569a` | `completionCondition` cancellation + `numberOf*` attributes (`bindParallelCounters`, `cancelRemainingInstances`) | +3 |
-| M4 | `0e8e2e4` | MI-aware `cancelHostScope` (`cancelOpenInstances` / `cancelParallelGroup`; `boundary_watch.go` MI branch) | +1 |
-| M5-A | `3582918` | thresher e2e + `examples/multi-instance-parallel/` (voting) + docs | +1 e2e |
 
 ### §10.2 Empirical findings vs the draft
 
-- **`compositeIteratorOf` sequential-only guard.** As `/review-srd` flagged, the
-  serial seam's `compositeIteratorOf` returned the sequential `miIterator` for
-  *any* MI; guarding it on `IsSequential()` (returns `nil` for parallel) is the
-  concrete mechanism that keeps a parallel MI off all four serial-seam sites,
-  including `scopeLoopCounter` (so the per-instance ordinal is published by the
-  parallel path, not the shared `host.loopCounter`).
-- **Pre-sized output staging.** Sequential MI appends in completion order;
-  parallel completes out of order, so the staging `values.Array` is pre-sized to
-  N and `SetAt(ordinal)` **replaces** — a canceled instance keeps its pre-run nil.
-- **The single loop goroutine removes the fan-out race.** `fanOutParallelMI` runs
-  to completion before the loop processes any instance drain, so the group is
-  fully populated before the first drain — no early host resume.
-- **`Commit` errors at an unopened scope** (not a silent lazy-create), which made
-  the publish/bind error paths white-box-triggerable rather than dead.
-- **Removed SRD-055's `TestParallelMultiInstanceRejected`** — its honest-gap gate
-  (a parallel MI faults "not yet implemented") is closed by this SRD; the parallel
-  suite replaces it.
-
 ### §10.3 Backlog
-
-- `behavior` / `ComplexBehaviorDefinition` / `ImplicitThrowEvent` (the None/One/
-  Complex event-throwing, boundary-catchable) → **SRD-056.B**.
-- `completionQuantity` → deferred (SRD-046 NFR-4).
-- MI compensation → future Transaction work (ADR-025 §2.10).
 
 ## Open questions
 

--- a/internal/instance/mi.go
+++ b/internal/instance/mi.go
@@ -237,17 +237,16 @@ func (it miIterator) bindInstance(
 
 // drivesOwnIteration reports whether a looped composite drives its OWN iteration
 // off the loop (the iteration decorator, ADR-025 v.2 §2.12): a Standard-Loop
-// composite (runCompositeLoop) or a SEQUENTIAL Multi-Instance composite
-// (runMISequential). A parallel Multi-Instance (fan-out driver) and a plain
-// composite do NOT — they park for the loop-driven scope re-entry.
+// composite (runCompositeLoop) or ANY Multi-Instance composite — sequential
+// (runMISequential, await-each) or parallel (runMIParallel, fan-out-then-await-all).
+// A plain (non-looped) composite does NOT — it parks for the loop-driven scope
+// re-entry.
 func drivesOwnIteration(node flow.Node) bool {
 	if standardLoopOf(node) != nil {
 		return true
 	}
 
-	mi := multiInstanceOf(node)
-
-	return mi != nil && mi.IsSequential()
+	return multiInstanceOf(node) != nil
 }
 
 // runMISequential drives a sequential Multi-Instance composite from the host's own
@@ -304,7 +303,7 @@ func (t *track) runMISequential(
 		}
 
 		if _, err := t.instance.scopeRoundtrip(ctx,
-			scopeRequest{host: t, node: step.node}); err != nil {
+			scopeRequest{op: scopeOpen, host: t, node: step.node}); err != nil {
 			return nil, err
 		}
 

--- a/internal/instance/mi_decorator_test.go
+++ b/internal/instance/mi_decorator_test.go
@@ -97,3 +97,51 @@ func TestRunMISequentialDrainError(t *testing.T) {
 		t.Context(), &stepInfo{node: node}, multiInstanceOf(node))
 	require.Error(t, err)
 }
+
+// miParFixture builds a parallel-MI composite instance (cardinality 3) and returns
+// the host track positioned on the MI node — the white-box pieces the runMIParallel
+// error-path tests drive directly (the loop is NOT running).
+func miParFixture(t *testing.T) (*Instance, flow.Node, *track) {
+	t.Helper()
+
+	var count atomic.Int32
+
+	mi := mustParallelMI(t, activities.WithCardinality(cardExpr(t, 3)))
+	inst := miSubProcessInstance(t, &count, mi)
+	inst.tracks = map[string]*track{}
+	node := findNode(t, inst.s, "body")
+
+	host, err := newTrack(node, inst, nil)
+	require.NoError(t, err)
+
+	return inst, node, host
+}
+
+// TestRunMIParallelRequestError: the fan-out request on a stopped instance faults
+// out of the decorator (the roundtrip's loopDone path) — after N is resolved, the
+// scopeFanOut roundtrip fails.
+func TestRunMIParallelRequestError(t *testing.T) {
+	inst, node, host := miParFixture(t)
+	close(inst.loopDone) // scopeRoundtrip returns the not-running error
+
+	_, err := host.runMIParallel(
+		t.Context(), &stepInfo{node: node}, multiInstanceOf(node))
+	require.Error(t, err)
+}
+
+// TestRunMIParallelDrainError: a stand-in loop accepts the fan-out then closes evtCh
+// (a mid-barrier stop) — the decorator's drain wait unblocks with an error rather
+// than hanging.
+func TestRunMIParallelDrainError(t *testing.T) {
+	inst, node, host := miParFixture(t)
+
+	go func() {
+		req := <-inst.scopeReq    // the scopeFanOut request
+		req.reply <- scopeReply{} // fan-out "succeeded"
+		close(host.evtCh)         // the loop closes evtCh on stop
+	}()
+
+	_, err := host.runMIParallel(
+		t.Context(), &stepInfo{node: node}, multiInstanceOf(node))
+	require.Error(t, err)
+}

--- a/internal/instance/mi_parallel.go
+++ b/internal/instance/mi_parallel.go
@@ -12,95 +12,280 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/observability"
 )
 
-// miGroup coordinates a parallel Multi-Instance activity's N concurrent instance
-// scopes (SRD-056.A): the shared host, the node, the frozen instance count, and
-// the set of still-open instance paths (path → 0-based ordinal). It is the
-// N-of-N barrier the per-scope scopeEntry model cannot express — the host
-// resumes only when the last instance drains. Loop-goroutine-owned; M3 extends it
-// with the completed / terminated counters and the completionCondition.
+// miGroup is the loop-owned barrier substrate for a parallel Multi-Instance
+// activity's N concurrent instance scopes (SRD-056.A): the shared host, the node,
+// the input collection (nil for a cardinality-driven MI), the pre-sized staging
+// collection, the still-open instance paths (path → 0-based ordinal), the output
+// names, the frozen N, and the count of drains that arrived while the host runner
+// was busy and could not be delivered yet. It is the N-of-N barrier the per-scope
+// scopeEntry model cannot express. Loop-goroutine-owned; the off-loop decorator
+// (runMIParallel) drives the counting / completion / cancellation policy and reads
+// no group field mid-flight — it counts delivered drains locally and learns the
+// terminated count from the scopeComplete reply.
 type miGroup struct {
 	host       *track
 	node       flow.Node
-	mi         multiInstance
-	collection data.Collection    // nil for a cardinality-driven Multi-Instance
-	staging    *values.Array[any] // pre-sized to N; nil when no output is assembled
+	collection data.Collection
+	staging    *values.Array[any]
 	open       map[scope.DataPath]int
 	inputItem  string
 	outputRef  string
 	outputItem string
 	n          int
-	completed  int
-	terminated int
+	pending    int
 }
 
-// fanOutParallelMI opens all N instance scopes of a parallel Multi-Instance host
-// at activation, each at a distinct segment `sp-<id>-i`, and parks the host once
-// for the whole group (ADR-025 §2.5). N is fixed here (`resolveActivation`,
-// reused). Because it runs to completion on the loop goroutine, every instance
-// is registered in the group before any drain is processed — so a fast instance
-// cannot resume the host before the fan-out finishes. N ≤ 0 completes the
-// activity with zero instances.
-func (ls *loopState) fanOutParallelMI(
-	ctx context.Context, host *track, node flow.Node, sh scopeHost,
-) {
-	mi := multiInstanceOf(node)
-
-	n, col, err := miIterator{mi: mi}.resolveActivation(ctx, host, node)
+// runMIParallel drives a parallel Multi-Instance composite from the host's own
+// runner goroutine — the off-loop iteration decorator (SRD-056.A, ADR-025 v.2
+// §2.12), the fan-out-then-await-all sibling of runMISequential. It resolves N once
+// off the loop, asks the loop to fan out N distinct instance scopes (scopeFanOut),
+// then runs the N-of-N barrier: each delivered drain advances the completed count,
+// binds the §2.9 attributes, and evaluates the completionCondition; a true condition
+// asks the loop to cancel the remainder (scopeComplete cancel), otherwise the runner
+// re-arms (scopeReArm) for the next drain and completes when all N have drained. The
+// loop performs the single-writer mutations — open N, capture each output before its
+// scope closes, cancel, publish — and delivers the concurrent drains one at a time
+// through the cap-1 re-arm handshake (§4.2). On exit it follows the composite's
+// single outgoing flow once.
+func (t *track) runMIParallel(
+	ctx context.Context, step *stepInfo, mi multiInstance,
+) ([]*flow.SequenceFlow, error) {
+	n, col, err := miIterator{mi: mi}.resolveActivation(ctx, t, step.node)
 	if err != nil {
-		ls.inst.fail(err)
-		ls.stopAll()
-
-		return
+		return nil, err
 	}
 
-	// the host parks once for the whole fan-out; it resumes when the group's
-	// last instance drains (or immediately, with zero instances).
-	ls.waiting[host.ID()] = struct{}{}
-
+	// N <= 0 runs zero instances — follow the outgoing flow once, no fan-out, no
+	// group, no publish.
 	if n <= 0 {
-		ls.dispatchToParked(ctx, trackEvent{
-			kind:  evDeliver,
-			track: host,
-			eDef:  newScopeDone(),
+		return t.executeNode(ctx, step)
+	}
+
+	// ask the loop to open all N instance scopes and build the group barrier; it
+	// marks the host waiting before replying, so the first drain dispatches.
+	if _, err := t.instance.scopeRoundtrip(ctx, scopeRequest{
+		op: scopeFanOut, host: t, node: step.node, n: n, col: col,
+	}); err != nil {
+		return nil, err
+	}
+
+	for completed := 0; ; {
+		if err := t.awaitScopeDrained(ctx); err != nil {
+			return nil, err
+		}
+
+		completed++
+
+		done, err := t.parallelBarrierStep(ctx, step, mi, n, completed)
+		if err != nil {
+			return nil, err
+		}
+
+		if done {
+			break
+		}
+	}
+
+	return t.executeNode(ctx, step)
+}
+
+// parallelBarrierStep processes one delivered instance drain of a parallel
+// Multi-Instance's N-of-N barrier (SRD-056.A): it binds the §2.9 attributes off the
+// loop, evaluates the completionCondition, and drives the loop-side finalize/re-arm.
+// It reports done when the activity completes — the completionCondition fired (the
+// loop cancels the remainder + publishes) or all N have drained (the loop publishes)
+// — otherwise it re-arms for the next drain.
+func (t *track) parallelBarrierStep(
+	ctx context.Context, step *stepInfo, mi multiInstance, n, completed int,
+) (bool, error) {
+	// the delivered count is authoritative (delivery is 1:1 with completion, in
+	// order), so the condition and the body see the running §2.9 attributes.
+	if err := t.bindMICounters(n, completed, 0); err != nil {
+		return false, err
+	}
+
+	// completionCondition true → the activity is done now: ask the loop to cancel
+	// the still-open instances, publish, and drop the group (§4.5).
+	if completed < n && mi.CompletionCondition() != nil {
+		met, err := miIterator{mi: mi}.evalCompletion(ctx, t, step.node)
+		if err != nil {
+			return false, err
+		}
+
+		if met {
+			r, err := t.instance.scopeExchange(ctx, scopeRequest{
+				op: scopeComplete, host: t, node: step.node, cancel: true,
+			})
+			if err != nil {
+				return false, err
+			}
+
+			return true, t.bindMICounters(n, completed, r.terminated)
+		}
+	}
+
+	// all N drained with no early completion — publish and drop the group.
+	if completed == n {
+		_, err := t.instance.scopeRoundtrip(ctx, scopeRequest{
+			op: scopeComplete, host: t, node: step.node,
 		})
 
+		return true, err
+	}
+
+	// re-arm for the next drain: the loop re-marks the host waiting and delivers
+	// the next queued drain, if any (§4.2).
+	_, err := t.instance.scopeRoundtrip(ctx, scopeRequest{
+		op: scopeReArm, host: t, node: step.node,
+	})
+
+	return false, err
+}
+
+// bindMICounters publishes the §2.9 runtime attributes at the host scope off the
+// loop (SRD-056.A FR-12) — the frozen instance count, the still-running count
+// (n − completed − terminated), and the completed / terminated counts. Called by
+// the decorator after each delivered drain, before it evaluates the
+// completionCondition. A mutex-safe plane write, like the sequential slice's
+// off-loop binds.
+func (t *track) bindMICounters(n, completed, terminated int) error {
+	binds := []miBinding{
+		{name: "numberOfInstances", value: n},
+		{name: "numberOfActiveInstances", value: n - completed - terminated},
+		{name: "numberOfCompletedInstances", value: completed},
+		{name: "numberOfTerminatedInstances", value: terminated},
+	}
+
+	for _, b := range binds {
+		if err := t.instance.sc.bindDataItemAt(
+			t.scopePath, b.name, b.value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// handleFanOut opens all N instance scopes of a parallel Multi-Instance on the loop
+// goroutine, builds the loop-owned group barrier, marks the host waiting for the
+// whole group, and replies to the decorator (SRD-056.A FR-3). Because it runs to
+// completion before the loop processes any drain, every instance is registered
+// before the first drain — so a fast instance cannot resume the host before the
+// fan-out finishes (§4.6). A partial-open error leaves cleanup to the runner's fault
+// (stopAll cancels the subtree).
+func (ls *loopState) handleFanOut(ctx context.Context, req scopeRequest) {
+	sh, ok := req.node.(scopeHost)
+	if !ok {
+		// checkNodeType only routes scopeHost nodes to the decorator; a mismatch
+		// is a corrupt graph.
+		req.reply <- scopeReply{err: errs.New(
+			errs.M("scope fan-out requested for a non-composite node %q",
+				req.node.ID()),
+			errs.C(errorClass, errs.TypeCastingError))}
+
 		return
 	}
 
+	mi := multiInstanceOf(req.node)
+
+	// the host parks once for the whole fan-out; it resumes as each instance
+	// drains, delivered one at a time via the re-arm handshake.
+	ls.waiting[req.host.ID()] = struct{}{}
+
 	grp := &miGroup{
-		host:       host,
-		node:       node,
-		mi:         mi,
-		collection: col,
-		open:       make(map[scope.DataPath]int, n),
+		host:       req.host,
+		node:       req.node,
+		collection: req.col,
+		open:       make(map[scope.DataPath]int, req.n),
 		inputItem:  mi.InputDataItem(),
 		outputRef:  mi.LoopDataOutputRef(),
 		outputItem: mi.OutputDataItem(),
-		n:          n,
+		n:          req.n,
 	}
 
-	// an output-assembling Multi-Instance stages into a slice PRE-SIZED to N, so
-	// an instance completing out of order writes its slot by ordinal (SetAt is a
+	// an output-assembling Multi-Instance stages into a slice PRE-SIZED to N, so an
+	// instance completing out of order writes its slot by ordinal (SetAt is a
 	// replace, not an append); a canceled slot keeps its pre-run nil (§2.7).
 	if grp.outputRef != "" {
-		grp.staging = values.NewArray[any](make([]any, n)...)
+		grp.staging = values.NewArray[any](make([]any, req.n)...)
 	}
 
-	ls.miGroups[host.ID()] = grp
+	ls.miGroups[req.host.ID()] = grp
 
-	for i := 0; i < n; i++ {
-		if err := ls.openParallelInstance(ctx, grp, host, node, sh, i); err != nil {
-			ls.inst.fail(err)
-			ls.stopAll()
+	for i := 0; i < req.n; i++ {
+		if err := ls.openParallelInstance(
+			ctx, grp, req.host, req.node, sh, i); err != nil {
+			req.reply <- scopeReply{err: err}
 
 			return
 		}
 	}
+
+	req.reply <- scopeReply{}
+}
+
+// handleReArm re-marks the host waiting and delivers the next queued drain, if any
+// accumulated while the runner was busy (SRD-056.A FR-6) — the handshake step that
+// serializes N concurrent drains onto the cap-1 park. If the group is already gone
+// (a boundary tore it down), it just replies so the runner unblocks. Runs on the
+// loop goroutine.
+func (ls *loopState) handleReArm(ctx context.Context, req scopeRequest) {
+	grp, ok := ls.miGroups[req.host.ID()]
+	if !ok {
+		req.reply <- scopeReply{}
+
+		return
+	}
+
+	ls.waiting[req.host.ID()] = struct{}{}
+
+	if grp.pending > 0 {
+		grp.pending--
+		ls.dispatchToParked(ctx, trackEvent{
+			kind:  evDeliver,
+			track: req.host,
+			eDef:  newScopeDone(),
+		})
+	}
+
+	req.reply <- scopeReply{}
+}
+
+// handleComplete finalizes a parallel Multi-Instance group (SRD-056.A FR-10/FR-11):
+// when the request carries cancel it tears down every still-open instance scope as a
+// unit (a completionCondition fired, §4.5) and reports the terminated count; it then
+// publishes the assembled staging collection once at the host scope (the visibility
+// barrier) and drops the group. Runs on the loop goroutine.
+func (ls *loopState) handleComplete(req scopeRequest) {
+	grp, ok := ls.miGroups[req.host.ID()]
+	if !ok {
+		req.reply <- scopeReply{}
+
+		return
+	}
+
+	terminated := 0
+	if req.cancel {
+		terminated = ls.cancelOpenInstances(grp)
+	}
+
+	if grp.staging != nil {
+		if err := ls.inst.sc.bindValueAt(
+			grp.host.scopePath, grp.outputRef, grp.staging); err != nil {
+			req.reply <- scopeReply{err: err}
+
+			return
+		}
+	}
+
+	delete(ls.miGroups, req.host.ID())
+
+	req.reply <- scopeReply{terminated: terminated}
 }
 
 // openParallelInstance opens instance i's distinct scope (segment `sp-<id>-i`),
 // registers it in the group, publishes its Opened fact with its OWN ordinal
-// (FR-11, not the shared host.loopCounter), and seeds + arms the inner tracks.
+// (FR-14, not the shared host.loopCounter), and seeds + arms the inner tracks.
 // It returns an error the caller faults on.
 func (ls *loopState) openParallelInstance(
 	ctx context.Context, grp *miGroup, host *track, node flow.Node,
@@ -178,85 +363,6 @@ func (ls *loopState) captureParallelOutput(
 	return grp.staging.SetAt(ctx, entry.ordinal, d.Value().Get(ctx))
 }
 
-// parallelInstanceDrained records one instance scope of a parallel
-// Multi-Instance as drained; when the group's last instance completes it
-// publishes the assembled output collection once (the visibility barrier),
-// resumes the shared host, and drops the group (SRD-056.A). It returns an error
-// the caller faults on. Runs on the loop goroutine (from completeScope).
-func (ls *loopState) parallelInstanceDrained(
-	ctx context.Context, path scope.DataPath, entry *scopeEntry,
-) error {
-	grp := entry.group
-	delete(grp.open, path)
-	grp.completed++
-
-	// publish the running §2.9 attributes at the host scope for the
-	// completionCondition (and the body) to resolve by name.
-	if err := ls.bindParallelCounters(grp); err != nil {
-		return err
-	}
-
-	done := len(grp.open) == 0
-
-	// completionCondition true → the activity is done now: cancel the still-open
-	// instances as a unit (§2.7).
-	if !done && grp.mi.CompletionCondition() != nil {
-		met, err := miIterator{mi: grp.mi}.
-			evalCompletion(ctx, grp.host, grp.node)
-		if err != nil {
-			return err
-		}
-
-		if met {
-			ls.cancelRemainingInstances(grp)
-
-			done = true
-		}
-	}
-
-	if !done {
-		return nil
-	}
-
-	if grp.staging != nil {
-		if err := ls.inst.sc.bindValueAt(
-			grp.host.scopePath, grp.outputRef, grp.staging); err != nil {
-			return err
-		}
-	}
-
-	delete(ls.miGroups, grp.host.ID())
-
-	ls.dispatchToParked(ctx, trackEvent{
-		kind:  evDeliver,
-		track: grp.host,
-		eDef:  newScopeDone(),
-	})
-
-	return nil
-}
-
-// bindParallelCounters publishes the §2.9 runtime attributes at the host scope:
-// the frozen instance count, the still-running count, and the completed /
-// terminated counts as they progress (SRD-056.A FR-9).
-func (ls *loopState) bindParallelCounters(grp *miGroup) error {
-	binds := []miBinding{
-		{name: "numberOfInstances", value: grp.n},
-		{name: "numberOfActiveInstances", value: len(grp.open)},
-		{name: "numberOfCompletedInstances", value: grp.completed},
-		{name: "numberOfTerminatedInstances", value: grp.terminated},
-	}
-
-	for _, b := range binds {
-		if err := ls.inst.sc.bindDataItemAt(
-			grp.host.scopePath, b.name, b.value); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // cancelOpenInstances cancels every still-open instance scope of the group as a
 // unit (ADR-018 mechanism) and clears the open set, returning the count.
 func (ls *loopState) cancelOpenInstances(grp *miGroup) int {
@@ -274,16 +380,9 @@ func (ls *loopState) cancelOpenInstances(grp *miGroup) int {
 	return len(paths)
 }
 
-// cancelRemainingInstances tears down the group's still-open instance scopes
-// because a completionCondition fired (§2.7) and counts them terminated. Each
-// canceled instance keeps its pre-run output slot (its nil).
-func (ls *loopState) cancelRemainingInstances(grp *miGroup) {
-	grp.terminated += ls.cancelOpenInstances(grp)
-}
-
 // cancelParallelGroup tears down all of a parallel Multi-Instance's open
 // instance scopes and drops the group — the companion for an interrupting
-// boundary firing on the fanned-out host (SRD-056.A FR-10). Unlike a
+// boundary firing on the fanned-out host (SRD-056.A FR-13). Unlike a
 // completionCondition (which completes the activity), the host is itself being
 // canceled, so the group is abandoned rather than resumed.
 func (ls *loopState) cancelParallelGroup(grp *miGroup) {

--- a/internal/instance/mi_parallel_test.go
+++ b/internal/instance/mi_parallel_test.go
@@ -385,7 +385,8 @@ func TestParallelMultiInstanceInputGetAtError(t *testing.T) {
 }
 
 // TestParallelMultiInstancePublishError covers the completion publish's error:
-// committing the assembled collection at an unopened host scope fails.
+// committing the assembled collection at an unopened host scope fails when the
+// decorator asks the loop to finalize the group (scopeComplete).
 func TestParallelMultiInstancePublishError(t *testing.T) {
 	var count atomic.Int32
 
@@ -405,13 +406,14 @@ func TestParallelMultiInstancePublishError(t *testing.T) {
 		host:      host,
 		node:      node,
 		staging:   values.NewArray[any](nil), // non-nil → publish is attempted
-		open:      map[scope.DataPath]int{},  // empty → this drain is the last
+		open:      map[scope.DataPath]int{},  // empty → nothing to cancel
 		outputRef: "res",
 	}
-	entry := &scopeEntry{group: grp, ordinal: 0}
+	ls.miGroups[host.ID()] = grp
 
-	err = ls.parallelInstanceDrained(t.Context(), scope.DataPath("/x"), entry)
-	require.Error(t, err)
+	reply := make(chan scopeReply, 1)
+	ls.handleComplete(scopeRequest{host: host, node: node, reply: reply})
+	require.Error(t, (<-reply).err)
 }
 
 // TestParallelMultiInstanceCardinalityError: a cardinality that errors on
@@ -431,15 +433,14 @@ func TestParallelMultiInstanceCardinalityError(t *testing.T) {
 
 // TestParallelMultiInstanceOpenScopeError covers the fan-out's defensive
 // data-plane open failure: pre-opening instance 0's child path makes its
-// OpenScope duplicate, faulting the instance (mirrors the onScopeOpen white-box).
+// OpenScope duplicate, so the fan-out handler replies an error the decorator
+// faults on.
 func TestParallelMultiInstanceOpenScopeError(t *testing.T) {
 	var count atomic.Int32
 
 	mi := mustParallelMI(t, activities.WithCardinality(cardExpr(t, 2)))
 
 	inst := miSubProcessInstance(t, &count, mi)
-	// no tracks are spawned in this white-box; clear the birth tracks so the
-	// fault path's stopAll has no un-spawned (nil-cancel) track to touch.
 	inst.tracks = map[string]*track{}
 	ls := newLoopState(inst)
 	node := findNode(t, inst.s, "body")
@@ -451,10 +452,10 @@ func TestParallelMultiInstanceOpenScopeError(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, inst.sc.plane.OpenScope(child))
 
-	ls.fanOutParallelMI(t.Context(), host, node, node.(scopeHost))
-
-	require.True(t, ls.stopping)
-	require.Error(t, inst.LastErr())
+	reply := make(chan scopeReply, 1)
+	ls.handleFanOut(t.Context(),
+		scopeRequest{host: host, node: node, n: 2, reply: reply})
+	require.Error(t, (<-reply).err)
 }
 
 // TestParallelMultiInstanceSequentialStillWorks: the parallel dispatch leaves the
@@ -469,4 +470,73 @@ func TestParallelMultiInstanceSequentialStillWorks(t *testing.T) {
 
 	require.Equal(t, Completed, inst.State())
 	require.Equal(t, int32(3), count.Load())
+}
+
+// TestParallelBarrierStepBindError: the per-drain §2.9 attribute bind at an unopened
+// host scope faults the barrier step (covering bindMICounters' error path too).
+func TestParallelBarrierStepBindError(t *testing.T) {
+	_, node, host := miParFixture(t)
+	host.scopePath = scope.DataPath("/does/not/exist") // bindDataItemAt fails
+
+	_, err := host.parallelBarrierStep(
+		t.Context(), &stepInfo{node: node}, multiInstanceOf(node), 3, 1)
+	require.Error(t, err)
+}
+
+// TestParallelBarrierStepCompleteError: a true completionCondition drives the
+// scopeComplete roundtrip, which faults on a stopped instance (loopDone closed).
+func TestParallelBarrierStepCompleteError(t *testing.T) {
+	var count atomic.Int32
+
+	mi := mustParallelMI(t, activities.WithCardinality(cardExpr(t, 3)),
+		activities.WithCompletionCondition(attrAtLeast(t, "numberOfInstances", 1)))
+
+	inst := miSubProcessInstance(t, &count, mi)
+	inst.tracks = map[string]*track{}
+	node := findNode(t, inst.s, "body")
+
+	host, err := newTrack(node, inst, nil)
+	require.NoError(t, err)
+	close(inst.loopDone) // the scopeComplete roundtrip returns not-running
+
+	_, err = host.parallelBarrierStep(
+		t.Context(), &stepInfo{node: node}, mi, 3, 1)
+	require.Error(t, err)
+}
+
+// TestHandleReArmGroupGone: re-arming a group already torn down (e.g. by an
+// interrupting boundary) just replies so the runner unblocks — no error.
+func TestHandleReArmGroupGone(t *testing.T) {
+	inst, node, host := miParFixture(t)
+	ls := newLoopState(inst)
+
+	reply := make(chan scopeReply, 1)
+	ls.handleReArm(t.Context(),
+		scopeRequest{op: scopeReArm, host: host, node: node, reply: reply})
+	require.NoError(t, (<-reply).err)
+}
+
+// TestHandleCompleteGroupGone: completing a group already torn down just replies —
+// no error, nothing to publish or cancel.
+func TestHandleCompleteGroupGone(t *testing.T) {
+	inst, node, host := miParFixture(t)
+	ls := newLoopState(inst)
+
+	reply := make(chan scopeReply, 1)
+	ls.handleComplete(
+		scopeRequest{op: scopeComplete, host: host, node: node, reply: reply})
+	require.NoError(t, (<-reply).err)
+}
+
+// TestHandleFanOutNonComposite: a fan-out for a node that is not a composite is a
+// corrupt-graph error surfaced to the decorator.
+func TestHandleFanOutNonComposite(t *testing.T) {
+	inst, _, host := miParFixture(t)
+	ls := newLoopState(inst)
+	leaf := findNode(t, inst.s, "start") // a StartEvent is not a scopeHost
+
+	reply := make(chan scopeReply, 1)
+	ls.handleFanOut(t.Context(),
+		scopeRequest{op: scopeFanOut, host: host, node: leaf, n: 1, reply: reply})
+	require.Error(t, (<-reply).err)
 }

--- a/internal/instance/mi_test.go
+++ b/internal/instance/mi_test.go
@@ -623,8 +623,8 @@ func TestDrivesOwnIteration(t *testing.T) {
 		"a Standard Loop composite self-drives")
 	require.True(t, drivesOwnIteration(seqNode),
 		"a sequential Multi-Instance composite self-drives")
-	require.False(t, drivesOwnIteration(parNode),
-		"a parallel Multi-Instance parks and fans out")
+	require.True(t, drivesOwnIteration(parNode),
+		"a parallel Multi-Instance composite self-drives (fan-out-then-await-all)")
 	require.False(t, drivesOwnIteration(plainNode))
 	require.False(t, drivesOwnIteration(evNode))
 }

--- a/internal/instance/scope_decorator.go
+++ b/internal/instance/scope_decorator.go
@@ -5,28 +5,62 @@ import (
 
 	"github.com/dr-dobermann/gobpm/internal/scope"
 	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/dr-dobermann/gobpm/pkg/observability"
 )
 
+// scopeOp is the operation a scopeRequest asks the single-writer loop to perform
+// for an off-loop iteration decorator (ADR-025 v.2 §2.12). scopeOpen is the
+// serial open (Standard Loop / sequential MI, one child scope per pass); the
+// remaining ops drive a PARALLEL Multi-Instance's fan-out-then-await-all barrier
+// (SRD-056.A), whose N concurrent drains the cap-1 runner park cannot take at
+// once — so the loop delivers them one at a time through the re-arm handshake.
+type scopeOp int
+
+const (
+	// scopeOpen opens one child scope for a serial pass and parks the host for
+	// its drain (Standard Loop, sequential MI).
+	scopeOpen scopeOp = iota
+	// scopeFanOut opens all N instance scopes of a parallel Multi-Instance,
+	// builds the loop-owned group barrier, and marks the host waiting.
+	scopeFanOut
+	// scopeReArm re-marks the host waiting and delivers the next queued drain —
+	// the handshake step that serializes N concurrent drains onto the cap-1 park.
+	scopeReArm
+	// scopeComplete finalizes the group: optionally cancels the still-open
+	// instances (a completionCondition fired), publishes the assembled output,
+	// and drops the group.
+	scopeComplete
+)
+
 // scopeRequest is a looped composite's off-loop iteration decorator asking the
-// single-writer loop to open the child scope for one pass (SRD-054 §2.12 / FR-8a):
-// host is the composite host track, node is the composite node, and reply carries
-// the loop's verdict (the opened path) back to the decorator's runner goroutine.
-// The pass ordinal is bound as loopCounter by the decorator itself, off the loop
-// (§4.6) — a plane write, mutex-safe like the leaf loop's bind — so it is set
-// before the continuation test reads it and before the scope opens.
+// single-writer loop to perform a scope operation (op) for one iteration step
+// (SRD-054 §2.12 / FR-8a; SRD-056.A for the parallel ops): host is the composite
+// host track, node is the composite node, and reply carries the loop's verdict
+// back to the decorator's runner goroutine. For a serial open the pass ordinal is
+// bound as loopCounter by the decorator itself, off the loop (§4.6) — a plane
+// write, mutex-safe like the leaf loop's bind — so it is set before the
+// continuation test reads it and before the scope opens. n / col carry a parallel
+// fan-out's instance count and input collection; cancel asks scopeComplete to tear
+// down the still-open instances first.
 type scopeRequest struct {
-	host  *track
-	node  flow.Node
-	reply chan scopeReply
+	col    data.Collection
+	host   *track
+	node   flow.Node
+	reply  chan scopeReply
+	op     scopeOp
+	n      int
+	cancel bool
 }
 
-// scopeReply is the loop's answer to a scopeRequest: the opened child path, or an
-// error the decorator faults on.
+// scopeReply is the loop's answer to a scopeRequest: the opened child path (open),
+// the count of instances torn down (scopeComplete with cancel), or an error the
+// decorator faults on.
 type scopeReply struct {
-	err       error
-	scopePath scope.DataPath
+	err        error
+	scopePath  scope.DataPath
+	terminated int
 }
 
 // scopeRoundtrip hands req to the loop and blocks for the reply, honoring ctx and
@@ -38,39 +72,70 @@ func (inst *Instance) scopeRoundtrip(
 	ctx context.Context,
 	req scopeRequest,
 ) (scope.DataPath, error) {
+	r, err := inst.scopeExchange(ctx, req)
+
+	return r.scopePath, err
+}
+
+// scopeExchange is scopeRoundtrip's full-reply form: it hands req to the loop and
+// returns the whole scopeReply, so a caller that needs a field other than the
+// opened path (a parallel scopeComplete reads the terminated count) can read it.
+// scopeRoundtrip is the thin path-only wrapper.
+func (inst *Instance) scopeExchange(
+	ctx context.Context,
+	req scopeRequest,
+) (scopeReply, error) {
 	req.reply = make(chan scopeReply, 1)
 
 	select {
 	case inst.scopeReq <- req:
 	case <-inst.loopDone:
-		return "", errs.New(
+		return scopeReply{}, errs.New(
 			errs.M("instance %q is not running", inst.ID()),
 			errs.C(errorClass, errs.InvalidState))
 	case <-ctx.Done():
-		return "", ctx.Err()
+		return scopeReply{}, ctx.Err()
 	}
 
 	select {
 	case r := <-req.reply:
-		return r.scopePath, r.err
+		return r, r.err
 	case <-inst.loopDone:
-		return "", errs.New(
+		return scopeReply{}, errs.New(
 			errs.M("instance %q stopped before scope reply", inst.ID()),
 			errs.C(errorClass, errs.InvalidState))
 	case <-ctx.Done():
-		return "", ctx.Err()
+		return scopeReply{}, ctx.Err()
 	}
 }
 
-// handleScopeRequest opens one pass's child scope on the loop goroutine and replies
-// to the decorator (SRD-054 FR-8a). It is the loop-side half of the scope protocol,
-// mirroring handleTaskRequest: it performs the single-writer mutations the off-loop
-// decorator must not do — open the data-plane child scope, register the entry, mark
-// the host parked-for-drain, seed the inner tracks, and arm the scope handlers. The
-// pass ordinal is already bound as loopCounter by the decorator (off the loop, §4.6)
-// before this request, so the seeded body reads it by walk-up. Scope close stays on
-// the existing drain path (completeScope), so no close request is needed here (§4.3).
+// handleScopeRequest is the loop-side half of the scope protocol (mirroring
+// handleTaskRequest): it runs on the loop goroutine and dispatches the decorator's
+// request to the single-writer mutation it names. scopeOpen serves the serial
+// drivers (Standard Loop, sequential MI); scopeFanOut / scopeReArm / scopeComplete
+// serve a parallel Multi-Instance's off-loop barrier (SRD-056.A).
 func (ls *loopState) handleScopeRequest(ctx context.Context, req scopeRequest) {
+	switch req.op {
+	case scopeFanOut:
+		ls.handleFanOut(ctx, req)
+	case scopeReArm:
+		ls.handleReArm(ctx, req)
+	case scopeComplete:
+		ls.handleComplete(req)
+	default:
+		ls.handleScopeOpen(ctx, req)
+	}
+}
+
+// handleScopeOpen opens one pass's child scope on the loop goroutine and replies
+// to the decorator (SRD-054 FR-8a). It performs the single-writer mutations the
+// off-loop decorator must not do — open the data-plane child scope, register the
+// entry, mark the host parked-for-drain, seed the inner tracks, and arm the scope
+// handlers. The pass ordinal is already bound as loopCounter by the decorator (off
+// the loop, §4.6) before this request, so the seeded body reads it by walk-up. Scope
+// close stays on the existing drain path (completeScope), so no close request is
+// needed here (§4.3).
+func (ls *loopState) handleScopeOpen(ctx context.Context, req scopeRequest) {
 	sh, ok := req.node.(scopeHost)
 	if !ok {
 		// checkNodeType only routes scopeHost nodes to the decorator; a mismatch
@@ -156,7 +221,7 @@ func (t *track) runCompositeLoop(
 		// acknowledgement (single-writer), then park for the scope's drain — the
 		// loop delivers scopeDone on evtCh, as for any composite host.
 		if _, err := t.instance.scopeRoundtrip(ctx,
-			scopeRequest{host: t, node: step.node}); err != nil {
+			scopeRequest{op: scopeOpen, host: t, node: step.node}); err != nil {
 			return nil, err
 		}
 

--- a/internal/instance/scope_runtime.go
+++ b/internal/instance/scope_runtime.go
@@ -92,16 +92,6 @@ func (ls *loopState) onScopeOpen(ctx context.Context, host *track, node flow.Nod
 		return
 	}
 
-	// a parallel Multi-Instance host fans out ALL its instances at once, each in
-	// a distinct scope, and completes only when the last drains (SRD-056.A) — a
-	// different control flow from the serial re-entry below, so it dispatches
-	// here before the single-scope path.
-	if mi := multiInstanceOf(node); mi != nil && !mi.IsSequential() {
-		ls.fanOutParallelMI(ctx, host, node, sh)
-
-		return
-	}
-
 	// a host may override the child segment (SRD-053): a non-interrupting
 	// Event Sub-Process handler carries a unique per-fire segment so concurrent
 	// instances of the same node open distinct scopes; every normal composite
@@ -349,13 +339,23 @@ func (ls *loopState) completeScope(
 
 	ls.reportScope(observability.PhaseCompleted, entry.node, path, ordinal)
 
-	// a parallel Multi-Instance instance drains into its group's N-of-N barrier;
-	// the shared host resumes only when the last instance completes (SRD-056.A),
-	// not through the serial re-entry.
+	// a parallel Multi-Instance instance drains into its group's N-of-N barrier
+	// (SRD-056.A): the off-loop decorator (runMIParallel) owns the counting and the
+	// completion policy, so the loop only removes the instance from the open set and
+	// delivers the drain to the parked runner — one at a time, queueing any that
+	// arrive while the runner is busy (the cap-1 handshake, §4.2).
 	if entry.group != nil {
-		if err := ls.parallelInstanceDrained(ctx, path, entry); err != nil {
-			ls.inst.fail(err)
-			ls.stopAll()
+		grp := entry.group
+		delete(grp.open, path)
+
+		if _, waiting := ls.waiting[grp.host.ID()]; waiting {
+			ls.dispatchToParked(ctx, trackEvent{
+				kind:  evDeliver,
+				track: grp.host,
+				eDef:  newScopeDone(),
+			})
+		} else {
+			grp.pending++
 		}
 
 		return
@@ -476,8 +476,15 @@ func (ls *loopState) cancelScope(path scope.DataPath, phase observability.Phase)
 				"scope_path", string(p), "error", err.Error())
 		}
 
-		ls.reportScope(phase, entry.node, p,
-			scopeLoopCounter(entry.node, entry.host))
+		// a parallel Multi-Instance instance reports its OWN ordinal (SRD-056.A
+		// FR-14), not the shared host.loopCounter that scopeLoopCounter surfaces
+		// now that a parallel MI self-drives.
+		ord := scopeLoopCounter(entry.node, entry.host)
+		if entry.group != nil {
+			ord = entry.ordinal
+		}
+
+		ls.reportScope(phase, entry.node, p, ord)
 	}
 }
 

--- a/internal/instance/std_loop.go
+++ b/internal/instance/std_loop.go
@@ -56,12 +56,16 @@ func (t *track) executeStep(
 		return t.runStandardLoop(ctx, step, sl)
 	}
 
-	// a sequential Multi-Instance composite drives itself off the loop via its own
-	// count-driven decorator (SRD-055 §2.12); a parallel MI parks and fans out
-	// through onScopeOpen (SRD-056.A), so it is not routed here.
-	if mi := multiInstanceOf(step.node); mi != nil && mi.IsSequential() {
+	// a Multi-Instance composite drives itself off the loop via its own decorator
+	// (ADR-025 v.2 §2.12): sequential await-each (runMISequential, SRD-055) or
+	// parallel fan-out-then-await-all (runMIParallel, SRD-056.A).
+	if mi := multiInstanceOf(step.node); mi != nil {
 		if _, ok := step.node.(scopeHost); ok {
-			return t.runMISequential(ctx, step, mi)
+			if mi.IsSequential() {
+				return t.runMISequential(ctx, step, mi)
+			}
+
+			return t.runMIParallel(ctx, step, mi)
 		}
 	}
 


### PR DESCRIPTION
## What

Re-lands **parallel Multi-Instance** on the off-loop iteration decorator
(ADR-025 v.2 §2.12), the third slice of the decorator rearchitecture after
composite Standard Loop (SRD-054) and sequential MI (SRD-055). Internal rework,
**behavior-preserving** — only *who drives* the fan-out and the N-of-N barrier
moves off the single-writer loop goroutine onto the host activity's own runner.

Part of #88 (activity iteration — loops / Multi-Instance).

## Why

The prior landing drove the parallel fan-out and the N-of-N barrier **entirely
on the loop goroutine** (`fanOutParallelMI` at `onScopeOpen`; `parallelInstanceDrained`
counting / evaluating `completionCondition` / cancelling / publishing / resuming).
The remaining slice, SRD-056.B's Multi-Instance `behavior` throw, is unimplementable
there: throwing hands an event to the loop's ordered inbound channel, and issued
*from* the loop goroutine that hand-off self-deadlocks (made fire-and-forget it drops
the boundary catch nondeterministically). Because the behavior decision depends on
the **aggregate** group state, it must run wherever the barrier lives — so the
barrier itself moves off the loop now, and SRD-056.B adds only the throw at an
already-off-loop decision point.

## Key decision — the per-drain handshake

A composite host's runner parks on a **single, cap-1, waiting-gated** channel
(`evtCh`, `eventBufferDepth == 1`). Sequential MI fits perfectly (one scope open at a
time), but parallel has **N concurrent** drains arriving in arbitrary order at that
single-slot runner — the loop cannot fire N `scopeDone`s at it. So the loop delivers
drains **one at a time** through a re-arm handshake: `completeScope` dispatches a
drain if the host is waiting, else queues it; the runner processes each off-loop
(count, bind the §2.9 attributes, evaluate `completionCondition`) and issues
`scopeReArm` for the next. All completion *policy* runs on the runner; the loop
performs only the single-writer *mutations* it requests.

## Key changes

- **`scope_decorator.go`** — `scopeRequest` gains an op (`scopeOpen` / `scopeFanOut`
  / `scopeReArm` / `scopeComplete`); `handleScopeRequest` dispatches; `scopeExchange`
  exposes the full reply (`scopeComplete`'s terminated count).
- **`mi_parallel.go`** — `runMIParallel` (runner) resolves N, requests the fan-out,
  then runs the barrier via `parallelBarrierStep`; loop-side `handleFanOut` /
  `handleReArm` / `handleComplete` perform the mutations (open N, dispatch-or-queue,
  cancel, publish). Deletes the loop-side driving (`fanOutParallelMI`,
  `parallelInstanceDrained`, the loop-side `bindParallelCounters`); reuses
  `openParallelInstance` / `captureParallelOutput` / `cancelOpenInstances` /
  `cancelParallelGroup`.
- **`scope_runtime.go`** — `completeScope` group-branch → capture (kept loop-side) +
  remove-from-open + dispatch-if-waiting-else-queue; `onScopeOpen` fan-out dispatch
  removed; `cancelScope` reports a grouped instance's own ordinal (widening
  `drivesOwnIteration` otherwise surfaces the shared `host.loopCounter`).
- **`mi.go` / `std_loop.go`** — `drivesOwnIteration` covers any MI composite;
  `executeStep` routes a parallel MI to `runMIParallel`.

## Verification

- `make ci` green (rebased onto master incl. #226 compensation) — golangci-lint 0,
  `-race`, **diff-coverage 100% of 185 changed lines (min 95%)**, govulncheck clean.
- Landed parallel suite (`mi_parallel_test.go`) + thresher `TestParallelMultiInstanceE2E`
  stay green under `-race` (the concurrent barrier); new white-box tests cover the
  decorator error/guard branches (`TestParallelBarrierStep*`, `TestHandle{ReArm,Complete}GroupGone`,
  `TestHandleFanOutNonComposite`, `TestRunMIParallel{RequestError,DrainError}`).
- `examples/multi-instance-parallel/` smokes end-to-end: exits 0, `[70 75 80 85]
  (average 77)`.
- `/check-srd` landing gate: **PASS**.

## Docs

- **SRD-056.A** rewritten (delete-and-reuse) for the decorator, flipped **Accepted**,
  §10 filled.
- `CHANGELOG.md` decorator Changed note now covers SRD-056.A.
- ADR-025 v.2 stays **Draft** until SRD-056.B (the behavior throw) completes the
  §2.12 re-landing.

## Commits

- `e21d7f9` docs(srd): SRD-056.A rewritten for the off-loop decorator (Draft)
- `14bdd10` feat(instance): parallel Multi-Instance on the off-loop decorator (M1)
- `ea32623` docs(srd): SRD-056.A Accepted — §10 summary + CHANGELOG (M2)
