### PR TITLE
docs(guides): re-point dangling links; clear the last go vet finding

### DIFF
--- a/docs/guides/concepts/execution-model.md
+++ b/docs/guides/concepts/execution-model.md
@@ -93,7 +93,7 @@ Inside the instance the four terms come to life:
 > This is why an idle instance holds no busy goroutines — and, with a
 > repository configured, an instance whose every track is parked on a held,
 > dehydratable wait releases **all** of them and leaves entirely, its checkpoint
-> the wake source. See [How events are processed](events-and-hub.md) and
+> the wake source. See [How events are processed](event-processing.md) and
 > [Dehydration](../operating/persistence.md).
 
 ## Run it
@@ -195,7 +195,7 @@ track's `MergedInto` to the survivor.
 ## See also
 
 - Full example: [`examples/parallel-gateway/`](../../../examples/parallel-gateway/)
-- Related: [How events are processed](events-and-hub.md) · [Scope & the data plane](scope-and-data.md) · [The engine (Thresher)](engine.md) · [Parallel (AND) gateway](../gateways/parallel.md)
+- Related: [How events are processed](event-processing.md) · [Scope & the data plane](scope-and-data.md) · [The engine (Thresher)](engine.md) · [Parallel (AND) gateway](../gateways/parallel.md)
 - In practice: [Registering & versioning](../operating/registering-and-versioning.md)
 - Design: [ADR-001 — execution model](../../design/ADR-001-execution-model.md)
 - Full API: `go doc github.com/dr-dobermann/gobpm/pkg/thresher`

--- a/docs/guides/concepts/index.md
+++ b/docs/guides/concepts/index.md
@@ -12,5 +12,5 @@ tracks and tokens, where data lives, and how events are routed.
 - [The engine (Thresher)](engine.md) — register, run, start, wait.
 - [Process, instance, track, token](execution-model.md) — how a definition becomes running work.
 - [Scope & the data plane](scope-and-data.md) — where data lives and how it's resolved by name.
-- [Events & the hub](events-and-hub.md) — how the engine routes signals, messages, timers.
+- [Events & the hub](event-processing.md) — how the engine routes signals, messages, timers.
 - [Observability](observability.md) — facts, reporters, observers, the operator log.

--- a/docs/guides/data/data-objects.md
+++ b/docs/guides/data/data-objects.md
@@ -190,6 +190,6 @@ a Data Store — only the residency differs.
 ## See also
 
 - Full example: [`examples/process-data/`](../../../examples/process-data/)
-- Related guides: [Working with data — overview](overview.md) · [Item definitions](item-definitions.md) · [Data Store](data-store.md) · [Reading & writing by path](structural.md)
+- Related guides: [Working with data — overview](index.md) · [Item definitions](item-definitions.md) · [Data Store](data-store.md) · [Reading & writing by path](structural.md)
 - Design: [ADR-030 — Data Objects & Data Store](../../design/ADR-030-data-objects-and-store.md)
 - Full API: `go doc github.com/dr-dobermann/gobpm/pkg/model/data_objects`

--- a/docs/guides/data/expressions.md
+++ b/docs/guides/data/expressions.md
@@ -223,6 +223,6 @@ Building your own engine is its own page: [Custom expression engine](../extendin
 ## See also
 
 - Example: [`examples/expression-routing/`](../../../examples/expression-routing/)
-- Related guides: [Reading & writing by path](structural.md) · [Data overview](overview.md) · [Exclusive gateway](../gateways/exclusive.md) · [Custom expression engine](../extending/expression-engine.md)
+- Related guides: [Reading & writing by path](structural.md) · [Data overview](index.md) · [Exclusive gateway](../gateways/exclusive.md) · [Custom expression engine](../extending/expression-engine.md)
 - Design: [ADR-032 — Language-routed expression engines](../../design/ADR-032-language-routed-expression-engines.md)
 - Full API: `go doc github.com/dr-dobermann/gobpm/pkg/model/expression` · `go doc github.com/dr-dobermann/gobpm/pkg/model/data`

--- a/docs/guides/data/index.md
+++ b/docs/guides/data/index.md
@@ -9,7 +9,7 @@ Data flows through a process as named values in scopes. This section covers the
 value model and tiers, structural data by path, wrapping native Go structs,
 expressions, and the two container kinds — Data Objects and the Data Store.
 
-- [Overview](overview.md) — the value model, tiers, reading & writing by path. *(`process-data`)*
+- [The value model](value-model.md) — values, tiers, reading & writing by path. *(`process-data`)*
 - [Structural data](structural.md) — records, lists, maps by path. *(`structural-data`, `structural-output-mapping`, `maps`)*
 - [Native Go structs](native-structs.md) — wrap your own types as process data. *(`native-structs`)*
 - [Expressions](expressions.md) — conditions and computed values. *(`expression-routing`)*

--- a/docs/guides/data/item-definitions.md
+++ b/docs/guides/data/item-definitions.md
@@ -5,7 +5,7 @@ description: The BPMN data-typing layer in gobpm — ItemDefinition, ItemAwareEl
 
 # Item definitions & item-aware elements
 
-Below the [value model](overview.md) sits BPMN's data-typing layer: an
+Below the [value model](value-model.md) sits BPMN's data-typing layer: an
 **`ItemDefinition`** says *what shape* a datum has, an **`ItemAwareElement`**
 is the *variable* that carries a value of that shape, a **`Property`** is a
 named item-aware element attached to a process/activity/event, and a
@@ -17,7 +17,7 @@ options, and how you read and write through them.
 > These are model-build types. You wire them up when you declare process
 > properties and task parameters; at run time the engine clones them per
 > instance and the values move through scope. See
-> [Working with data — overview](overview.md) for the runtime data plane.
+> [Working with data — overview](index.md) for the runtime data plane.
 
 ## The layer at a glance
 
@@ -35,7 +35,7 @@ BPMN hats.
 
 ## ItemDefinition — the type
 
-`ItemDefinition` wraps a `Value` (see the [value model](overview.md)) as a
+`ItemDefinition` wraps a `Value` (see the [value model](value-model.md)) as a
 reusable data shape.
 
 ```go
@@ -242,6 +242,6 @@ parallel branches through their operations, and each branch returns an
 ## See also
 
 - Examples: `examples/process-data/`
-- Related guides: [Working with data — overview](overview.md) · [Reading & writing by path](structural.md) · [Data Objects](data-objects.md)
+- Related guides: [Working with data — overview](index.md) · [Reading & writing by path](structural.md) · [Data Objects](data-objects.md)
 - Design: [ADR-010 — Process data model](../../design/ADR-010-process-data-model.md) · [ADR-011 — Process data flow](../../design/ADR-011-process-data-flow.md)
 - Full API: `go doc github.com/dr-dobermann/gobpm/pkg/model/data`

--- a/docs/guides/data/native-structs.md
+++ b/docs/guides/data/native-structs.md
@@ -185,6 +185,6 @@ the commit-diff reports a `DataChange` fact per changed path:
 ## See also
 
 - Example: [`native-structs`](../../../examples/native-structs/)
-- Related guides: [Reading & writing by path](structural.md) · [Data overview](overview.md) · [Expressions](expressions.md)
+- Related guides: [Reading & writing by path](structural.md) · [Data overview](index.md) · [Expressions](expressions.md)
 - Design: [ADR-011 — process data flow](../../design/ADR-011-process-data-flow.md)
 - Full API: `go doc github.com/dr-dobermann/gobpm/pkg/model/data/adapters`

--- a/docs/guides/data/structural.md
+++ b/docs/guides/data/structural.md
@@ -28,7 +28,7 @@ the three and is a path leaf; a structural value implements **at most one**.
 
 Package: `github.com/dr-dobermann/gobpm/pkg/model/data` (interfaces + path
 functions) and `github.com/dr-dobermann/gobpm/pkg/model/data/values` (the
-dynamic implementations). See [The value model](overview.md) for the tiers.
+dynamic implementations). See [The value model](value-model.md) for the tiers.
 
 ```mermaid
 flowchart LR
@@ -253,6 +253,6 @@ subtree to one `Change` at its root.
 ## See also
 
 - Examples: `examples/structural-data/` (read) · `examples/structural-output-mapping/` (assemble) · `examples/maps/` (the map kind)
-- Related guides: [Working with data — overview](overview.md) · [Native Go structs](native-structs.md) · [Data Objects](data-objects.md)
+- Related guides: [Working with data — overview](index.md) · [Native Go structs](native-structs.md) · [Data Objects](data-objects.md)
 - Design: [ADR-011 — process data flow](../../design/ADR-011-process-data-flow.md)
 - Full API: `go doc github.com/dr-dobermann/gobpm/pkg/model/data` · `go doc github.com/dr-dobermann/gobpm/pkg/model/data/values`

--- a/docs/guides/operating/correlation.md
+++ b/docs/guides/operating/correlation.md
@@ -224,6 +224,6 @@ OK: each payment routed to its originating handler conversation
 ## See also
 
 - Examples: [`examples/inter-instance-correlation/`](../../../examples/inter-instance-correlation/) · [`examples/conversation-routing/`](../../../examples/conversation-routing/)
-- Related guides: [Message](../events/message.md) · [Send / Receive Task](../tasks/send-receive-task.md) · [How events are processed](../concepts/event-processing.md) · [Definition versioning](versioning.md)
+- Related guides: [Message](../events/message.md) · [Send / Receive Task](../tasks/send-receive-task.md) · [How events are processed](../concepts/event-processing.md) · [Definition versioning](registering-and-versioning.md)
 - Design: [ADR-016 — Message correlation](../../design/ADR-016-message-correlation.md) · [ADR-015 — Event-triggered instantiation](../../design/ADR-015-event-triggered-instantiation.md)
 - Full API: `go doc github.com/dr-dobermann/gobpm/pkg/model/bpmncommon`

--- a/docs/guides/operating/index.md
+++ b/docs/guides/operating/index.md
@@ -10,7 +10,7 @@ subscribing to and filtering facts, managing definition versions, correlating
 messages to the right instance, and dispatching work to external workers.
 
 - [Observability in practice](observability.md) — subscribe, filter facts, tune log level. *(`data-change`)*
-- [Definition versioning](versioning.md) — register versions, latest vs pinned. *(`versioning`)*
+- [Definition versioning](registering-and-versioning.md) — register versions, latest vs pinned. *(`versioning`)*
 - [Correlation & conversations](correlation.md) — route messages to the right instance. *(`inter-instance-correlation`, `conversation-routing`)*
 - [External workers](external-workers.md) — fetch-and-lock job execution. *(`service-task-worker`)*
 - [Persistence & recovery](persistence.md) — checkpoints, restart recovery, dehydration (a long wait costs no goroutines), leases & fencing for shared stores. *(`restart-recovery`)*

--- a/docs/guides/operating/starting-instances.md
+++ b/docs/guides/operating/starting-instances.md
@@ -19,7 +19,7 @@ and what the handle gives you back.
 ## The three ways to start
 
 You always start a *registered* process (see [Definition
-versioning](versioning.md)). What differs is how you name the version to launch:
+versioning](registering-and-versioning.md)). What differs is how you name the version to launch:
 
 | Method | Names the version by | Reach for it when |
 |---|---|---|
@@ -65,7 +65,7 @@ engine-internal snapshot), and it is what `StartProcess` addresses:
 > message start event spawns instances) and for explicit `StartProcess`.
 > `RegisterProcess(p, thresher.WithManualStart())` opts out of
 > auto-instantiation — the process then starts **only** via the start methods
-> above. See [Definition versioning](versioning.md).
+> above. See [Definition versioning](registering-and-versioning.md).
 
 ## Start it
 
@@ -150,6 +150,6 @@ grows additively as new subsystems land:
 ## See also
 
 - Examples: `examples/basic-process/`
-- Related guides: [Registering & versioning](versioning.md) · [Instance lifecycle](instance-lifecycle.md) · [The engine (Thresher)](../concepts/engine.md)
+- Related guides: [Registering & versioning](registering-and-versioning.md) · [Instance lifecycle](instance-lifecycle.md) · [The engine (Thresher)](../concepts/engine.md)
 - Design: [ADR-013 — instance observability](../../design/ADR-013-instance-observability.md) · [ADR-019 — definition versioning](../../design/ADR-019-definition-versioning.md)
 - Full API: `go doc github.com/dr-dobermann/gobpm/pkg/thresher`

--- a/internal/instance/compensation_watch_test.go
+++ b/internal/instance/compensation_watch_test.go
@@ -529,7 +529,7 @@ func TestCompensationNodeByIDNested(t *testing.T) {
 func TestCompensateForkBornThrow(t *testing.T) {
 	require.NoError(t, data.CreateDefaultStates())
 
-	var aRan, undoRan, after1, after2 atomic.Int32
+	var aRan, after1, after2 atomic.Int32
 
 	p, err := process.New("comp-fork-born")
 	require.NoError(t, err)
@@ -549,7 +549,6 @@ func TestCompensateForkBornThrow(t *testing.T) {
 	require.NoError(t, err)
 	bnd, err := events.NewCompensationBoundaryEvent("comp-undoA", a, ced, undoA)
 	require.NoError(t, err)
-	_ = undoRan
 
 	for _, e := range []flow.Element{
 		start, a, fork, throw, afterT, end1, end2, bnd, undoA,


### PR DESCRIPTION
The 7-part manual rework renamed three pages and left 19 inbound links pointing at the old names — re-pointed by what each link promises (value model → value-model.md, section-level→ the section index, two clean renames as renames). Zero unresolved relative links remain and no page links to itself. Also removes a dead atomic.Int32 whose `_ =` silencer vet flagged as a copied lock; the assertion it would have made already exists as a Compensated-fact check. make ci green.