### PR TITLE
Multi-Instance behavior on the off-loop decorator — ADR-025 v.2 Accepted (SRD-056.B)

### DIFF
--- a/docs/srd/SRD-056.B-multi-instance-behavior.md
+++ b/docs/srd/SRD-056.B-multi-instance-behavior.md
@@ -1,0 +1,299 @@
+# SRD-056.B — Multi-Instance (behavior)
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-07-20 |
+| Owner | Ruslan Gabitov |
+| Implements | [ADR-025 v.1](../design/ADR-025-activity-iteration-loop-and-multi-instance.md) §2.8 (`behavior` — the Multi-Instance event-throwing slice; the last of #88's MI work) |
+| Upstream | [ADR-006 v.4](../design/ADR-006-events-and-subscriptions.md) (event throwing/catching this rides), [ADR-018 v.1](../design/ADR-018-boundary-events-and-activity-interruption.md) (the boundary-catch mechanism the thrown events are caught by), [ADR-025 v.1](../design/ADR-025-activity-iteration-loop-and-multi-instance.md) §2.9 (the runtime attributes the events carry), [ADR-010 v.2](../design/ADR-010-process-data-model.md) (name-based data), [ADR-013 v.2](../design/ADR-013-instance-observability.md) (facts) |
+| Refines | — |
+| Related | SRD-055 (sequential MI), SRD-056.A (parallel MI) — `behavior` wires into both |
+
+## §1 Background
+
+Multi-Instance **sequential** (SRD-055) and **parallel** (SRD-056.A) landed; both
+already resolve a completionCondition on each instance completion. ADR-025 §2.8
+decides the last slice: **`behavior`** — throwing a **boundary-catchable event** as
+instances complete, so a model can react to progress (e.g. *quorum-reached* once
+3 of 5 approvals arrive).
+
+The machinery this rides exists. A throw event emits its definition through
+`Instance.PropagateEvent(ctx, eDef)` (`eventproducer.go`) → the EventHub; a
+boundary on an activity catches a matching event via `armBoundaries` /
+`boundaryWatch.ProcessEvent` / `fireBoundary` (ADR-018). Crucially, **an MI host's
+boundaries are armed for the whole MI window** — armed when the host track
+arrives on the node, disarmed only when it moves off — so an event thrown from a
+completion hook (while instances still run *or* at the last completion) reaches a
+live boundary waiter.
+
+**Absent** (this SRD adds): a `MultiInstanceBehavior` enum, a
+`ComplexBehaviorDefinition` type, an `ImplicitThrowEvent` model type, and the
+`behavior` / `noneBehaviorEventRef` / `oneBehaviorEventRef` /
+`complexBehaviorDefinition` fields. **In scope:** all four behavior modes, wired
+into **both** the sequential and parallel completion paths (behavior is
+orthogonal to `isSequential`, §2.8). **Deferred:** `completionQuantity` (SRD-046
+NFR-4); MI compensation (Transaction, ADR-025 §2.10). This SRD **completes the
+Multi-Instance feature** (#88's MI work).
+
+## §2 Requirements
+
+### Functional — the model
+
+- **FR-1 — the new model types.** (a) `MultiInstanceBehavior` — a named string
+  type with typed constants `All` (default), `None`, `One`, `Complex`
+  (`activities/multiinstance.go`; the data-over-code convention). (b)
+  `ImplicitThrowEvent` (`pkg/model/events/`) — a `ThrowEvent` that is **not** a
+  token node (no incoming/outgoing, no `Exec` in the flow); it embeds the shared
+  `throwEvent` base (carrying the `EventDefinition`(s) + optional data
+  associations) and is thrown implicitly by the MI (spec `events.md`
+  §ImplicitThrowEvent). (c) `ComplexBehaviorDefinition` (`activities/`, →
+  `foundation.BaseElement`): a `condition data.FormalExpression` + an
+  `event *events.ImplicitThrowEvent` (spec `activities.md` §ComplexBehaviorDefinition).
+- **FR-2 — MI fields, options, validation.** `MultiInstanceLoopCharacteristics`
+  gains `behavior` (default `All`), `noneBehaviorEventRef` / `oneBehaviorEventRef`
+  (`flow.EventDefinition`), and `complexBehaviorDefinition` (`[]*ComplexBehaviorDefinition`),
+  with options `WithBehavior` / `WithNoneBehaviorEvent` / `WithOneBehaviorEvent` /
+  `WithComplexBehavior`. `NewMultiInstance` validates **behavior⇄ref consistency**
+  (mirroring the existing cardinality-source switch): `None` requires
+  `noneBehaviorEventRef` (and no other behavior ref); `One` requires
+  `oneBehaviorEventRef`; `Complex` requires ≥1 `complexBehaviorDefinition` (each
+  `condition` a boolean expression); `All` (default) forbids all three. Self-
+  identifying errors.
+- **FR-3 — runtime capability accessors.** The `internal/instance` `multiInstance`
+  interface (which recognizes an MI by capability) gains `Behavior()`,
+  `NoneBehaviorEvent()`, `OneBehaviorEvent()`, `ComplexBehavior()` — matched
+  exactly by the model getters, or the capability assertion silently fails.
+
+### Functional — the runtime throw
+
+- **FR-4 — one shared behavior-throw helper, both shapes.** A single
+  `throwMIBehavior` is called from **both** completion points — the sequential
+  `miIterator.afterDrain` (`mi.go`) and the parallel `parallelInstanceDrained`
+  (`mi_parallel.go`) — on **each** instance completion, since the event fires per
+  completion regardless of whether that completion ends the activity. It switches
+  on `Behavior()`: `All` → no-op (the zero-cost common case, early return); `None`
+  → throw `noneBehaviorEventRef`; `One` → throw `oneBehaviorEventRef` **only on the
+  first** completion (`completed == 1`); `Complex` → evaluate each definition's
+  `condition` (the `evalCompletion`-shaped frame at the host scope) and throw its
+  `event`'s definition when `true` (a single completion may throw several).
+- **FR-5 — throw via `PropagateEvent`, minimally.** The helper throws through
+  `host.instance.PropagateEvent(ctx, eDef)` — cloning the definition with the
+  current payload when it is a `flow.EventDefCloner`, **without** the node-frame
+  `emitEvent` ceremony (the MI has no node execution frame; a Complex condition
+  opens its own frame like `evalCompletion`).
+- **FR-6 — throw before the host resume (ordering).** The behavior throw is issued
+  **before** the completion path dispatches the host's synthetic resume
+  (`scopeDone`). The resulting `evBoundary` is therefore enqueued ahead of the
+  resume, so a boundary armed on the MI host catches it while still armed — even
+  for the event thrown at the **last** instance's completion (the host has not yet
+  moved off the node and disarmed). Without this ordering the last-completion event
+  races the disarm and is lost.
+- **FR-7 — the events carry the current §2.9 attributes.** Before evaluating a
+  Complex `condition` and throwing, the helper ensures the runtime attributes
+  (`numberOfInstances` / `numberOfActiveInstances` / `numberOfCompletedInstances` /
+  `numberOfTerminatedInstances`) are current at the host scope. Parallel already
+  publishes them per drain (`bindParallelCounters`); sequential publishes them
+  only on the *next* pass, so the helper publishes the current counts for the
+  sequential path (§2.8 "the thrown events implicitly carry the runtime attributes").
+
+### Functional — the catch & front door
+
+- **FR-8 — caught on the MI boundary (existing machinery).** A thrown behavior
+  event is caught by a boundary event on the MI activity through the unchanged
+  ADR-018 path (`armBoundaries` / `fireBoundary`, the `armedFor` completion-race
+  guard). The recommended carrier is a **Signal** `EventDefinition` — matched by
+  **name broadcast** (`eventhub` `broadcastSignal`), which cleanly supports one
+  throw caught by several boundaries (Complex) — but any definition whose id the
+  boundary references is caught. **Both** interrupting and non-interrupting
+  boundaries are supported by the existing machinery; a non-interrupting boundary
+  is the progress-notification case, an interrupting one cancels the MI (its
+  completion-race is the `armedFor` guard's job). This SRD adds **no** boundary
+  logic — it only throws.
+- **FR-9 — front door.** A runnable example (a review board that throws a
+  *quorum-reached* signal, caught by a non-interrupting boundary that spawns a
+  notification), the iteration guide, `CHANGELOG.md`, the conformance tracker row 4
+  (behavior ✅ — the MI feature complete), and the READMEs (EN + RU).
+
+### Non-functional
+
+- **NFR-1 — reuse the throw + boundary machinery.** No new event infrastructure —
+  the helper rides `PropagateEvent` and the ADR-018 boundary catch. The genuinely
+  new code is the three model types + the one runtime helper + its two call sites.
+- **NFR-2 — behavior is orthogonal to `isSequential`.** One helper, both shapes;
+  the sequential (SRD-055) and parallel (SRD-056.A) suites re-verify unchanged.
+- **NFR-3 — `All` is zero-cost.** The helper early-returns on `All` so the common
+  case (no behavior) adds nothing to the hot completion path.
+- **NFR-4 — coverage.** Every touched file ≥95% diff-coverage; `make ci` green,
+  `-race` clean.
+
+## §3 Models
+
+### §3.1 `pkg/model/events/implicit_throw.go` — the new throw type
+
+```go
+// ImplicitThrowEvent is a ThrowEvent thrown implicitly by an activity (BPMN
+// §ImplicitThrowEvent), never reached by a token: it carries an EventDefinition
+// (+ optional data) and is emitted by the engine (here, a Multi-Instance
+// behavior). Unlike IntermediateThrowEvent it declares no flow-node wiring.
+type ImplicitThrowEvent struct {
+    throwEvent
+}
+
+func NewImplicitThrowEvent(name string, def flow.EventDefinition,
+    baseOpts ...options.Option) (*ImplicitThrowEvent, error)
+```
+
+### §3.2 `pkg/model/activities/multiinstance.go` — behavior on the MI type
+
+```go
+type MultiInstanceBehavior string
+const (
+    BehaviorAll     MultiInstanceBehavior = "all"  // default — no event thrown
+    BehaviorNone    MultiInstanceBehavior = "none" // throw on every completion
+    BehaviorOne     MultiInstanceBehavior = "one"  // throw on the first completion
+    BehaviorComplex MultiInstanceBehavior = "complex"
+)
+
+// ComplexBehaviorDefinition — a condition + the event thrown when it holds.
+type ComplexBehaviorDefinition struct {
+    foundation.BaseElement
+    condition data.FormalExpression
+    event     *events.ImplicitThrowEvent
+}
+
+// added to MultiInstanceLoopCharacteristics:
+//   behavior              MultiInstanceBehavior   // default BehaviorAll
+//   noneBehaviorEventRef  flow.EventDefinition
+//   oneBehaviorEventRef   flow.EventDefinition
+//   complexBehaviorDefinition []*ComplexBehaviorDefinition
+```
+
+Options `WithBehavior` / `WithNoneBehaviorEvent` / `WithOneBehaviorEvent` /
+`WithComplexBehavior`; getters `Behavior` / `NoneBehaviorEvent` /
+`OneBehaviorEvent` / `ComplexBehavior`. **No import cycle:** `activities` already
+depends on `events` (`service_task.go`, `receive_task.go`); `events` does not
+depend on `activities`.
+
+### §3.3 Runtime deltas (`internal/instance/`)
+
+- **`mi.go`** — the `multiInstance` interface gains the four behavior accessors; a
+  new `throwMIBehavior(ctx, inst, mi, host, completed)` helper (the shared switch).
+- **`mi.go` `afterDrain` / `mi_parallel.go` `parallelInstanceDrained`** — each calls
+  `throwMIBehavior` on completion, before the host-resume dispatch (FR-6).
+- **`scope.go`** — the sequential path reuses `bindDataItemAt` to publish the
+  current `numberOf*` at the host scope before a Complex eval (FR-7).
+
+## §4 Analysis
+
+### §4.1 One helper, both completion shapes (FR-4, NFR-2)
+
+Sequential `afterDrain` and parallel `parallelInstanceDrained` both increment a
+completed count on each instance completion. `behavior` fires there, independent
+of the completion-condition outcome, so a single helper — taking the
+`multiInstance`, the host, and the completed count — serves both. Sequential
+passes `host.instance` + `it.mi` + `st.completed`; parallel passes `ls.inst` +
+`grp.mi` + `grp.completed`. `One` keys off `completed == 1`.
+
+### §4.2 Throw before the host resume — the ordering contract (FR-6)
+
+The behavior throw runs on the loop goroutine inside the completion hook. A catch
+does not apply inline: `boundaryWatch.ProcessEvent` enqueues an `evBoundary` to the
+loop, resolved later by `fireBoundary` under the `armedFor` guard. The hazard is
+the **last** completion: the same hook both throws and resumes the host, and the
+host's move-off eventually **disarms** its boundaries. Issuing the throw **before**
+the resume dispatch enqueues `evBoundary` ahead of the resume — and the host's
+disarm is several loop steps further still (resume → run-goroutine advance →
+`evMoved` → disarm) — so the boundary is caught while armed. The `All`-guard
+(eventproducer's `Active` check) also holds: at last-instance drain the instance is
+still `Active` (it reaches `Completed` only after the host resumes and the token
+leaves via an end event), so the throw is accepted.
+
+### §4.3 Signal name-broadcast vs. id-matched catch (FR-8)
+
+The EventHub matches a **Signal** by name broadcast (`broadcastSignal`) and every
+other definition by the thrown `eDef.ID()` against the boundary's registered def
+id. §2.8's events "are referenced from `MultiInstanceLoopCharacteristics`" and the
+spec notes they are `SignalEventDefinition`s — so a Signal carrier is the clean
+fit: the boundary catches by the signal's name, and one throw can be caught by
+several boundaries (Complex). The engine imposes no restriction; a non-signal
+behavior event simply requires the boundary to reference the same definition.
+
+### §4.4 `ImplicitThrowEvent` reuses the throw base (FR-1)
+
+`ImplicitThrowEvent` embeds the same `throwEvent` base `IntermediateThrowEvent`
+uses — inheriting the `EventDefinition` list, `Definitions()`, per-instance
+definition cloning, and `emitDefinition` — so no new emit path is needed. It
+differs only behaviorally: it is never a token target, so it declares none of the
+flow-node/executor interface assertions. The MI helper reads the configured
+definition and propagates it.
+
+### §4.5 Current runtime attributes for the thrown events (FR-7)
+
+§2.8 says the thrown events implicitly carry the §2.9 attributes. Parallel already
+binds them at the host scope on each drain; sequential binds them only on the next
+pass (and clears `miState` at completion), so a behavior throw at the last
+sequential completion would read stale/absent counts. The helper publishes the
+current counts at the host scope before a Complex condition evaluates — unifying
+the attribute availability across both shapes.
+
+## §6 Test scenarios
+
+| Test | Level | Asserts (FR) |
+|---|---|---|
+| `TestMultiInstanceBehaviorModelValidation` | model | FR-1/FR-2 enum + fields + behavior⇄ref validation (None/One/Complex/All) |
+| `TestImplicitThrowEventBuild` | model | FR-1 `ImplicitThrowEvent` carries its definition |
+| `TestParallelBehaviorNoneThrowsEach` | instance | FR-4 `None` throws on every completion (N throws) |
+| `TestParallelBehaviorOneThrowsFirst` | instance | FR-4 `One` throws once, on the first completion |
+| `TestParallelBehaviorComplexCondition` | instance | FR-4 `Complex` throws when a definition's condition holds (quorum) |
+| `TestSequentialBehaviorNoneThrowsEach` | instance | FR-4/NFR-2 `behavior` works on the sequential path too |
+| `TestBehaviorAllThrowsNothing` | instance | NFR-3 `All` (default) throws no event |
+| `TestBehaviorEventCaughtOnBoundary` | instance | FR-8 a thrown behavior signal is caught by a non-interrupting boundary on the MI host (progress notification) |
+| `TestBehaviorLastCompletionCaught` | instance | FR-6 the event thrown at the last completion is still caught (ordering) |
+| `TestParallelMultiInstanceBehaviorE2E` | thresher | FR-4–FR-8 end-to-end quorum-reached notification |
+
+## §7 Milestones
+
+| M | Scope | Files |
+|---|---|---|
+| **M1** | Model types + fields + options + validation + runtime accessors | `pkg/model/events/implicit_throw.go`, `pkg/model/activities/multiinstance.go`, `internal/instance/mi.go` (interface) |
+| **M2** | The shared `throwMIBehavior` helper + wiring into both completion points (None/One/Complex, throw-before-resume, current attributes) | `internal/instance/mi.go`, `mi_parallel.go` |
+| **M3** | Boundary-catch test + e2e + `examples/multi-instance-behavior/` (quorum notification) + docs (guide/CHANGELOG/tracker/READMEs) + Accepted | `pkg/thresher/…`, `examples/…`, docs |
+
+## §8 Cross-doc
+
+- **Implements** ADR-025 v.1 §2.8 (upward; the behavior slice).
+- **Upstream** ADR-006 v.4 (throw/catch), ADR-018 v.1 (boundary catch), ADR-025 v.1
+  §2.9 (attributes), ADR-010 v.2, ADR-013 v.2 — all up/sideways, version-pinned.
+- **Related** SRD-055, SRD-056.A (sideways, number-only per the one-shot rule).
+- No downward references.
+
+## §9 Definition of Done
+
+- FR-1…FR-9 wired and covered by the §6 tests; the e2e green; the SRD-055 +
+  SRD-056.A suites still pass (NFR-2).
+- `make ci` green (diff-coverage ≥95% touched; `-race`; govulncheck; all modules).
+- `examples/multi-instance-behavior/` runs to completion (binary gitignored).
+- Conformance tracker row 4 advanced (Standard Loop ✅ + MI sequential ✅ + parallel
+  ✅ + **behavior ✅**; only `completionQuantity` remains, deferred); CHANGELOG
+  `[Unreleased]`; iteration guide behavior note; README EN+RU.
+- `/check-srd` PASS. ADR-025 stays Accepted (this SRD implements it — no change).
+
+## §10 Implementation summary
+
+> ⚠️ TODO: fill AFTER landing — stage commits, empirical deltas vs this draft,
+> backlog.
+
+### §10.1 Stages by commit (branch `feat/mi-behavior`)
+
+| Stage | Commit | Scope | Tests |
+|---|---|---|---|
+
+### §10.2 Empirical findings vs the draft
+
+### §10.3 Backlog
+
+## Open questions
+
+None.

--- a/internal/instance/boundary_watch_test.go
+++ b/internal/instance/boundary_watch_test.go
@@ -35,12 +35,14 @@ var errRegRejected = errors.New("registration rejected")
 // track (see the failEventProducer note in message_flow_test.go). regErr, when set,
 // fails every registration to exercise the arm-failure fault path.
 type recordingProducer struct {
-	mu       sync.Mutex
-	watch    *boundaryWatch
-	regIDs   []string
-	unreg    []string
-	regErr   error
-	unregErr error
+	mu           sync.Mutex
+	watch        *boundaryWatch
+	regIDs       []string
+	unreg        []string
+	propagated   []flow.EventDefinition
+	regErr       error
+	unregErr     error
+	propagateErr error
 }
 
 func (r *recordingProducer) RegisterEvent(
@@ -73,9 +75,23 @@ func (r *recordingProducer) UnregisterEvent(
 }
 
 func (r *recordingProducer) PropagateEvent(
-	context.Context, flow.EventDefinition,
+	_ context.Context, d flow.EventDefinition,
 ) error {
-	return nil
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.propagated = append(r.propagated, d)
+
+	return r.propagateErr
+}
+
+// propagatedDefs returns a copy of the event definitions the host propagated,
+// so a Multi-Instance behavior test can count and identify the thrown events.
+func (r *recordingProducer) propagatedDefs() []flow.EventDefinition {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]flow.EventDefinition(nil), r.propagated...)
 }
 
 // capturedWatch returns the last registered boundaryWatch (nil until a boundary arms).

--- a/internal/instance/mi.go
+++ b/internal/instance/mi.go
@@ -142,10 +142,24 @@ func (it miIterator) beforeClose(
 // publishes the assembled output collection once (the visibility barrier) and
 // the activity completes.
 func (it miIterator) afterDrain(
-	ctx context.Context, _ *loopState, host *track, node flow.Node,
+	ctx context.Context, ls *loopState, host *track, node flow.Node,
 ) (bool, error) {
 	st := host.miState
 	st.completed++
+
+	// publish the §2.9 attributes at the host scope (parallel does this per drain
+	// via bindParallelCounters; sequential publishes them only on the next pass,
+	// so a behavior throw at the last completion needs them here) and throw the
+	// behavior event before the host resumes (SRD-056.B FR-6/FR-7).
+	if err := ls.bindMICounters(
+		host.scopePath, st.numberOfInstances, 1, st.completed, 0); err != nil {
+		return false, err
+	}
+
+	if err := ls.throwMIBehavior(
+		ctx, it.mi, host, node, st.completed); err != nil {
+		return false, err
+	}
 
 	done := st.completed >= st.numberOfInstances
 	if !done && it.mi.CompletionCondition() != nil {
@@ -183,30 +197,39 @@ func (it miIterator) afterDrain(
 func (it miIterator) evalCompletion(
 	ctx context.Context, host *track, node flow.Node,
 ) (bool, error) {
-	frame, err := host.instance.sc.openFrameAt(
-		"mi-completion", node.ID(), host.scopePath)
+	return evalBoolAtHost(
+		ctx, host, "mi-completion", node.ID(), it.mi.CompletionCondition())
+}
+
+// evalBoolAtHost evaluates a boolean expression against a transient frame at the
+// host scope, where the loopCounter and the §2.9 attributes are published (the
+// shape completionCondition and a Complex behavior condition share). A
+// non-boolean result is a modeling error surfaced to the caller.
+func evalBoolAtHost(
+	ctx context.Context, host *track, label, nodeID string,
+	expr data.FormalExpression,
+) (bool, error) {
+	frame, err := host.instance.sc.openFrameAt(label, nodeID, host.scopePath)
 	if err != nil {
 		return false, err
 	}
 	defer frame.Discard()
 
 	res, err := host.instance.ExpressionEngine().Evaluate(
-		ctx, it.mi.CompletionCondition(),
-		newExecEnv(host.instance, frame, nil))
+		ctx, expr, newExecEnv(host.instance, frame, nil))
 	if err != nil {
 		return false, err
 	}
 
-	met, ok := res.Get(ctx).(bool)
+	b, ok := res.Get(ctx).(bool)
 	if !ok {
 		return false, errs.New(
-			errs.M("Multi-Instance completionCondition evaluated to a "+
-				"non-boolean value"),
+			errs.M("Multi-Instance expression evaluated to a non-boolean value"),
 			errs.C(errorClass, errs.TypeCastingError),
-			errs.D("node_id", node.ID()))
+			errs.D("node_id", nodeID))
 	}
 
-	return met, nil
+	return b, nil
 }
 
 // publishOutput commits the staged output collection at the host scope under the

--- a/internal/instance/mi.go
+++ b/internal/instance/mi.go
@@ -23,6 +23,10 @@ type multiInstance interface {
 	LoopDataOutputRef() string
 	InputDataItem() string
 	OutputDataItem() string
+	Behavior() activities.MultiInstanceBehavior
+	NoneBehaviorEvent() flow.EventDefinition
+	OneBehaviorEvent() flow.EventDefinition
+	ComplexBehavior() []*activities.ComplexBehaviorDefinition
 }
 
 // multiInstanceOf reports the node's Multi-Instance characteristics, or nil when

--- a/internal/instance/mi_behavior.go
+++ b/internal/instance/mi_behavior.go
@@ -1,0 +1,85 @@
+package instance
+
+import (
+	"context"
+
+	"github.com/dr-dobermann/gobpm/internal/scope"
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+)
+
+// bindMICounters publishes the §2.9 runtime attributes at the host scope, shared
+// by the sequential and parallel completion paths (SRD-056.B FR-7): the current
+// counts a completionCondition, a Complex behavior condition, and the body
+// resolve by name.
+func (ls *loopState) bindMICounters(
+	hostScope scope.DataPath, n, active, completed, terminated int,
+) error {
+	binds := []miBinding{
+		{name: "numberOfInstances", value: n},
+		{name: "numberOfActiveInstances", value: active},
+		{name: "numberOfCompletedInstances", value: completed},
+		{name: "numberOfTerminatedInstances", value: terminated},
+	}
+
+	for _, b := range binds {
+		if err := ls.inst.sc.bindDataItemAt(hostScope, b.name, b.value); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// throwMIBehavior throws the Multi-Instance's boundary-catchable behavior event
+// for one instance completion (ADR-025 §2.8): None on every completion, One on
+// the first, Complex per matching condition; All (the default) throws nothing.
+// Called from both completion paths BEFORE the host resumes, so the event's
+// boundary fire is enqueued while the host boundary is still armed (FR-6). Runs
+// on the loop goroutine.
+func (ls *loopState) throwMIBehavior(
+	ctx context.Context, mi multiInstance, host *track, node flow.Node,
+	completed int,
+) error {
+	switch mi.Behavior() {
+	case activities.BehaviorNone:
+		return ls.inst.PropagateEvent(ctx, mi.NoneBehaviorEvent())
+
+	case activities.BehaviorOne:
+		if completed == 1 {
+			return ls.inst.PropagateEvent(ctx, mi.OneBehaviorEvent())
+		}
+
+	case activities.BehaviorComplex:
+		return ls.throwComplexBehavior(ctx, mi, host, node)
+	}
+
+	return nil
+}
+
+// throwComplexBehavior evaluates each ComplexBehaviorDefinition's condition at
+// the host scope and throws the definition's event when it holds — a single
+// completion may throw several (ADR-025 §2.8).
+func (ls *loopState) throwComplexBehavior(
+	ctx context.Context, mi multiInstance, host *track, node flow.Node,
+) error {
+	for _, cbd := range mi.ComplexBehavior() {
+		met, err := evalBoolAtHost(
+			ctx, host, "mi-behavior", node.ID(), cbd.Condition())
+		if err != nil {
+			return err
+		}
+
+		if !met {
+			continue
+		}
+
+		for _, d := range cbd.Event().Definitions() {
+			if err := ls.inst.PropagateEvent(ctx, d); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/instance/mi_behavior_test.go
+++ b/internal/instance/mi_behavior_test.go
@@ -1,0 +1,231 @@
+package instance
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dr-dobermann/gobpm/internal/scope"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+)
+
+// miShape is a Multi-Instance builder for one execution shape (sequential or
+// parallel), so a behavior test can assert the same semantics on both — the
+// behavior helper is shared between the two paths (SRD-056.B).
+type miShape struct {
+	name string
+	mk   func(
+		t *testing.T, opts ...activities.MultiInstanceOption,
+	) *activities.MultiInstanceLoopCharacteristics
+}
+
+// miShapes returns the two Multi-Instance execution shapes a behavior test runs
+// against.
+func miShapes() []miShape {
+	return []miShape{
+		{"sequential", mustSeqMI},
+		{"parallel", mustParallelMI},
+	}
+}
+
+// signalDef builds a signal event definition to use as a Multi-Instance behavior
+// event reference (SRD-056.B).
+func signalDef(t *testing.T, name string) flow.EventDefinition {
+	t.Helper()
+
+	sig, err := events.NewSignal(name, nil)
+	require.NoError(t, err)
+	def, err := events.NewSignalEventDefinition(sig)
+	require.NoError(t, err)
+
+	return def
+}
+
+// boolExprBoom is a boolean expression whose evaluation errors — the runtime
+// failure a Complex behavior condition can hit.
+func boolExprBoom(t *testing.T) data.FormalExpression {
+	t.Helper()
+
+	return goexpr.Must(nil,
+		data.MustItemDefinition(values.NewVariable(false)),
+		func(_ context.Context, _ data.Source) (data.Value, error) {
+			return nil, errs.New(errs.M("condition boom"),
+				errs.C(errorClass, errs.OperationFailed))
+		})
+}
+
+// runMIBehavior runs a Multi-Instance host to completion and returns the event
+// definitions its behavior throws propagated (SRD-056.B FR-6). The same builder
+// drives both the sequential and the parallel shape — the mi's IsSequential()
+// selects the path.
+func runMIBehavior(
+	t *testing.T, mi *activities.MultiInstanceLoopCharacteristics,
+) []flow.EventDefinition {
+	t.Helper()
+
+	var count atomic.Int32
+
+	inst, prod := miBehaviorInstance(t, countOp(t, &count), mi)
+	runToDone(t, inst)
+
+	require.Equal(t, Completed, inst.State())
+
+	return prod.propagatedDefs()
+}
+
+// TestMultiInstanceBehaviorThrows: the §2.9 behavior modes throw the right event
+// the right number of times on each completion, for BOTH the sequential and the
+// parallel shape (ADR-025 §2.8, SRD-056.B FR-1..FR-6). None throws on every
+// completion, One only on the first, Complex only when its condition holds, and
+// All (the default) throws nothing.
+func TestMultiInstanceBehaviorThrows(t *testing.T) {
+	for _, sh := range miShapes() {
+		t.Run(sh.name, func(t *testing.T) {
+			t.Run("None throws on every completion", func(t *testing.T) {
+				def := signalDef(t, "none")
+				mi := sh.mk(t,
+					activities.WithCardinality(cardExpr(t, 3)),
+					activities.WithBehavior(activities.BehaviorNone),
+					activities.WithNoneBehaviorEvent(def))
+
+				got := runMIBehavior(t, mi)
+
+				require.Len(t, got, 3, "None throws once per completion")
+				for _, d := range got {
+					require.Equal(t, def.ID(), d.ID())
+				}
+			})
+
+			t.Run("One throws once", func(t *testing.T) {
+				def := signalDef(t, "one")
+				mi := sh.mk(t,
+					activities.WithCardinality(cardExpr(t, 3)),
+					activities.WithBehavior(activities.BehaviorOne),
+					activities.WithOneBehaviorEvent(def))
+
+				got := runMIBehavior(t, mi)
+
+				require.Len(t, got, 1, "One throws only on the first completion")
+				require.Equal(t, def.ID(), got[0].ID())
+			})
+
+			t.Run("Complex throws when the condition holds", func(t *testing.T) {
+				def := signalDef(t, "complex")
+				ite, err := events.NewImplicitThrowEvent("cx", def)
+				require.NoError(t, err)
+
+				cbd, err := activities.NewComplexBehaviorDefinition(
+					attrAtLeast(t, "numberOfCompletedInstances", 3), ite)
+				require.NoError(t, err)
+
+				mi := sh.mk(t,
+					activities.WithCardinality(cardExpr(t, 3)),
+					activities.WithBehavior(activities.BehaviorComplex),
+					activities.WithComplexBehavior(cbd))
+
+				got := runMIBehavior(t, mi)
+
+				require.Len(t, got, 1,
+					"Complex throws only on the completion where the condition holds")
+				require.Equal(t, def.ID(), got[0].ID())
+			})
+
+			t.Run("All throws nothing", func(t *testing.T) {
+				mi := sh.mk(t, activities.WithCardinality(cardExpr(t, 3)))
+
+				got := runMIBehavior(t, mi)
+
+				require.Empty(t, got, "All (the default) throws no behavior event")
+			})
+		})
+	}
+}
+
+// TestMultiInstanceComplexConditionError: a Complex behavior whose condition
+// errors on evaluation faults the instance — the error propagates out of the
+// completion path on both shapes (SRD-056.B).
+func TestMultiInstanceComplexConditionError(t *testing.T) {
+	for _, sh := range miShapes() {
+		t.Run(sh.name, func(t *testing.T) {
+			var count atomic.Int32
+
+			ite, err := events.NewImplicitThrowEvent("cx", signalDef(t, "cx"))
+			require.NoError(t, err)
+			cbd, err := activities.NewComplexBehaviorDefinition(boolExprBoom(t), ite)
+			require.NoError(t, err)
+
+			mi := sh.mk(t,
+				activities.WithCardinality(cardExpr(t, 3)),
+				activities.WithBehavior(activities.BehaviorComplex),
+				activities.WithComplexBehavior(cbd))
+
+			inst, _ := miBehaviorInstance(t, countOp(t, &count), mi)
+			runToDone(t, inst)
+
+			require.NotEqual(t, Completed, inst.State(),
+				"a Complex condition evaluation error faults the instance")
+			require.Error(t, inst.LastErr())
+		})
+	}
+}
+
+// TestMultiInstanceBehaviorPropagateError: a failed behavior-event propagation
+// faults the instance — the always-true Complex condition throws, and the
+// producer's propagate error surfaces out of the completion path on both shapes.
+func TestMultiInstanceBehaviorPropagateError(t *testing.T) {
+	for _, sh := range miShapes() {
+		t.Run(sh.name, func(t *testing.T) {
+			var count atomic.Int32
+
+			ite, err := events.NewImplicitThrowEvent("cx", signalDef(t, "cx"))
+			require.NoError(t, err)
+			cbd, err := activities.NewComplexBehaviorDefinition(
+				attrAtLeast(t, "numberOfCompletedInstances", 1), ite)
+			require.NoError(t, err)
+
+			mi := sh.mk(t,
+				activities.WithCardinality(cardExpr(t, 2)),
+				activities.WithBehavior(activities.BehaviorComplex),
+				activities.WithComplexBehavior(cbd))
+
+			inst, prod := miBehaviorInstance(t, countOp(t, &count), mi)
+			prod.propagateErr = errRegRejected
+			runToDone(t, inst)
+
+			require.NotEqual(t, Completed, inst.State(),
+				"a failed behavior-event propagation faults the instance")
+			require.Error(t, inst.LastErr())
+		})
+	}
+}
+
+// TestMultiInstanceAfterDrainBindCountersError covers the sequential completion
+// path's defensive counter-publish error: draining against an unopened host
+// scope fails at bindMICounters before any behavior is thrown.
+func TestMultiInstanceAfterDrainBindCountersError(t *testing.T) {
+	var count atomic.Int32
+
+	mi := mustSeqMI(t, activities.WithCardinality(cardExpr(t, 1)))
+
+	inst := miSubProcessInstance(t, &count, mi)
+	inst.tracks = map[string]*track{}
+	ls := newLoopState(inst)
+	node := findNode(t, inst.s, "body")
+
+	host, err := newTrack(node, inst, nil)
+	require.NoError(t, err)
+	// an unopened host scope makes the counter Commit fail.
+	host.scopePath = scope.DataPath("/does/not/exist")
+	host.miState = &miState{numberOfInstances: 1}
+
+	_, err = miIterator{mi: mi}.afterDrain(t.Context(), ls, host, node)
+	require.Error(t, err)
+}

--- a/internal/instance/mi_parallel.go
+++ b/internal/instance/mi_parallel.go
@@ -196,6 +196,13 @@ func (ls *loopState) parallelInstanceDrained(
 		return err
 	}
 
+	// throw the behavior event (if any) before the host resumes (SRD-056.B
+	// FR-6), so its boundary fire is enqueued while the host boundary is armed.
+	if err := ls.throwMIBehavior(
+		ctx, grp.mi, grp.host, grp.node, grp.completed); err != nil {
+		return err
+	}
+
 	done := len(grp.open) == 0
 
 	// completionCondition true → the activity is done now: cancel the still-open
@@ -238,23 +245,11 @@ func (ls *loopState) parallelInstanceDrained(
 
 // bindParallelCounters publishes the §2.9 runtime attributes at the host scope:
 // the frozen instance count, the still-running count, and the completed /
-// terminated counts as they progress (SRD-056.A FR-9).
+// terminated counts as they progress (SRD-056.A FR-9) — the parallel shape's
+// call into the shared bindMICounters.
 func (ls *loopState) bindParallelCounters(grp *miGroup) error {
-	binds := []miBinding{
-		{name: "numberOfInstances", value: grp.n},
-		{name: "numberOfActiveInstances", value: len(grp.open)},
-		{name: "numberOfCompletedInstances", value: grp.completed},
-		{name: "numberOfTerminatedInstances", value: grp.terminated},
-	}
-
-	for _, b := range binds {
-		if err := ls.inst.sc.bindDataItemAt(
-			grp.host.scopePath, b.name, b.value); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return ls.bindMICounters(grp.host.scopePath,
+		grp.n, len(grp.open), grp.completed, grp.terminated)
 }
 
 // cancelOpenInstances cancels every still-open instance scope of the group as a

--- a/internal/instance/mi_test.go
+++ b/internal/instance/mi_test.go
@@ -107,6 +107,21 @@ func miSubProcessInstanceOp(
 ) *Instance {
 	t.Helper()
 
+	inst, _ := miBehaviorInstance(t, op, mi, props...)
+
+	return inst
+}
+
+// miBehaviorInstance is miSubProcessInstanceOp returning the recording event
+// producer too, so a Multi-Instance behavior test can count the behavior events
+// the host throws (SRD-056.B).
+func miBehaviorInstance(
+	t *testing.T, op service.Operation,
+	mi *activities.MultiInstanceLoopCharacteristics,
+	props ...*data.Property,
+) (*Instance, *recordingProducer) {
+	t.Helper()
+
 	_ = data.CreateDefaultStates()
 
 	p, err := process.New("mi-sp", data.WithProperties(props...))
@@ -147,11 +162,11 @@ func miSubProcessInstanceOp(
 	s, err := snapshot.New(p)
 	require.NoError(t, err)
 
-	inst, err := New(s, scope.EmptyDataPath, enginert.Default(),
-		&recordingProducer{}, nil)
+	prod := &recordingProducer{}
+	inst, err := New(s, scope.EmptyDataPath, enginert.Default(), prod, nil)
 	require.NoError(t, err)
 
-	return inst
+	return inst, prod
 }
 
 // mustSeqMI builds a valid sequential Multi-Instance from the given options.

--- a/pkg/model/activities/multiinstance.go
+++ b/pkg/model/activities/multiinstance.go
@@ -3,23 +3,89 @@ package activities
 import (
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 )
+
+// MultiInstanceBehavior governs whether the activity throws a boundary-catchable
+// event as its instances complete (BPMN §13.3.7, ADR-025 §2.8).
+type MultiInstanceBehavior string
+
+const (
+	// BehaviorAll (the default) throws no event — the common, zero-cost case.
+	BehaviorAll MultiInstanceBehavior = "all"
+	// BehaviorNone throws noneBehaviorEventRef for EVERY instance completion.
+	BehaviorNone MultiInstanceBehavior = "none"
+	// BehaviorOne throws oneBehaviorEventRef once, on the FIRST completion.
+	BehaviorOne MultiInstanceBehavior = "one"
+	// BehaviorComplex consults the complexBehaviorDefinition entries on each
+	// completion, throwing the event of each whose condition holds.
+	BehaviorComplex MultiInstanceBehavior = "complex"
+)
+
+// ComplexBehaviorDefinition drives BehaviorComplex (BPMN §ComplexBehaviorDefinition):
+// on each instance completion its condition is evaluated, and when true its event
+// is thrown (catchable on the Multi-Instance activity's boundary).
+type ComplexBehaviorDefinition struct {
+	condition data.FormalExpression
+	event     *events.ImplicitThrowEvent
+	foundation.BaseElement
+}
+
+// NewComplexBehaviorDefinition builds a complex-behavior entry. The boolean
+// condition and the thrown event are both required.
+func NewComplexBehaviorDefinition(
+	condition data.FormalExpression, event *events.ImplicitThrowEvent,
+) (*ComplexBehaviorDefinition, error) {
+	if condition == nil || event == nil {
+		return nil, errs.New(
+			errs.M("NewComplexBehaviorDefinition: both a condition and an event "+
+				"are required"),
+			errs.C(errorClass, errs.InvalidParameter, errs.EmptyNotAllowed))
+	}
+
+	if condition.ResultType() != resultTypeBool {
+		return nil, errs.New(
+			errs.M("NewComplexBehaviorDefinition: condition must be a boolean "+
+				"expression, got %q", condition.ResultType()),
+			errs.C(errorClass, errs.InvalidParameter))
+	}
+
+	return &ComplexBehaviorDefinition{
+		BaseElement: *foundation.MustBaseElement(),
+		condition:   condition,
+		event:       event,
+	}, nil
+}
+
+// Condition returns the boolean expression gating the throw.
+func (c *ComplexBehaviorDefinition) Condition() data.FormalExpression {
+	return c.condition
+}
+
+// Event returns the implicit throw event thrown when the condition holds.
+func (c *ComplexBehaviorDefinition) Event() *events.ImplicitThrowEvent {
+	return c.event
+}
 
 // MultiInstanceLoopCharacteristics is a Multi-Instance marker (BPMN §13.3.7):
 // the activity runs a fixed number of times, decided once at activation from
 // loopCardinality (an integer expression) or the size of the loopDataInputRef
-// collection. This slice implements the sequential shape (isSequential); the
-// data references are scope-datum names, resolved by name like any per-scope
-// datum. behavior/ComplexBehaviorDefinition and parallel execution land later
-// (SRD-056).
+// collection, sequentially (SRD-055) or in parallel (SRD-056.A). The data
+// references are scope-datum names, resolved by name. behavior throws a
+// boundary-catchable event as instances complete (SRD-056.B).
 type MultiInstanceLoopCharacteristics struct {
-	loopCardinality     data.FormalExpression
-	completionCondition data.FormalExpression
-	loopDataInputRef    string
-	loopDataOutputRef   string
-	inputDataItem       string
-	outputDataItem      string
+	loopCardinality           data.FormalExpression
+	completionCondition       data.FormalExpression
+	noneBehaviorEventRef      flow.EventDefinition
+	oneBehaviorEventRef       flow.EventDefinition
+	complexBehaviorDefinition []*ComplexBehaviorDefinition
+	loopDataInputRef          string
+	loopDataOutputRef         string
+	inputDataItem             string
+	outputDataItem            string
+	behavior                  MultiInstanceBehavior
 	foundation.BaseElement
 	isSequential bool
 }
@@ -114,6 +180,76 @@ func WithCompletionCondition(expr data.FormalExpression) MultiInstanceOption {
 	}
 }
 
+// WithBehavior sets the event-throwing behavior (BPMN §13.3.7, ADR-025 §2.8);
+// the default is BehaviorAll (no event). See BehaviorNone/One/Complex.
+func WithBehavior(b MultiInstanceBehavior) MultiInstanceOption {
+	return func(mi *MultiInstanceLoopCharacteristics) error {
+		switch b {
+		case BehaviorAll, BehaviorNone, BehaviorOne, BehaviorComplex:
+			mi.behavior = b
+
+			return nil
+
+		default:
+			return errs.New(
+				errs.M("WithBehavior: unknown Multi-Instance behavior %q", b),
+				errs.C(errorClass, errs.InvalidParameter))
+		}
+	}
+}
+
+// WithNoneBehaviorEvent sets the event thrown on every instance completion under
+// BehaviorNone. A nil definition is rejected.
+func WithNoneBehaviorEvent(def flow.EventDefinition) MultiInstanceOption {
+	return func(mi *MultiInstanceLoopCharacteristics) error {
+		if def == nil {
+			return errs.New(
+				errs.M("WithNoneBehaviorEvent: a nil event definition isn't "+
+					"allowed"),
+				errs.C(errorClass, errs.InvalidParameter, errs.EmptyNotAllowed))
+		}
+
+		mi.noneBehaviorEventRef = def
+
+		return nil
+	}
+}
+
+// WithOneBehaviorEvent sets the event thrown once, on the first instance
+// completion, under BehaviorOne. A nil definition is rejected.
+func WithOneBehaviorEvent(def flow.EventDefinition) MultiInstanceOption {
+	return func(mi *MultiInstanceLoopCharacteristics) error {
+		if def == nil {
+			return errs.New(
+				errs.M("WithOneBehaviorEvent: a nil event definition isn't "+
+					"allowed"),
+				errs.C(errorClass, errs.InvalidParameter, errs.EmptyNotAllowed))
+		}
+
+		mi.oneBehaviorEventRef = def
+
+		return nil
+	}
+}
+
+// WithComplexBehavior sets the complex-behavior definitions consulted on each
+// completion under BehaviorComplex. At least one non-nil definition is required.
+func WithComplexBehavior(defs ...*ComplexBehaviorDefinition) MultiInstanceOption {
+	return func(mi *MultiInstanceLoopCharacteristics) error {
+		for _, d := range defs {
+			if d == nil {
+				return errs.New(
+					errs.M("WithComplexBehavior: a nil definition isn't allowed"),
+					errs.C(errorClass, errs.InvalidParameter, errs.EmptyNotAllowed))
+			}
+		}
+
+		mi.complexBehaviorDefinition = defs
+
+		return nil
+	}
+}
+
 // NewMultiInstance creates a MultiInstanceLoopCharacteristics from options. It
 // requires exactly one cardinality source (WithCardinality XOR
 // WithInputCollection), an integer cardinality expression, and — when present —
@@ -156,7 +292,59 @@ func NewMultiInstance(
 			errs.C(errorClass, errs.InvalidParameter))
 	}
 
+	if mi.behavior == "" {
+		mi.behavior = BehaviorAll
+	}
+
+	if err := validateBehavior(mi); err != nil {
+		return nil, err
+	}
+
 	return mi, nil
+}
+
+// behaviorSource reports whether the Multi-Instance carries the one event source
+// a non-All behavior requires — a data table, not a per-mode branch.
+var behaviorSource = map[MultiInstanceBehavior]func(*MultiInstanceLoopCharacteristics) bool{
+	BehaviorNone:    func(mi *MultiInstanceLoopCharacteristics) bool { return mi.noneBehaviorEventRef != nil },
+	BehaviorOne:     func(mi *MultiInstanceLoopCharacteristics) bool { return mi.oneBehaviorEventRef != nil },
+	BehaviorComplex: func(mi *MultiInstanceLoopCharacteristics) bool { return len(mi.complexBehaviorDefinition) > 0 },
+}
+
+// validateBehavior enforces the behavior⇄ref consistency (ADR-025 §2.8): each
+// non-All mode requires exactly its own event source (no other set), and
+// BehaviorAll forbids all.
+func validateBehavior(mi *MultiInstanceLoopCharacteristics) error {
+	sources := 0
+	if mi.noneBehaviorEventRef != nil {
+		sources++
+	}
+	if mi.oneBehaviorEventRef != nil {
+		sources++
+	}
+	if len(mi.complexBehaviorDefinition) > 0 {
+		sources++
+	}
+
+	if mi.behavior == BehaviorAll {
+		if sources > 0 {
+			return errs.New(
+				errs.M("NewMultiInstance: BehaviorAll throws no event — no "+
+					"behavior event may be set"),
+				errs.C(errorClass, errs.InvalidParameter))
+		}
+
+		return nil
+	}
+
+	if sources != 1 || !behaviorSource[mi.behavior](mi) {
+		return errs.New(
+			errs.M("NewMultiInstance: %s behavior requires exactly its own "+
+				"event source", mi.behavior),
+			errs.C(errorClass, errs.InvalidParameter))
+	}
+
+	return nil
 }
 
 // IsSequential reports whether the instances run one after another (§13.3.7).
@@ -195,4 +383,24 @@ func (mi *MultiInstanceLoopCharacteristics) InputDataItem() string {
 // OutputDataItem returns the per-instance output datum name.
 func (mi *MultiInstanceLoopCharacteristics) OutputDataItem() string {
 	return mi.outputDataItem
+}
+
+// Behavior returns the event-throwing behavior (BehaviorAll by default).
+func (mi *MultiInstanceLoopCharacteristics) Behavior() MultiInstanceBehavior {
+	return mi.behavior
+}
+
+// NoneBehaviorEvent returns the BehaviorNone event definition, or nil.
+func (mi *MultiInstanceLoopCharacteristics) NoneBehaviorEvent() flow.EventDefinition {
+	return mi.noneBehaviorEventRef
+}
+
+// OneBehaviorEvent returns the BehaviorOne event definition, or nil.
+func (mi *MultiInstanceLoopCharacteristics) OneBehaviorEvent() flow.EventDefinition {
+	return mi.oneBehaviorEventRef
+}
+
+// ComplexBehavior returns the BehaviorComplex definitions, or nil.
+func (mi *MultiInstanceLoopCharacteristics) ComplexBehavior() []*ComplexBehaviorDefinition {
+	return mi.complexBehaviorDefinition
 }

--- a/pkg/model/activities/multiinstance_behavior_test.go
+++ b/pkg/model/activities/multiinstance_behavior_test.go
@@ -1,0 +1,144 @@
+package activities_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+)
+
+// sigDef builds a signal event definition to use as a behavior event ref.
+func sigDef(t *testing.T, name string) flow.EventDefinition {
+	t.Helper()
+
+	sig, err := events.NewSignal(name, nil)
+	require.NoError(t, err)
+	def, err := events.NewSignalEventDefinition(sig)
+	require.NoError(t, err)
+
+	return def
+}
+
+// mustImplicitThrow builds an ImplicitThrowEvent over a signal definition.
+func mustImplicitThrow(t *testing.T) *events.ImplicitThrowEvent {
+	t.Helper()
+
+	ite, err := events.NewImplicitThrowEvent("beh", sigDef(t, "c"))
+	require.NoError(t, err)
+
+	return ite
+}
+
+// baseMI builds a minimal valid sequential collection MI plus the given options.
+func baseMI(
+	t *testing.T, opts ...activities.MultiInstanceOption,
+) (*activities.MultiInstanceLoopCharacteristics, error) {
+	t.Helper()
+
+	return activities.NewMultiInstance(append([]activities.MultiInstanceOption{
+		activities.WithSequential(),
+		activities.WithInputCollection("items", "item"),
+	}, opts...)...)
+}
+
+// TestMultiInstanceBehaviorValidation: behavior defaults to All, and each mode
+// requires exactly its own event source (ADR-025 §2.8).
+func TestMultiInstanceBehaviorValidation(t *testing.T) {
+	t.Run("default is All, no event", func(t *testing.T) {
+		mi, err := baseMI(t)
+		require.NoError(t, err)
+		require.Equal(t, activities.BehaviorAll, mi.Behavior())
+	})
+
+	t.Run("None requires the none event", func(t *testing.T) {
+		_, err := baseMI(t, activities.WithBehavior(activities.BehaviorNone))
+		require.Error(t, err)
+
+		mi, err := baseMI(t, activities.WithBehavior(activities.BehaviorNone),
+			activities.WithNoneBehaviorEvent(sigDef(t, "n")))
+		require.NoError(t, err)
+		require.NotNil(t, mi.NoneBehaviorEvent())
+	})
+
+	t.Run("One requires the one event", func(t *testing.T) {
+		_, err := baseMI(t, activities.WithBehavior(activities.BehaviorOne))
+		require.Error(t, err)
+
+		mi, err := baseMI(t, activities.WithBehavior(activities.BehaviorOne),
+			activities.WithOneBehaviorEvent(sigDef(t, "o")))
+		require.NoError(t, err)
+		require.NotNil(t, mi.OneBehaviorEvent())
+	})
+
+	t.Run("Complex requires a definition", func(t *testing.T) {
+		_, err := baseMI(t, activities.WithBehavior(activities.BehaviorComplex))
+		require.Error(t, err)
+
+		cbd, err := activities.NewComplexBehaviorDefinition(
+			boolExpr(t), mustImplicitThrow(t))
+		require.NoError(t, err)
+
+		mi, err := baseMI(t, activities.WithBehavior(activities.BehaviorComplex),
+			activities.WithComplexBehavior(cbd))
+		require.NoError(t, err)
+		require.Len(t, mi.ComplexBehavior(), 1)
+	})
+
+	t.Run("All forbids a behavior event", func(t *testing.T) {
+		_, err := baseMI(t, activities.WithNoneBehaviorEvent(sigDef(t, "n")))
+		require.Error(t, err)
+	})
+
+	t.Run("mismatched ref for the mode is rejected", func(t *testing.T) {
+		_, err := baseMI(t, activities.WithBehavior(activities.BehaviorNone),
+			activities.WithOneBehaviorEvent(sigDef(t, "o")))
+		require.Error(t, err)
+	})
+
+	t.Run("unknown behavior is rejected", func(t *testing.T) {
+		_, err := baseMI(t, activities.WithBehavior("bogus"))
+		require.Error(t, err)
+	})
+
+	t.Run("a nil behavior event is rejected", func(t *testing.T) {
+		_, err := baseMI(t, activities.WithNoneBehaviorEvent(nil))
+		require.Error(t, err)
+
+		_, err = baseMI(t, activities.WithOneBehaviorEvent(nil))
+		require.Error(t, err)
+
+		_, err = baseMI(t, activities.WithComplexBehavior(nil))
+		require.Error(t, err)
+	})
+}
+
+// TestComplexBehaviorDefinition: the constructor requires a boolean condition
+// and a non-nil event.
+func TestComplexBehaviorDefinition(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		cbd, err := activities.NewComplexBehaviorDefinition(
+			boolExpr(t), mustImplicitThrow(t))
+		require.NoError(t, err)
+		require.NotNil(t, cbd.Condition())
+		require.NotNil(t, cbd.Event())
+	})
+
+	t.Run("nil condition rejected", func(t *testing.T) {
+		_, err := activities.NewComplexBehaviorDefinition(nil, mustImplicitThrow(t))
+		require.Error(t, err)
+	})
+
+	t.Run("nil event rejected", func(t *testing.T) {
+		_, err := activities.NewComplexBehaviorDefinition(boolExpr(t), nil)
+		require.Error(t, err)
+	})
+
+	t.Run("non-boolean condition rejected", func(t *testing.T) {
+		_, err := activities.NewComplexBehaviorDefinition(
+			intExpr(t), mustImplicitThrow(t))
+		require.Error(t, err)
+	})
+}

--- a/pkg/model/events/implicit_throw.go
+++ b/pkg/model/events/implicit_throw.go
@@ -1,0 +1,39 @@
+package events
+
+import (
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/options"
+)
+
+// ImplicitThrowEvent is a ThrowEvent thrown implicitly by an activity (BPMN
+// §ImplicitThrowEvent), never reached by a token: it carries an EventDefinition
+// and is emitted by the engine — here, a Multi-Instance behavior event thrown as
+// instances complete (ADR-025 §2.8). Unlike IntermediateThrowEvent it declares
+// no flow-node wiring and no trigger allow-list — the behavior event is the
+// modeler's choice (typically a Signal, caught on the Multi-Instance activity's
+// boundary). It reuses the shared throwEvent base, so its definition, per-instance
+// cloning, and emit path come for free.
+type ImplicitThrowEvent struct {
+	throwEvent
+}
+
+// NewImplicitThrowEvent builds an implicit throw for def. A nil def is rejected.
+func NewImplicitThrowEvent(
+	name string,
+	def flow.EventDefinition,
+	baseOpts ...options.Option,
+) (*ImplicitThrowEvent, error) {
+	if def == nil {
+		return nil, errs.New(
+			errs.M("an event definition is required for the ImplicitThrowEvent"),
+			errs.C(errorClass, errs.EmptyNotAllowed))
+	}
+
+	te, err := newThrowEvent(name, nil, []flow.EventDefinition{def}, baseOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ImplicitThrowEvent{throwEvent: *te}, nil
+}

--- a/pkg/model/events/implicit_throw_test.go
+++ b/pkg/model/events/implicit_throw_test.go
@@ -1,0 +1,25 @@
+package events_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+)
+
+// TestImplicitThrowEventBuild: an ImplicitThrowEvent carries its definition; a
+// nil definition is rejected.
+func TestImplicitThrowEventBuild(t *testing.T) {
+	sig, err := events.NewSignal("quorum", nil)
+	require.NoError(t, err)
+	def, err := events.NewSignalEventDefinition(sig)
+	require.NoError(t, err)
+
+	ite, err := events.NewImplicitThrowEvent("quorum-reached", def)
+	require.NoError(t, err)
+	require.Len(t, ite.Definitions(), 1)
+
+	_, err = events.NewImplicitThrowEvent("bad", nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## What

Lands **Multi-Instance `behavior`** — throwing a boundary-catchable event as
instances complete — on the off-loop iteration decorator (ADR-025 v.2 §2.8/§2.12).
This is the **final slice** of the decorator re-landing: Standard Loop (SRD-054),
sequential MI (SRD-055), parallel MI (SRD-056.A), and now behavior (SRD-056.B) all
iterate on the activity's own off-loop runner. **ADR-025 v.2 flips to Accepted** —
the decorator conception is now the accepted model for all composite iteration.

Closes #88 (activity iteration — loops / Multi-Instance). Only `completionQuantity`
stays deferred (SRD-046 NFR-4).

## Why

This slice is the one the whole decorator rework existed to enable. A superseded
attempt (never merged) threw behavior events **on the loop goroutine**, where the
`PropagateEvent` round trip — throw → EventHub → the boundary catch delivered back to
this instance's inbound channel — **self-deadlocks** (the loop is the channel's only
reader, busy inside the throw), and made fire-and-forget it dropped the catch
nondeterministically. §2.12 moved iteration control onto the activity's own off-loop
runner, so the throw becomes an **ordinary off-loop emit**: `PropagateEvent` blocks
only until the loop accepts the event, then the runner completes the activity — the
boundary catch ordered before completion, on a still-armed boundary, by construction.

## `behavior` modes (BPMN §13.3.7, ADR-025 §2.8)

- **`All`** (default) — no event thrown (zero cost).
- **`None`** — thrown on every instance completion.
- **`One`** — thrown once, on the first completion.
- **`Complex`** — each `NewComplexBehaviorDefinition(condition, event)` is evaluated
  on every completion; each whose boolean condition holds throws its
  `ImplicitThrowEvent` (one completion may throw several). Caught by a boundary on the
  Multi-Instance activity — interrupting or non-interrupting.

## Key changes

- **`pkg/model/events/implicit_throw.go`** — `ImplicitThrowEvent` (a `ThrowEvent`
  never reached by a token, embedding the shared `throwEvent` base).
- **`pkg/model/activities/multiinstance.go`** — `MultiInstanceBehavior` enum,
  `ComplexBehaviorDefinition`, the `behavior`/`*BehaviorEventRef`/
  `complexBehaviorDefinition` fields + `WithBehavior`/`WithNoneBehaviorEvent`/
  `WithOneBehaviorEvent`/`WithComplexBehavior` options + behavior⇄ref data-table
  validation (`behaviorSource` map). Expression type checks at the constructors
  (Complex condition + `completionCondition` boolean, `loopCardinality` integer).
- **`internal/instance/mi_behavior.go`** (new) — `throwMIBehavior` /
  `throwComplexBehavior` (`*track`, runner-side, ride `t.instance.PropagateEvent`);
  wired into `runMISequential` and `parallelBarrierStep` after each drain, before
  the driver completes the activity. `evalBoolAtHost` extracted (shared by
  `completionCondition` and Complex conditions).

## Verification

- `make ci` green (rebased onto master incl. #228/#229) — golangci-lint 0, `-race`,
  **diff-coverage 98.9% of 177 changed lines (min 95%)**, govulncheck clean.
- Behavior modes tested None/One/Complex/All × **sequential and parallel** under
  `-race`, plus the Complex-condition and propagate error faults.
- **The FR-6 ordering risk did not materialize:** `TestMultiInstanceBehaviorE2E`
  (quorum caught by a non-interrupting boundary through the real EventHub) and
  `TestBehaviorLastCompletionCaught` (the event thrown at the **last** completion is
  still caught before disarm) pass **8× under `-race`** — the §4.3 yield fallback
  stays unused; the original loop-goroutine deadlock is gone by construction.
- `examples/multi-instance-behavior/` smokes end-to-end (the quorum notification
  fires as votes cross the threshold).
- `/check-srd` landing gate: **PASS**.

## Docs

- **SRD-056.B** Accepted, §10 filled. **ADR-025 v.2 → Accepted** (EN + RU twin
  re-translated to v.2).
- `CHANGELOG.md`; iteration guide behavior section; conformance tracker row 4
  (**behavior ✅** — MI complete); README EN + RU; examples index.

## Commits

- `de498f3` docs(srd): SRD-056.B authored for the off-loop decorator (Draft)
- `a6a4428` feat(model): Multi-Instance behavior model types (M1)
- `dd72fc9` feat(instance): throw Multi-Instance behavior events off the loop (M2)
- `afa951a` feat: behavior e2e, example, docs — ADR-025 v.2 Accepted (M3)
