### PR TITLE
feat: Rules/Script invocation facts and the registrar audit (SRD-069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Rules/Script invocation facts and the registrar audit (SRD-069).**
+  The decision/script observability stream becomes a closed ledger:
+  the new **`Invoked`** phase opens every Business Rule / Script Task
+  engine call (engine-call latency derivable, a hung engine
+  attributable), and every opening now **closes** — commit-stage
+  failures, previously silent on the stream, emit `Failed` with the
+  new `stage` attr (`engine` | `commit`). The **registrar surfaces**
+  gain their audit through the optional `rules.ReporterBinder`
+  capability (bound automatically by `thresher.New`): `gorules` and
+  `adapters/dtable` registration emit `Registered` (names and counts
+  only), and a runtime `dtable` **`Deploy` emits `Deployed` at Info**
+  — the decision-governance milestone, flagged `replaced` when it
+  overwrote a live table. Unbound engines stay silent; engine
+  internals deliberately stay off the stream (Tracer territory).
+
 - **The `gobpm:lite` text-expression evaluator (SRD-067; completes
   ADR-032 and closes #74 together with the routing half).** The
   stdlib-only battery behind the expression seam: `##Lite` claims

--- a/adapters/dtable/deploy.go
+++ b/adapters/dtable/deploy.go
@@ -2,8 +2,10 @@ package dtable
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
 	"github.com/dr-dobermann/gobpm/pkg/rules"
 )
 
@@ -64,7 +66,14 @@ func (e *Engine) Deploy(_ context.Context, definition []byte) error {
 	}
 
 	e.mu.Lock()
+	_, replaced := e.tables[t.name]
 	e.tables[t.name] = t
+	// The deploy audit (SRD-069 FR-5): a definition landed on a LIVE
+	// engine — the runtime governance milestone, flagged when it
+	// overwrote a served decision.
+	e.reportTable(observability.PhaseDeployed, t, map[string]string{
+		"replaced": strconv.FormatBool(replaced),
+	})
 	e.mu.Unlock()
 
 	return nil

--- a/adapters/dtable/engine.go
+++ b/adapters/dtable/engine.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
 	"github.com/dr-dobermann/gobpm/pkg/rules"
 )
 
@@ -17,11 +18,15 @@ import (
 type Engine struct {
 	decoder Decoder
 	tables  map[string]*Table
+	sink    observability.Reporter
 	mu      sync.RWMutex
 }
 
-// interface check
-var _ rules.Engine = (*Engine)(nil)
+// interface checks
+var (
+	_ rules.Engine         = (*Engine)(nil)
+	_ rules.ReporterBinder = (*Engine)(nil)
+)
 
 // Option configures the Engine at construction (the Decoder seam arrives
 // through it).
@@ -69,7 +74,51 @@ func (e *Engine) Register(t *Table) error {
 
 	e.tables[t.name] = t
 
+	// The registrar audit (SRD-069 FR-5): names and counts only,
+	// successes only, silent while unbound.
+	e.reportTable(observability.PhaseRegistered, t, nil)
+
 	return nil
+}
+
+// reportTable emits one registrar fact for t when a sink is bound; extra
+// details merge over the standard name/kind/count set. Callers hold e.mu.
+func (e *Engine) reportTable(
+	phase observability.Phase, t *Table, extra map[string]string,
+) {
+	if e.sink == nil {
+		return
+	}
+
+	details := map[string]string{
+		observability.AttrDecisionRef:    t.name,
+		observability.AttrImplementation: DTableType,
+		observability.AttrRuleCount:      strconv.Itoa(len(t.rules)),
+	}
+
+	for k, v := range extra {
+		details[k] = v
+	}
+
+	e.sink.Report(observability.Fact{
+		Kind:    observability.KindRules,
+		Phase:   phase,
+		Details: details,
+	})
+}
+
+// BindReporter binds the engine's observable-event sink (SRD-069 FR-3) —
+// the registrar surfaces emit KindRules facts once bound. A nil sink is
+// ignored, keeping the current silence.
+func (e *Engine) BindReporter(sink observability.Reporter) {
+	if sink == nil {
+		return
+	}
+
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	e.sink = sink
 }
 
 // MustRegister is the panic-on-error Register twin for tests and static

--- a/adapters/dtable/registrar_facts_test.go
+++ b/adapters/dtable/registrar_facts_test.go
@@ -1,0 +1,137 @@
+package dtable_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dr-dobermann/gobpm/adapters/dtable"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
+	"github.com/dr-dobermann/gobpm/pkg/thresher"
+)
+
+// reporterSink collects facts reported by the engine's registrar surfaces.
+type reporterSink struct {
+	facts []observability.Fact
+}
+
+func (rs *reporterSink) Report(f observability.Fact) {
+	rs.facts = append(rs.facts, f)
+}
+
+// TestRegistrarFacts covers SRD-069 T-4's unit half: Register and Deploy
+// emit the audit facts once bound — names and counts only — and stay
+// silent unbound.
+func TestRegistrarFacts(t *testing.T) {
+	t.Run("unbound register and deploy are silent",
+		func(t *testing.T) {
+			dec := &switchDecoder{tbl: oneRowTable(t, "quiet", 1)}
+
+			e, err := dtable.New(dtable.WithDecoder(dec))
+			require.NoError(t, err)
+
+			e.BindReporter(nil) // ignored
+
+			require.NoError(t, e.Register(oneRowTable(t, "r", 1)))
+			require.NoError(t, e.Deploy(ctx, []byte(`v1`)))
+		})
+
+	t.Run("bound register emits Registered with the rule count",
+		func(t *testing.T) {
+			sink := &reporterSink{}
+
+			e, err := dtable.New()
+			require.NoError(t, err)
+
+			e.BindReporter(sink)
+			require.NoError(t, e.Register(oneRowTable(t, "discount", 1)))
+
+			require.Len(t, sink.facts, 1)
+			f := sink.facts[0]
+			require.Equal(t, observability.KindRules, f.Kind)
+			require.Equal(t, observability.PhaseRegistered, f.Phase)
+			require.Equal(t, "discount",
+				f.Details[observability.AttrDecisionRef])
+			require.Equal(t, dtable.DTableType,
+				f.Details[observability.AttrImplementation])
+			require.Equal(t, "1",
+				f.Details[observability.AttrRuleCount])
+		})
+
+	t.Run("a rejected duplicate emits nothing",
+		func(t *testing.T) {
+			sink := &reporterSink{}
+
+			e, err := dtable.New()
+			require.NoError(t, err)
+
+			e.BindReporter(sink)
+			require.NoError(t, e.Register(oneRowTable(t, "once", 1)))
+			require.Error(t, e.Register(oneRowTable(t, "once", 1)))
+
+			require.Len(t, sink.facts, 1, "only the success is audited")
+		})
+
+	t.Run("deploy emits Deployed and flags the replacement",
+		func(t *testing.T) {
+			dec := &switchDecoder{tbl: oneRowTable(t, "d", 1)}
+
+			e, err := dtable.New(dtable.WithDecoder(dec))
+			require.NoError(t, err)
+
+			sink := &reporterSink{}
+			e.BindReporter(sink)
+
+			require.NoError(t, e.Deploy(ctx, []byte(`v1`)))
+
+			dec.tbl = oneRowTable(t, "d", 2)
+			require.NoError(t, e.Deploy(ctx, []byte(`v2`)))
+
+			require.Len(t, sink.facts, 2)
+
+			fresh := sink.facts[0]
+			require.Equal(t, observability.PhaseDeployed, fresh.Phase)
+			require.Equal(t, "false", fresh.Details["replaced"])
+
+			redeploy := sink.facts[1]
+			require.Equal(t, observability.PhaseDeployed, redeploy.Phase)
+			require.Equal(t, "true", redeploy.Details["replaced"])
+			require.Equal(t, "d",
+				redeploy.Details[observability.AttrDecisionRef])
+		})
+}
+
+// TestDeployAuditE2E covers SRD-069 T-4's e2e half: thresher.New binds its
+// producer into the dtable engine, and a runtime Deploy lands on the
+// engine-wide observer stream as the Deployed governance fact.
+func TestDeployAuditE2E(t *testing.T) {
+	dec := &switchDecoder{tbl: oneRowTable(t, "discount", 25)}
+
+	e, err := dtable.New(dtable.WithDecoder(dec))
+	require.NoError(t, err)
+
+	th, err := thresher.New("test-deploy-audit",
+		thresher.WithoutBanner(), thresher.WithRuleEngine(e))
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	require.NoError(t, th.Run(ctx))
+
+	c := &collector{}
+	sub := th.Observe(c)
+	defer sub.Cancel()
+
+	require.NoError(t, e.Deploy(ctx, []byte(`v1`)))
+
+	require.Eventually(t, func() bool {
+		f, ok := c.rulesFact(observability.PhaseDeployed)
+
+		return ok &&
+			f.Details[observability.AttrDecisionRef] == "discount" &&
+			f.Details["replaced"] == "false"
+	}, 2*time.Second, 10*time.Millisecond,
+		"the runtime deploy must reach the engine-wide observer")
+}

--- a/docs/srd/SRD-069-rules-script-invocation-and-registrar-facts.md
+++ b/docs/srd/SRD-069-rules-script-invocation-and-registrar-facts.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| Status | Draft |
+| Status | Accepted |
 | Version | v.1 |
 | Date | 2026-07-26 |
 | Owner | Ruslan Gabitov |
@@ -198,16 +198,32 @@ the pair still closes.
 
 ## §9 Definition of Done
 
-- [ ] FR-1…FR-6 implemented; every §6 test exists and passes.
-- [ ] `make ci` green (core) + the dtable module suite green;
+- [x] FR-1…FR-6 implemented; every §6 test exists and passes.
+- [x] `make ci` green (core) + the dtable module suite green;
       diff-coverage ≥95% (aim 100%); touched functions ≥80%.
-- [ ] Masking/volume audit: no new detail carries a body/source/value;
+- [x] Masking/volume audit: no new detail carries a body/source/value;
       no per-evaluation fact added.
-- [ ] §10 filled; CHANGELOG synced.
+- [x] §10 filled; CHANGELOG synced.
 
 ## §10 Implementation summary
 
-*Filled at landing.*
+Landed on `feat/rules-script-observability` in two milestones, as
+planned:
+
+| Milestone | Commit | Scope |
+|---|---|---|
+| M1 | `a1f9336` | FR-1/FR-2: `PhaseInvoked` + `AttrStage`, both task `Exec` paths open and close the pair (commit failures included); T-1/T-2 |
+| M2 | `93f99ef` | FR-3…FR-6: `rules.ReporterBinder` + the `thresher.New`/`enginert` binds, gorules/dtable `Registered`, dtable `Deployed{replaced}` at Info, `AttrRuleCount`; T-3…T-5; CHANGELOG |
+
+- **Verification**: post-M2 `make ci` exit 0; diff-coverage **100.0% of
+  55 changed lines**; the dtable module suite green with every touched
+  function at 100%; the decision-table example smokes exit 0 (it
+  deploys pre-`New` — unbound, silent, the §4.3 posture demonstrated).
+- **Deltas vs the draft**: none — the plan landed as written. One
+  emphasis note: gorules emits under its registration write-lock
+  (Report is contractually non-blocking, `fact.go` Reporter doc);
+  dtable emits inside the deploy critical section for the same reason —
+  the `replaced` probe and the emission stay atomic with the swap.
 
 ## Open questions
 

--- a/docs/srd/SRD-069-rules-script-invocation-and-registrar-facts.md
+++ b/docs/srd/SRD-069-rules-script-invocation-and-registrar-facts.md
@@ -1,0 +1,220 @@
+# SRD-069 — Rules/Script invocation facts and the registrar audit
+
+| Field | Value |
+|---|---|
+| Status | Draft |
+| Version | v.1 |
+| Date | 2026-07-26 |
+| Owner | Ruslan Gabitov |
+| Implements | [ADR-013 v.2](../design/ADR-013-instance-observability.md) §2.6 (the open phase taxonomy — two new phases, one reused; the masking and volume rules govern every addition) |
+| Upstream | [ADR-027 v.1](../design/ADR-027-business-rule-engine-seam.md) (the rules seam whose calls and registrars this audits), [ADR-031 v.1](../design/ADR-031-script-task-and-script-engine-seam.md) (the script seam), [ADR-029 v.1](../design/ADR-029-decision-table-engine-adapter.md) §2.6 (the deploy surface) |
+| Refines | SRD-060 v.1 (the `KindRules` outcome pair), SRD-064 v.1 (the `KindScript` outcome pair) — sideways |
+
+Closes two observability gaps found reviewing the Business Rule / Script
+task facts (the post-ADR-032 review the owner requested): (1) both kinds
+are **outcome-only** — no invocation-phase fact, so engine-call latency
+and a hung engine are invisible; (2) the **commit-stage blind spot** — a
+successful engine call whose result *commit* fails faults the task with
+no closing `KindRules`/`KindScript` fact at all. It also extends the
+audit to the **registrar surfaces** (register/deploy) the engines expose
+outside instance execution.
+
+## §1 Background
+
+- **The outcome pairs today.** `KindRules`: `Evaluated`
+  (`brule_task.go:136` — decision_ref, implementation, row_count,
+  result_variable) / `Failed` on an evaluation error
+  (`brule_task.go:118`; Warn echo, `echolevel.go:57`). `KindScript`:
+  `Executed` (`script_task.go:149`) / `Failed` on an execution error
+  (`script_task.go:132`; Warn echo). Both emit **only after the engine
+  call returns**.
+- **The commit blind spot.** `commitResult` (`brule_task.go:168`) and
+  `commitOutput` (`script_task.go:173`) failures return straight to the
+  fault machinery — no `KindRules`/`KindScript` fact marks them; the
+  decision/script audit stream goes silent mid-story.
+- **`KindNodeProgress`** (`Entered`/`Executing`, Debug) brackets every
+  node but cannot distinguish "inside the engine call" from anything
+  else the node does.
+- **The registrar surfaces are invisible.** `gorules.Registry.Register`
+  (`gorules.go:46`), `dtable.Engine.Register` (`engine.go:53`) and
+  `dtable.Engine.Deploy` (`deploy.go:44` — decode, then **replace**
+  `e.tables[t.name]` under the mutex) run outside instance execution,
+  called by user code; the adapters hold no Reporter. A runtime `Deploy`
+  that replaces a live decision emits nothing today. No
+  remove/unregister surface exists in-repo (grep) — no `Removed` phase
+  is invented.
+- **The binding precedent.** `tasks.ReporterBinder`
+  (`workerdispatcher.go:204`) is the optional capability the engine
+  binds its sink into at startup: `thresher.New` does
+  `ob.BindReporter(t.producer)` (`thresher.go:257-258`); a dispatcher
+  that doesn't implement it simply doesn't emit. `enginert.Runtime`
+  carries its own reporter (`enginert.go:50`).
+- **The e2e hook**: `Thresher.Observe(o) *Subscription`
+  (`producer.go:153`) subscribes an engine-wide observer;
+  `dtable` (its own module, `replace ../..`) can import `thresher` in
+  its tests, while core tests cannot import adapters — the e2e split
+  follows the module boundary.
+- `AttrDecisionRef`/`AttrImplementation`/`AttrError` exist
+  (`fact.go:162-167`); no `stage`/`rule_count` attrs yet;
+  `PhaseRegistered` exists (`fact.go:56`), `Invoked`/`Deployed` do not.
+
+## §2 Requirements
+
+### §2.1 Functional
+
+- **FR-1 — the invocation phase.** New reused **`PhaseInvoked`**
+  (`// Rules / Script`): emitted immediately **before** the engine call
+  — `BusinessRuleTask.Exec` before `eng.Evaluate` (details:
+  decision_ref, implementation) and `ScriptTask.Exec` before
+  `eng.Execute` (details: script_format, implementation via
+  `routedKind`). One extra fact per task execution — bounded and
+  per-task, not the per-expression flood ADR-032 §2.4 forbids. Paired
+  with the closing fact it makes engine-call latency derivable and a
+  hung engine attributable.
+- **FR-2 — close the pair.** Every `Invoked` closes with
+  `Evaluated`/`Executed` or `Failed`. Commit-stage failures
+  (`commitResult`/`commitOutput`) now also emit `Failed`, distinguished
+  by the new **`AttrStage = "stage"`** detail: `engine` on an engine
+  failure, `commit` on a commit failure. Success facts are unchanged
+  (no stage attr).
+- **FR-3 — the engine Reporter seam.** New optional capability
+  **`rules.ReporterBinder`** (the `tasks.ReporterBinder` shape:
+  `BindReporter(sink observability.Reporter)`). `thresher.New` binds
+  `t.producer` into `cfg.RuleEngine()` when implemented (beside the
+  dispatcher binds, `thresher.go:257`); `enginert` binds its own
+  reporter likewise. An engine that doesn't implement it doesn't emit —
+  and an implementing engine emits **nothing while unbound** (the
+  pre-`New` construction wiring is code, not runtime governance; the
+  audit targets what changes after the engine is live).
+- **FR-4 — gorules registration facts.** `gorules.Registry` implements
+  `rules.ReporterBinder` (sink guarded by the existing mutex);
+  `Register` emits **`KindRules`/`PhaseRegistered`** after success —
+  details: decision_ref, implementation (`##GoRules`). Failed
+  registrations return their error to the caller and emit nothing (the
+  audit records the catalog, not caller mistakes). `MustRegister` rides
+  `Register`.
+- **FR-5 — dtable registration/deploy facts.** `dtable.Engine`
+  implements the binder; `Register` emits `Registered` (decision_ref,
+  implementation `##DTable`, **`AttrRuleCount = "rule_count"`**);
+  `Deploy` emits new **`PhaseDeployed`** — details: decision_ref,
+  implementation, rule_count, `replaced` (`"true"` when the name
+  overwrote a live table, else `"false"`). Emission after the swap,
+  outside the lock's hot section where practical.
+- **FR-6 — echo posture.** `{KindRules, PhaseDeployed}` overrides to
+  **Info** (a runtime governance milestone — the `ProcessLifecycle`
+  analog); `Registered` and `Invoked` ride the kind default (Debug).
+
+### §2.2 Non-functional
+
+- **NFR-1 — masking**: every new detail is a name, kind, count or flag —
+  never a rule body, script source, or payload value.
+- **NFR-2 — volume**: no per-evaluation/per-rule/per-row facts; engine
+  **internals stay out of the observer stream** (their future home is
+  the Tracer seam, not facts) — this SRD adds at most one fact per task
+  execution and one per registrar call.
+- **NFR-3 — no `Must*` in library paths; validate-all-params** (a nil
+  sink in `BindReporter` is ignored, keeping the current no-op).
+- **NFR-4 — coverage**: `make ci` green; diff-coverage ≥95% (aim 100%);
+  touched functions ≥80%; the dtable module's own suite green.
+
+## §3 Models (shapes)
+
+```go
+// pkg/observability/fact.go
+PhaseInvoked  Phase = "Invoked"  // Rules / Script — the engine call opens
+PhaseDeployed Phase = "Deployed" // Rules — a definition landed at runtime
+
+AttrStage     = "stage"      // engine | commit (Failed only)
+AttrRuleCount = "rule_count" // registrar facts (dtable)
+
+// pkg/rules (FR-3) — the tasks.ReporterBinder shape
+type ReporterBinder interface {
+	BindReporter(sink observability.Reporter)
+}
+```
+
+Worked trace (the audit stream for one BRT execution against a deployed
+table): `engine.Deploy(tableJSON)` at runtime →
+`Rules/Deployed{decision_ref: discount, implementation: ##DTable,
+rule_count: 3, replaced: true}` at **Info**; the instance reaches the
+task → `Rules/Invoked{decision_ref: discount, implementation:
+##DTable}` → the call returns rows and the fold commits →
+`Rules/Evaluated{…, row_count: 1, result_variable: discount}`. Had the
+commit failed instead: `Rules/Failed{…, stage: commit, error: …}` —
+the pair still closes.
+
+## §4 Analysis & decisions
+
+- **§4.1 One reused `Invoked`, not "Called"/"Loaded".** The taxonomy
+  reuses phases across kinds (`Completed`, `Failed`, `Registered`);
+  two kind-specific synonyms would say nothing extra.
+- **§4.2 The binder over a constructor option.** The engines are built
+  by the user before `thresher.New`, so only the engine (not the core)
+  can emit registrar facts — but the sink is the core's. The
+  established answer is the optional-capability bind at `New`
+  (`tasks.ReporterBinder` precedent); a `WithReporter` constructor
+  option would demand the user hold a reporter before the engine
+  exists.
+- **§4.3 Unbound = silent, deliberately.** Pre-`New` registrations are
+  construction-time wiring — auditable as code; the governance-relevant
+  events are the ones that change a **live** engine (runtime `Deploy`),
+  and those happen bound. No buffering/replay machinery for pre-bind
+  facts.
+- **§4.4 Registrar failures emit nothing.** The error returns to the
+  caller synchronously — the caller is present and told; the audit
+  records the resulting catalog. (Task-side `Failed` differs: the
+  "caller" is a process instance and the stream is its audit.)
+- **§4.5 Internals stay out.** Per-rule condition hits, hit-policy row
+  matching, script VM activity are per-evaluation × per-rule — the
+  flood ADR-013's volume rules exist to prevent; their diagnostic
+  content already rides the `Failed` error details (dtable errors name
+  decision/rule/datum). Deep latency insight belongs to the Tracer.
+
+## §6 Test scenarios
+
+| # | Test | Verifies |
+|---|---|---|
+| T-1 | BRT facts (`pkg/model/activities`) | FR-1/FR-2: the `Invoked→Evaluated` pair with details; engine failure → `Invoked` + `Failed{stage: engine}`; commit failure (Put rejected) → `Invoked` + `Failed{stage: commit}` |
+| T-2 | ScriptTask facts (`pkg/model/activities`) | FR-1/FR-2: the same trio over the script pair (`Executed`/`Failed`) |
+| T-3 | gorules registrar (`pkg/rules/gorules`) | FR-3/FR-4: bound → `Registered` with details; unbound → no fact, no panic; a rejected duplicate emits nothing; nil sink ignored |
+| T-4 | dtable registrar (`adapters/dtable`) | FR-5: `Register` → `Registered` with rule_count; `Deploy` fresh → `Deployed{replaced: false}`, redeploy → `{replaced: true}`; unbound silent; plus the module-side e2e — deploy against a live thresher and see `Deployed` at the engine observer |
+| T-5 | wiring + e2e (`pkg/thresher`) | FR-3/FR-6: `New` binds the producer into a fake `ReporterBinder` rules engine; a BRT process run shows `Invoked→Evaluated` on the `Observe` stream; the `{KindRules, Deployed}` Info override in the echo table |
+
+## §7 Milestones
+
+- **M1 — task invocation facts.** FR-1/FR-2 (+ the two attrs and
+  `PhaseInvoked`); T-1/T-2.
+  `feat(observability): Rules/Script invocation facts close the pair (SRD-069 M1)`.
+- **M2 — the registrar audit.** FR-3…FR-6 (+ `PhaseDeployed`); T-3…T-5;
+  CHANGELOG.
+  `feat(rules): the engine Reporter seam and registrar facts (SRD-069 M2)`.
+
+## §8 Cross-doc
+
+- Implements **ADR-013 v.2** §2.6 (open phases; masking/volume rules).
+- Upstream: **ADR-027 v.1**, **ADR-029 v.1** §2.6, **ADR-031 v.1**.
+- Sideways: **SRD-060 v.1**, **SRD-064 v.1** (the outcome pairs this
+  completes).
+
+## §9 Definition of Done
+
+- [ ] FR-1…FR-6 implemented; every §6 test exists and passes.
+- [ ] `make ci` green (core) + the dtable module suite green;
+      diff-coverage ≥95% (aim 100%); touched functions ≥80%.
+- [ ] Masking/volume audit: no new detail carries a body/source/value;
+      no per-evaluation fact added.
+- [ ] §10 filled; CHANGELOG synced.
+
+## §10 Implementation summary
+
+*Filled at landing.*
+
+## Open questions
+
+*None — §4 resolves the design points inline.*
+
+## Document History
+
+| Version | Date | Author | Change |
+|---|---|---|---|
+| v.1 | 2026-07-26 | Ruslan Gabitov | Initial draft — the post-ADR-032 observability review's remediation: the reused `Invoked` phase opens the Rules/Script audit pair (engine-call latency derivable, hung engines attributable), commit-stage failures close it (`stage: engine｜commit` — the blind spot where a successful call's failed commit left the stream silent), and the registrar surfaces gain their audit through the `rules.ReporterBinder` capability (the dispatcher-binder precedent): `Registered` for gorules/dtable registration, `Deployed` at Info for runtime dtable deploys (`replaced` flagged). Unbound engines stay silent by design; engine internals stay out of the stream (Tracer territory). |

--- a/internal/enginert/enginert.go
+++ b/internal/enginert/enginert.go
@@ -124,10 +124,17 @@ func (r *Runtime) WithExpressionRegistry(reg *expression.Registry) *Runtime {
 }
 
 // WithRuleEngine overrides the Business Rule Engine and returns the Runtime. A
-// nil engine is ignored (the bundled default is kept).
+// nil engine is ignored (the bundled default is kept). An engine with the
+// registrar-audit capability gets the runtime's sink bound at set time
+// (SRD-069 FR-3) — apply WithReporter first when a custom sink should
+// receive the registrar facts.
 func (r *Runtime) WithRuleEngine(e rules.Engine) *Runtime {
 	if e != nil {
 		r.ruleEng = e
+
+		if rb, ok := e.(rules.ReporterBinder); ok {
+			rb.BindReporter(r.Reporter())
+		}
 	}
 
 	return r

--- a/pkg/model/activities/brule_task.go
+++ b/pkg/model/activities/brule_task.go
@@ -113,11 +113,17 @@ func (bt *BusinessRuleTask) Exec(
 
 	eng := re.RuleEngine()
 
+	bt.reportDecision(re, observability.PhaseInvoked, map[string]string{
+		observability.AttrDecisionRef:    bt.decisionRef,
+		observability.AttrImplementation: eng.Type(),
+	})
+
 	rows, err := eng.Evaluate(ctx, bt.decisionRef, re)
 	if err != nil {
 		bt.reportDecision(re, observability.PhaseFailed, map[string]string{
 			observability.AttrDecisionRef:    bt.decisionRef,
 			observability.AttrImplementation: eng.Type(),
+			observability.AttrStage:          "engine",
 			observability.AttrError:          err.Error(),
 		})
 
@@ -129,6 +135,16 @@ func (bt *BusinessRuleTask) Exec(
 	if len(rows) > 0 {
 		resultVar, err = bt.commitResult(rows, re)
 		if err != nil {
+			// The pair still closes: the engine call succeeded, the
+			// result commit did not (SRD-069 FR-2).
+			bt.reportDecision(re, observability.PhaseFailed,
+				map[string]string{
+					observability.AttrDecisionRef:    bt.decisionRef,
+					observability.AttrImplementation: eng.Type(),
+					observability.AttrStage:          "commit",
+					observability.AttrError:          err.Error(),
+				})
+
 			return nil, err
 		}
 	}

--- a/pkg/model/activities/brule_task_test.go
+++ b/pkg/model/activities/brule_task_test.go
@@ -124,9 +124,19 @@ func TestBusinessRuleTaskExec(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, flows)
 
-			// the FR-6 Evaluated fact carries the decision-level details.
-			require.Len(t, sink.facts, 1)
-			f := sink.facts[0]
+			// the SRD-069 pair: Invoked opens, Evaluated closes.
+			require.Len(t, sink.facts, 2)
+
+			inv := sink.facts[0]
+			require.Equal(t, observability.KindRules, inv.Kind)
+			require.Equal(t, observability.PhaseInvoked, inv.Phase)
+			require.Equal(t, "discount",
+				inv.Details[observability.AttrDecisionRef])
+			require.Equal(t, gorules.GoRulesType,
+				inv.Details[observability.AttrImplementation])
+			require.Empty(t, inv.Details[observability.AttrStage])
+
+			f := sink.facts[1]
 			require.Equal(t, observability.KindRules, f.Kind)
 			require.Equal(t, observability.PhaseEvaluated, f.Phase)
 			require.Equal(t, "check", f.NodeName)
@@ -168,9 +178,9 @@ func TestBusinessRuleTaskExec(t *testing.T) {
 
 			_, err := newBRT(t, "route").Exec(ctx, re)
 			require.NoError(t, err)
-			require.Len(t, sink.facts, 1)
+			require.Len(t, sink.facts, 2)
 			require.Equal(t, "route",
-				sink.facts[0].Details[observability.AttrResultVariable])
+				sink.facts[1].Details[observability.AttrResultVariable])
 		})
 
 	t.Run("an empty result commits nothing",
@@ -191,11 +201,11 @@ func TestBusinessRuleTaskExec(t *testing.T) {
 
 			_, err := newBRT(t, "silent").Exec(ctx, re)
 			require.NoError(t, err)
-			require.Len(t, sink.facts, 1)
+			require.Len(t, sink.facts, 2)
 			require.Equal(t, "0",
-				sink.facts[0].Details[observability.AttrRowCount])
+				sink.facts[1].Details[observability.AttrRowCount])
 			require.Empty(t,
-				sink.facts[0].Details[observability.AttrResultVariable])
+				sink.facts[1].Details[observability.AttrResultVariable])
 		})
 
 	t.Run("an empty output name fails the commit",
@@ -208,12 +218,20 @@ func TestBusinessRuleTaskExec(t *testing.T) {
 					return rules.Row{"": values.NewVariable(1)}, nil
 				})
 
+			sink := &factSink{}
 			re := mockrenv.NewMockRuntimeEnvironment(t)
 			re.EXPECT().RuleEngine().Return(eng)
+			re.EXPECT().Reporter().Return(sink)
 
 			_, err := newBRT(t, "anon").Exec(ctx, re)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "anon")
+
+			// the pair closes on the commit stage (SRD-069 FR-2).
+			require.Len(t, sink.facts, 2)
+			require.Equal(t, observability.PhaseFailed, sink.facts[1].Phase)
+			require.Equal(t, "commit",
+				sink.facts[1].Details[observability.AttrStage])
 		})
 
 	t.Run("an empty output name in a multi-output row fails the fold",
@@ -229,12 +247,16 @@ func TestBusinessRuleTaskExec(t *testing.T) {
 					}, nil
 				})
 
+			sink := &factSink{}
 			re := mockrenv.NewMockRuntimeEnvironment(t)
 			re.EXPECT().RuleEngine().Return(eng)
+			re.EXPECT().Reporter().Return(sink)
 
 			_, err := newBRT(t, "anon2").Exec(ctx, re)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "couldn't fold decision result")
+			require.Equal(t, "commit",
+				sink.facts[1].Details[observability.AttrStage])
 		})
 
 	t.Run("engine error fails the task and reports the Failed fact",
@@ -248,12 +270,16 @@ func TestBusinessRuleTaskExec(t *testing.T) {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "unknown")
 
-			require.Len(t, sink.facts, 1)
-			f := sink.facts[0]
+			require.Len(t, sink.facts, 2)
+			require.Equal(t, observability.PhaseInvoked, sink.facts[0].Phase)
+
+			f := sink.facts[1]
 			require.Equal(t, observability.KindRules, f.Kind)
 			require.Equal(t, observability.PhaseFailed, f.Phase)
 			require.Equal(t, "unknown",
 				f.Details[observability.AttrDecisionRef])
+			require.Equal(t, "engine",
+				f.Details[observability.AttrStage])
 			require.NotEmpty(t, f.Details[observability.AttrError])
 		})
 
@@ -269,8 +295,10 @@ func TestBusinessRuleTaskExec(t *testing.T) {
 					}, nil
 				})
 
+			sink := &factSink{}
 			re := mockrenv.NewMockRuntimeEnvironment(t)
 			re.EXPECT().RuleEngine().Return(eng)
+			re.EXPECT().Reporter().Return(sink)
 			re.EXPECT().Put(mock.Anything).
 				Return(errs.New(errs.M("scope rejected the parameter")))
 
@@ -278,5 +306,7 @@ func TestBusinessRuleTaskExec(t *testing.T) {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "couldn't commit decision result")
 			require.Contains(t, err.Error(), "check")
+			require.Equal(t, "commit",
+				sink.facts[1].Details[observability.AttrStage])
 		})
 }

--- a/pkg/model/activities/script_task.go
+++ b/pkg/model/activities/script_task.go
@@ -129,11 +129,17 @@ func (st *ScriptTask) Exec(
 
 	eng := re.ScriptEngine()
 
+	st.reportScript(re, observability.PhaseInvoked, map[string]string{
+		observability.AttrScriptFormat:   st.scriptFormat,
+		observability.AttrImplementation: st.routedKind(eng),
+	})
+
 	outs, err := eng.Execute(ctx, st.scriptFormat, st.script, re)
 	if err != nil {
 		st.reportScript(re, observability.PhaseFailed, map[string]string{
 			observability.AttrScriptFormat:   st.scriptFormat,
 			observability.AttrImplementation: st.routedKind(eng),
+			observability.AttrStage:          "engine",
 			observability.AttrError:          err.Error(),
 		})
 
@@ -142,6 +148,16 @@ func (st *ScriptTask) Exec(
 
 	for _, name := range sortedNames(outs) {
 		if err := st.commitOutput(name, outs[name], re); err != nil {
+			// The pair still closes: the script ran, its output commit
+			// did not (SRD-069 FR-2).
+			st.reportScript(re, observability.PhaseFailed,
+				map[string]string{
+					observability.AttrScriptFormat:   st.scriptFormat,
+					observability.AttrImplementation: st.routedKind(eng),
+					observability.AttrStage:          "commit",
+					observability.AttrError:          err.Error(),
+				})
+
 			return nil, err
 		}
 	}

--- a/pkg/model/activities/script_task_test.go
+++ b/pkg/model/activities/script_task_test.go
@@ -155,9 +155,19 @@ func TestScriptTaskExec(t *testing.T) {
 			require.Equal(t, "text/x-fake", eng.gotFmt)
 			require.Equal(t, "out = total * 2", eng.gotBody)
 
-			// the FR-5 Executed fact.
-			require.Len(t, sink.facts, 1)
-			f := sink.facts[0]
+			// the SRD-069 pair: Invoked opens, Executed closes.
+			require.Len(t, sink.facts, 2)
+
+			inv := sink.facts[0]
+			require.Equal(t, observability.KindScript, inv.Kind)
+			require.Equal(t, observability.PhaseInvoked, inv.Phase)
+			require.Equal(t, "text/x-fake",
+				inv.Details[observability.AttrScriptFormat])
+			require.Equal(t, "##Fake",
+				inv.Details[observability.AttrImplementation])
+			require.Empty(t, inv.Details[observability.AttrStage])
+
+			f := sink.facts[1]
 			require.Equal(t, observability.KindScript, f.Kind)
 			require.Equal(t, observability.PhaseExecuted, f.Phase)
 			require.Equal(t, "text/x-fake",
@@ -185,9 +195,12 @@ func TestScriptTaskExec(t *testing.T) {
 			_, err = newST(t).Exec(ctx, re)
 			require.NoError(t, err)
 
-			require.Equal(t, "##Fake",
-				sink.facts[0].Details[observability.AttrImplementation],
-				"the fact must name the ROUTED engine, not the aggregate")
+			require.Len(t, sink.facts, 2)
+			for _, f := range sink.facts {
+				require.Equal(t, "##Fake",
+					f.Details[observability.AttrImplementation],
+					"the facts must name the ROUTED engine, not the aggregate")
+			}
 		})
 
 	t.Run("empty outputs commit nothing",
@@ -203,8 +216,9 @@ func TestScriptTaskExec(t *testing.T) {
 
 			_, err := newST(t).Exec(ctx, re)
 			require.NoError(t, err)
+			require.Len(t, sink.facts, 2)
 			require.Equal(t, "0",
-				sink.facts[0].Details[observability.AttrOutputCount])
+				sink.facts[1].Details[observability.AttrOutputCount])
 		})
 
 	t.Run("engine error fails the task and reports the Failed fact",
@@ -222,9 +236,13 @@ func TestScriptTaskExec(t *testing.T) {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "syntax error")
 
-			require.Len(t, sink.facts, 1)
-			f := sink.facts[0]
+			require.Len(t, sink.facts, 2)
+			require.Equal(t, observability.PhaseInvoked, sink.facts[0].Phase)
+
+			f := sink.facts[1]
 			require.Equal(t, observability.PhaseFailed, f.Phase)
+			require.Equal(t, "engine",
+				f.Details[observability.AttrStage])
 			require.NotEmpty(t, f.Details[observability.AttrError])
 		})
 
@@ -234,8 +252,10 @@ func TestScriptTaskExec(t *testing.T) {
 				formats: []string{"text/x-fake"},
 				outs:    script.Outputs{"x": values.NewVariable(1)}}
 
+			sink := &factSink{}
 			re := mockrenv.NewMockRuntimeEnvironment(t)
 			re.EXPECT().ScriptEngine().Return(eng)
+			re.EXPECT().Reporter().Return(sink)
 			re.EXPECT().Put(mock.Anything).
 				Return(errs.New(errs.M("scope rejected the parameter")))
 
@@ -243,6 +263,12 @@ func TestScriptTaskExec(t *testing.T) {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "couldn't commit script output")
 			require.Contains(t, err.Error(), "calc")
+
+			// the pair closes on the commit stage (SRD-069 FR-2).
+			require.Len(t, sink.facts, 2)
+			require.Equal(t, observability.PhaseFailed, sink.facts[1].Phase)
+			require.Equal(t, "commit",
+				sink.facts[1].Details[observability.AttrStage])
 		})
 
 	t.Run("a bad output name fails the commit loud",
@@ -251,11 +277,15 @@ func TestScriptTaskExec(t *testing.T) {
 				formats: []string{"text/x-fake"},
 				outs:    script.Outputs{"": values.NewVariable(1)}}
 
+			sink := &factSink{}
 			re := mockrenv.NewMockRuntimeEnvironment(t)
 			re.EXPECT().ScriptEngine().Return(eng)
+			re.EXPECT().Reporter().Return(sink)
 
 			_, err := newST(t).Exec(ctx, re)
 			require.Error(t, err)
 			require.Contains(t, err.Error(), "couldn't commit script output")
+			require.Equal(t, "commit",
+				sink.facts[1].Details[observability.AttrStage])
 		})
 }

--- a/pkg/observability/echolevel.go
+++ b/pkg/observability/echolevel.go
@@ -55,6 +55,9 @@ var phaseOverride = map[phaseKey]slog.Level{
 	// A decision-evaluation failure is operator-relevant context for the fault
 	// that follows it (SRD-060 FR-6).
 	{KindRules, PhaseFailed}: slog.LevelWarn,
+	// A runtime deploy is a governance milestone — the ProcessLifecycle
+	// analog on the rules seam (SRD-069 FR-6).
+	{KindRules, PhaseDeployed}: slog.LevelInfo,
 	// A script-execution failure — same posture (SRD-064 FR-5).
 	{KindScript, PhaseFailed}: slog.LevelWarn,
 	// Same rule for a compensation throw that resolved to nothing (SRD-059

--- a/pkg/observability/echolevel_test.go
+++ b/pkg/observability/echolevel_test.go
@@ -40,6 +40,9 @@ func TestEchoLevel(t *testing.T) {
 		{"caught fault stays debug", KindFault, PhaseCaught, slog.LevelDebug},
 		{"retries exhausted warns", KindJobState, PhaseRetriesExhausted, slog.LevelWarn},
 		{"lock reclaimed warns", KindJobState, PhaseLockReclaimed, slog.LevelWarn},
+		{"rules failure warns", KindRules, PhaseFailed, slog.LevelWarn},
+		{"runtime deploy is an info milestone", KindRules, PhaseDeployed, slog.LevelInfo},
+		{"rules invocation stays debug", KindRules, PhaseInvoked, slog.LevelDebug},
 		{"ordinary job phase stays debug", KindJobState, PhaseEnqueued, slog.LevelDebug},
 		{"unclassified kind surfaces at error", Kind("Mystery"), Phase("X"), slog.LevelError},
 	}

--- a/pkg/observability/fact.go
+++ b/pkg/observability/fact.go
@@ -123,6 +123,11 @@ const (
 	PhaseCompensating Phase = "Compensating"
 	PhaseCompensated  Phase = "Compensated"
 
+	// PhaseDeployed: a decision definition landed on a LIVE rule engine
+	// through its deploy surface (SRD-069 FR-5) — a runtime governance
+	// milestone (the ProcessLifecycle analog), echoed at Info.
+	PhaseDeployed Phase = "Deployed" // Rules
+
 	// PhaseInvoked: a Business Rule / Script Task's engine call opens
 	// (SRD-069 FR-1) — the start mark that pairs with Evaluated/Executed
 	// (or Failed), making engine-call latency derivable and a hung engine
@@ -181,6 +186,9 @@ const (
 	// engine call itself failed ("engine") or the call succeeded and the
 	// result commit failed ("commit") — every Invoked closes either way.
 	AttrStage = "stage"
+	// AttrRuleCount (SRD-069 FR-5): a registered/deployed decision
+	// table's rule count — a count, never rule bodies (the masking rule).
+	AttrRuleCount = "rule_count"
 	// AttrOrdinal (SRD-059): a completion-ledger entry's 0-based completion
 	// order within its scope — the reverse-compensation order's authority.
 	AttrOrdinal     = "ordinal"

--- a/pkg/observability/fact.go
+++ b/pkg/observability/fact.go
@@ -123,6 +123,12 @@ const (
 	PhaseCompensating Phase = "Compensating"
 	PhaseCompensated  Phase = "Compensated"
 
+	// PhaseInvoked: a Business Rule / Script Task's engine call opens
+	// (SRD-069 FR-1) — the start mark that pairs with Evaluated/Executed
+	// (or Failed), making engine-call latency derivable and a hung engine
+	// attributable. One fact per task execution, never per evaluation.
+	PhaseInvoked Phase = "Invoked" // Rules / Script
+
 	// PhaseEvaluated: a Business Rule Task's decision call returned and its
 	// result committed (SRD-060 FR-6). Failure reuses PhaseFailed with the
 	// decision-level details; the task failure itself still rides KindFault.
@@ -171,6 +177,10 @@ const (
 	// count only — never script source or output values (the masking rule).
 	AttrScriptFormat = "script_format"
 	AttrOutputCount  = "output_count"
+	// AttrStage (SRD-069 FR-2) qualifies a Rules/Script Failed fact: the
+	// engine call itself failed ("engine") or the call succeeded and the
+	// result commit failed ("commit") — every Invoked closes either way.
+	AttrStage = "stage"
 	// AttrOrdinal (SRD-059): a completion-ledger entry's 0-based completion
 	// order within its scope — the reverse-compensation order's authority.
 	AttrOrdinal     = "ordinal"

--- a/pkg/rules/gorules/gorules.go
+++ b/pkg/rules/gorules/gorules.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
 	"github.com/dr-dobermann/gobpm/pkg/rules"
 )
 
@@ -28,11 +29,15 @@ const (
 // Evaluate read-locks, so concurrent tracks evaluate freely.
 type Registry struct {
 	decisions map[string]rules.DecisionFunc
+	sink      observability.Reporter
 	mu        sync.RWMutex
 }
 
-// interface check
-var _ rules.Engine = (*Registry)(nil)
+// interface checks
+var (
+	_ rules.Engine         = (*Registry)(nil)
+	_ rules.ReporterBinder = (*Registry)(nil)
+)
 
 // New creates an empty decision registry.
 func New() *Registry {
@@ -69,7 +74,34 @@ func (reg *Registry) Register(name string, d rules.DecisionFunc) error {
 
 	reg.decisions[name] = d
 
+	// The registrar audit (SRD-069 FR-4): names only, successes only,
+	// silent while unbound.
+	if reg.sink != nil {
+		reg.sink.Report(observability.Fact{
+			Kind:  observability.KindRules,
+			Phase: observability.PhaseRegistered,
+			Details: map[string]string{
+				observability.AttrDecisionRef:    name,
+				observability.AttrImplementation: GoRulesType,
+			},
+		})
+	}
+
 	return nil
+}
+
+// BindReporter binds the engine's observable-event sink (SRD-069 FR-3) —
+// the registrar surfaces emit KindRules facts once bound. A nil sink is
+// ignored, keeping the current silence.
+func (reg *Registry) BindReporter(sink observability.Reporter) {
+	if sink == nil {
+		return
+	}
+
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+
+	reg.sink = sink
 }
 
 // MustRegister is the panic-on-error Register twin for fixture and example

--- a/pkg/rules/gorules/gorules_test.go
+++ b/pkg/rules/gorules/gorules_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
 	"github.com/dr-dobermann/gobpm/pkg/rules"
 	"github.com/dr-dobermann/gobpm/pkg/rules/gorules"
 )
@@ -196,3 +197,66 @@ func TestEvaluate(t *testing.T) {
 
 // compile-time seam check: the registry is a rules.Engine.
 var _ rules.Engine = (*gorules.Registry)(nil)
+
+// factSink collects reported facts for the registrar-audit assertions.
+type factSink struct {
+	facts []observability.Fact
+}
+
+func (fs *factSink) Report(f observability.Fact) {
+	fs.facts = append(fs.facts, f)
+}
+
+// TestRegistrarFacts covers SRD-069 T-3: bound registration emits the
+// Registered audit fact; unbound and nil-sink registries stay silent; a
+// rejected duplicate emits nothing.
+func TestRegistrarFacts(t *testing.T) {
+	noop := func(
+		_ context.Context, _ service.DataReader,
+	) (rules.Row, error) {
+		return nil, nil
+	}
+
+	t.Run("unbound registration is silent",
+		func(t *testing.T) {
+			reg := gorules.New()
+			require.NoError(t, reg.Register("quiet", noop))
+		})
+
+	t.Run("a nil sink is ignored",
+		func(t *testing.T) {
+			reg := gorules.New()
+			reg.BindReporter(nil)
+			require.NoError(t, reg.Register("still-quiet", noop))
+		})
+
+	t.Run("bound registration emits Registered with names only",
+		func(t *testing.T) {
+			sink := &factSink{}
+
+			reg := gorules.New()
+			reg.BindReporter(sink)
+			require.NoError(t, reg.Register("discount", noop))
+
+			require.Len(t, sink.facts, 1)
+			f := sink.facts[0]
+			require.Equal(t, observability.KindRules, f.Kind)
+			require.Equal(t, observability.PhaseRegistered, f.Phase)
+			require.Equal(t, "discount",
+				f.Details[observability.AttrDecisionRef])
+			require.Equal(t, gorules.GoRulesType,
+				f.Details[observability.AttrImplementation])
+		})
+
+	t.Run("a rejected duplicate emits nothing",
+		func(t *testing.T) {
+			sink := &factSink{}
+
+			reg := gorules.New()
+			reg.BindReporter(sink)
+			require.NoError(t, reg.Register("once", noop))
+			require.Error(t, reg.Register("once", noop))
+
+			require.Len(t, sink.facts, 1, "only the success is audited")
+		})
+}

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
 )
 
 // Row is one decision result record — output name → value — the
@@ -50,6 +51,17 @@ type Engine interface {
 // operation.
 type Deployer interface {
 	Deploy(ctx context.Context, definition []byte) error
+}
+
+// ReporterBinder is an optional rule-engine capability (SRD-069 FR-3, the
+// tasks.ReporterBinder shape): the engine binds its observable-event sink
+// at startup so the rule engine's registrar surfaces (register/deploy) can
+// emit KindRules audit facts. An engine that doesn't implement it simply
+// doesn't emit — and an implementing engine emits nothing while unbound
+// (pre-startup registrations are construction-time wiring, not runtime
+// governance).
+type ReporterBinder interface {
+	BindReporter(sink observability.Reporter)
 }
 
 // DecisionFunc is an in-process decision body for registry-style engines:

--- a/pkg/thresher/business_rule_task_test.go
+++ b/pkg/thresher/business_rule_task_test.go
@@ -207,6 +207,13 @@ func TestBusinessRuleTaskE2E(t *testing.T) {
 			require.True(t, big.Load(), "the big-discount lane must run")
 			require.False(t, small.Load(), "the default lane must not run")
 
+			// the SRD-069 pair opens on the observe stream too.
+			inv, ok := rulesFact(facts, observability.PhaseInvoked)
+			require.True(t, ok, "the Rules/Invoked fact must be observed")
+			require.Equal(t, "discount",
+				inv.Details[observability.AttrDecisionRef])
+			require.Empty(t, inv.Details[observability.AttrStage])
+
 			f, ok := rulesFact(facts, observability.PhaseEvaluated)
 			require.True(t, ok, "the Rules/Evaluated fact must be observed")
 			require.Equal(t, "discount",
@@ -327,4 +334,35 @@ func TestBusinessRuleTaskZeroConfig(t *testing.T) {
 	require.Equal(t, gorules.GoRulesType,
 		f.Details[observability.AttrImplementation],
 		"the bundled default registry answered the call")
+}
+
+// binderEngine is a rules.Engine implementing the SRD-069 ReporterBinder
+// capability — it records the sink the engine binds at New.
+type binderEngine struct {
+	sink observability.Reporter
+}
+
+func (be *binderEngine) Type() string { return "##Binder" }
+
+func (be *binderEngine) Evaluate(
+	_ context.Context, _ string, _ service.DataReader,
+) ([]rules.Row, error) {
+	return nil, nil
+}
+
+func (be *binderEngine) BindReporter(sink observability.Reporter) {
+	be.sink = sink
+}
+
+// TestRuleEngineReporterBinding covers SRD-069 T-5's wiring half: New binds
+// its producer into a rule engine that implements rules.ReporterBinder.
+func TestRuleEngineReporterBinding(t *testing.T) {
+	be := &binderEngine{}
+
+	_, err := thresher.New("test-binder-wiring",
+		thresher.WithoutBanner(), thresher.WithRuleEngine(be))
+	require.NoError(t, err)
+
+	require.NotNil(t, be.sink,
+		"New must bind the observable-event sink into the capable engine")
 }

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -55,6 +55,7 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/dr-dobermann/gobpm/pkg/model/process"
 	"github.com/dr-dobermann/gobpm/pkg/observability"
+	"github.com/dr-dobermann/gobpm/pkg/rules"
 	"github.com/dr-dobermann/gobpm/pkg/script"
 	"github.com/dr-dobermann/gobpm/pkg/tasks"
 )
@@ -279,6 +280,14 @@ func New(id string, opts ...Option) (*Thresher, error) {
 	// ExpressionEngineBinder.
 	if eb, ok := cfg.WorkerDispatcher().(tasks.ExpressionEngineBinder); ok {
 		eb.BindExpressionEngine(cfg.ExpressionEngine())
+	}
+
+	// Bind the sink into the rule engine's registrar surfaces (SRD-069
+	// FR-3): once bound, register/deploy calls on the live engine emit
+	// their KindRules audit facts. An engine without the capability
+	// simply doesn't emit.
+	if rb, ok := cfg.RuleEngine().(rules.ReporterBinder); ok {
+		rb.BindReporter(t.producer)
 	}
 
 	// The EventHub receives the engine's resolved runtime (&t.cfg implements


### PR DESCRIPTION
## Rules/Script invocation facts and the registrar audit (SRD-069)

The remediation of the post-ADR-032 observability review of the
Business Rule / Script task facts: the decision/script stream becomes
a **closed audit ledger**, and the engines' registrar surfaces —
invisible until now — gain their governance audit.

### The task-level pair (M1)

- New reused **`PhaseInvoked`** opens every Business Rule / Script Task
  engine call (BRT: decision_ref + implementation; Script:
  script_format + the routed engine kind) — engine-call latency becomes
  derivable from the stream, and a hung engine attributable. One fact
  per task execution, never per evaluation (the ADR-032 §2.4 flood rule
  holds).
- **Every `Invoked` now closes.** Commit-stage failures — a successful
  engine call whose result commit fails — previously faulted the task
  with *no* closing `KindRules`/`KindScript` fact at all. They now emit
  `Failed` with the new **`stage`** attr (`engine` | `commit`); success
  facts are unchanged.

### The registrar audit (M2)

- New optional capability **`rules.ReporterBinder`** (the
  `tasks.ReporterBinder` shape): `thresher.New` binds its producer into
  a capable rule engine automatically; `enginert.WithRuleEngine` binds
  the runtime's sink at set time. Engines without the capability don't
  emit; implementing engines stay **silent while unbound** — pre-`New`
  registration is construction-time wiring, the audit targets what
  changes on a *live* engine.
- **`gorules`** and **`adapters/dtable`** registration emit
  `KindRules/Registered` (names and counts only — dtable adds the new
  `rule_count` attr). A runtime **`dtable.Deploy` emits the new
  `Deployed` phase at Info** — the decision-governance milestone,
  flagged `replaced: true` when it overwrote a served table.
- Registrar failures return to the present caller and emit nothing;
  **engine internals stay off the stream by design** (per-rule/per-row
  activity is Tracer territory; its diagnostic content already rides
  the `Failed` error details).

### Verification

- Core `make ci` exit 0; **diff-coverage 100.0% of 55 changed lines**;
  the dtable module suite green with **every touched function at
  100%**.
- Tests: the ordered pair + both `stage` halves across both task
  suites (T-1/T-2); gorules/dtable registrar units incl.
  bound/unbound/duplicate/nil-sink (T-3/T-4); the dtable module e2e —
  a runtime `Deploy` reaching the engine-wide `Observe` stream through
  the `New`-time binding; the thresher wiring probe and the
  `Invoked` fact on the BRT e2e stream (T-5); the echo-table rows
  (`Deployed` → Info).
- The decision-table example smokes exit 0 — its pre-`New` deploy
  demonstrates the unbound-silent posture.

### Docs

SRD-069 Accepted with §10 filled; CHANGELOG `[Unreleased]` entry. No
cross-doc pins moved (ADR-013 v.2's open phase taxonomy hosts the two
new phases, the SRD-060/064 precedent).
