### PR TITLE
docs(examples): a mermaid process diagram for every example

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -26,6 +26,16 @@ the data-layer clone precondition. Governing: **ADR-010**.
 
 ## Planned work / deferred
 
+- **Generated true-BPMN example diagrams (rides ADR-024)** — the example READMEs
+  carry hand-written mermaid *approximations* of BPMN (no event icons, no
+  attached-boundary notation — mermaid has no BPMN diagram type; added
+  2026-07-22). Once the ADR-024 model→BPMN-XML exporter lands, add a make/CI
+  step that runs each example's own process definition through the exporter +
+  `bpmn-to-image` → true-notation SVGs that regenerate from the code and can
+  never drift. Optional interim: a mermaid v11 "BPMN-ish" shape convention
+  (`dbl-circ` ends, `diam` gateways, `subproc` frames + a classDef palette) —
+  pilot one example against GitHub's renderer first.
+
 Genuinely un-homed items — not yet tracked in an ADR/SRD, the roadmap, or the
 audit-backlog. Each graduates out into an ADR/SRD (when designed) or a FIX (when
 implemented), and leaves this list.

--- a/examples/basic-process/README.md
+++ b/examples/basic-process/README.md
@@ -2,6 +2,11 @@
 
 This example demonstrates the fundamental concepts of creating a simple BPMN process using GoBPM.
 
+```mermaid
+flowchart LR
+    s((start)) --> w["work (greet Go functor)"] --> e((end))
+```
+
 ## What it demonstrates
 
 - Creating a BPM engine (Thresher)

--- a/examples/boundary-events/README.md
+++ b/examples/boundary-events/README.md
@@ -9,6 +9,15 @@ start → [process-payment] ───────────────> end-p
              └─> [cancel-order] ─────────> end-cancelled
 ```
 
+```mermaid
+flowchart LR
+    start((start)) --> payment[process-payment]
+    payment --> endPaid((end-paid))
+    payment -.- timeout(("payment-timeout<br>timer 2s, interrupting"))
+    timeout --> cancel[cancel-order]
+    cancel --> endCancelled((end-cancelled))
+```
+
 A 2s timer boundary attached to a ~4s payment ServiceTask fires first: the engine
 cancels the payment track, the activity's context-honouring op returns early, its
 result is discarded by the interruption checkpoint, and a token is routed onto the

--- a/examples/compensation-events/README.md
+++ b/examples/compensation-events/README.md
@@ -8,6 +8,17 @@ start → [book-hotel] → [book-flight] → cancel-trip (Compensation End Event
             ╳ undo-hotel   ╳ undo-flight     (Compensation boundaries)
 ```
 
+```mermaid
+flowchart LR
+    start((start)) --> hotel[book-hotel]
+    hotel --> flight[book-flight]
+    flight --> cancelTrip(("cancel-trip<br>Compensation End"))
+    hotel -.- compHotel((comp-hotel))
+    compHotel -.-> undoHotel["undo-hotel<br>isForCompensation"]
+    flight -.- compFlight((comp-flight))
+    compFlight -.-> undoFlight["undo-flight<br>isForCompensation"]
+```
+
 Each booking carries a **Compensation boundary** linked to its
 `isForCompensation` undo handler. When a booking completes, it enters the
 engine's **completion ledger** with a **data snapshot** taken at that instant.
@@ -26,7 +37,8 @@ Key semantics on display:
 ## Run
 
 ```bash
-go run ./examples/compensation-events/
+cd examples/compensation-events
+go run .
 ```
 
 Expected: both bookings print, then the undo handlers print **flight first,

--- a/examples/complex-gateway/README.md
+++ b/examples/complex-gateway/README.md
@@ -1,0 +1,40 @@
+# complex-gateway
+
+**Complex gateway: an activation-threshold join — fire once N of M arrive**
+(ADR-005 §2.11).
+
+Three approvers run in parallel; the Complex join fires on the data-aware
+activation rule `[(amount<1000, 2), (amount>=1000, 3)]`:
+
+- the AND-split runs all three approvers concurrently;
+- the join picks its threshold by guard — two approvals suffice for a small
+  order, all three for a large one (partial-join / discriminator family,
+  WCP-30 / WCP-9);
+- any approval arriving after the join has fired is consumed as a
+  **trailing token** — it does not re-fire the join;
+- the demo runs with `amount = 500`, so the join fires on the 2nd approval.
+
+```mermaid
+flowchart LR
+    s((start)) --> split{AND-split}
+    split --> manager --> join{"Complex join"}
+    split --> finance --> join
+    split --> cfo --> join
+    join --> finalize --> e((end))
+```
+
+`process.go` builds the process (the activation rule lives in
+`approvalJoin`), `main.go` wires the engine and runs.
+
+```bash
+cd examples/complex-gateway && go run .
+```
+
+```
+order amount = 500 (needs 2 approvals)
+  ▶ manager approved
+  ▶ finance approved
+  ▶ cfo approved
+  ✓ order finalized
+✓ complex-gateway completed (Completed): the join fired on the 2nd approval; ...
+```

--- a/examples/conversation-routing/README.md
+++ b/examples/conversation-routing/README.md
@@ -1,0 +1,41 @@
+# conversation-routing
+
+**A follow-up message routes back to the specific handler instance whose
+conversation it belongs to; two conversations stay isolated** (SRD-017
+phase-2c — conversation-token threading).
+
+- each `order placed` message spawns a keyed `order-handler` instance
+  (phase-2b instantiation) and **seeds its conversation key** with the
+  order id derived from the payload (`orderId` correlation property);
+- the in-instance `await-payment` ReceiveTask subscribes **keyed to that
+  conversation**, so a `payment received` carrying the same order id routes
+  back to the originating handler — never the other one;
+- the driver runs two conversations (`ORD-1`, `ORD-2`) concurrently and
+  verifies each handler reported its own order paired with its own payment
+  (no cross-talk).
+
+```mermaid
+flowchart LR
+    subgraph driver["main (driver)"]
+        po["publish order placed"]
+        pp["publish payment received"]
+    end
+    subgraph handler["order-handler (one instance per order)"]
+        s((order-received)) --> await[await-payment] --> report --> e((handled))
+    end
+    po -.->|instantiates and seeds the key| s
+    pp -.->|routes by orderId| await
+```
+
+`correlation.go` builds the correlation key, `handler.go` the handler
+process, `main.go` drives both conversations and verifies.
+
+```bash
+cd examples/conversation-routing && go run .
+```
+
+```
+handler reported order/payment: ORD-1/ORD-1
+handler reported order/payment: ORD-2/ORD-2
+OK: each payment routed to its originating handler conversation
+```

--- a/examples/escalation-events/README.md
+++ b/examples/escalation-events/README.md
@@ -11,6 +11,18 @@ start → [review-order] ──────────────────�
              └─> [notify-manager] ──────────> end-escalated
 ```
 
+```mermaid
+flowchart LR
+    start((start)) --> review
+    subgraph review["review-order — Sub-Process"]
+        subStart((sub-start)) --> raise(("raise-over-budget<br>Escalation End"))
+    end
+    review --> approved((end-approved))
+    review -.- boundary(("over-budget<br>escalation boundary, interrupting"))
+    boundary --> notify[notify-manager]
+    notify --> escalated((end-escalated))
+```
+
 The `review-order` sub-process reaches an **Escalation End Event** that raises
 `OVER_BUDGET`. Unlike an Error End Event, this does **not** fault the instance:
 the escalation climbs the scope chain to the innermost matching catcher. Here an
@@ -26,7 +38,8 @@ silently dropped and never a fault.
 ## Run
 
 ```bash
-go run ./examples/escalation-events/
+cd examples/escalation-events
+go run .
 ```
 
 Expected: the interrupting boundary fires (`Scope Canceled review-order`),

--- a/examples/event-based-gateway/README.md
+++ b/examples/event-based-gateway/README.md
@@ -1,0 +1,32 @@
+# event-based-gateway
+
+**Mid-flow deferred choice — the first of several events to fire wins; the
+rest are dropped** (ADR-005 §2.12).
+
+- the Event-Based gateway subscribes to **both** arms — an `approval`
+  message catch and a 10s `timeout` timer catch — and routes the token down
+  whichever fires first, dropping the other subscription;
+- the demo publishes the approval message after the gate has parked on both
+  arms, so the approval arm wins;
+- the timer arm is the self-terminating fallback — the run completes even
+  if no message ever arrives.
+
+```mermaid
+flowchart LR
+    s((start)) --> gate{event-gate}
+    gate --> a((approval)) --> approved --> ea((end-approved))
+    gate --> t(("timeout (10s timer)")) --> timedOut --> et((end-timeout))
+```
+
+`process.go` builds the process, `main.go` wires the engine, publishes the
+approval and runs.
+
+```bash
+cd examples/event-based-gateway && go run .
+```
+
+```
+deferred choice: waiting for an approval message OR a 10s timeout...
+  ✓ approval arrived first → order approved
+✓ event-based-gateway completed (Completed): the gate fired the arm whose ...
+```

--- a/examples/event-based-parallel-start/README.md
+++ b/examples/event-based-parallel-start/README.md
@@ -1,0 +1,39 @@
+# event-based-parallel-start
+
+**A process started by an event gateway — two correlated messages, one
+instance** (parallel instantiating Event-Based gateway, BPMN §13.2).
+
+- the gate has **no incoming flow and no start event**: it is built with
+  `WithInstantiate()` + `ParallelEvents`, so the FIRST of its two messages
+  creates the instance;
+- both arms share one correlation key (`orderId`, derived from either
+  message's payload), so the second message **re-arms keyed** to the
+  instance the first one created;
+- the instance completes only once **both** arms have fired — order placed
+  AND payment received;
+- the driver never calls `StartProcess` — it discovers the event-born
+  instance through the engine's instance-observation API (SRD-019) and
+  waits for its completion.
+
+```mermaid
+flowchart LR
+    gate{"event-gate (instantiate, parallel)"}
+    gate --> ao((await-order)) --> ro[record-order] --> eo((end-order))
+    gate --> ap((await-payment)) --> rp[record-payment] --> ep((end-payment))
+```
+
+`process.go` builds the process and the correlation key, `fulfill.go`
+publishes the two messages and awaits the born instance, `main.go` wires
+the engine.
+
+```bash
+cd examples/event-based-parallel-start && go run .
+```
+
+```
+publishing 'order placed' (creates the instance)...
+  ✓ order placed   → recorded
+publishing 'payment received' (routes to the same instance)...
+  ✓ payment received → recorded
+✓ order-fulfillment completed (Completed): one instance, born by the first ...
+```

--- a/examples/gateway-routing/README.md
+++ b/examples/gateway-routing/README.md
@@ -1,0 +1,32 @@
+# gateway-routing
+
+**Exclusive (XOR) data-based routing — first-true condition, else the
+default flow** (ADR-005 §2.8).
+
+- the order's `amount` property decides which **single** branch the token
+  takes;
+- the `amount > 1000` condition guards the manager-review flow; the
+  auto-approve flow is registered as the gateway's **default flow**
+  (`UpdateDefaultFlow`) and is taken only when no condition is true;
+- the demo runs with `amount = 2500`, so the token routes to manager
+  review.
+
+```mermaid
+flowchart LR
+    s((start)) --> xor{XOR}
+    xor -->|amount greater than 1000| mr[manager-review] --> er((end-review))
+    xor -->|default| aa[auto-approve] --> ea((end-approve))
+```
+
+`process.go` builds the process (the condition lives in `amountGt1000`),
+`main.go` wires the engine and runs.
+
+```bash
+cd examples/gateway-routing && go run .
+```
+
+```
+order amount = 2500
+  ▶ amount > 1000 → routed to manager review
+✓ gateway-routing completed (Completed): the exclusive gateway chose the branch by data
+```

--- a/examples/inclusive-join/README.md
+++ b/examples/inclusive-join/README.md
@@ -1,0 +1,36 @@
+# inclusive-join
+
+**Inclusive (OR) split — every true branch forks — and the OR-join**
+(ADR-005 §2.9 / §2.10).
+
+- the OR-split forks the **subset** of branches whose condition is true —
+  not exactly one (XOR) and not all (AND);
+- the converging OR-join waits for **exactly that subset** before
+  continuing once;
+- a never-taken branch (here `fast-track`, `amount < 100`) is found
+  **unreachable** and does not stall the join;
+- the demo runs with `amount = 1500` — `> 1000` and `> 500` are both true,
+  so manager-review and fraud-check fork and the join merges the two.
+
+```mermaid
+flowchart LR
+    s((start)) --> split{OR-split}
+    split -->|amount greater than 1000| mr[manager-review] --> join{OR-join}
+    split -->|amount greater than 500| fc[fraud-check] --> join
+    split -->|amount less than 100| ft[fast-track] --> join
+    join --> finalize --> e((end))
+```
+
+`process.go` builds the OR diamond, `main.go` wires the engine and runs.
+
+```bash
+cd examples/inclusive-join && go run .
+```
+
+```
+order amount = 1500
+  ▶ amount > 1000 → manager review
+  ▶ amount > 500 → fraud check
+  ✓ branches merged → order finalized
+✓ inclusive-join completed (Completed): the OR-join merged the active branches and fired once
+```

--- a/examples/inter-instance-correlation/README.md
+++ b/examples/inter-instance-correlation/README.md
@@ -1,0 +1,41 @@
+# inter-instance-correlation
+
+**A message instantiates a handler process and correlates by a key derived
+from the payload — one instance per distinct order** (ADR-015 / ADR-016
+v.1, SRD-015).
+
+- process A (`order-source`) is started explicitly and publishes two
+  `order placed` messages (`ORD-1`, `ORD-2`); each SendTask stamps the
+  payload-derived correlation key onto the envelope (the producer side,
+  ADR-016 v.1 §2.2);
+- process B (`order-handler`) has a **correlation-keyed message start
+  event** and is never started explicitly — the engine instantiates one B
+  per distinct order key when the message arrives (no instance exists
+  before its trigger);
+- two orders ⇒ two handler instances, disambiguated by the `orderId` key
+  both sides derive from the same payload.
+
+```mermaid
+flowchart LR
+    subgraph A["order-source (started explicitly)"]
+        b((begin)) --> s1[send-ORD-1] --> s2[send-ORD-2] --> se((sent))
+    end
+    subgraph B["order-handler (auto-instantiated per key)"]
+        or((order-received)) --> report --> h((handled))
+    end
+    s1 -.->|order placed ORD-1| or
+    s2 -.->|order placed ORD-2| or
+```
+
+`producer.go` builds A, `consumer.go` builds B, `correlation.go` the shared
+key, `main.go` wires, runs and verifies.
+
+```bash
+cd examples/inter-instance-correlation && go run .
+```
+
+```
+  ✓ order "ORD-1" instantiated its own handler instance
+  ✓ order "ORD-2" instantiated its own handler instance
+✓ inter-instance correlation: 2 orders ⇒ 2 handler instances, routed by key
+```

--- a/examples/message-intermediate-events/README.md
+++ b/examples/message-intermediate-events/README.md
@@ -1,0 +1,33 @@
+# message-intermediate-events
+
+**Throw / catch intermediate message events** (SRD-014 / ADR-014 v.1) —
+the event-shaped peers of the SendTask/ReceiveTask.
+
+- the IntermediateThrowEvent `throw-order` reads the `order_out` property
+  from scope and publishes it as the `order placed` message to the engine's
+  MessageBroker;
+- downstream the IntermediateCatchEvent `catch-order` waits for it (through
+  a MessageWaiter) and binds the payload into scope as `order_in`;
+- both events live on **one track**, so the throw completes before the
+  catch subscribes — the in-memory broker buffers the published message
+  until then;
+- the `confirm` ServiceTask reads the bound payload and proves the
+  round-trip.
+
+```mermaid
+flowchart LR
+    s((start)) --> t((throw-order)) --> c((catch-order)) --> confirm --> e((end))
+```
+
+Everything lives in `main.go` — model build, engine wiring and the
+verification.
+
+```bash
+cd examples/message-intermediate-events && go run .
+```
+
+```
+  ✓ throw-order published "ORD-2026-002"
+  ✓ catch-order bound it; confirm read order_in = "ORD-2026-002"
+✓ message-events-demo completed: the message travelled the broker from the throw event to the catch event
+```

--- a/examples/message-send-receive/README.md
+++ b/examples/message-send-receive/README.md
@@ -1,0 +1,32 @@
+# message-send-receive
+
+**A SendTask publishes to the broker; a ReceiveTask waits and binds the
+payload** (SRD-013 / ADR-014 v.1).
+
+- `send-order` binds the `order_out` process property and publishes it as
+  the `order placed` message to the engine's MessageBroker;
+- `receive-order` waits for that message through a MessageWaiter and, on
+  arrival, binds the payload into scope as `order_in`;
+- an **output association** lands the bound payload in the
+  `received-order` DataObject, which the driver reads back to verify;
+- both tasks live on **one track**, so the send completes before the
+  receive subscribes — the in-memory broker buffers the message until then.
+
+```mermaid
+flowchart LR
+    s((start)) --> send[send-order] --> recv[receive-order] --> confirm --> e((end))
+    recv -.->|output association| do[("received-order")]
+```
+
+Everything lives in `main.go` — model build, engine wiring and the
+verification.
+
+```bash
+cd examples/message-send-receive && go run .
+```
+
+```
+  ✓ send-order published "ORD-2026-001"
+  ✓ receive-order bound it into received-order = "ORD-2026-001"
+✓ message-demo completed: the message travelled the broker from the SendTask to the ReceiveTask
+```

--- a/examples/multi-instance-parallel/README.md
+++ b/examples/multi-instance-parallel/README.md
@@ -8,6 +8,16 @@ distinct scopes**, completing when the last drains.
 start → panel [Multi-Instance over reviewers, parallel] → end
 ```
 
+```mermaid
+flowchart LR
+    start((start)) --> panel
+    subgraph panel["panel — Sub-Process, parallel Multi-Instance over reviewers"]
+        pStart((p-start)) --> score[score]
+        score --> pEnd((p-end))
+    end
+    panel --> theEnd((end))
+```
+
 `panel` is a Sub-Process marked with a **parallel** Multi-Instance (no
 `WithSequential`). One instance per reviewer runs at the same time; each sees its
 `reviewer` name in its own scope and assembles its `score` — positionally, by

--- a/examples/multi-instance-sequential/README.md
+++ b/examples/multi-instance-sequential/README.md
@@ -8,6 +8,16 @@ collection — the instances running one after another.
 start → orders [Multi-Instance over amounts, sequential] → end
 ```
 
+```mermaid
+flowchart LR
+    start((start)) --> orders
+    subgraph orders["orders — Sub-Process, sequential Multi-Instance over amounts"]
+        bStart((b-start)) --> tax[tax]
+        tax --> bEnd((b-end))
+    end
+    orders --> theEnd((end))
+```
+
 `orders` is a Sub-Process marked with a sequential Multi-Instance. Its instance
 count is fixed at activation from the `amounts` collection (`100, 250, 80`); each
 instance sees its element bound as `amount`, applies 20% tax, and its `withTax`

--- a/examples/parallel-gateway/README.md
+++ b/examples/parallel-gateway/README.md
@@ -10,6 +10,14 @@ start ─> split ─┬─> worker-a ─┬─> join ─> end
                 └─> worker-b ─┘
 ```
 
+```mermaid
+flowchart LR
+    s((start)) --> sp{split}
+    sp --> a[worker-a] --> j{join}
+    sp --> b[worker-b] --> j
+    j --> e((end))
+```
+
 Each worker is a `ServiceTask` whose operation prints when it runs, so the
 output shows both branches executing before the join lets a single token reach
 the End.

--- a/examples/process-data/README.md
+++ b/examples/process-data/README.md
@@ -10,6 +10,17 @@ start ─> split ─┬─> greet-a ─> end-a    (result-a DataObject)
                 └─> greet-b ─> end-b    (result-b DataObject)
 ```
 
+```mermaid
+flowchart LR
+    start((start)) --> split{"split<br>parallel, diverging"}
+    split --> greetA[greet-a]
+    split --> greetB[greet-b]
+    greetA --> endA((end-a))
+    greetB --> endB((end-b))
+    greetA -.-> resultA[/"greet-a-result DataObject"/]
+    greetB -.-> resultB[/"greet-b-result DataObject"/]
+```
+
 The data path per branch: `user_name` property → container scope → the
 frame's container walk → the operation's input message → the Go functor →
 the frame (node-produced put) → the output instance → the output

--- a/examples/signal-broadcast/README.md
+++ b/examples/signal-broadcast/README.md
@@ -1,0 +1,41 @@
+# signal-broadcast
+
+**One thrown signal is caught by EVERY waiting catcher, across independent
+instances** — signal broadcast (ADR-006 §2.1).
+
+Two instances of the `watcher` process each park on an intermediate catch of
+the signal `order-cancelled`; a single `canceller` instance throws it once and
+BOTH watchers resume:
+
+- a signal has **no correlation** — one throw broadcasts to every catcher in
+  reach;
+- catcher and thrower each build their **own** `SignalEventDefinition`
+  (distinct nodes) — they meet by signal **name**;
+- the watchers wait on an **Intermediate Catch Event**; the canceller throws
+  via an **Intermediate Throw Event**.
+
+```mermaid
+flowchart LR
+    subgraph watcher["watcher (2 instances)"]
+        ws((start)) --> wc((await-order-cancelled)) --> we((end))
+    end
+    subgraph canceller
+        cs((start)) --> ct((raise-order-cancelled)) --> ce((end))
+    end
+    ct -. broadcast .-> wc
+```
+
+`process.go` builds both processes, `main.go` wires + runs.
+
+```bash
+cd examples/signal-broadcast
+go run .
+```
+
+```
+  ▶ two watcher instances are waiting on "order-cancelled"
+  ▶ one canceller threw the signal once
+  ✓ watcher 1 completed (Completed) — caught the broadcast
+  ✓ watcher 2 completed (Completed) — caught the broadcast
+✓ one throw → every waiting instance caught it (broadcast)
+```

--- a/examples/signal-start/README.md
+++ b/examples/signal-start/README.md
@@ -1,0 +1,42 @@
+# signal-start
+
+**A broadcast signal CREATES process instances — no StartProcess call.**
+
+Both `fulfillment` and `audit` are registered with a **signal Start Event** on
+`order-received` (no incoming flow). One broadcast of the signal instantiates
+BOTH processes:
+
+- the Start Event carries a signal trigger (`events.WithSignalTrigger`);
+- the broadcast comes from `engine.PropagateEvent` — signals are broadcast,
+  not point-to-point, so every registered process starting on that name gets
+  its own instance;
+- signal-born instances have no StartProcess handle — `observe.go` discovers
+  them via `engine.Instances` and waits for their completion.
+
+```mermaid
+flowchart LR
+    pe(["engine.PropagateEvent: order-received"])
+    subgraph fulfillment
+        fs(("start (signal)")) --> fh[fulfillment-handle] --> fe((end))
+    end
+    subgraph audit
+        au(("start (signal)")) --> ah[audit-handle] --> ae((end))
+    end
+    pe -. broadcast .-> fs
+    pe -. broadcast .-> au
+```
+
+`process.go` builds the signal-started processes, `observe.go` tracks the
+signal-born instances, `main.go` wires + runs.
+
+```bash
+cd examples/signal-start
+go run .
+```
+
+```
+  ▶ broadcasting "order-received" once (no StartProcess call)...
+  order-received → handling fulfillment
+  order-received → recording audit
+✓ one broadcast signal created and completed both instances
+```

--- a/examples/simple-timer/README.md
+++ b/examples/simple-timer/README.md
@@ -2,6 +2,11 @@
 
 A minimal example focusing on timer functionality with the simplest possible implementation.
 
+```mermaid
+flowchart LR
+    t(("timer-start (fires in 3s)")) --> e((end))
+```
+
 ## What it demonstrates
 
 - Minimal timer setup with timeDate

--- a/examples/standard-loop/README.md
+++ b/examples/standard-loop/README.md
@@ -7,6 +7,12 @@ Demonstrates a BPMN **Standard Loop** (§13.3.6, SRD-054): an activity marked
 start → work [loopCounter < 3] → end
 ```
 
+```mermaid
+flowchart LR
+    start((start)) --> work["work<br>Standard Loop: loopCounter #lt; 3, post-tested"]
+    work --> theEnd((end))
+```
+
 `work` is a Service Task carrying a post-tested (`do…while`) Standard Loop. Each
 pass reads the engine-published 0-based `loopCounter` and prints it; the loop
 stops when `loopCounter < 3` is false, so the body runs three times

--- a/examples/terminate-end-event/README.md
+++ b/examples/terminate-end-event/README.md
@@ -8,6 +8,13 @@ start → split ─┬─ fraud-check ──> terminate-end   (kills the instanc
                └─ process-payment ──> payment-done
 ```
 
+```mermaid
+flowchart LR
+    s((start)) --> g{split}
+    g --> f[fraud-check] --> t(("terminate-order (Terminate)"))
+    g --> p[process-payment] --> pd((payment-done))
+```
+
 The fraud check finishes first and reaches a Terminate End Event: the engine
 terminates the whole instance, cancelling the in-flight payment mid-charge. The
 instance settles in `Terminated` (not `Completed`).

--- a/examples/timer-event/README.md
+++ b/examples/timer-event/README.md
@@ -2,6 +2,11 @@
 
 This example shows how to work with timer-based events in BPMN processes using GoBPM.
 
+```mermaid
+flowchart LR
+    t(("timer-start (fires in 5s)")) --> h["handle-timeout (ServiceTask)"] --> e((end))
+```
+
 ## What it demonstrates
 
 - Creating timer expressions with FormalExpression

--- a/examples/usertask/README.md
+++ b/examples/usertask/README.md
@@ -1,0 +1,28 @@
+# usertask
+
+**A UserTask driven from the console: the engine parks the task, the console
+TaskDistributor Takes it, renders its form, and Completes it**, resuming the
+process to its End Event.
+
+- the `approve` UserTask is claimable by candidate user `operator` and
+  collects a `decision` (string) output;
+- the form is a console renderer (`consinp`) fed a scripted answer
+  (`approved`), so the run needs no interactive input;
+- the console driver (`pkg/interactor/console`) is passed to the engine as its
+  TaskDistributor and bound back to it (`driver.Bind(th)`).
+
+```mermaid
+flowchart LR
+    s((start)) --> a["approve (UserTask)"] --> e((end))
+```
+
+`process.go` builds the process, `main.go` wires the console driver + runs.
+
+```bash
+cd examples/usertask
+go run .
+```
+
+```
+process finished: Completed
+```

--- a/examples/versioning/README.md
+++ b/examples/versioning/README.md
@@ -4,6 +4,17 @@ Demonstrates Camunda-style definition versioning (ADR-019 / SRD-031.A): one
 process **key** carries many **versions**, and each version can be addressed by
 latest, by number, or by the registration handle.
 
+```mermaid
+flowchart LR
+    start((start)) --> greet[greet]
+    greet --> theEnd((end))
+```
+
+The graph itself is trivial — the point is that this same `greeter` process is
+built and registered **twice** under the same key (its process id), producing
+versions `1` and `2` of one definition; only the label the `greet` task prints
+differs between the builds.
+
 ## What it demonstrates
 
 - Registering a process twice under the **same key** (the process id) yields


### PR DESCRIPTION
## Every example gets a mermaid process diagram

A consistency sweep of the examples front door: previously **12 of 36
examples had no README at all** and **13 more** described their process only
in text or ASCII. Now **every example README carries a mermaid flowchart of
the process its code actually builds**.

### What's in

- **12 new READMEs** (complex-gateway, conversation-routing,
  event-based-gateway, event-based-parallel-start, gateway-routing,
  inclusive-join, inter-instance-correlation, message-intermediate-events,
  message-send-receive, signal-broadcast, signal-start, usertask) in the
  house style: a bold what-it-demonstrates line with ADR/SRD refs,
  code-grounded semantics bullets, the diagram, and a Run section with the
  expected output.
- **13 diagram inserts** into existing READMEs (basics, timers, terminate,
  parallel-gateway, boundary/escalation/compensation events, both
  Multi-Instance examples, standard-loop, process-data, versioning) — the
  existing prose and ASCII sketches kept.
- **Diagram fidelity**: node names, flows, conditional-edge labels, gateway
  kinds, sub-process subgraphs, boundary attachments (dashed edges) and
  `isForCompensation` handlers are read from each example's process builder —
  nothing invented. All 36 blocks render-verified with `mermaid-cli`.
- **Run-command fix**: 5 READMEs used `go run ./examples/<x>/`, which fails
  from the repo root (each example is its own Go module) — normalized to the
  working `cd examples/<x> && go run .` form.
- **Backlog note**: mermaid has no BPMN diagram type, so these are deliberate
  approximations; once the ADR-024 model→BPMN-XML exporter lands, a
  `bpmn-to-image` step can generate true-notation SVGs from the examples' own
  definitions (never drifting from the code).

### Verification

Doc-only (no `.go` touched). All 36 mermaid blocks extracted and rendered
with `@mermaid-js/mermaid-cli` — zero parse errors; diagrams spot-checked
against the process builders (gateway conditions, terminate branch,
compensation boundary links).
