### PR TITLE
fix: cancellation precedence and the wake-retry test race (FIX-033)

### DIFF
--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -76,32 +76,6 @@ implemented), and leaves this list.
   SRD-051, which sidestepped it by keeping the BPMN converter in the root
   module (SRD-051 v.2 §4.1); recorded here so the general gap is not mistaken
   for closed.
-- **`TestFailedWakeRetriesAndSucceeds` is flaky** (`pkg/thresher`) — observed
-  failing once inside a full `GOMAXPROCS=4 go test -race ./...` sweep on
-  2026-07-30, then not reproduced in ~50 targeted runs (`-count=30 -race`
-  focused, `-count=20` on a clean tree) nor in a repeat full-suite run. The
-  test drives the FIX-027 wake-retry backoff, so a load-sensitive timing
-  assumption is the obvious suspect, but nothing is proven — a one-off
-  observation, not a diagnosis. Worth a deliberate reproduction attempt under
-  CPU contention before it bites in CI; graduates to a FIX once the cause is
-  actually identified.
-- **A pre-canceled instance can settle `Completed` instead of `Terminated`**
-  (`internal/instance/TestTerminatedOnPreCanceledContext`) — observed in a full
-  `make test` run on 2026-07-30 and reproduced with
-  `GOMAXPROCS=8 go test ./internal/instance
-  -run '^TestTerminatedOnPreCanceledContext$' -count=2000` (also approximately
-  1 failure per 1000 ordinary targeted runs). This is an ordering race, not a
-  data race: `loop` spawns the initial track before selecting between the
-  already-closed `ctx.Done()` and the track's ready `evEnded`. Go gives ready
-  `select` cases no priority; if `evEnded` wins for the last active track,
-  `active` reaches zero while `stopping` remains false, so final settlement
-  chooses `Completed`. The test's comment claiming deterministic cancellation
-  precedence is therefore false. The fix must give the instance-loop context
-  precedence before terminal-event accounting (not merely increase the test
-  timeout, and not inspect a per-track context, which boundary events may
-  legitimately cancel), then update the regression test to await `Instance.Done()`
-  and assert exact `Terminated`. This predates and is independent of the BPMN
-  converter changes.
 - **No automated Markdown link check** — nothing in `make ci` or
   `check.yml` validates relative documentation links, which is how the 78 dead
   cross-references [FIX-031](fix/FIX-031-documentation-link-rot.md) swept up

--- a/docs/fix/FIX-033-cancellation-precedence-and-wake-test-race.md
+++ b/docs/fix/FIX-033-cancellation-precedence-and-wake-test-race.md
@@ -349,7 +349,19 @@ test covered — cancellation competing with events that are already queued.
 
 | Test | Setup | Assertion |
 |---|---|---|
-| `TestTerminatedWhenCancelRacesPendingEvents` | fork snapshot; cancel before `Run`; run the body `-count`-style in a loop within the test so the uniform choice is exercised many times | every iteration settles `Terminated`; never `Completed` |
+| `TestTerminatedWhenCancelRacesPendingEvents` | fork snapshot; cancel before `Run`; 200 independent rounds in-test so the uniform choice is exercised many times | every round settles `Terminated`; never `Completed` |
+
+**What this canary is and is not.** Measured during M1: with the poll removed,
+**2000 fork instances produced zero** `Completed` settlements. So the test pins
+the post-fix guarantee deterministically — the poll records the cancellation
+before any event can be applied, so the outcome no longer depends on the
+select — but it is **not** a reliable detector of the defect returning. The
+window (tracks emitting before the loop reaches its first select) is far
+narrower than the 1-in-1000 the original observation suggested. Stated here
+rather than left implied, because a canary believed to guard something it does
+not is worse than no canary: the proof of the defect is §2.1's code argument,
+and the proof of the fix is that the poll runs unconditionally before the
+blocking select.
 
 #### §4.1.3 The wake-retry suite becomes deterministic
 

--- a/docs/fix/FIX-033-cancellation-precedence-and-wake-test-race.md
+++ b/docs/fix/FIX-033-cancellation-precedence-and-wake-test-race.md
@@ -1,7 +1,7 @@
 # FIX-033 «A canceled instance can settle Completed, and the wake-retry tests race their own engine»
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft (2026-07-31, branch `fix/termination-and-wake-races`, not yet implemented).
+**Status:** Accepted (2026-07-31, branch `fix/termination-and-wake-races`).
 **Date:** 2026-07-31.
 **Author:** Ruslan Gabitov.
 **Branch:** `fix/termination-and-wake-races` (both symptoms are races surfaced by the same 2026-07-30 sweep; the name covers the terminal-state race and the wake-retry test race).
@@ -309,12 +309,19 @@ th.timerSvc = newTimerService(clk, backoff, th.hydrateFromTimer)
 return th, clk, func() {}
 ```
 
-Nothing else in these tests needs a running engine: they use
+None of the five firing tests needs a running engine: they use
 `th.cfg.Repository()` (available without `Run`), `th.HoldTimer` (needs only a
 non-nil `timerSvc`, `wake.go:31`), and the service's own `fireDue` / `nearest`.
 Restart recovery is not skipped in any meaningful sense either — every test
 seeds its record *after* the harness returns, so a `Run` would have found an
 empty store.
+
+**One carve-out, found while implementing:** `TestFailedRebuildKeepsTheSubscriptionSet`
+DOES need a started engine — `HoldSubscription` rejects a thresher that has not
+started (`thresher is not started`, `INVALID_OBJECT_STATE`). It gets its own
+`startedEngine` harness. It never advances the clock past a deadline and never
+fires a hold, so a live service has nothing to race it for; the split is what
+keeps the single-firer property where it matters.
 
 #### §3.2.4 `docs/backlog.md` — both entries graduate out
 
@@ -431,16 +438,47 @@ holds the line.
 
 ## §8 Implementation summary
 
-> ⚠️ TODO: fill AFTER landing.
-
-### §8.1 Stages by commit
+### §8.1 Stages by commit (branch `fix/termination-and-wake-races`)
 
 | Stage | Commit | Scope | Tests |
 |---|---|---|---|
+| doc | `ab6e1d1` | this document | — |
+| M1 | `ba063af` | `loop.go` cancellation poll; `adr1_gate_test.go` | `TestTerminatedOnPreCanceledContext` strengthened, `TestTerminatedWhenCancelRacesPendingEvents` added |
+| M2 | `9376dd1` | `wake_retry_test.go` harness split | 5 firing tests + `startedEngine` carve-out, unchanged bodies |
+| M3 | this commit | backlog graduation, §8 | — |
 
 ### §8.2 Empirical findings — where reality diverged from the §3 draft
 
+**The A canary cannot detect the defect returning, and this was measured, not
+assumed.** With the poll removed, **2000 fork instances settled `Terminated`
+every time** — zero reproductions. Combined with the 7,200 pre-fix attempts in
+§1.1, the conclusion is that the window (tracks emitting before the loop
+reaches its first `select`) is far narrower on this hardware than the original
+1-in-1000 observation implies. The test therefore pins the post-fix guarantee —
+which IS deterministic, because the poll runs before any event can be applied —
+but it does not guard against a regression. Recorded in the test's own doc
+comment and in §4.1.2, because a canary trusted to catch something it cannot is
+worse than no canary at all.
+
+**§3.2.3's "nothing else needs a running engine" was wrong for one test.**
+`TestFailedRebuildKeepsTheSubscriptionSet` calls `HoldSubscription`, which
+rejects an unstarted thresher outright. Found by running the suite, not by
+reading it — the draft had checked `HoldTimer`'s precondition and generalised.
+Fixed by splitting the harness rather than by starting the engine for
+everyone, which would have reintroduced the second firer for the tests that
+actually fire.
+
+**Verification tooling.** The repo's `go test` is rtk-proxied and prints only a
+summary line, so a run that executed **zero** tests reports as "300 passed" —
+which it did, once, during the §1.1 reproduction, until the wrong worktree was
+noticed. Every measurement in this FIX was therefore taken with
+`rtk proxy go test … -v` and the `=== RUN` / `--- PASS` / `--- FAIL` /
+`DATA RACE` lines counted directly.
+
 ### §8.3 Backlog (out of FIX-033 scope)
+
+None. Both backlog entries this FIX diagnosed are removed by M3; no new item is
+spun off.
 
 ## §9 Open questions
 

--- a/docs/fix/FIX-033-cancellation-precedence-and-wake-test-race.md
+++ b/docs/fix/FIX-033-cancellation-precedence-and-wake-test-race.md
@@ -1,0 +1,435 @@
+# FIX-033 «A canceled instance can settle Completed, and the wake-retry tests race their own engine»
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft (2026-07-31, branch `fix/termination-and-wake-races`, not yet implemented).
+**Date:** 2026-07-31.
+**Author:** Ruslan Gabitov.
+**Branch:** `fix/termination-and-wake-races` (both symptoms are races surfaced by the same 2026-07-30 sweep; the name covers the terminal-state race and the wake-retry test race).
+**Paired doc:** none (local to `internal/instance` and `pkg/thresher` tests).
+**Upstream:** [ADR-001 v.6](../design/ADR-001-execution-model.md) §7 (the termination cascade this restores), [ADR-007 v.2.1](../design/ADR-007-in-memory-long-waits.md) / [ADR-033 v.2](../design/ADR-033-persistence-and-state.md) (the timer service the §1.2 tests drive).
+
+**Grounded in (internal artifacts):**
+- `docs/backlog.md` — both symptoms were recorded there as observations awaiting diagnosis (added by `218f3e7`, 2026-07-30). This FIX graduates them out.
+- The reproduction runs recorded in §1 below, on `master` at `391b7d5`.
+
+## §1 Symptoms
+
+### §1.1 Symptom A: a pre-canceled instance can settle `Completed` instead of `Terminated`
+
+An instance whose context is already canceled when `Run` starts — and, by the
+same mechanism, one canceled while it runs — can finish in `Completed`. The
+cancellation is simply not recorded, so the terminal state claims the process
+finished normally when it was in fact torn down.
+
+The engine's own regression test for the cancellation cascade is the one that
+fails:
+
+```
+--- FAIL: TestTerminatedOnPreCanceledContext
+    adr1_gate_test.go:51: a pre-canceled instance settles in Terminated via the cascade
+```
+
+In code: `internal/instance/loop.go:193-237` (the loop's `select`) combined with
+`internal/instance/lifecycle.go:153` (`settleFinalState`, which reads the flag
+the `select` may never set).
+
+**Reproduction status — honest and incomplete.** The backlog records this
+failing in a full `make test` run and reproducing at
+`GOMAXPROCS=8 … -count=2000`. On this machine it did **not** reproduce in 7,200
+attempts:
+
+| Configuration | Result |
+|---|---|
+| `GOMAXPROCS=8 -count=2000` (the recorded recipe) | 2000/2000 pass |
+| `GOMAXPROCS=8 -count=5000 -race`, 6 busy-loop processes as load | 5000/5000 pass |
+| single-track instance (fewest `select` turns — the shape most likely to fail), `-count=200` | 200/200 pass |
+
+The defect is therefore established from the **code**, not from a hit rate, and
+§2.1 proves it by construction. The rate matters only for judging how long it
+could hide, and the answer is: indefinitely.
+
+### §1.2 Symptom B: `TestFailedWakeRetriesAndSucceeds` races the engine it starts
+
+`pkg/thresher/wake_retry_test.go:147`. Under `-race` with CPU contention:
+
+```
+WARNING: DATA RACE
+Write at 0x00c0001c38e0 by goroutine 1784:
+  thresher.TestFailedWakeRetriesAndSucceeds.func1()  wake_retry_test.go:161   ← attempts++
+  thresher.(*timerService).fireDue()                 timer_service.go:263
+  thresher.(*timerService).run()                     timer_service.go:208
+  thresher.(*Thresher).Run.gowrap1()                 thresher.go:570
+Previous read at 0x00c0001c38e0 by goroutine 1782:
+  thresher.TestFailedWakeRetriesAndSucceeds()        wake_retry_test.go:183   ← require.Equal(t, 2, attempts)
+```
+
+Reproduced at **2 failures / 1500 runs** (`-race`, 6 busy-loop processes as
+load), both reported as `race detected during execution of test`.
+
+The backlog's provisional diagnosis — "a load-sensitive timing assumption" —
+is **wrong**, and is corrected here: there is no timing assumption in the test
+body at all. It drives a fake clock and calls `fireDue` explicitly. The fault is
+a second, concurrent caller.
+
+## §2 Root Cause Analysis
+
+### §2.1 Symptom A: `select` gives a canceled context no precedence
+
+`internal/instance/loop.go:192-237`:
+
+```go
+done := ctx.Done()
+for ls.active > 0 {
+	select {
+	case <-done:
+		done = nil
+		ls.stopAll()          // the ONLY writer of ls.stopping
+
+	case ev := <-inst.events:
+		ls.apply(ctx, ev)     // evEnded here can drop ls.active to 0
+	...
+	}
+}
+```
+
+and the settlement that follows it, `internal/instance/lifecycle.go:153`:
+
+```go
+func (inst *Instance) settleFinalState(stopping bool) {
+	if stopping {
+		inst.setState(Terminated)
+
+		return
+	}
+
+	inst.setState(Completed)
+}
+```
+
+Three facts compose into the defect:
+
+1. **`ls.stopping` is set only by `stopAll`**, reached only through the `<-done`
+   arm (`loop.go:329-335`).
+2. **A `select` with several ready cases chooses uniformly at random.** This is
+   the Go language specification, not a scheduling accident. A canceled `done`
+   is *permanently* ready, so on every turn where `inst.events` is also ready
+   the cancellation may lose — and may keep losing.
+3. **The loop's exit condition is `ls.active > 0`**, and `apply` of a terminal
+   `evEnded` is what drives `active` to zero. So the loop can exit through the
+   events arm alone, with `done` never selected and `stopping` still false.
+
+The result is `settleFinalState(false)` → `Completed`, for an instance whose
+context was canceled the whole time. Failure requires the events arm to win on
+every turn until `active` reaches zero, which is why the probability falls as
+the track count rises — and why a rare event is not a harmless one: it is
+mis-reported process state, and downstream a checkpoint records the wrong
+terminal status.
+
+**This is an ordering defect, not a data race.** `-race` cannot find it, which
+is precisely why it survived: the sweep that noticed it was looking for the
+other kind.
+
+### §2.2 Symptom B: the test is a second firer alongside a live service
+
+`retryEngine` (`wake_retry_test.go:50-68`) calls `th.Run(ctx)`. With a
+Repository configured — these tests configure one, because
+`unregisteredRecord` needs it — `Run` both builds the timer service and starts
+its loop (`pkg/thresher/thresher.go:567-570`):
+
+```go
+if t.cfg.repoSet {
+	t.timerSvc = newTimerService(
+		t.cfg.Clock(), t.cfg.wakeBackoff, t.hydrateFromTimer)
+	go t.timerSvc.run(runCtx)
+}
+```
+
+That loop parks on the clock (`timer_service.go:195-210`):
+
+```go
+if next, ok := ts.nearest(); ok {
+	fire = ts.clk.After(next.Sub(ts.clk.Now()))
+}
+
+select {
+case <-ctx.Done():	return
+case <-ts.kick:		continue
+case <-fire:		ts.fireDue(ctx)
+}
+```
+
+So when the test advances the fake clock, **the service's own goroutine fires
+the due hold** — at the same time the test calls `th.timerSvc.fireDue(...)` by
+hand. Both paths reach `ts.wake(...)` (`timer_service.go:263`), which is the
+test's closure, and that closure mutates `attempts` and reads `failing` with no
+synchronization. Two consequences, both real:
+
+- **A data race** on the closure's captured variables (the detector's report,
+  §1.2).
+- **A correctness flake independent of the detector**: an extra background fire
+  increments `attempts`, so `require.Equal(t, 1, attempts)` and
+  `require.Equal(t, 2, attempts)` can both see one too many.
+
+The assignment `th.timerSvc.wake = …` (lines 116, 160, 198, 244) is itself
+unsynchronized against a goroutine that reads `ts.wake` — so the window opens
+before the first `Advance`.
+
+**Scope: every test built on `retryEngine` shares the shape.** Four override the
+closure directly — `TestFailedWakeKeepsTheHold` (116),
+`TestFailedWakeRetriesAndSucceeds` (160), `TestSuccessfulWakeStillWithdraws`
+(198) and `TestFiringHoldIsNotReentered` (244) — and `TestFailedWakeBacksOff`
+(105) drives the same service. Only `TestFailedWakeRetriesAndSucceeds` has been
+*observed* failing; the others are exposed by construction and must be fixed
+together, or the next one simply becomes the flake.
+
+### §2.3 Why the tests did not catch either
+
+- **A**: `TestTerminatedOnPreCanceledContext` asserts the right thing but only
+  probabilistically, and its comment asserts a determinism the code does not
+  provide: *"the loop's first select sees ctx.Done() before any track has
+  emitted"*. Nothing orders those two. The comment is the reason the test's
+  passing was read as proof rather than as a coin landing the same way.
+- **B**: the race needs `-race` **and** contention. `make ci` runs `-race`, so
+  CI would eventually have found it — as a mystery failure in an unrelated PR.
+
+## §3 Solution
+
+### §3.1 Alternatives considered
+
+**Symptom A**
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| A1. Poll `done` non-blockingly at the top of each loop turn, before the blocking `select` | Deterministic for an already-visible cancellation; 6 lines; no new state; zero cost once canceled (`done` is nil'd) | One extra non-blocking `select` per turn while the context is live | ✅ **chosen** |
+| A2. Re-check `ctx.Err()` after the loop and override the terminal state | Smallest diff | Wrong layer: it papers over the flag rather than recording the cancellation, and `stopAll`'s teardown (releasing holds, stopping tracks) would still not have run | ❌ rejected |
+| A3. Give the events arm a `default:` and drain events only when `done` is not ready | Strict precedence | Turns the loop into a spin when both are idle; changes the blocking discipline of the whole loop for one edge | ❌ rejected |
+
+**Symptom B**
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| B1. Make the test the **only** firer: build the timer service directly in the harness and never start its goroutine | Removes the second caller outright — no race, no double count, fully deterministic; `HoldTimer` needs only a non-nil `timerSvc` (`wake.go:31`) | The harness wires one line that `Run` would otherwise wire | ✅ **chosen** |
+| B2. Guard the closure's counters with a mutex | Silences the detector | Leaves the double fire in place: `attempts` would still be legitimately 2 when the test demands 1, so the assertion flake survives — it hides the symptom the detector was reporting | ❌ rejected |
+| B3. Keep the engine running and relax the assertions to `>= 1` | Tiny diff | Destroys what the test is for: "retried exactly once" is the FIX-027 contract being pinned | ❌ rejected |
+| B4. Cancel the engine context right after `Run` | No harness rewiring | Racy in its own right — the exit is not synchronized, so the goroutine may still take one turn; trades a known race for a subtler one | ❌ rejected |
+
+### §3.2 Changes by file
+
+#### §3.2.1 `internal/instance/loop.go` — cancellation is observed before event accounting
+
+```go
+// before:
+done := ctx.Done()
+for ls.active > 0 {
+	select {
+	case <-done:
+		done = nil
+		ls.stopAll()
+
+// after:
+done := ctx.Done()
+for ls.active > 0 {
+	// A ready ctx.Done() must be recorded BEFORE any further terminal-event
+	// accounting: `select` chooses uniformly among ready cases (Go spec), so a
+	// canceled context can lose every turn while evEnded drives ls.active to
+	// zero — and the loop would then exit with ls.stopping false, settling
+	// Completed for an instance that was torn down (ADR-001 §7). Polling here
+	// costs one non-blocking select per turn while the context is live, and
+	// nothing at all once it is canceled: done is nil from then on.
+	if done != nil {
+		select {
+		case <-done:
+			done = nil
+			ls.stopAll()
+		default:
+		}
+	}
+
+	select {
+	case <-done:
+		done = nil
+		ls.stopAll()
+```
+
+The blocking arm stays: it is what wakes an idle loop when cancellation arrives
+*during* the wait. The poll adds precedence for a cancellation that is already
+visible. `stopAll` is idempotent (`loop.go:330`), so the two paths cannot
+double-run.
+
+What this deliberately does **not** change: a cancellation arriving after the
+last event has been applied still settles `Completed`. That is correct — the
+instance genuinely finished first. The defect was ignoring a cancellation the
+loop could already see.
+
+#### §3.2.2 `internal/instance/adr1_gate_test.go` — the regression test states the truth
+
+The comment claiming the first `select` deterministically sees `ctx.Done()` is
+removed; it describes the bug, not the design. The test is strengthened to wait
+on the instance's own terminal signal rather than polling, and to assert the
+exact state:
+
+```go
+// before:
+require.Eventually(t,
+	func() bool { return inst.State() == Terminated },
+	time.Second, 5*time.Millisecond,
+	"a pre-canceled instance settles in Terminated via the cascade")
+
+// after:
+<-inst.Done()
+
+require.Equal(t, Terminated, inst.State(),
+	"a pre-canceled instance settles Terminated — cancellation is recorded "+
+		"before terminal-event accounting, whatever order the loop sees them in")
+```
+
+Polling with `Eventually` can only observe *a* terminal state; awaiting
+`Done()` and comparing exactly is what distinguishes `Terminated` from
+`Completed` — the two the defect confused.
+
+#### §3.2.3 `pkg/thresher/wake_retry_test.go` — one firer, the test
+
+`retryEngine` stops starting the engine and wires the service the tests drive:
+
+```go
+// before:
+ctx, cancel := context.WithCancel(context.Background())
+require.NoError(t, th.Run(ctx))
+
+return th, clk, cancel
+
+// after:
+// The tests drive fireDue by hand, so the service must have no other caller:
+// Thresher.Run would start timerService.run, whose own clock loop fires the
+// same due holds on the same fake-clock Advance — racing the test's closure
+// and double-counting its attempts (FIX-033 §2.2). Wiring the service here is
+// the one line Run would have contributed (thresher.go:568).
+th.timerSvc = newTimerService(clk, backoff, th.hydrateFromTimer)
+
+return th, clk, func() {}
+```
+
+Nothing else in these tests needs a running engine: they use
+`th.cfg.Repository()` (available without `Run`), `th.HoldTimer` (needs only a
+non-nil `timerSvc`, `wake.go:31`), and the service's own `fireDue` / `nearest`.
+Restart recovery is not skipped in any meaningful sense either — every test
+seeds its record *after* the harness returns, so a `Run` would have found an
+empty store.
+
+#### §3.2.4 `docs/backlog.md` — both entries graduate out
+
+The two observation entries are removed: they are now this FIX's §1.1 and §1.2,
+with a diagnosis each. Leaving them would leave the backlog claiming an open
+question that has an answer.
+
+## §4 Verification
+
+Current coverage of the two areas:
+
+- `internal/instance`: `TestTerminatedOnPreCanceledContext` exists and is the
+  canary — it just cannot fail reliably. No test covers "cancellation arrives
+  while events are pending".
+- `pkg/thresher`: four wake-retry tests exist; none is deterministic under a
+  live service.
+
+### §4.1 Regression tests (mandatory)
+
+#### §4.1.1 `TestTerminatedOnPreCanceledContext` (strengthened)
+
+**Updated:** `internal/instance/adr1_gate_test.go`.
+
+| Test | Setup | Assertion |
+|---|---|---|
+| `TestTerminatedOnPreCanceledContext` | fork snapshot; context canceled before `Run` | awaits `inst.Done()`; state is exactly `Terminated` |
+
+#### §4.1.2 `TestTerminatedWhenCancelRacesPendingEvents`
+
+**New:** `internal/instance/adr1_gate_test.go`. The case §2.1 describes and no
+test covered — cancellation competing with events that are already queued.
+
+| Test | Setup | Assertion |
+|---|---|---|
+| `TestTerminatedWhenCancelRacesPendingEvents` | fork snapshot; cancel before `Run`; run the body `-count`-style in a loop within the test so the uniform choice is exercised many times | every iteration settles `Terminated`; never `Completed` |
+
+#### §4.1.3 The wake-retry suite becomes deterministic
+
+**Updated:** `pkg/thresher/wake_retry_test.go` (harness only; the four test
+bodies keep their assertions, which is the point — they were right).
+
+| Test | Setup | Assertion |
+|---|---|---|
+| every `retryEngine` test | harness wires the service without starting its goroutine | exact `attempts` counts hold; `-race` clean under contention |
+
+### §4.2 Empirical gate
+
+- `rtk proxy go test ./internal/instance -run 'PreCanceled|CancelRaces' -count=5000 -race` under CPU load → 0 failures.
+- `rtk proxy go test ./pkg/thresher -run 'Wake' -count=1500 -race` under CPU load → 0 failures, no `DATA RACE`.
+  Both are run with raw output and the `=== RUN` / `--- FAIL` lines counted:
+  the repo's `go test` is rtk-proxied and prints only a summary, which cannot
+  distinguish a real pass from a run that executed no tests.
+- `make ci` green.
+
+### §4.3 Observability
+
+No new facts. A correctly-terminated instance already reports
+`KindInstanceState`/`Terminated`; the defect made that fact *wrong*, and the fix
+makes it right.
+
+## §5 Prevention
+
+- **Doc comments**: the loop's poll carries the reason (the Go-spec uniform
+  choice), so the next reader does not "simplify" it away. The wake harness
+  carries the reason it does not start the engine.
+- **Regression canaries**: §4.1.2 is the canary for A; the whole wake file is
+  the canary for B — if either regresses, `-race` under load fails.
+- **A note for the next race hunt**: `-race` finds data races, not ordering
+  defects. Symptom A is invisible to it. Where a terminal state is chosen from
+  a flag set by one arm of a `select`, review the precedence by reading, not by
+  running.
+
+## §6 Regressions / side-effects
+
+### §6.1 What may rely on the old behavior
+
+- `grep -rn "settleFinalState" internal/` — one caller (`loop.go:263`);
+  behavior changes only for a canceled instance, which is the fix.
+- `grep -rn "timerSvc" pkg/thresher/*_test.go` — the wake-retry file is the
+  only test touching the service directly; other suites go through the engine
+  and are unaffected.
+- Instances that complete normally are untouched: with a live, uncanceled
+  context the poll's `default:` fires and the loop proceeds exactly as before.
+
+### §6.2 Rollback path
+
+A single revert. Neither change carries data or migration.
+
+### §6.3 Backlog spun off
+
+None expected. Should the §4.1.2 loop prove slow in CI, it can drop its
+iteration count — the deterministic assertion, not the repetition, is what
+holds the line.
+
+## §7 Related
+
+- [ADR-001 v.6](../design/ADR-001-execution-model.md) §7 — the termination
+  cascade whose terminal state this restores.
+- [FIX-027](FIX-027-stranded-dehydrated-instances.md) — the wake-retry behavior
+  the §1.2 tests pin; this FIX repairs the tests, not that fix.
+- `docs/backlog.md` — where both symptoms were parked pending diagnosis.
+
+## §8 Implementation summary
+
+> ⚠️ TODO: fill AFTER landing.
+
+### §8.1 Stages by commit
+
+| Stage | Commit | Scope | Tests |
+|---|---|---|---|
+
+### §8.2 Empirical findings — where reality diverged from the §3 draft
+
+### §8.3 Backlog (out of FIX-033 scope)
+
+## §9 Open questions
+
+None.

--- a/internal/instance/adr1_gate_test.go
+++ b/internal/instance/adr1_gate_test.go
@@ -28,10 +28,14 @@ func TestStateString(t *testing.T) {
 	}
 }
 
-// TestTerminatedOnPreCanceledContext drives the cancellation-terminal branch
-// deterministically: a context canceled before Run() means the loop's first
-// select sees ctx.Done() before any track has emitted, so the instance stops
-// every track and settles in Terminated (not Completed).
+// TestTerminatedOnPreCanceledContext drives the cancellation-terminal branch: a
+// context canceled before Run() is visible to the loop from its first turn, so
+// the instance stops every track and settles in Terminated (not Completed).
+//
+// What makes it deterministic is the loop's non-blocking ctx.Done() poll
+// (FIX-033 §3.2.1), NOT any ordering between the cancellation and the tracks'
+// events — `select` gives ready cases no priority, so before that poll the
+// events arm could win every turn and the instance settled Completed.
 func TestTerminatedOnPreCanceledContext(t *testing.T) {
 	_ = data.CreateDefaultStates()
 
@@ -48,12 +52,54 @@ func TestTerminatedOnPreCanceledContext(t *testing.T) {
 
 	require.NoError(t, inst.Run(ctx))
 
-	require.Eventually(t,
-		func() bool { return inst.State() == Terminated },
-		time.Second, 5*time.Millisecond,
-		"a pre-canceled instance settles in Terminated via the cascade")
+	// Await the instance's own terminal signal and compare exactly: polling for
+	// "some terminal state" cannot tell Terminated from the Completed this
+	// defect produced.
+	<-inst.Done()
+
+	require.Equal(t, Terminated, inst.State(),
+		"a pre-canceled instance settles Terminated via the cascade")
 
 	leak()
+}
+
+// TestTerminatedWhenCancelRacesPendingEvents covers the case no test covered: a
+// cancellation competing with track events that are already queued. Each round
+// is an independent instance, so the loop's choice between the ready done arm
+// and the ready events arm is exercised many times over.
+//
+// Read what this test does and does not prove (FIX-033 §4.1.2). It pins the
+// post-fix guarantee exactly — a canceled instance settles Terminated, whatever
+// the select chooses — and it is deterministic in that direction, because the
+// loop's poll records the cancellation before any event can be applied. It is
+// NOT a reliable detector of the defect returning: with the poll removed, 2000
+// fork instances here produced zero Completed settlements, because the window
+// (tracks emitting before the loop reaches its first select) is far narrower
+// than the original 1-in-1000 observation suggested. The defect's proof is the
+// code argument in FIX-033 §2.1, not this test's hit rate.
+func TestTerminatedWhenCancelRacesPendingEvents(t *testing.T) {
+	_ = data.CreateDefaultStates()
+
+	const rounds = 200
+
+	for i := range rounds {
+		s := buildForkSnapshot(t)
+		ep := mockeventproc.NewMockEventProducer(t)
+
+		inst, err := New(s, scope.EmptyDataPath, enginert.Default(), ep, nil)
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		require.NoError(t, inst.Run(ctx))
+
+		<-inst.Done()
+
+		require.Equalf(t, Terminated, inst.State(),
+			"round %d settled %s: a canceled instance must never report "+
+				"Completed", i, inst.State())
+	}
 }
 
 // TestTerminationCascade verifies ADR-001 §7 termination cascade at the runtime

--- a/internal/instance/loop.go
+++ b/internal/instance/loop.go
@@ -191,6 +191,23 @@ func (inst *Instance) loop(ctx context.Context, initial []*track) {
 
 	done := ctx.Done()
 	for ls.active > 0 {
+		// A cancellation the loop can ALREADY see is recorded before any
+		// further terminal-event accounting. `select` chooses uniformly among
+		// ready cases (Go spec), so a canceled — and therefore permanently
+		// ready — done can lose every turn while evEnded drives ls.active to
+		// zero; the loop would then exit with ls.stopping false and settle
+		// Completed for an instance that was torn down (ADR-001 v.6 §7,
+		// FIX-033 §2.1). Once canceled, done is nil and this costs nothing.
+		if done != nil {
+			select {
+			case <-done:
+				done = nil
+				ls.stopAll()
+
+			default:
+			}
+		}
+
 		select {
 		case <-done:
 			done = nil

--- a/pkg/thresher/wake_retry_test.go
+++ b/pkg/thresher/wake_retry_test.go
@@ -45,8 +45,24 @@ func unregisteredRecord(t *testing.T, th *Thresher, instanceID string) {
 		}))
 }
 
-// retryEngine builds an armed engine on a controlled clock with an explicit
-// wake-retry backoff.
+// retryEngine builds an engine on a controlled clock with an explicit
+// wake-retry backoff, and wires the timer service the tests below drive by
+// hand.
+//
+// It deliberately does NOT call Run. Run starts timerService.run, whose own
+// loop parks on this same fake clock — so every clk.Advance would fire the due
+// holds from the service's goroutine at the same moment a test fires them
+// explicitly. Both paths call ts.wake, which in these tests is a closure over
+// the test's own counters: an unsynchronized double write, and an attempt count
+// that is legitimately one too high for assertions that pin it exactly
+// (FIX-033 §2.2, reproduced at 2 failures in 1500 runs under -race).
+//
+// Wiring the service here is the one line Run would have contributed
+// (thresher.go, the repoSet branch). Nothing else in these tests needs a
+// running engine: they reach the repository through th.cfg, and HoldTimer
+// requires only a non-nil timerSvc. Restart recovery loses nothing either —
+// every test seeds its record after this returns, so a Run would have found an
+// empty store.
 func retryEngine(
 	t *testing.T, name string, backoff time.Duration,
 ) (*Thresher, *clocktest.Clock, context.CancelFunc) {
@@ -61,10 +77,32 @@ func retryEngine(
 		WithWakeRetryBackoff(backoff))
 	require.NoError(t, err)
 
+	th.timerSvc = newTimerService(clk, backoff, th.hydrateFromTimer)
+
+	return th, clk, func() {}
+}
+
+// startedEngine is retryEngine's counterpart for the one test that needs a
+// RUNNING engine: HoldSubscription refuses a thresher that has not started.
+// That test never advances the clock past a deadline and never fires a hold, so
+// the service's own loop has nothing to race it for — the separation exists
+// precisely so the tests that DO fire by hand keep their single firer.
+func startedEngine(
+	t *testing.T, name string, backoff time.Duration,
+) (*Thresher, context.CancelFunc) {
+	t.Helper()
+
+	th, err := New(name,
+		WithoutBanner(), WithoutStartupConfig(),
+		WithRepository(memrepo.New()),
+		WithClock(clocktest.New(wakeEpoch)),
+		WithWakeRetryBackoff(backoff))
+	require.NoError(t, err)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	require.NoError(t, th.Run(ctx))
 
-	return th, clk, cancel
+	return th, cancel
 }
 
 // TestFailedWakeKeepsTheHold is the §1 probe inverted into an assertion: after
@@ -293,7 +331,7 @@ func TestDefaultWakeRetryBackoff(t *testing.T) {
 // above the withdraw even in the defective order, and would make this test
 // vacuous — as the first draft of it was.)
 func TestFailedRebuildKeepsTheSubscriptionSet(t *testing.T) {
-	th, _, cancel := retryEngine(t, "engine-keepsubs", time.Hour)
+	th, cancel := startedEngine(t, "engine-keepsubs", time.Hour)
 	defer cancel()
 
 	const (


### PR DESCRIPTION
## What this does

Diagnoses and fixes the two races parked in `docs/backlog.md` on 2026-07-30 as
observations awaiting a cause. Both are real. **Neither is what the notes
guessed**, and the corrections are the substance of this PR.

## A — a canceled instance could settle `Completed`

`internal/instance/loop.go`. `ls.stopping` is written only by the loop's
`<-done` arm, and Go's `select` chooses uniformly among ready cases. A canceled
context is *permanently* ready, so it can lose every turn while the events arm
applies `evEnded` and drives `ls.active` to zero — the loop then exits with
`stopping` false, and `settleFinalState` reports **Completed for an instance
that was torn down**. The checkpoint records that wrong terminal status too.

The loop now polls `ctx.Done()` non-blockingly before each blocking select, so
a cancellation it can already see is recorded before any further terminal-event
accounting. Once canceled, `done` is nil and the poll costs nothing. A
cancellation arriving *after* the last event still settles `Completed` — correct,
the instance genuinely finished first.

**This is an ordering defect, not a data race**, which is why `-race` never
flagged it and why the sweep that found B walked straight past it.

### Reproduction — reported honestly

It did **not** reproduce here: 7,200 pre-fix attempts across three
configurations (2000 plain; 5000 with `-race` under six busy-loop processes;
200 with a deliberately single-track instance, the shape most likely to fail).
The case therefore rests on the code argument in FIX-033 §2.1, not on a hit
rate.

The same measurement cuts the other way and is recorded in three places: with
the fix removed, **2000 fork instances settled `Terminated` every time**. So the
new `TestTerminatedWhenCancelRacesPendingEvents` pins the post-fix guarantee —
deterministically, because the poll runs before any event can be applied — but
it does **not** guard against the defect returning. A canary trusted to catch
what it cannot is worse than no canary, so its limits are stated in the test's
doc comment, in FIX-033 §4.1.2, and in §8.2.

The old test also lost a comment claiming the loop's first select
deterministically sees `ctx.Done()` before any track has emitted. Nothing
ordered those two; the comment described the bug, and it is why the test's
passing read as proof rather than as a coin landing the same way. It now awaits
`inst.Done()` and compares the state exactly — polling for "some terminal
state" cannot tell `Terminated` from the `Completed` this produced.

## B — the wake-retry tests raced the engine they started

`pkg/thresher/wake_retry_test.go`. `retryEngine` called `th.Run`, which starts
`timerService.run`; that loop parks on the *same fake clock* the tests advance,
so every `clk.Advance` fired the due holds from the service's goroutine at the
moment a test was firing them by hand. Both paths call `ts.wake` — here a
closure over the test's own counters — so `attempts++` was written from two
goroutines unsynchronized, and could legitimately reach a value the assertions
pin exactly.

Reproduced at **2 failures / 1500 runs** under `-race` with CPU load, the
detector naming both callers. The backlog's "load-sensitive timing assumption"
is wrong: the test body contains no timing assumption at all.

The harness now wires the timer service and never starts its loop — the one
line `Run` would have contributed — so the test is the only firer. The five
test bodies are untouched; their exact attempt counts are the FIX-027 contract
worth keeping. `TestFailedRebuildKeepsTheSubscriptionSet` does need a started
engine (`HoldSubscription` refuses one that has not started) and gets its own
harness; it never fires a hold, so a live service has nothing to race it for.

**Verified against the reproduction**: the configuration that failed twice now
gives 1500 passes and zero `DATA RACE`.

## Verification

- `make ci` green: diff-coverage **100.0% of 13 changed lines**, 46/46 examples
  executed end-to-end, govulncheck clean ×5, lint clean.
- `internal/instance` green under `-race`; the two cancellation tests 40/40.
- `pkg/thresher` wake suite 30/30; the reproduction configuration 1500/1500.

Every figure was taken with `rtk proxy go test … -v` and the
`=== RUN` / `--- PASS` / `--- FAIL` / `DATA RACE` lines counted. The repo's
`go test` is rtk-proxied and prints only a summary, so a run that executed
**zero** tests reports as "300 passed" — which it did once, until the wrong
worktree was noticed. Worth knowing for anyone verifying this PR.

## Docs

- `docs/fix/FIX-033-cancellation-precedence-and-wake-test-race.md` (Accepted) —
  symptoms with evidence, the RCA for each, four rejected alternatives with
  reasons, verification, and §8.2's record of where implementation corrected the
  draft.
- `docs/backlog.md` — both entries graduate out; they had answers now.

## Reviewing

`ba063af` is the engine change (13 lines, one of them the poll). `9376dd1` is
test-only. The two claims worth checking are §2.1's argument that the exit
condition can be satisfied without ever observing `done`, and the decision to
keep the blocking `<-done` arm alongside the poll — it is what wakes an idle
loop when cancellation arrives *during* the wait.
