### PR TITLE
Engineering odds and ends: fail-fast on invariant errors (FIX-028) + CI runs the examples (FIX-029)

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -118,5 +118,5 @@ jobs:
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v2.11.4/install.sh \
             | sh -s -- -b "$(go env GOPATH)/bin" v2.11.4
 
-      - name: Examples sweep (tidy + lint + build)
+      - name: Examples sweep (tidy + lint + build + run)
         run: make ci-examples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI now runs every example end-to-end, not just builds it (FIX-029).**
+  The examples job (and the local `make ci`) gained a `run-examples` step:
+  each of the 46 example modules executes under a timeout with stdin
+  closed, asserting exit 0 — closing the FIX-002 §5 follow-up (a
+  runtime-broken example used to ship green; it happened twice). The
+  measured full sweep costs 33 seconds on the warm build cache.
 - **Invariant-only errors are no longer silently discarded (FIX-028).**
   The commit-diff collection walk ignored `GetAt` errors (a corrupted
   `Collection` would silently diff a slot as nil and misfire conditional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Invariant-only errors are no longer silently discarded (FIX-028).**
+  The commit-diff collection walk ignored `GetAt` errors (a corrupted
+  `Collection` would silently diff a slot as nil and misfire conditional
+  events), and a task's parameter access ignored the `Parameters` error
+  (surfacing as a parameterless task copying nothing). Both branches are
+  impossible while contracts hold and now fail fast with a classified
+  panic naming the violated invariant. The FIX also closes the repo-wide
+  discard sweep: every remaining bare-discard site is either the
+  documented console carve-out or a comma-ok assertion, recorded in the
+  doc's inventory.
 - **A failed wake no longer strands a dehydrated instance (FIX-027).** A
   dehydrated instance has no goroutines — the engine-held wait (a timer
   deadline, a subscription, a task hold) *is* its liveness. The engine

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,9 +69,11 @@ all modules. Run it before pushing — if it's green, CI is green.
 
 On GitHub the same set is split into two parallel jobs for PR speed: the
 REQUIRED `check` job runs the core gate (`make ci-core` — the non-example
-modules), and the non-blocking `examples` job sweeps the ~35 `examples/*`
-modules (`make ci-examples` — tidy+lint+build; they carry no tests, and the
-core govulncheck already covers their `replace ../..` dependency graph).
+modules), and the non-blocking `examples` job sweeps the `examples/*`
+modules (`make ci-examples` — tidy+lint+build **+ run**: each example
+executes end-to-end under a timeout asserting exit 0, FIX-029; they carry
+no tests, and the core govulncheck already covers their `replace ../..`
+dependency graph).
 Locally `make ci` still runs BOTH halves — the full gate stays obligatory
 before every push.
 

--- a/Makefile
+++ b/Makefile
@@ -284,15 +284,36 @@ vuln-core:
 	@$(MAKE) vuln MODULES="$(CORE_MODULES)"
 .PHONY: vuln-core
 
-# The examples sweep: tidy + lint + build over every examples/* module. No
-# per-example test loop (the examples carry no tests — `go build` already
-# compiles them) and no per-example govulncheck (each example consumes the
-# library through `replace ../..`, so the core `vuln` scan already covers the
-# shared dependency graph; scanning it 35 more times added minutes of CI for
-# no new signal). Runs as CI's parallel non-blocking job AND inside the local
-# `make ci`.
+# A future example that genuinely blocks on stdin goes here (FIX-029 §5);
+# empty today — consinp degrades gracefully on EOF, and the run loop closes
+# stdin so a read gets EOF, never a terminal hang.
+EXAMPLE_RUN_SKIP :=
+# Generous per-example ceiling: the slowest (timer-driven) examples finish
+# well under it; a hang is cut at the ceiling with timeout's exit 124.
+EXAMPLE_RUN_TIMEOUT := 90s
+
+# run-examples executes every example module end-to-end (FIX-029): a runtime
+# regression — deadlock, panic, model drift — fails the gate that `go build`
+# alone kept green (the FIX-002 class). Stdout is discarded (the examples
+# narrate); stderr stays visible inside the group fold.
+run-examples:
+	@set -e; for dir in $(filter-out $(EXAMPLE_RUN_SKIP),$(EXAMPLE_MODULES)); do \
+		echo "::group::run $$dir"; \
+		(cd $$dir && timeout $(EXAMPLE_RUN_TIMEOUT) $(GO) run . < /dev/null > /dev/null) || exit 1; \
+		echo "::endgroup::"; \
+	done
+.PHONY: run-examples
+
+# The examples sweep: tidy + lint + build + run over every examples/* module.
+# No per-example test loop (the examples carry no tests — the run step
+# executes each `main` end-to-end instead, FIX-029) and no per-example
+# govulncheck (each example consumes the library through `replace ../..`, so
+# the core `vuln` scan already covers the shared dependency graph; scanning it
+# 35 more times added minutes of CI for no new signal). Runs as CI's parallel
+# non-blocking job AND inside the local `make ci`.
 ci-examples:
 	@$(MAKE) tidy-check-all lint-all-modules build-all MODULES="$(EXAMPLE_MODULES)"
+	@$(MAKE) run-examples
 .PHONY: ci-examples
 
 # The core gate — everything the REQUIRED CI job runs, in the same order.

--- a/docs/fix/FIX-028-close-silent-error-discards.md
+++ b/docs/fix/FIX-028-close-silent-error-discards.md
@@ -1,7 +1,7 @@
 # FIX-028 «Invariant-only errors silently discarded in the diff walk and task parameter access»
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft v.1 (2026-07-29, branch `fix/engineering-odds-and-ends`, not yet implemented).
+**Status:** Accepted (2026-07-29, branch `fix/engineering-odds-and-ends`, landed).
 **Date:** 2026-07-29.
 **Author:** Ruslan Gabitov.
 **Branch:** `fix/engineering-odds-and-ends` (bundles the small engineering-backlog
@@ -248,18 +248,27 @@ Single-commit revert; no data or contract migration.
 
 ## §8 Implementation summary (stage-by-stage actual landings + deltas vs draft)
 
-> ⚠️ TODO: fill AFTER landing; records the implementation history and empirical
-> findings vs the §3 draft.
-
 ### §8.1 Stages by commit (branch `fix/engineering-odds-and-ends`)
 
 | Stage | Commit | Scope | Tests |
 |---|---|---|---|
-| 1 | `<sha>` | §3.2.1–§3.2.4 | 2 |
+| doc | `e291f86` | this document (Draft) | — |
+| 1 | `4bd875e` | §3.2.1–§3.2.4: both guards + both canaries | 2 (the new-side walk canary runs as two subtests) |
+
+Verification: `make ci` green; diff-coverage **100.0% of 17 changed coverable
+lines** (`task.go` 7/7, `diff.go` 10/10); touched functions `diffInto`,
+`diffCollections`, `getParams` at 100%; `conditional-events` and
+`multi-instance-sequential` examples smoke-ran to exit 0.
 
 ### §8.2 Empirical findings — where reality diverged from the §3 draft
 
-*TODO after landing.*
+**One canary covers two branches, not one.** The drafted single
+`TestDiffCollectionsFailFastOnBrokenGetAt` case panicked on the *old*-side
+guard before the new-side guard could ever execute, leaving `diffCollections`
+at 91.7% — the coverage gate caught it. The landed test runs two subtests
+(broken old side; empty old + broken new side) so both §3.2.1 guards are
+exercised. Lesson for symmetric guards: one failing fixture cannot cover both
+arms — the first panic shadows the second.
 
 ### §8.3 Backlog (out of FIX-028 scope)
 

--- a/docs/fix/FIX-028-close-silent-error-discards.md
+++ b/docs/fix/FIX-028-close-silent-error-discards.md
@@ -1,0 +1,272 @@
+# FIX-028 «Invariant-only errors silently discarded in the diff walk and task parameter access»
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft v.1 (2026-07-29, branch `fix/engineering-odds-and-ends`, not yet implemented).
+**Date:** 2026-07-29.
+**Author:** Ruslan Gabitov.
+**Branch:** `fix/engineering-odds-and-ends` (bundles the small engineering-backlog
+closures; sibling doc FIX-029 shares the branch — the `fix/audit-remediation-2026-06`
+bundling precedent).
+**Paired doc:** none (local to `pkg/model/data` / `pkg/model/activities`).
+**Upstream:** [ADR-022 v.1](../design/ADR-022-error-propagation-and-logging-policy.md)
+(silent discards are forbidden; the §2.3 logger-less carve-out);
+[ADR-011 v.7](../design/ADR-011-process-data-flow.md) §2.9.4 (the commit-diff
+walk the first symptom lives in).
+
+**Grounded in (internal artifacts):**
+- The queued repo-wide error-discard sweep (owner directive: one pass, not
+  piecemeal). This FIX **is** that pass — §6.1 records the full inventory and
+  the classification of every non-fixed site.
+
+## §1 Symptoms
+
+No runtime artifact exists — the defect class is *latent by construction*:
+both sites discard an error that is impossible while invariants hold, so a
+violated invariant (a future refactor breaking a guard, a lying `Collection`
+implementation, memory corruption) would be **masked**, not reported. The
+observable-when-it-matters failures would be:
+
+### §1.1 Symptom A: a corrupted collection diffs as nil — conditional events misfire
+
+`diffCollections` reads both sides positionally and ignores `GetAt` errors:
+
+```go
+// pkg/model/data/diff.go:196,200
+if i < oldN {
+    ov, _ = oldV.GetAt(ctx, i)
+}
+if i < newN {
+    nv, _ = newV.GetAt(ctx, i)
+}
+```
+
+If `GetAt` ever failed there, the element would silently diff as `nil` —
+producing a false `Deleted`/`Added`/`Changed` record or masking a real one.
+The walk's output feeds the commit-diff change stream
+(`internal/scope/scope.go:381` → `data.DiffValues(...)`), which is the
+Conditional-Event substrate (ADR-011 v.7 §2.9.4): a masked slot means a
+conditional event silently not firing, far from the cause.
+
+### §1.2 Symptom B: a task with an invalid direction yields empty parameters, no error
+
+```go
+// pkg/model/activities/task.go:529
+func (t *task) getParams(dir data.Direction) []*data.ItemAwareElement {
+    params, _ := t.IoSpec.Parameters(dir)
+    ...
+```
+
+If `Parameters` ever failed, `getParams` would return an empty slice —
+`Outputs()`/`Inputs()` (the `flow.AssociationSource`/`AssociationTarget`
+contracts, `task.go:517`/`task.go:565`) would report a task with *no
+parameters*, and data associations would quietly copy nothing.
+
+## §2 Root Cause Analysis
+
+### §2.1 The discards mask *invariant-only* error surfaces
+
+Per-site classification against the callee's **actual** error surface (the
+WaiterFired precedent — classify by what the callee can really return, not a
+generic best-effort label):
+
+- **`Array.GetAt` / `Collection.GetAt`** (`pkg/model/data/values/array.go:243`)
+  errors only on a non-`int` index (`checkValue[int]`) or an out-of-range index
+  (`checkIndex`). In `diffCollections` the index is a loop `int` bounded by
+  `i < oldN` / `i < newN` where `oldN, newN` come from `Count()` — **both
+  failure modes are impossible while the invariant holds**.
+- **`InputOutputSpecification.Parameters`** (`pkg/model/data/io_spec.go:48`)
+  errors only on `dir.Validate()` failure. Both `getParams` call sites pass
+  the package constants `data.Output` (`task.go:518`) and `data.Input`
+  (`task.go:566`) — **the failure mode is impossible while the constants are
+  valid directions**.
+
+An impossible error is exactly the case the fail-fast rule reserves: silently
+converting it to a zero value turns an invariant violation into wrong data
+downstream. Log-and-continue is equally wrong — there is nothing to continue
+*with*.
+
+### §2.2 Why these two sites are unlike the walk's or-nil helpers
+
+The neighbouring `fieldOrNil` (`diff.go:134`) and `entryOrNil` (`diff.go:175`)
+also swallow errors — **deliberately and correctly**: the record/map walk
+descends over the *union* of keys, so "key absent on one side" is an expected
+outcome that *is* the diff signal (`Added`/`Deleted`). Their error surfaces
+include legitimate absence (`Field` → `ObjectNotFound`); the collection sites'
+do not (the index guard removes absence). Same syntax, opposite semantics —
+which is why the collection discards survived the walk's design review.
+
+### §2.3 The audited non-defects (recorded so the sweep can close)
+
+- `pkg/interactor/console/console.go:113` `_, _ = fmt.Fprintf(d.w, ...)` —
+  an **explicit, documented carve-out**: the doc comment cites ADR-022 v.1
+  §2.3 (the Driver *is* the output channel; no logger to report to). Verified
+  correct; untouched.
+- Every other `, _ :=` hit in library code is a **comma-ok type assertion or
+  comma-ok map/bool API**, not an error discard — capability probes
+  (`authz.(observability.LogRedactor)`, `node.(interactor.HumanTask)`,
+  `ew.WorkerTopic()` → `(Topic, ok bool)`, `linkDefName` → `(string, bool)`,
+  `strings.Cut`, `debug.ReadBuildInfo`, `adapterCache.LoadOrStore`). The full
+  audit greps and per-hit classification are in §6.1.
+
+### §2.4 Test coverage of the invariant branches
+
+None: `grep -rnF "diffCollections" pkg/model/data/*_test.go` → 0 hits;
+`grep -rnF "getParams" pkg/model/activities/*_test.go` → 0 hits. No test
+exercises either discard branch — they are unreachable through the public
+walk with well-behaved values (which is the point: covering them needs a
+lying-`Collection` stub / an invalid direction).
+
+## §3 Solution
+
+### §3.1 Alternatives considered
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| A. Or-nil helper (align with `fieldOrNil`/`entryOrNil`) | uniform look | masks an *impossible* state as data; §2.2 shows the semantics are opposite — absence is expected there, forbidden here | ❌ rejected |
+| B. Thread `error` up the walk (`DiffValues` → `([]Change, error)`) and out of `getParams` (interface change) | textbook propagation | breaks the landed `DiffValues` public contract and the `flow.AssociationSource`/`Target` model-wide interfaces — recursive signature churn across 6+ functions and every implementor, for branches that cannot fire | ❌ rejected |
+| C. `errs.Panic` on the impossible branch, with the invariant named in a comment | loud at the violation point; zero API change; the established house idiom for impossible states (5 sites in `pkg/model/events` — `signal.go:101`, `link.go:56`, …) | a genuine violation crashes the goroutine — accepted: that is what fail-fast means for a corrupted invariant | ✅ chosen |
+
+### §3.2 Changes by file
+
+#### §3.2.1 `pkg/model/data/diff.go` — fail-fast on the impossible `GetAt` error
+
+```go
+// before:
+if i < oldN {
+    ov, _ = oldV.GetAt(ctx, i)
+}
+
+// after:
+if i < oldN {
+    var err error
+    if ov, err = oldV.GetAt(ctx, i); err != nil {
+        // i is an int in [0, Count()) — GetAt cannot fail here unless the
+        // Collection contract is violated; surface the corruption loudly
+        // (FIX-028) instead of diffing the slot as nil.
+        errs.Panic(err)
+    }
+}
+```
+
+Same shape for the `newV` read. The comment names the invariant; the walk's
+signature (and the `DiffValues` public contract) stays untouched.
+
+#### §3.2.2 `pkg/model/activities/task.go` — fail-fast on the impossible `Parameters` error
+
+```go
+// before:
+params, _ := t.IoSpec.Parameters(dir)
+
+// after:
+params, err := t.IoSpec.Parameters(dir)
+if err != nil {
+    // getParams is called only with the data.Input/data.Output constants
+    // (Outputs/Inputs) — Parameters cannot fail here unless the Direction
+    // constants are broken; fail loudly (FIX-028) instead of reporting a
+    // parameterless task.
+    errs.Panic(err)
+}
+```
+
+#### §3.2.3 `pkg/model/data/diff_test.go` — regression test, symptom A
+
+Black-box (the file is `package data_test`; `DiffValues` is public): a stub
+`Collection` whose `Count()` reports 1 but whose `GetAt` always errors (the
+lying-implementation case) → `require.Panics` on the walk.
+
+#### §3.2.4 `pkg/model/activities/task_internal_test.go` — regression test, symptom B (new file)
+
+White-box, following the package's `*_internal_test.go` convention
+(`brule_task_internal_test.go`, `receive_task_options_internal_test.go`):
+`getParams` with an invalid `Direction` → `require.Panics`; the
+valid-constant paths (`Outputs()`/`Inputs()`) still return normally.
+
+## §4 Verification
+
+Current coverage in the test dirs: unit — extensive on the happy walk
+(`diff_test.go`, landed with SRD-044) and task I/O; **none** on either discard
+branch (§2.4).
+
+### §4.1 Regression tests (mandatory)
+
+| Test | Setup | Assertion |
+|---|---|---|
+| `TestDiffCollectionsFailFastOnBrokenGetAt` | stub `Collection`: `Count()=1`, `GetAt` → error; `DiffValues` over it | panics (via `errs.Panic`); no nil-slot diff emitted |
+| `TestGetParamsFailFastOnInvalidDirection` | a built `task`; call `getParams` with an invalid direction | panics; `Outputs()`/`Inputs()` with valid constants still return normally |
+
+Coverage standard: both touched files finish ≥95% on changed lines (target
+100% — the panic branches are coverable via `require.Panics`).
+
+### §4.5 Observability
+
+`errs.Panic` produces a classified panic value — a violated invariant surfaces
+as a crash at the corruption point with the causing error attached, instead of
+a wrong diff / empty parameter list N steps later.
+
+## §5 Prevention
+
+- The §3.2.1/§3.2.2 comments name the invariant *and* the FIX, so a future
+  refactor that weakens the guard trips over the rationale.
+- The §4.1 tests are the canaries: if they fall, the fail-fast regressed to a
+  silent discard.
+- Backlog (not this FIX): a lint guard (`forbidigo`/custom) rejecting new
+  `_ =` on error-returning calls in library paths — noted in §8.3 alongside
+  the ADR-034 v.1 §5 `.Get(ctx).(` guard; one lint-config pass can carry both.
+
+## §6 Regressions / side-effects
+
+### §6.1 What may rely on the old behaviour — the closing sweep inventory
+
+Audit greps run over `pkg/` + `internal/` (non-test, non-generated):
+
+```
+grep -rn "^\s*_ = \|, _ = \|, _ :=" --include=*.go pkg/ internal/ | grep -v _test.go
+```
+
+Classification of every hit: **2 defects** (this FIX — §1.1, §1.2);
+**1 documented carve-out** (console `printf`, ADR-022 v.1 §2.3 — §2.3);
+**all remaining hits are comma-ok assertions / bool APIs** (§2.3 list), which
+are total by language definition — no error exists to discard. No caller can
+observe the old masked-nil/empty-slice behaviour on the fixed sites, because
+the error branches are unreachable while invariants hold — the change is
+behaviourally invisible until a real corruption, which is the point.
+
+### §6.2 Rollback path
+
+Single-commit revert; no data or contract migration.
+
+## §7 Related
+
+- [ADR-022 v.1](../design/ADR-022-error-propagation-and-logging-policy.md) —
+  the no-silent-discard policy this FIX closes out repo-wide.
+- [ADR-011 v.7](../design/ADR-011-process-data-flow.md) §2.9.4 — the
+  commit-diff walk (symptom A's blast radius: conditional events).
+- FIX-026 — the sibling library-paths hygiene pass (Must-constructors), same
+  spirit.
+- SRD-044 — landed the diff walk this FIX hardens.
+- FIX-029 (same branch) — the examples run-step; independent scope.
+
+## §8 Implementation summary (stage-by-stage actual landings + deltas vs draft)
+
+> ⚠️ TODO: fill AFTER landing; records the implementation history and empirical
+> findings vs the §3 draft.
+
+### §8.1 Stages by commit (branch `fix/engineering-odds-and-ends`)
+
+| Stage | Commit | Scope | Tests |
+|---|---|---|---|
+| 1 | `<sha>` | §3.2.1–§3.2.4 | 2 |
+
+### §8.2 Empirical findings — where reality diverged from the §3 draft
+
+*TODO after landing.*
+
+### §8.3 Backlog (out of FIX-028 scope)
+
+- The combined lint guard: `forbidigo` patterns for bare `_ =` on
+  error-returning calls **and** `.Get(ctx).(` assertions (ADR-034 v.1 §5) —
+  one lint-config pass, separate change-set.
+
+## §9 Open questions
+
+None.

--- a/docs/fix/FIX-029-ci-runs-examples.md
+++ b/docs/fix/FIX-029-ci-runs-examples.md
@@ -1,0 +1,210 @@
+# FIX-029 «CI builds the examples but never runs them — runtime regressions ship green»
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft v.1 (2026-07-29, branch `fix/engineering-odds-and-ends`, not yet implemented).
+**Date:** 2026-07-29.
+**Author:** Ruslan Gabitov.
+**Branch:** `fix/engineering-odds-and-ends` (shared with FIX-028 — the
+engineering-backlog bundle).
+**Paired doc:** none (build/CI infrastructure only; no library code changes).
+**Upstream:** FIX-002 §5 (the prescribing prevention item: *"CI runs examples,
+not just builds them … Add a CI step (and a make target) that runs each
+example with a timeout and asserts exit 0. Tracked as a follow-up"*).
+
+**Grounded in (internal artifacts):**
+- `docs/fix/FIX-002-event-start-registration-lifecycle.md:30` — *"Masked from
+  CI because CI only **builds** the example modules, never **runs** them"*.
+- The FIX-002 incident itself: two of three then-existing examples deadlocked
+  at runtime for weeks while every CI gate was green.
+
+## §1 Symptoms
+
+A runtime-broken example — a deadlock, a panic, a nil-channel wait, an
+`OBJECT_NOT_FOUND` from a model change — passes CI. Observed twice:
+
+- **FIX-002 (2026-05):** examples deadlocked at runtime; invisible until run
+  by hand (`FIX-002-…md:30`).
+- **2026-07-26 (the guides rework):** `examples/message-send-receive` failed
+  at runtime (`OBJECT_NOT_FOUND` after SRD-063 made DataObjects
+  scope-resident — the example never `proc.Add`-ed its `received-order`
+  object); found only because the documentation work happened to run it, and
+  fixed in PR #242. CI had been green the whole time.
+
+In code: `Makefile:294-296` — the examples gate stops at build:
+
+```make
+ci-examples:
+	@$(MAKE) tidy-check-all lint-all-modules build-all MODULES="$(EXAMPLE_MODULES)"
+```
+
+`.github/workflows/check.yml:121-122` — the `examples` job runs exactly that
+(`make ci-examples`, step named "Examples sweep (tidy + lint + build)").
+
+## §2 Root Cause Analysis
+
+### §2.1 The gate's blind spot is structural, not accidental
+
+`ci-examples` sweeps `EXAMPLE_MODULES` (`Makefile:63` —
+`$(filter ./examples/%,$(MODULES))`, currently **46 modules**) through
+tidy-check, lint, and build. Nothing executes a produced program: the examples
+carry no tests (by design — they are teaching artifacts), so `go build` is the
+last time CI touches them. Everything after `main()` starts — engine wiring,
+event delivery, data movement, clean shutdown — is unverified.
+
+### §2.2 Why the class recurs
+
+The examples consume the library through `replace ../..`, so **every** library
+change alters their runtime behaviour with zero CI signal. Both incidents
+(§1) were library-side changes that kept the examples *compiling* while
+breaking them *running* — the exact failure shape a build-only gate cannot
+see.
+
+### §2.3 The interactive exception
+
+Two examples use the console interactor (`consinp`), but only one blocks:
+`examples/usertask` (`process.go`) — and it is the one example dir **without**
+`go.mod` (it belongs to the root module), so `EXAMPLE_MODULES` already
+excludes it structurally. `examples/expression-routing` (`tasks.go`) also
+uses `consinp`, yet a headless probe shows the reader degrades gracefully on
+EOF — `go run . < /dev/null` completes with exit 0 in under 20s, printing the
+full success narrative. No run-gate skip is needed for it; the loop runs
+every module with stdin closed so any future stdin read gets EOF, never a
+hang on the runner's terminal.
+
+## §3 Solution
+
+### §3.1 Alternatives considered
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| A. Add tests to every example | real assertions | 40+ test files duplicating what `main` already exercises; violates the examples' teaching-artifact design; huge upkeep | ❌ rejected |
+| B. Smoke-run only a hand-picked subset | fast | the subset rots — the two §1 incidents were in examples nobody would have picked; partial coverage re-creates the blind spot | ❌ rejected |
+| C. `run-examples` make target: every example module runs under `timeout` with stdin closed, asserting exit 0; chained into `ci-examples` | catches the whole class; zero per-example upkeep; `go run` leaves no binary to gitignore; local↔CI parity for free (the CI job already calls `make ci-examples`) | adds minutes to the non-blocking examples job (its `timeout-minutes` must grow); a slow example needs the timeout tuned | ✅ chosen |
+
+### §3.2 Changes by file
+
+#### §3.2.1 `Makefile` — the `run-examples` target, chained into `ci-examples`
+
+```make
+# A future example that genuinely blocks on stdin goes here (FIX-029 §5);
+# empty today — consinp degrades gracefully on EOF (§2.3), and the loop
+# closes stdin so a read gets EOF, never a terminal hang.
+EXAMPLE_RUN_SKIP :=
+# Generous per-example ceiling: the slowest (timer-driven) examples finish
+# well under it; a hang is cut at the ceiling with timeout's exit 124.
+EXAMPLE_RUN_TIMEOUT := 90s
+
+# run-examples executes every example module end-to-end (FIX-029): a runtime
+# regression — deadlock, panic, model drift — fails the gate that `go build`
+# alone kept green (the FIX-002 class).
+run-examples:
+	@set -e; for dir in $(filter-out $(EXAMPLE_RUN_SKIP),$(EXAMPLE_MODULES)); do \
+		echo "::group::run $$dir"; \
+		(cd $$dir && timeout $(EXAMPLE_RUN_TIMEOUT) $(GO) run . < /dev/null > /dev/null) || exit 1; \
+		echo "::endgroup::"; \
+	done
+.PHONY: run-examples
+
+ci-examples:
+	@$(MAKE) tidy-check-all lint-all-modules build-all MODULES="$(EXAMPLE_MODULES)"
+	@$(MAKE) run-examples
+```
+
+Stdout is discarded (the examples narrate) and stdin is closed; stderr stays
+visible, so a failure's panic/log output lands in the CI log inside its
+`::group::`. `timeout` is coreutils — present on every dev box and the
+`ubuntu-latest` runner; no new tool pin.
+
+#### §3.2.2 `.github/workflows/check.yml` — honest step name + job headroom
+
+The `examples` job already runs `make ci-examples`, so the logic lands with
+no workflow-command change; two edits keep the workflow honest:
+- step name: `Examples sweep (tidy + lint + build)` →
+  `Examples sweep (tidy + lint + build + run)`;
+- `timeout-minutes: 15` → `30` (44 sequential `go run`s add single-digit
+  minutes; the job stays non-blocking and parallel).
+
+#### §3.2.3 `docs/fix/FIX-002-event-start-registration-lifecycle.md` — no edit (frozen)
+
+FIX-002 is an Accepted one-shot; its §5 "tracked as a follow-up" stays as the
+historical record. This doc is the follow-up it tracks.
+
+## §4 Verification
+
+### §4.1 Regression gate (the deliverable IS the test)
+
+| Check | Setup | Assertion |
+|---|---|---|
+| `make run-examples` | the branch tree, warm build cache | exits 0; every module's `::group::run` line appears; total wall time recorded in §8 |
+| negative probe | a scratch copy of one example patched to `select {}` (hang) | `run-examples` fails with `timeout`'s exit 124 — the gate actually cuts a deadlock (the FIX-002 shape); probe is discarded, not committed |
+| `make ci-examples` | unchanged invocation | runs the build sweep **then** the run sweep |
+
+### §4.5 Observability
+
+Each example runs inside a `::group::run ./examples/<name>` fold in the CI
+log; a failure's stderr (panic, error output) is the first thing visible on
+unfold.
+
+## §5 Prevention
+
+- The gate itself is the prevention — the FIX-002 §5 prescription realized;
+  the whole runtime-regression class now fails the `examples` job.
+- A future example that genuinely blocks on stdin goes into
+  `EXAMPLE_RUN_SKIP` (empty today; the variable's comment says so); a
+  wrongly-skipped example shows up as a missing `::group::run` line in the
+  job log.
+- After landing, update the project memory note that tracked this follow-up
+  (`project_examples_runtime_broken`).
+
+## §6 Regressions / side-effects
+
+### §6.1 What may rely on the old behaviour
+
+Nothing consumes `ci-examples` besides the CI `examples` job and the local
+`make ci` umbrella (grep: `Makefile` + `check.yml` only). The job is
+**non-blocking** (not in branch-protection required checks), so a newly
+red run-step can never block an unrelated merge — it surfaces honestly
+instead.
+
+### §6.2 Rollback path
+
+Single-commit revert (Makefile + workflow); no state.
+
+### §6.3 Cost
+
+The examples job grows by the sum of example runtimes (measured in §8);
+locally `make ci` grows by the same amount. Accepted: the job is parallel
+and non-blocking, and the local run is the pre-push gate where this signal
+belongs.
+
+## §7 Related
+
+- FIX-002 — the prescribing incident (§5 prevention item this realizes).
+- FIX-028 (same branch) — independent scope.
+- PR #242 — the second incident's fix (`message-send-receive` runtime break).
+
+## §8 Implementation summary (stage-by-stage actual landings + deltas vs draft)
+
+> ⚠️ TODO: fill AFTER landing; records the implementation history and empirical
+> findings vs the §3 draft.
+
+### §8.1 Stages by commit (branch `fix/engineering-odds-and-ends`)
+
+| Stage | Commit | Scope | Tests |
+|---|---|---|---|
+| 1 | `<sha>` | §3.2.1–§3.2.2 | the §4.1 gate runs |
+
+### §8.2 Empirical findings — where reality diverged from the §3 draft
+
+*TODO after landing (record: full-sweep wall time; any example needing a
+timeout bump or an unexpected skip).*
+
+### §8.3 Backlog (out of FIX-029 scope)
+
+- Output assertions (expected lines per example) — a stronger gate; add only
+  if silent-wrong-output regressions actually appear.
+- Parallelizing the run sweep (`-P` fan-out) if wall time becomes a problem.
+
+## §9 Open questions
+
+None.

--- a/docs/fix/FIX-029-ci-runs-examples.md
+++ b/docs/fix/FIX-029-ci-runs-examples.md
@@ -1,7 +1,7 @@
 # FIX-029 «CI builds the examples but never runs them — runtime regressions ship green»
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft v.1 (2026-07-29, branch `fix/engineering-odds-and-ends`, not yet implemented).
+**Status:** Accepted (2026-07-29, branch `fix/engineering-odds-and-ends`, landed).
 **Date:** 2026-07-29.
 **Author:** Ruslan Gabitov.
 **Branch:** `fix/engineering-odds-and-ends` (shared with FIX-028 — the
@@ -185,19 +185,36 @@ belongs.
 
 ## §8 Implementation summary (stage-by-stage actual landings + deltas vs draft)
 
-> ⚠️ TODO: fill AFTER landing; records the implementation history and empirical
-> findings vs the §3 draft.
-
 ### §8.1 Stages by commit (branch `fix/engineering-odds-and-ends`)
 
 | Stage | Commit | Scope | Tests |
 |---|---|---|---|
-| 1 | `<sha>` | §3.2.1–§3.2.2 | the §4.1 gate runs |
+| doc | `6ec07dd` | this document (Draft, amended pre-implementation with the §8.2-1 finding) | — |
+| 1 | `635dc16` | §3.2.1–§3.2.2: `run-examples` + chain + workflow step name | full sweep 46/46 exit 0; both negative probes |
+
+Verification: full sweep **46/46 modules, exit 0, 33s wall** (warm cache —
+`build-all` fills it in the same job); a live hang (`time.Sleep`) is cut with
+`timeout`'s exit 124; a full deadlock (`select {}`) fails even faster —
+the Go runtime detects it (`all goroutines are asleep`, exit 2) before the
+timeout matters; `make ci` green with the run step chained in.
 
 ### §8.2 Empirical findings — where reality diverged from the §3 draft
 
-*TODO after landing (record: full-sweep wall time; any example needing a
-timeout bump or an unexpected skip).*
+1. **The drafted skip-list was unnecessary** (caught pre-implementation, at
+   the owner's prompt): `expression-routing` was assumed stdin-blocking, but
+   `go run . < /dev/null` completes with exit 0 in <20s — `consinp` degrades
+   gracefully on EOF. The Draft was amended before the code commit;
+   `EXAMPLE_RUN_SKIP` ships empty as the extension point.
+2. **The `timeout-minutes: 15 → 30` bump proved unnecessary**: the drafted
+   estimate ("single-digit minutes") assumed cold compiles, but `go run`
+   reuses the cache `build-all` just filled — the measured sweep is 33
+   seconds. The workflow keeps `timeout-minutes: 15`; §3.2.2's bump is
+   superseded by this finding.
+3. **The Go runtime beats the timeout on full deadlocks**: the §4.1 negative
+   probe planned to demonstrate exit 124 on `select {}`, but a total
+   deadlock is runtime-detected (exit 2) — only a *live* hang (a sleeping
+   goroutine, a never-firing wait) needs the timeout. Both shapes fail the
+   gate.
 
 ### §8.3 Backlog (out of FIX-029 scope)
 

--- a/pkg/model/activities/task.go
+++ b/pkg/model/activities/task.go
@@ -526,7 +526,14 @@ func (t *task) BindOutgoing(oa *data.Association) error {
 // getParams returns a list of the Task parameters input or output according to
 // direction dir.
 func (t *task) getParams(dir data.Direction) []*data.ItemAwareElement {
-	params, _ := t.IoSpec.Parameters(dir)
+	params, err := t.IoSpec.Parameters(dir)
+	if err != nil {
+		// getParams is called only with the data.Input/data.Output constants
+		// (Outputs/Inputs) — Parameters cannot fail here unless the Direction
+		// constants are broken; fail loudly (FIX-028) instead of reporting a
+		// parameterless task.
+		errs.Panic(err)
+	}
 	pp := make([]*data.ItemAwareElement, 0, len(params))
 	for _, p := range params {
 		pp = append(pp, &p.ItemAwareElement)

--- a/pkg/model/activities/task_internal_test.go
+++ b/pkg/model/activities/task_internal_test.go
@@ -1,0 +1,27 @@
+package activities
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+)
+
+// TestGetParamsFailFastOnInvalidDirection is the FIX-028 §4.1 canary
+// (white-box): getParams is only ever called with the data.Input/data.Output
+// constants, so a Parameters error is an invariant violation — it must panic
+// loudly, not surface as a parameterless task.
+func TestGetParamsFailFastOnInvalidDirection(t *testing.T) {
+	tsk := &task{
+		activity: activity{IoSpec: &data.InputOutputSpecification{}},
+	}
+
+	require.Panics(t, func() {
+		tsk.getParams(data.Direction("sideways"))
+	})
+
+	// The valid constants stay on the normal path.
+	require.Empty(t, tsk.Outputs())
+	require.Empty(t, tsk.Inputs())
+}

--- a/pkg/model/data/diff.go
+++ b/pkg/model/data/diff.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"reflect"
 	"strconv"
+
+	"github.com/dr-dobermann/gobpm/pkg/errs"
 )
 
 // Change is one entry of a commit-diff: a data path and how it changed
@@ -192,12 +194,22 @@ func diffCollections(changes *[]Change, path string, oldV, newV Collection) {
 	for i := range max(oldN, newN) {
 		var ov, nv any
 
+		var err error
+
 		if i < oldN {
-			ov, _ = oldV.GetAt(ctx, i)
+			if ov, err = oldV.GetAt(ctx, i); err != nil {
+				// i is an int in [0, Count()) — GetAt cannot fail here unless
+				// the Collection contract is violated; surface the corruption
+				// loudly (FIX-028) instead of diffing the slot as nil.
+				errs.Panic(err)
+			}
 		}
 
 		if i < newN {
-			nv, _ = newV.GetAt(ctx, i)
+			if nv, err = newV.GetAt(ctx, i); err != nil {
+				// The same [0, Count()) invariant as the old side (FIX-028).
+				errs.Panic(err)
+			}
 		}
 
 		diffInto(changes, path+"["+strconv.Itoa(i)+"]", ov, nv)

--- a/pkg/model/data/diff_test.go
+++ b/pkg/model/data/diff_test.go
@@ -1,8 +1,10 @@
 package data_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
 	"github.com/stretchr/testify/require"
@@ -157,4 +159,34 @@ func TestDiffValues(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// brokenCollection lies about its contract: Count reports the embedded
+// array's length but GetAt always fails — the FIX-028 corrupted-implementation
+// case the walk must surface loudly instead of diffing the slot as nil.
+type brokenCollection struct {
+	*values.Array[int]
+}
+
+func (b brokenCollection) GetAt(_ context.Context, _ any) (any, error) {
+	return nil, errs.New(errs.M("broken GetAt"))
+}
+
+// TestDiffCollectionsFailFastOnBrokenGetAt is the FIX-028 §4.1 canary: a
+// Collection whose GetAt fails inside the [0, Count()) invariant panics the
+// walk instead of emitting a nil-slot diff.
+func TestDiffCollectionsFailFastOnBrokenGetAt(t *testing.T) {
+	broken := brokenCollection{Array: values.NewArray(1)}
+
+	t.Run("old side", func(t *testing.T) {
+		require.Panics(t, func() {
+			data.DiffValues("order", broken, broken)
+		})
+	})
+
+	t.Run("new side", func(t *testing.T) {
+		require.Panics(t, func() {
+			data.DiffValues("order", values.NewArray[int](), broken)
+		})
+	})
 }


### PR DESCRIPTION
## What this PR does

Closes two queued engineering-backlog items as a bundle (the
`fix/audit-remediation-2026-06` precedent), each with its own FIX doc,
both Accepted:

### FIX-028 — invariant-only errors are no longer silently discarded

The repo-wide error-discard sweep, closed with evidence. Of every
bare-discard site in library code, exactly **two were defects**:

- `diffCollections` ignored `GetAt` errors — a `Collection` violating its
  contract would silently diff a slot as nil, feeding a false change record
  into the conditional-event commit-diff stream (ADR-011 v.7 §2.9.4).
- `getParams` ignored the `Parameters` error — a failure would surface as a
  parameterless task whose associations copy nothing.

Both callee error surfaces are invariant-only (index bounded by `Count()`;
direction passed as package constants), so the impossible branches now
**`errs.Panic` fail-fast** with the invariant named in a comment — the
established house idiom — rather than or-nil masking or breaking the landed
`DiffValues`/`AssociationSource` contracts. The doc's §6.1 records the full
sweep inventory: the console `printf` is the documented ADR-022 v.1 §2.3
carve-out; every other hit is a comma-ok assertion with no error to discard.

Regression canaries: a lying-`Collection` stub panics the walk (both sides);
an invalid direction panics `getParams`.

### FIX-029 — CI runs every example end-to-end, not just builds it

The FIX-002 §5 follow-up realized. `run-examples` executes each of the 46
example modules under a 90s timeout with stdin closed, asserting exit 0,
chained into `ci-examples` (so the CI job needed no command change and the
local `make ci` gains the same signal). A runtime-broken example can no
longer ship green — the class that hid the FIX-002 deadlocks for weeks and
the `message-send-receive` break after SRD-063.

Empirical findings recorded in §8.2: no skip-list is needed (`consinp`
degrades gracefully on EOF — `expression-routing` runs headless;
`usertask` is root-module and never enters the loop); the sweep costs
**33 seconds** on the warm cache `build-all` fills, so `timeout-minutes`
stays 15; the Go runtime catches full deadlocks (exit 2) even before the
timeout's exit 124 catches live hangs.

## Also in this PR

- `CLAUDE.md` CI-parity section updated (`ci-examples` = tidy+lint+build+run).
- `CHANGELOG.md` `[Unreleased]` gains both Fixed entries.

## Verification

- `make ci` green across all modules for each milestone (make's own exit;
  lint 0 issues, `-race` tests, consumer-smoke, govulncheck clean).
- FIX-028 diff-coverage: **100.0% of 17 changed coverable lines**; touched
  functions (`diffInto`, `diffCollections`, `getParams`) at 100%.
- FIX-029: full sweep 46/46 exit 0 in 33s; negative probes — live hang cut
  with exit 124, full deadlock runtime-detected with exit 2.
- `/review-srd` pre-approval and `/check-srd` landing audits on both docs;
  all cross-doc pins verified (ADR-022 v.1, ADR-011 v.7; FIX/PR refs).

## Out of scope (recorded in the docs' backlogs)

- The combined lint guard (`forbidigo`: bare `_ =` on error-returning calls
  + `.Get(ctx).(` assertions per ADR-034 v.1 §5) — one lint-config pass,
  separate change-set.
- Per-example output assertions and run-sweep parallelization — only if the
  need appears.
