### PR TITLE
fix(ci): split the examples sweep off the PR-blocking gate

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -49,7 +49,9 @@ jobs:
           go install github.com/dr-dobermann/covercheck/cmd/covercheck@v0.2.0
 
       # All subsequent checks call into Makefile targets so that running
-      # `make ci` locally matches what CI runs. This is the project's
+      # `make ci` locally matches what CI runs (this REQUIRED job = the
+      # `ci-core` half; the parallel `examples` job below = the `ci-examples`
+      # half; local `make ci` runs both). This is the project's
       # "no local/CI drift" rule (see Makefile ci umbrella target).
 
       # The mocks are committed (FIX-023); this fails if they drift from the
@@ -57,22 +59,22 @@ jobs:
       - name: Verify committed mocks are current
         run: make mock-check
 
-      - name: Verify all modules tidy
-        run: make tidy-check-all
+      - name: Verify core modules tidy
+        run: make tidy-check-core
 
-      - name: Lint all modules (ADR-003 import-direction rules enforced)
-        run: make lint-all-modules
+      - name: Lint core modules (ADR-003 import-direction rules enforced)
+        run: make lint-core
 
-      - name: Build all modules
-        run: make build-all
+      - name: Build core modules
+        run: make build-core
 
       # Library-consumption guard (FIX-024): an external module must build
       # against gobpm with no test-only (testify) / mock dep leak.
       - name: Consumer-consumption smoke
         run: make consumer-smoke
 
-      - name: Test all modules with race detector
-        run: make test-all
+      - name: Test core modules with race detector
+        run: make test-core
 
       # Diff-coverage gate (SRD-002): reuses the coverage.txt that test-all just
       # wrote (no second test run); same `make cover-check` / COVER_MIN the
@@ -82,10 +84,39 @@ jobs:
           git fetch --no-tags origin master
           make cover-check COVER_BASE=origin/master
 
-      - name: Vulnerability scan (core)
-        run: make vuln
+      # Core modules only: every example consumes the library through
+      # `replace ../..`, so this scan already covers their shared graph —
+      # the per-example rescan added minutes for no new signal.
+      - name: Vulnerability scan
+        run: make vuln-core
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  # The examples sweep (tidy + lint + build over the ~35 examples/* modules) —
+  # split out of the required job because it dominated PR wall time while the
+  # examples carry no tests and share the library's dependency graph. Runs in
+  # PARALLEL on every PR and on master pushes (the post-merge safety net). It
+  # fails honestly (no continue-on-error) so breakage is visible, but it is
+  # NOT in the branch-protection required checks — a red here never blocks a
+  # merge. Locally, `make ci` still runs this via its `ci-examples` half.
+  examples:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version: '1.25.12'
+          cache: true
+
+      - name: Install tools
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.11.4/install.sh \
+            | sh -s -- -b "$(go env GOPATH)/bin" v2.11.4
+
+      - name: Examples sweep (tidy + lint + build)
+        run: make ci-examples

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,14 @@ make tag
 tidy-check → lint → build → race tests → **diff-coverage gate** → govulncheck, across
 all modules. Run it before pushing — if it's green, CI is green.
 
+On GitHub the same set is split into two parallel jobs for PR speed: the
+REQUIRED `check` job runs the core gate (`make ci-core` — the non-example
+modules), and the non-blocking `examples` job sweeps the ~35 `examples/*`
+modules (`make ci-examples` — tidy+lint+build; they carry no tests, and the
+core govulncheck already covers their `replace ../..` dependency graph).
+Locally `make ci` still runs BOTH halves — the full gate stays obligatory
+before every push.
+
 The **diff-coverage gate** (`make cover-check`, SRD-002) fails when the lines a change
 adds/modifies are covered below `COVER_MIN` (95% now, rising toward 100). It judges
 only changed lines — reusing the `coverage.txt` `test-all` writes — so the untouched-code

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,15 @@ COVER_EXCLUDE ?= \.(logger|Logger\(\))\.(Debug|Info|Warn|Error)\(,func \(.*\) Op
 # Discovered dynamically so adding a new module needs no Makefile edit.
 MODULES := $(shell /usr/bin/find . -name go.mod -not -path './.git/*' -exec dirname {} \;)
 
+# CORE vs EXAMPLES split: the examples/* modules (~35 of ~38) dominate a full
+# multi-module sweep, yet carry no tests and share the library's dependency
+# graph through `replace ../..`. CI runs the core gate as the REQUIRED job and
+# the examples sweep as a parallel, non-blocking job; `make ci` locally still
+# runs BOTH (the full pre-push gate stays obligatory on dev). The loops below
+# iterate $(MODULES), so a sub-make with MODULES="…" scopes any of them.
+CORE_MODULES    := $(filter-out ./examples/%,$(MODULES))
+EXAMPLE_MODULES := $(filter ./examples/%,$(MODULES))
+
 # ---------------------------------------------------------------------------
 # Tooling — versions are the single source of truth, mirrored by the
 # "Install tools" step in .github/workflows/check.yml. `make tools` installs
@@ -237,9 +246,47 @@ cover-check:
 		-profiles coverage.txt
 .PHONY: cover-check
 
-# Umbrella target that runs the full local-equivalent of CI.
+# Core-scoped aliases — the REQUIRED CI job's steps (one target per workflow
+# step, so the per-step log groups and timings survive the split). Each scopes
+# the shared loop to the non-example modules via the MODULES override.
+tidy-check-core:
+	@$(MAKE) tidy-check-all MODULES="$(CORE_MODULES)"
+.PHONY: tidy-check-core
+
+lint-core:
+	@$(MAKE) lint-all-modules MODULES="$(CORE_MODULES)"
+.PHONY: lint-core
+
+build-core:
+	@$(MAKE) build-all MODULES="$(CORE_MODULES)"
+.PHONY: build-core
+
+test-core:
+	@$(MAKE) test-all MODULES="$(CORE_MODULES)"
+.PHONY: test-core
+
+vuln-core:
+	@$(MAKE) vuln MODULES="$(CORE_MODULES)"
+.PHONY: vuln-core
+
+# The examples sweep: tidy + lint + build over every examples/* module. No
+# per-example test loop (the examples carry no tests — `go build` already
+# compiles them) and no per-example govulncheck (each example consumes the
+# library through `replace ../..`, so the core `vuln` scan already covers the
+# shared dependency graph; scanning it 35 more times added minutes of CI for
+# no new signal). Runs as CI's parallel non-blocking job AND inside the local
+# `make ci`.
+ci-examples:
+	@$(MAKE) tidy-check-all lint-all-modules build-all MODULES="$(EXAMPLE_MODULES)"
+.PHONY: ci-examples
+
+# The core gate — everything the REQUIRED CI job runs, in the same order.
+ci-core: mock-check tidy-check-core lint-core build-core consumer-smoke test-core cover-check vuln-core
+.PHONY: ci-core
+
+# Umbrella target that runs the full local-equivalent of CI (BOTH CI jobs).
 # Use this before pushing to catch regressions before GitHub runs them.
-# test-all writes coverage.txt; cover-check consumes it (single test run).
-ci: mock-check tidy-check-all lint-all-modules build-all consumer-smoke test-all cover-check vuln
+# test-core writes coverage.txt; cover-check consumes it (single test run).
+ci: ci-core ci-examples
 .PHONY: ci
 


### PR DESCRIPTION
## Faster PRs: the examples sweep leaves the required gate

The repo has **38 Go modules — 35 of them examples** — and every `make ci`
loop (tidy / lint / build / test / vuln) iterated all 38. ~90% of the
required PR check's wall time went to modules that carry **no tests** and
share the library's dependency graph via `replace ../..`; the worst
offender was `govulncheck` scanning the same graph 38 times.

### The split

- **Makefile**: `CORE_MODULES` (`.`, `adapters/sqlite`, `runtime`) vs
  `EXAMPLE_MODULES` (`examples/*`). The existing loops remain the single
  source of truth, scoped by a `MODULES` override. New targets: per-step
  core aliases (`tidy-check-core`, `lint-core`, `build-core`, `test-core`,
  `vuln-core`), the `ci-examples` sweep (tidy+lint+build over the examples —
  no test loop, no per-example govulncheck: the core scan covers their
  shared graph), and `ci-core`.
  **`make ci` = `ci-core` + `ci-examples`** — the full gate stays
  obligatory locally before every push; nothing changes on dev.
- **Workflow**: the required `check` job now runs the core steps only; a
  new **parallel `examples` job** runs `make ci-examples` on every PR *and*
  on master pushes (the post-merge safety net). It fails honestly (no
  `continue-on-error`) so breakage stays visible — but it should stay out
  of the required checks, so a red there never blocks a merge.
- **CLAUDE.md**: the CI-parity section documents the two-job split; the
  local↔CI parity contract holds (`make ci` = the union of both jobs).

### Measured locally

`ci-core` **1m14s** · `ci-examples` **1m21s** — previously serial inside
one required job; on GitHub they now run concurrently and the examples
cost is entirely off the PR critical path.

### ⚠ One repo-settings action after merge

In **branch protection → required status checks**, keep only the `check`
job required (do **not** add the new `examples` job) — that's what makes
it non-blocking.
