### PR TITLE
Examples assert their own outcome

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Every example now asserts the outcome it demonstrates.** All 46 example
+  modules previously failed only on a returned error, so one that completed
+  down the wrong branch, computed a wrong value or skipped an activity still
+  exited 0 and passed the CI run-step. Each now compares what it claims to
+  show — the branch taken, the ordering, the value read back, the version
+  resolved — and fails when it differs, turning the existing exit-0 gate into
+  an outcome gate with no new CI machinery.
+- **`timer-event` faulted on every run.** Its ServiceTask was built on an
+  operation with no implementation, so the instance failed and terminated; the
+  example blocked on the context deadline and printed "Process completed"
+  regardless. It now has a real operation and requires a completed instance.
+- **`simple-timer` demonstrated behaviour the engine does not have.** It
+  claimed a timer Start Event instantiates a process on schedule; no instance
+  was ever created, because a timer start is deliberately not an instantiating
+  trigger and scheduled instantiation is unimplemented. It now starts the
+  instance explicitly and asserts the timer held the token for its full delay.
+
 ## [v0.10.0] - 2026-07-30
 
 **The BPMN Common Executable Subclass is complete.** Ad-Hoc Sub-Process was the last

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -50,16 +50,20 @@ implemented), and leaves this list.
   options actually accepted. Surfaced by `NewUserTask`'s list going stale when the
   triad options were added (SRD-034 M1). A comment-only correctness pass, no
   behaviour change.
-- **Examples assert their own outcome** — every example currently fails only on
-  an *error* (`if err != nil { log.Fatal(err) }`), so one that completes while
-  taking the wrong branch, computing a wrong value or skipping an activity
-  still exits 0 and passes the FIX-029 run-step. Add an outcome assertion to
-  each of the 46 example modules — compare the result the example claims to
-  demonstrate and `log.Fatalf` when it differs — which turns the existing
-  exit-0 gate into an outcome gate with no new CI machinery. Golden-output
-  files are the wrong tool here (generated ids, timestamps and map ordering
-  make them brittle); a self-assertion also reads as teaching material. Needs
-  no design doc — examples work lands as plain commits.
+- **Examples assert their own outcome** — **DONE** (2026-07-31). All 46 example
+  modules now compare the outcome they claim to demonstrate — the branch taken,
+  the execution order, the value read back, the version resolved — and fail
+  when it differs, so the existing exit-0 run-step became an outcome gate with
+  no new CI machinery. Assertions record from inside the tasks (synchronous
+  with the run) rather than from engine observers, whose facts arrive
+  asynchronously and can still be in flight when `WaitCompletion` returns;
+  the exception is `DataChange`, which is observer-only, and those examples
+  cancel the subscription first so the drain settles it. Golden-output files
+  stayed rejected for the reasons recorded here. Two examples turned out to be
+  broken and were fixed in the same work: `timer-event` faulted on every run
+  (a ServiceTask on an implementation-less operation) and `simple-timer`
+  demonstrated scheduled instantiation, which the engine deliberately does not
+  do. Landed as plain commits on `test/examples-assert-outcome`; no design doc.
 - **Discard/assertion lint guard** — one `golangci-lint` config pass adding
   `forbidigo` (or equivalent) patterns for two idioms the codebase has decided
   against: a bare `_ =` on an error-returning call outside the documented

--- a/examples/adhoc-subprocess/main.go
+++ b/examples/adhoc-subprocess/main.go
@@ -36,7 +36,10 @@ func run() error {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	proc, err := buildProcess("high")
+	// Records the order the Router drove the activities in.
+	log := newRunLog()
+
+	proc, err := buildProcess(log, "high")
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -60,6 +63,19 @@ func run() error {
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	// With severity=high the Router runs gather-logs first, then fans out to
+	// notify-customer and escalate — whose relative order is genuinely up to
+	// the scheduler — and closes only once both have settled. So the two
+	// checkable claims are the boundaries, not the middle.
+	if err := log.first("gather-logs"); err != nil {
+		return fmt.Errorf("router order: %w", err)
+	}
+
+	if err := log.last("close-incident",
+		"gather-logs", "notify-customer", "escalate"); err != nil {
+		return fmt.Errorf("router order: %w", err)
 	}
 
 	fmt.Printf("\n✓ adhoc-subprocess completed (%s): the Router drove four "+

--- a/examples/adhoc-subprocess/process.go
+++ b/examples/adhoc-subprocess/process.go
@@ -20,7 +20,7 @@ import (
 // The triage container holds four activities and NO sequence flows between
 // them — an Ad-Hoc Sub-Process is exactly that: work whose order the model
 // declines to fix. What runs, and when, is the Router's answer.
-func buildProcess(severity string) (*process.Process, error) {
+func buildProcess(log *runLog, severity string) (*process.Process, error) {
 	proc, err := process.New("incident-triage",
 		data.WithProperties(
 			data.MustProperty("severity",
@@ -52,7 +52,7 @@ func buildProcess(severity string) (*process.Process, error) {
 		{"escalate", "paged the on-call engineer"},
 		{"close-incident", "closed the incident"},
 	} {
-		task, terr := reportTask(step.name, step.says)
+		task, terr := reportTask(log, step.name, step.says)
 		if terr != nil {
 			return nil, terr
 		}
@@ -86,10 +86,13 @@ func buildProcess(severity string) (*process.Process, error) {
 
 // reportTask builds a Service Task that announces what it did. Inside an ad-hoc
 // container the activities are ordinary tasks — only their succession differs.
-func reportTask(name, says string) (*activities.ServiceTask, error) {
+func reportTask(
+	log *runLog, name, says string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name,
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			log.mark(name)
 			fmt.Printf("    ▶ %s: %s\n", name, says)
 
 			return nil, nil

--- a/examples/adhoc-subprocess/runlog.go
+++ b/examples/adhoc-subprocess/runlog.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// runLog records the ORDER in which the ad-hoc activities executed. A set is
+// not enough here: the Router decides what runs and when, and the claim this
+// example demonstrates is that close-incident runs LAST — only once the work
+// it depends on has settled. A run that closed the incident first would still
+// execute all four activities and complete the container.
+//
+// Recorded from inside the tasks rather than from an engine observer: observer
+// facts are delivered asynchronously and can still be in flight when
+// WaitCompletion returns, whereas a task that records as it executes is
+// synchronous with the run by construction.
+type runLog struct {
+	seq []string
+	m   sync.Mutex
+}
+
+func newRunLog() *runLog {
+	return &runLog{}
+}
+
+// mark appends the named step to the execution order.
+func (r *runLog) mark(name string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.seq = append(r.seq, name)
+}
+
+// first reports an error unless name was the first activity to run.
+func (r *runLog) first(name string) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if len(r.seq) == 0 || r.seq[0] != name {
+		return fmt.Errorf("ran %v, want %q first", r.seq, name)
+	}
+
+	return nil
+}
+
+// last reports an error unless name ran once, ran after every one of others,
+// and each of those ran too.
+func (r *runLog) last(name string, others ...string) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	at := func(n string) int {
+		for i, s := range r.seq {
+			if s == n {
+				return i
+			}
+		}
+
+		return -1
+	}
+
+	end := at(name)
+	if end != len(r.seq)-1 {
+		return fmt.Errorf("ran %v, want %q last", r.seq, name)
+	}
+
+	for _, o := range others {
+		if at(o) < 0 {
+			return fmt.Errorf("ran %v, but %q never ran", r.seq, o)
+		}
+	}
+
+	return nil
+}

--- a/examples/basic-process/process.go
+++ b/examples/basic-process/process.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/dr-dobermann/gobpm/pkg/model/activities"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
@@ -16,13 +17,17 @@ import (
 )
 
 // buildProcess assembles start → work(greet) → end, with a process-level
+// userName is the property value the ServiceTask reads back — declared once
+// and read by both the process data and the check, so they cannot drift.
+const userName = "dr.Dobermann"
+
 // "user_name" property the ServiceTask reads at runtime.
 func buildProcess() (*process.Process, error) {
 	proc, err := process.New("basic-process",
 		data.WithProperties(
 			data.MustProperty("user_name",
 				data.MustItemDefinition(
-					values.NewVariable("dr.Dobermann"),
+					values.NewVariable(userName),
 					foundation.WithID("user_name")),
 				data.ReadyDataState)))
 	if err != nil {
@@ -84,8 +89,24 @@ func greetOp() (service.Operation, error) {
 				return nil, fmt.Errorf("read RUNTIME/STARTED_AT: %w", err)
 			}
 
+			// Both reads are the demonstration — a declared property and an
+			// engine-published RUNTIME variable — so both are checked. A
+			// property that resolved to nothing, or a RUNTIME var that came
+			// back zero, would print a odd-looking line and complete.
+			if got := user.Value().Get(ctx); got != userName {
+				return nil, fmt.Errorf("user_name = %v, want %q",
+					got, userName)
+			}
+
+			at, ok := started.Value().Get(ctx).(time.Time)
+			if !ok || at.IsZero() {
+				return nil, fmt.Errorf(
+					"RUNTIME/STARTED_AT = %v, want a real start time",
+					started.Value().Get(ctx))
+			}
+
 			fmt.Printf("  ▶ hello, %v (instance started at %v)\n",
-				user.Value().Get(ctx), started.Value().Get(ctx))
+				user.Value().Get(ctx), at)
 
 			return nil, nil
 		})

--- a/examples/boundary-events/handlers.go
+++ b/examples/boundary-events/handlers.go
@@ -15,7 +15,7 @@ import (
 // take ~4s but honours its context, so when the timer boundary fires and the engine
 // cancels the track, it returns early. Its result is then discarded by the
 // interruption checkpoint (SRD-029 §3.7) — the normal "paid" flow is never taken.
-func paymentTask() (*activities.ServiceTask, error) {
+func paymentTask(ran *pathSet) (*activities.ServiceTask, error) {
 	op, err := gooper.New("process-payment",
 		func(ctx context.Context, _ service.DataReader,
 			_ *data.ItemDefinition,
@@ -24,11 +24,13 @@ func paymentTask() (*activities.ServiceTask, error) {
 
 			select {
 			case <-time.After(4 * time.Second):
+				ran.mark("payment-charged")
 				fmt.Println("  → process-payment: charged")
 
 				return nil, nil
 
 			case <-ctx.Done():
+				ran.mark("payment-interrupted")
 				fmt.Println("  ✗ process-payment: interrupted before it finished")
 
 				return nil, ctx.Err()
@@ -49,11 +51,14 @@ func paymentTask() (*activities.ServiceTask, error) {
 
 // printTask builds a ServiceTask that prints msg when it runs — used for the
 // exception handler the boundary routes to.
-func printTask(id, msg string) (*activities.ServiceTask, error) {
+func printTask(
+	ran *pathSet, id, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(id,
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition,
 		) (*data.ItemDefinition, error) {
+			ran.mark(id)
 			fmt.Println(msg)
 
 			return nil, nil

--- a/examples/boundary-events/main.go
+++ b/examples/boundary-events/main.go
@@ -45,7 +45,10 @@ func run() error {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records which tasks ran, so the interruption claim is checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(ran)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -69,6 +72,17 @@ func run() error {
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	// An INTERRUPTING boundary must do two things: run the exception handler
+	// and stop the host activity. Checking only the handler would pass even if
+	// the payment had gone on to charge the card after the boundary fired —
+	// the double-charge this pattern exists to prevent.
+	if err := ran.check(
+		[]string{"payment-interrupted", "cancel-order"},
+		[]string{"payment-charged"},
+	); err != nil {
+		return fmt.Errorf("boundary interruption: %w", err)
 	}
 
 	fmt.Printf("\n✓ boundary-events completed (%s): the 2s timer boundary fired "+

--- a/examples/boundary-events/pathset.go
+++ b/examples/boundary-events/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/boundary-events/process.go
+++ b/examples/boundary-events/process.go
@@ -23,7 +23,7 @@ import (
 // The 2s interrupting timer boundary fires before the ~4s payment finishes, so the
 // engine cancels the payment track, discards its result, and routes a token onto the
 // boundary's exception flow to cancel-order — the canonical "timeout on a long task".
-func buildProcess() (*process.Process, error) {
+func buildProcess(ran *pathSet) (*process.Process, error) {
 	proc, err := process.New("boundary-events")
 	if err != nil {
 		return nil, fmt.Errorf("new process: %w", err)
@@ -34,12 +34,12 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("start: %w", err)
 	}
 
-	payment, err := paymentTask()
+	payment, err := paymentTask(ran)
 	if err != nil {
 		return nil, err
 	}
 
-	cancelOrder, err := printTask("cancel-order",
+	cancelOrder, err := printTask(ran, "cancel-order",
 		"  → cancel-order: payment timed out, releasing the reservation")
 	if err != nil {
 		return nil, err

--- a/examples/bpmn-convert/main.go
+++ b/examples/bpmn-convert/main.go
@@ -17,7 +17,7 @@ import (
 	_ "embed"
 	"fmt"
 	"log"
-	"os"
+	"strings"
 	"time"
 
 	"github.com/dr-dobermann/gobpm/pkg/convert"
@@ -88,11 +88,41 @@ func run() error {
 
 	fmt.Println("--- exported BPMN ---")
 
-	if err := convert.Export(ctx, convert.BPMN, os.Stdout, p); err != nil {
+	// Exported into a buffer first, so the XML can be CHECKED before it is
+	// shown. Writing straight to stdout meant an exporter that emitted an
+	// empty definitions element — or dropped the flows between the nodes —
+	// printed something plausible and exited 0.
+	var bpmn bytes.Buffer
+
+	if err := convert.Export(ctx, convert.BPMN, &bpmn, p); err != nil {
 		return fmt.Errorf("export: %w", err)
 	}
 
-	fmt.Println()
+	if err := checkExport(bpmn.String()); err != nil {
+		return fmt.Errorf("exported BPMN: %w", err)
+	}
+
+	fmt.Println(bpmn.String())
+
+	return nil
+}
+
+// checkExport requires the exported XML to carry every element of the process
+// that was built — each node by id and name, and each sequence flow with the
+// pair of nodes it connects. A round-trip of the model is the whole point of
+// the exporter, so anything missing here is a silent loss.
+func checkExport(xml string) error {
+	for _, want := range []string{
+		`<bpmn:startEvent id="s1" name="start">`,
+		`<bpmn:task id="t1" name="work">`,
+		`<bpmn:endEvent id="e1" name="done">`,
+		`<bpmn:sequenceFlow id="f1" sourceRef="s1" targetRef="t1">`,
+		`<bpmn:sequenceFlow id="f2" sourceRef="t1" targetRef="e1">`,
+	} {
+		if !strings.Contains(xml, want) {
+			return fmt.Errorf("missing %s", want)
+		}
+	}
 
 	return nil
 }

--- a/examples/business-rule-task/main.go
+++ b/examples/business-rule-task/main.go
@@ -69,6 +69,33 @@ func run() error {
 		return fmt.Errorf("waiting for completion: %w", err)
 	}
 
+	if state != thresher.StateCompleted {
+		return fmt.Errorf("process finished %s, want %s",
+			state, thresher.StateCompleted)
+	}
+
+	// The claim below is specific — discount_pct=15 — so check it. A rule engine
+	// that returned nothing, or the wrong rate, would still complete the process.
+	pctD, err := h.Data().GetData("discount_pct")
+	if err != nil {
+		return fmt.Errorf("read discount_pct: %w", err)
+	}
+
+	// int here, though the Lua and Decision-Table examples read the same named
+	// output as float64: the committed Go type follows whichever engine produced
+	// it. data.As names the type instead of silently yielding a zero.
+	pct, err := data.As[int](ctx, pctD.Value())
+	if err != nil {
+		return fmt.Errorf("discount_pct: %w", err)
+	}
+
+	const wantPct = 15
+
+	if pct != wantPct {
+		return fmt.Errorf("rule engine committed discount_pct=%v, want %v",
+			pct, wantPct)
+	}
+
 	fmt.Printf("\n✓ business-rule-task completed (%s): the pluggable rule "+
 		"engine (##GoRules) evaluated \"discount\" for a 250 order, the task "+
 		"committed discount_pct=15, and the conditional flow routed to "+

--- a/examples/call-activity/main.go
+++ b/examples/call-activity/main.go
@@ -23,6 +23,14 @@ func main() {
 	}
 }
 
+// The child adds 20% tax, so a caller passing subtotal must read back
+// wantTotal. Both the input and the assertion read these, so the expected
+// figure cannot drift from the one actually passed in.
+const (
+	subtotal  = 100
+	wantTotal = 120
+)
+
 func run() error {
 	fmt.Print(`
   call-activity:
@@ -56,7 +64,10 @@ func run() error {
 		return fmt.Errorf("build callee: %w", err)
 	}
 
-	caller, err := buildCaller(100)
+	// Captures what the caller read back, so the data contract is checked.
+	got := newSeen()
+
+	caller, err := buildCaller(got, subtotal)
 	if err != nil {
 		return fmt.Errorf("build caller: %w", err)
 	}
@@ -80,6 +91,14 @@ func run() error {
 	}
 
 	sub.Cancel()
+
+	// The point of a Call Activity is the data contract across the boundary:
+	// subtotal crosses in, the child computes, and total comes back. A child
+	// that computed the wrong figure — or an output mapping that never landed
+	// — would leave both processes completing normally.
+	if err := got.check(wantTotal); err != nil {
+		return fmt.Errorf("call contract: %w", err)
+	}
 
 	fmt.Printf("  ✓ completed (%s)\n", state)
 

--- a/examples/call-activity/process.go
+++ b/examples/call-activity/process.go
@@ -59,7 +59,7 @@ func buildCallee() (*process.Process, error) {
 
 // buildCaller assembles start → checkout[calls tax-calc] → show → end, seeding
 // "subtotal" and reading the child's "total" back.
-func buildCaller(subtotal int) (*process.Process, error) {
+func buildCaller(got *seen, subtotal int) (*process.Process, error) {
 	p, err := process.New("checkout",
 		data.WithProperties(prop("subtotal", subtotal)))
 	if err != nil {
@@ -78,7 +78,7 @@ func buildCaller(subtotal int) (*process.Process, error) {
 		return nil, err
 	}
 
-	show, err := showTask()
+	show, err := showTask(got)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func buildCaller(subtotal int) (*process.Process, error) {
 
 // showTask builds the ServiceTask that prints the child's "total" the loop
 // committed into the caller's scope.
-func showTask() (*activities.ServiceTask, error) {
+func showTask(got *seen) (*activities.ServiceTask, error) {
 	op, err := gooper.New("show",
 		func(ctx context.Context, ds service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
@@ -97,7 +97,10 @@ func showTask() (*activities.ServiceTask, error) {
 				return nil, err
 			}
 
-			fmt.Printf("  ✓ caller sees total=%v\n", d.Value().Get(ctx))
+			total := d.Value().Get(ctx)
+			got.record(total)
+
+			fmt.Printf("  ✓ caller sees total=%v\n", total)
 
 			return nil, nil
 		})

--- a/examples/call-activity/seen.go
+++ b/examples/call-activity/seen.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// seen captures the value the caller actually read back from the child, so the
+// example can ASSERT the data contract rather than only print it. The child
+// computing the wrong total — or the output mapping never landing at all —
+// would still complete both processes and exit 0.
+//
+// Captured inside the task rather than through an engine observer: observer
+// facts are delivered asynchronously and can still be in flight when
+// WaitCompletion returns.
+type seen struct {
+	total any
+	got   bool
+	m     sync.Mutex
+}
+
+func newSeen() *seen {
+	return &seen{}
+}
+
+// record stores the total the show task read from the caller's scope.
+func (s *seen) record(total any) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	s.total, s.got = total, true
+}
+
+// check reports an error unless the caller read exactly want.
+func (s *seen) check(want int) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	if !s.got {
+		return fmt.Errorf("the caller never read %q back from the child",
+			"total")
+	}
+
+	if s.total != want {
+		return fmt.Errorf("caller read total=%v, want %d", s.total, want)
+	}
+
+	return nil
+}

--- a/examples/compensation-events/handlers.go
+++ b/examples/compensation-events/handlers.go
@@ -14,10 +14,13 @@ import (
 )
 
 // bookTask builds a booking step that prints its action.
-func bookTask(name, msg string) (*activities.ServiceTask, error) {
+func bookTask(
+	log *runLog, name, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name+"-op",
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			log.mark(name)
 			fmt.Println(msg)
 
 			return nil, nil
@@ -36,10 +39,13 @@ func bookTask(name, msg string) (*activities.ServiceTask, error) {
 
 // undoTask builds an isForCompensation handler that prints its undo action —
 // it lives outside the normal flow and runs only when compensation is thrown.
-func undoTask(name, msg string) (*activities.ServiceTask, error) {
+func undoTask(
+	log *runLog, name, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name+"-op",
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			log.mark(name)
 			fmt.Println(msg)
 
 			return nil, nil

--- a/examples/compensation-events/main.go
+++ b/examples/compensation-events/main.go
@@ -34,7 +34,10 @@ func run() error {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records the execution order, so the reverse-order claim is checked.
+	log := newRunLog()
+
+	proc, err := buildProcess(log)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -58,6 +61,14 @@ func run() error {
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	// Reverse order is the claim: hotel and flight are booked forwards, and
+	// the Compensation End Event must undo the LAST completed activity first.
+	if err := log.check(
+		"book-hotel", "book-flight", "undo-flight", "undo-hotel",
+	); err != nil {
+		return fmt.Errorf("compensation order: %w", err)
 	}
 
 	fmt.Printf("\n✓ compensation-events completed (%s): both bookings entered "+

--- a/examples/compensation-events/process.go
+++ b/examples/compensation-events/process.go
@@ -17,7 +17,7 @@ import (
 // snapshot each). The Compensation End Event then compensates the whole
 // scope in REVERSE completion order — undo-flight runs before undo-hotel —
 // waiting for both handlers before the instance completes.
-func buildProcess() (*process.Process, error) {
+func buildProcess(log *runLog) (*process.Process, error) {
 	proc, err := process.New("compensation-events")
 	if err != nil {
 		return nil, fmt.Errorf("new process: %w", err)
@@ -28,22 +28,22 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("start: %w", err)
 	}
 
-	hotel, err := bookTask("book-hotel", "  ✓ hotel booked")
+	hotel, err := bookTask(log, "book-hotel", "  ✓ hotel booked")
 	if err != nil {
 		return nil, err
 	}
 
-	flight, err := bookTask("book-flight", "  ✓ flight booked")
+	flight, err := bookTask(log, "book-flight", "  ✓ flight booked")
 	if err != nil {
 		return nil, err
 	}
 
-	undoHotel, err := undoTask("undo-hotel", "  ↩ hotel booking canceled")
+	undoHotel, err := undoTask(log, "undo-hotel", "  ↩ hotel booking canceled")
 	if err != nil {
 		return nil, err
 	}
 
-	undoFlight, err := undoTask("undo-flight", "  ↩ flight booking canceled")
+	undoFlight, err := undoTask(log, "undo-flight", "  ↩ flight booking canceled")
 	if err != nil {
 		return nil, err
 	}

--- a/examples/compensation-events/runlog.go
+++ b/examples/compensation-events/runlog.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// runLog records the ORDER in which the booking and undo steps executed. A set
+// would not be enough here: the claim this example demonstrates is that
+// compensation runs the handlers in REVERSE order of the activities that
+// completed, so "both undo handlers ran" is true even of a wrong implementation
+// that ran them forwards.
+//
+// Recorded from inside the tasks rather than from an engine observer: observer
+// facts are delivered asynchronously and can still be in flight when
+// WaitCompletion returns, whereas a task that records as it executes is
+// synchronous with the run by construction.
+type runLog struct {
+	seq []string
+	m   sync.Mutex
+}
+
+func newRunLog() *runLog {
+	return &runLog{}
+}
+
+// mark appends the named step to the execution order.
+func (r *runLog) mark(name string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.seq = append(r.seq, name)
+}
+
+// check reports an error unless the steps executed in exactly this order.
+func (r *runLog) check(want ...string) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if strings.Join(r.seq, ",") != strings.Join(want, ",") {
+		return fmt.Errorf("ran %v, want %v", r.seq, want)
+	}
+
+	return nil
+}

--- a/examples/complex-gateway/main.go
+++ b/examples/complex-gateway/main.go
@@ -46,7 +46,10 @@ func run() error {
 
 	const amount = 500 // < 1000 → two of the three approvals are enough
 
-	proc, err := buildProcess(amount)
+	// Records which approval tasks ran, so the join claim can be checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(amount, ran)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -72,6 +75,23 @@ func run() error {
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	if state != thresher.StateCompleted {
+		return fmt.Errorf("process finished %s, want %s",
+			state, thresher.StateCompleted)
+	}
+
+	// The join fires on the 2nd of 3 approvals, so finalize must run — and at
+	// least two approvals must have happened. WHICH two is a race, so the count
+	// is asserted rather than the names: pinning specific approvers here would
+	// itself be a flaky assertion.
+	if err := ran.check([]string{"finalize"}, nil); err != nil {
+		return fmt.Errorf("join: %w", err)
+	}
+
+	if got := ran.ranCount("manager", "finance", "cfo"); got < 2 {
+		return fmt.Errorf("join fired after %d approvals, want at least 2", got)
 	}
 
 	fmt.Printf("✓ complex-gateway completed (%s): the join fired on the 2nd "+

--- a/examples/complex-gateway/pathset.go
+++ b/examples/complex-gateway/pathset.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}
+
+// ranCount reports how many of the named tasks ran — for a join that fires on
+// the Nth of M branches, where WHICH ones arrive first is not fixed.
+func (p *pathSet) ranCount(names ...string) int {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	n := 0
+
+	for _, name := range names {
+		if p.ran[name] {
+			n++
+		}
+	}
+
+	return n
+}

--- a/examples/complex-gateway/process.go
+++ b/examples/complex-gateway/process.go
@@ -27,7 +27,7 @@ import (
 // activation rule [(amount<1000, 2), (amount>=1000, 3)] — two approvals suffice
 // for a small order, all three for a large — consuming any later approval as a
 // trailing token (partial-join / discriminator family, WCP-30 / WCP-9).
-func buildProcess(amount int) (*process.Process, error) {
+func buildProcess(amount int, ran *pathSet) (*process.Process, error) {
 	proc, err := process.New("order-approval",
 		data.WithProperties(
 			data.MustProperty("amount",
@@ -53,7 +53,7 @@ func buildProcess(amount int) (*process.Process, error) {
 		return nil, err
 	}
 
-	finalize, err := printTask("finalize", "  ✓ order finalized")
+	finalize, err := printTask(ran, "finalize", "  ✓ order finalized")
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func buildProcess(amount int) (*process.Process, error) {
 		return nil, fmt.Errorf("create end: %w", err)
 	}
 
-	approvers, err := approverTasks()
+	approvers, err := approverTasks(ran)
 	if err != nil {
 		return nil, err
 	}
@@ -104,11 +104,11 @@ func approvalJoin() (*gateways.ComplexGateway, error) {
 }
 
 // approverTasks builds the three parallel approver service tasks.
-func approverTasks() ([]flow.Element, error) {
+func approverTasks(ran *pathSet) ([]flow.Element, error) {
 	tasks := []flow.Element{}
 
 	for _, name := range []string{"manager", "finance", "cfo"} {
-		t, err := printTask(name, "  ▶ "+name+" approved")
+		t, err := printTask(ran, name, "  ▶ "+name+" approved")
 		if err != nil {
 			return nil, err
 		}
@@ -159,10 +159,14 @@ func amountCond(pred func(a int) bool) data.FormalExpression {
 }
 
 // printTask builds a ServiceTask whose Go functor prints msg.
-func printTask(name, msg string) (*activities.ServiceTask, error) {
+func printTask(
+	ran *pathSet, name, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name,
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.mark(name)
+
 			fmt.Println(msg)
 
 			return nil, nil

--- a/examples/conditional-events/main.go
+++ b/examples/conditional-events/main.go
@@ -50,7 +50,10 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records whether the conditional catch actually fired.
+	ran := newPathSet()
+
+	proc, err := buildProcess(ran)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -72,6 +75,14 @@ func run() error {
 	// Cancel drains the buffered facts so the fire line lands before the
 	// final status prints.
 	sub.Cancel()
+
+	// notify sits behind the conditional catch, so it runs only if the
+	// condition observed the false→true edge. A catch that never fired would
+	// leave its branch parked — and the process would still complete through
+	// the sibling branch's end event.
+	if err := ran.check([]string{"notify"}, nil); err != nil {
+		return fmt.Errorf("conditional catch: %w", err)
+	}
 
 	fmt.Printf("  ✓ completed (%s)\n", state)
 

--- a/examples/conditional-events/model.go
+++ b/examples/conditional-events/model.go
@@ -20,7 +20,7 @@ import (
 // addItems' committed total=140 re-evaluates the condition and the
 // false→true edge releases the notify path — data-driven waiting without
 // polling.
-func buildProcess() (*process.Process, error) {
+func buildProcess(ran *pathSet) (*process.Process, error) {
 	proc, err := process.New("conditional-events",
 		data.WithProperties(
 			data.MustProperty("total",
@@ -57,7 +57,7 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("create watch catch: %w", err)
 	}
 
-	notify, err := notifyTask()
+	notify, err := notifyTask(ran)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/conditional-events/pathset.go
+++ b/examples/conditional-events/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/conditional-events/process.go
+++ b/examples/conditional-events/process.go
@@ -34,10 +34,11 @@ func commitTask(taskName, dataName string, value int) (*activities.ServiceTask, 
 }
 
 // notifyTask prints the released-path marker.
-func notifyTask() (*activities.ServiceTask, error) {
+func notifyTask(ran *pathSet) (*activities.ServiceTask, error) {
 	op, err := gooper.New("notify",
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.mark("notify")
 			fmt.Println("  notify → the total crossed 100, shipping upgraded")
 
 			return nil, nil

--- a/examples/data-change/main.go
+++ b/examples/data-change/main.go
@@ -41,7 +41,8 @@ func run() error {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	sub := engine.Observe(&dataChangePrinter{})
+	changes := &dataChangePrinter{}
+	sub := engine.Observe(changes)
 	defer sub.Cancel()
 
 	if err := engine.Run(ctx); err != nil {
@@ -70,6 +71,18 @@ func run() error {
 	// Cancel drains the buffered facts so both DataChange lines land before
 	// the final status prints.
 	sub.Cancel()
+
+	// The commit-diff granularity is the whole demonstration: a whole-value
+	// first commit must surface as ONE Value_Added at the root, and a later
+	// commit touching one field as ONE Value_Updated at that field's path.
+	// A diff that reported per-field adds on the first commit, or re-reported
+	// the root on the second, would print more lines and complete identically.
+	if err := changes.check(
+		"Value_Added receipt @produce",
+		"Value_Updated receipt.sum @reprice",
+	); err != nil {
+		return fmt.Errorf("change stream: %w", err)
+	}
 
 	fmt.Printf("  ✓ completed (%s)\n", state)
 

--- a/examples/data-change/observer.go
+++ b/examples/data-change/observer.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+	"sync"
 
 	"github.com/dr-dobermann/gobpm/pkg/observability"
 )
@@ -10,7 +13,17 @@ import (
 // DataChange facts — the per-path change signal the commit-diff produces.
 // DataChange is observer-only (never echoed to the operator log), so an
 // observer like this is the way to see it.
-type dataChangePrinter struct{}
+//
+// It also RECORDS what it saw, so the example can assert the change stream
+// rather than only print it: a commit-diff that reported the wrong kind, the
+// wrong path, or nothing at all would leave the process completing normally.
+// Reading the record is safe because the example cancels the subscription
+// first, and Cancel drains the facts still in flight — the asynchronous
+// delivery that makes observer assertions racy elsewhere is settled by then.
+type dataChangePrinter struct {
+	seen []string
+	m    sync.Mutex
+}
 
 // OnFact prints one line per DataChange fact: the change kind (the phase),
 // the changed data path, and the node whose commit produced it.
@@ -19,6 +32,44 @@ func (p *dataChangePrinter) OnFact(f observability.Fact) {
 		return
 	}
 
-	fmt.Printf("  ▶ %s %s @%s\n",
+	change := fmt.Sprintf("%s %s @%s",
 		f.Phase, f.Details[observability.AttrDataPath], f.NodeName)
+
+	p.m.Lock()
+	p.seen = append(p.seen, change)
+	p.m.Unlock()
+
+	fmt.Printf("  ▶ %s\n", change)
+}
+
+// check reports an error unless exactly these changes were observed, in order.
+func (p *dataChangePrinter) check(want ...string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if strings.Join(p.seen, " | ") != strings.Join(want, " | ") {
+		return fmt.Errorf("saw %v, want %v", p.seen, want)
+	}
+
+	return nil
+}
+
+// checkSet reports an error unless exactly these changes were observed, in any
+// order — for commits whose changes come from a map, whose iteration order is
+// deliberately unspecified.
+func (p *dataChangePrinter) checkSet(want ...string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	got := append([]string(nil), p.seen...)
+	sort.Strings(got)
+
+	w := append([]string(nil), want...)
+	sort.Strings(w)
+
+	if strings.Join(got, " | ") != strings.Join(w, " | ") {
+		return fmt.Errorf("saw %v, want %v (in any order)", p.seen, want)
+	}
+
+	return nil
 }

--- a/examples/decision-table/main.go
+++ b/examples/decision-table/main.go
@@ -36,17 +36,24 @@ func run() error {
 		return err
 	}
 
+	// wantPct is the rate the deployed FIRST-policy table must choose for each
+	// profile — the same claim this example prints when it finishes. Checking it
+	// is what separates "the table was consulted" from "the table was right":
+	// a table that returned the fallthrough rate for every order would otherwise
+	// complete three times and exit 0.
 	for _, order := range []struct {
-		tier  string
-		total int
+		tier    string
+		total   int
+		wantPct float64
 	}{
-		{tier: "vip", total: 500},
-		{tier: "retail", total: 150},
-		{tier: "retail", total: 40},
+		{tier: "vip", total: 500, wantPct: 25},
+		{tier: "retail", total: 150, wantPct: 15},
+		{tier: "retail", total: 40, wantPct: 5},
 	} {
 		fmt.Printf("\norder: tier=%s total=%d\n", order.tier, order.total)
 
-		if err := runOrder(ruleEngine, order.total, order.tier); err != nil {
+		if err := runOrder(
+			ruleEngine, order.total, order.tier, order.wantPct); err != nil {
 			return err
 		}
 	}
@@ -59,7 +66,9 @@ func run() error {
 
 // runOrder runs one process instance for an order profile against the
 // shared, already-deployed rule engine.
-func runOrder(ruleEngine *dtable.Engine, total int, tier string) error {
+func runOrder(
+	ruleEngine *dtable.Engine, total int, tier string, wantPct float64,
+) error {
 	engine, err := thresher.New(
 		fmt.Sprintf("decision-table-%s-%d", tier, total),
 		thresher.WithoutBanner(),
@@ -90,8 +99,31 @@ func runOrder(ruleEngine *dtable.Engine, total int, tier string) error {
 		return fmt.Errorf("start process: %w", err)
 	}
 
-	if _, err := h.WaitCompletion(ctx); err != nil {
+	state, err := h.WaitCompletion(ctx)
+	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	if state != thresher.StateCompleted {
+		return fmt.Errorf("order tier=%s total=%d finished %s, want %s",
+			tier, total, state, thresher.StateCompleted)
+	}
+
+	pctD, err := h.Data().GetData("discount_pct")
+	if err != nil {
+		return fmt.Errorf("read discount_pct: %w", err)
+	}
+
+	// data.As rather than a bare .(T): the yields commit float64, and a silent
+	// mismatch would compare a zero against the expected rate.
+	pct, err := data.As[float64](ctx, pctD.Value())
+	if err != nil {
+		return fmt.Errorf("discount_pct: %w", err)
+	}
+
+	if pct != wantPct {
+		return fmt.Errorf("order tier=%s total=%d got %v%%, want %v%%",
+			tier, total, pct, wantPct)
 	}
 
 	return nil

--- a/examples/embedded-subprocess/main.go
+++ b/examples/embedded-subprocess/main.go
@@ -48,7 +48,10 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Captures what each step resolved, so the scope walk-up is checked.
+	saw := newSightings()
+
+	proc, err := buildProcess(saw)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -68,6 +71,15 @@ func run() error {
 	}
 
 	sub.Cancel()
+
+	// Scope visibility is the demonstration: pick and pack run INSIDE the
+	// embedded sub-process and must still resolve the parent's order-id by
+	// walking up. Without this, a broken walk-up would print a shorter line
+	// and the process would complete exactly as before.
+	if err := saw.check(orderID,
+		"accept", "pick", "pack", "notify"); err != nil {
+		return fmt.Errorf("scope walk-up: %w", err)
+	}
 
 	fmt.Printf("  ✓ completed (%s)\n", state)
 

--- a/examples/embedded-subprocess/model.go
+++ b/examples/embedded-subprocess/model.go
@@ -13,6 +13,10 @@ import (
 )
 
 // intValue wraps an int as a process value.
+// orderID is the property the parent declares and every step must resolve by
+// walking up the scope chain — read by both the declaration and the assertion.
+const orderID = 4711
+
 func intValue(v int) data.Value { return values.NewVariable(v) }
 
 // buildProcess assembles the order flow with the fulfillment fragment as
@@ -23,7 +27,7 @@ func intValue(v int) data.Value { return values.NewVariable(v) }
 // The fragment runs in its own scope: pick/pack read the parent's
 // order-id through the walk-up, their scratch data stays scoped, and the
 // parent resumes only when the fragment drains (BPMN §13.3.4).
-func buildProcess() (*process.Process, error) {
+func buildProcess(saw *sightings) (*process.Process, error) {
 	fulfil, err := activities.NewSubProcess("fulfil")
 	if err != nil {
 		return nil, fmt.Errorf("create sub-process: %w", err)
@@ -34,12 +38,12 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("create f-start: %w", err)
 	}
 
-	pick, err := step("pick", "picked", 1)
+	pick, err := step(saw, "pick", "picked", 1)
 	if err != nil {
 		return nil, err
 	}
 
-	pack, err := step("pack", "", 0)
+	pack, err := step(saw, "pack", "", 0)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +62,7 @@ func buildProcess() (*process.Process, error) {
 	proc, err := process.New("embedded-subprocess",
 		data.WithProperties(
 			data.MustProperty("order-id",
-				data.MustItemDefinition(intValue(4711),
+				data.MustItemDefinition(intValue(orderID),
 					foundation.WithID("order-id")),
 				data.ReadyDataState)))
 	if err != nil {
@@ -70,12 +74,12 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("create start: %w", err)
 	}
 
-	accept, err := step("accept", "", 0)
+	accept, err := step(saw, "accept", "", 0)
 	if err != nil {
 		return nil, err
 	}
 
-	notify, err := step("notify", "", 0)
+	notify, err := step(saw, "notify", "", 0)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/embedded-subprocess/process.go
+++ b/examples/embedded-subprocess/process.go
@@ -14,15 +14,24 @@ import (
 // step builds an in-process task printing its name; when put is non-empty
 // the task also commits put=val — inside a sub-process the commit lands in
 // the CHILD scope and dies with it (§10.5.7).
-func step(name, put string, val int) (*activities.ServiceTask, error) {
+func step(
+	saw *sightings, name, put string, val int,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name,
 		func(_ context.Context, ds service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
 			if d, err := ds.GetData("order-id"); err == nil {
-				fmt.Printf("  %s (sees order-id=%v)\n",
-					name, d.Value().Get(context.Background()))
+				id := d.Value().Get(context.Background())
+				saw.record(name, id)
+
+				fmt.Printf("  %s (sees order-id=%v)\n", name, id)
 			} else {
-				fmt.Printf("  %s\n", name)
+				// Recorded as nil rather than skipped: a failed walk-up is
+				// exactly what the assertion in main needs to catch, and
+				// printing a shorter line used to hide it.
+				saw.record(name, nil)
+
+				fmt.Printf("  %s (could not see order-id)\n", name)
 			}
 
 			if put == "" {

--- a/examples/embedded-subprocess/sightings.go
+++ b/examples/embedded-subprocess/sightings.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// sightings records what each step saw when it looked up "order-id". The claim
+// this example demonstrates is the scope walk-up: a task inside the embedded
+// sub-process resolves a property declared on the PARENT. A step that failed to
+// resolve it would print a shorter line and carry on, and the process would
+// still complete — so the lookup result is what has to be checked, per step.
+//
+// Recorded inside the tasks rather than through an engine observer: observer
+// facts are delivered asynchronously and can still be in flight when
+// WaitCompletion returns.
+type sightings struct {
+	saw map[string]any
+	m   sync.Mutex
+}
+
+func newSightings() *sightings {
+	return &sightings{saw: map[string]any{}}
+}
+
+// record stores what step saw; a step that could not resolve the property
+// records nil, which is what makes the failure visible.
+func (s *sightings) record(step string, value any) {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	s.saw[step] = value
+}
+
+// check reports an error unless every named step resolved the property to want.
+func (s *sightings) check(want any, steps ...string) error {
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	var bad []string
+
+	for _, st := range steps {
+		got, ran := s.saw[st]
+		switch {
+		case !ran:
+			bad = append(bad, fmt.Sprintf("%s never ran", st))
+		case got != want:
+			bad = append(bad, fmt.Sprintf("%s saw %v", st, got))
+		}
+	}
+
+	if len(bad) > 0 {
+		sort.Strings(bad)
+
+		return fmt.Errorf("want every step to see %v: %s",
+			want, strings.Join(bad, "; "))
+	}
+
+	return nil
+}

--- a/examples/escalation-events/handlers.go
+++ b/examples/escalation-events/handlers.go
@@ -12,10 +12,11 @@ import (
 
 // notifyManager builds the ServiceTask on the boundary's exception flow — the
 // escalation handler that runs when the order review escalates over budget.
-func notifyManager() (*activities.ServiceTask, error) {
+func notifyManager(ran *pathSet) (*activities.ServiceTask, error) {
 	op, err := gooper.New("notify-manager",
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.mark("notify-manager")
 			fmt.Println("  → notify-manager: order escalated (OVER_BUDGET), " +
 				"routing to a human approver")
 

--- a/examples/escalation-events/main.go
+++ b/examples/escalation-events/main.go
@@ -35,7 +35,10 @@ func run() error {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records which tasks ran, so the escalation routing is checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(ran)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -59,6 +62,14 @@ func run() error {
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	// notify-manager sits on the boundary's exception flow and is reachable
+	// ONLY through it, so its having run is what proves the escalation was
+	// caught. A sub-process that swallowed the escalation would take the
+	// normal flow to end-approved and still complete the process.
+	if err := ran.check([]string{"notify-manager"}, nil); err != nil {
+		return fmt.Errorf("escalation routing: %w", err)
 	}
 
 	fmt.Printf("\n✓ escalation-events completed (%s): review-order raised a "+

--- a/examples/escalation-events/pathset.go
+++ b/examples/escalation-events/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/escalation-events/process.go
+++ b/examples/escalation-events/process.go
@@ -17,7 +17,7 @@ import (
 //	             (raise OVER_BUDGET, Escalation End Event)
 //	             ╳ (escalation boundary OVER_BUDGET, interrupting)
 //	             └─> [notify-manager] ──────────> end-escalated
-func buildProcess() (*process.Process, error) {
+func buildProcess(ran *pathSet) (*process.Process, error) {
 	proc, err := process.New("escalation-events")
 	if err != nil {
 		return nil, fmt.Errorf("new process: %w", err)
@@ -48,7 +48,7 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("boundary: %w", err)
 	}
 
-	notify, err := notifyManager()
+	notify, err := notifyManager(ran)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/event-based-gateway/main.go
+++ b/examples/event-based-gateway/main.go
@@ -47,7 +47,10 @@ func run() error {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records which tasks ran, so the routing claim can be checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(ran)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -80,6 +83,15 @@ func run() error {
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	// The deferred choice is the whole point: the arm whose event arrived
+	// first must run and the other must NOT. Without this, a run that took
+	// the timer arm — or neither — still exits 0.
+	if err := ran.check(
+		[]string{"approved"}, []string{"timedOut"},
+	); err != nil {
+		return fmt.Errorf("deferred choice: %w", err)
 	}
 
 	fmt.Printf("✓ event-based-gateway completed (%s): the gate fired the arm "+

--- a/examples/event-based-gateway/pathset.go
+++ b/examples/event-based-gateway/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/event-based-gateway/process.go
+++ b/examples/event-based-gateway/process.go
@@ -30,7 +30,7 @@ const approvalMessage = "approval"
 // The gate subscribes to BOTH arms and routes the token down whichever fires first;
 // the other subscription is dropped. The demo publishes the approval message, so the
 // approval arm wins before the timer — the timer is the self-terminating fallback.
-func buildProcess() (*process.Process, error) {
+func buildProcess(ran *pathSet) (*process.Process, error) {
 	proc, err := process.New("event-based-gateway")
 	if err != nil {
 		return nil, fmt.Errorf("new process: %w", err)
@@ -57,13 +57,13 @@ func buildProcess() (*process.Process, error) {
 		return nil, err
 	}
 
-	approved, err := printTask("approved",
+	approved, err := printTask(ran, "approved",
 		"  ✓ approval arrived first → order approved")
 	if err != nil {
 		return nil, err
 	}
 
-	timedOut, err := printTask("timedOut",
+	timedOut, err := printTask(ran, "timedOut",
 		"  ✓ 10s elapsed first → order timed out")
 	if err != nil {
 		return nil, err
@@ -143,10 +143,14 @@ func timerCatch(id string, d time.Duration) (*events.IntermediateCatchEvent, err
 }
 
 // printTask builds a ServiceTask whose Go functor prints msg when the arm runs.
-func printTask(id, msg string) (*activities.ServiceTask, error) {
+func printTask(
+	ran *pathSet, id, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(id,
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.mark(id)
+
 			fmt.Println(msg)
 
 			return nil, nil

--- a/examples/event-based-parallel-start/fulfill.go
+++ b/examples/event-based-parallel-start/fulfill.go
@@ -15,7 +15,8 @@ const orderID = "ORD-7"
 // fulfill publishes the two correlated messages and waits for the event-born
 // instance (no StartProcess — the gate instantiates) to complete on both.
 func fulfill(
-	ctx context.Context, engine *thresher.Thresher, broker *membroker.Broker,
+	ctx context.Context, engine *thresher.Thresher,
+	broker *membroker.Broker, ran *pathSet,
 ) error {
 	fmt.Println("publishing 'order placed' (creates the instance)...")
 
@@ -41,6 +42,15 @@ func fulfill(
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	// The claim is that ONE instance handled BOTH messages: if the second
+	// message had created a second instance instead of re-arming this one,
+	// this instance would still complete and the run would still exit 0.
+	if err := ran.check(
+		[]string{"record-order", "record-payment"}, nil,
+	); err != nil {
+		return fmt.Errorf("parallel instantiation: %w", err)
 	}
 
 	fmt.Printf("✓ order-fulfillment completed (%s): one instance, born by the "+

--- a/examples/event-based-parallel-start/main.go
+++ b/examples/event-based-parallel-start/main.go
@@ -39,7 +39,10 @@ func run() error {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records which tasks ran, so the routing claim can be checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(ran)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -55,5 +58,5 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	return fulfill(ctx, engine, broker)
+	return fulfill(ctx, engine, broker, ran)
 }

--- a/examples/event-based-parallel-start/pathset.go
+++ b/examples/event-based-parallel-start/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/event-based-parallel-start/process.go
+++ b/examples/event-based-parallel-start/process.go
@@ -29,7 +29,7 @@ const (
 // Event-Based gateway: the gate has no incoming flow, so the FIRST of its two
 // correlated messages creates the instance and the other re-arms keyed to it;
 // the instance completes only once BOTH have arrived (BPMN §13.2).
-func buildProcess() (*process.Process, error) {
+func buildProcess(ran *pathSet) (*process.Process, error) {
 	proc, err := process.New("order-fulfillment")
 	if err != nil {
 		return nil, fmt.Errorf("new process: %w", err)
@@ -58,13 +58,13 @@ func buildProcess() (*process.Process, error) {
 		return nil, err
 	}
 
-	recordOrder, err := printTask("record-order",
+	recordOrder, err := printTask(ran, "record-order",
 		"  ✓ order placed   → recorded")
 	if err != nil {
 		return nil, err
 	}
 
-	recordPay, err := printTask("record-payment",
+	recordPay, err := printTask(ran, "record-payment",
 		"  ✓ payment received → recorded")
 	if err != nil {
 		return nil, err
@@ -175,10 +175,14 @@ func messageCatch(
 	return ice, nil
 }
 
-func printTask(id, msg string) (*activities.ServiceTask, error) {
+func printTask(
+	ran *pathSet, id, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(id,
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.mark(id)
+
 			fmt.Println(msg)
 
 			return nil, nil

--- a/examples/event-subprocess/main.go
+++ b/examples/event-subprocess/main.go
@@ -47,7 +47,10 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records which steps ran, so the interruption claim is checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(ran)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -67,6 +70,17 @@ func run() error {
 	}
 
 	sub.Cancel()
+
+	// The event sub-process is INTERRUPTING: releaseHold must run and charge
+	// must not, because the payment never arrives. Checking only that the
+	// process completed would pass even if the handler had left the scope's
+	// normal flow running and charged an unpaid order.
+	if err := ran.check(
+		[]string{"checkout", "releaseHold", "notify"},
+		[]string{"charge"},
+	); err != nil {
+		return fmt.Errorf("event sub-process interruption: %w", err)
+	}
 
 	fmt.Printf("  ✓ completed (%s)\n", state)
 

--- a/examples/event-subprocess/model.go
+++ b/examples/event-subprocess/model.go
@@ -19,8 +19,8 @@ import (
 // The payment message is never sent, so the timer fires first: the handler
 // cancels the blocked wait, runs releaseHold, and — reaching its End without
 // re-throwing — absorbs the event, so the parent resumes on its normal flow.
-func buildProcess() (*process.Process, error) {
-	timeout, err := buildTimeoutHandler()
+func buildProcess(ran *pathSet) (*process.Process, error) {
+	timeout, err := buildTimeoutHandler(ran)
 	if err != nil {
 		return nil, err
 	}
@@ -38,7 +38,7 @@ func buildProcess() (*process.Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	charge, err := step("charge")
+	charge, err := step(ran, "charge")
 	if err != nil {
 		return nil, err
 	}
@@ -54,12 +54,12 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("assemble await-payment: %w", err)
 	}
 
-	return assembleProcess(await)
+	return assembleProcess(ran, await)
 }
 
 // buildTimeoutHandler builds the interrupting Event Sub-Process:
 // timer-start → releaseHold → end.
-func buildTimeoutHandler() (*activities.SubProcess, error) {
+func buildTimeoutHandler(ran *pathSet) (*activities.SubProcess, error) {
 	timeout, err := activities.NewSubProcess("payment-timeout",
 		activities.WithTriggeredByEvent())
 	if err != nil {
@@ -71,7 +71,7 @@ func buildTimeoutHandler() (*activities.SubProcess, error) {
 	if err != nil {
 		return nil, err
 	}
-	release, err := step("releaseHold")
+	release, err := step(ran, "releaseHold")
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,9 @@ func buildTimeoutHandler() (*activities.SubProcess, error) {
 }
 
 // assembleProcess wires the top-level flow start → checkout → await → notify → end.
-func assembleProcess(await *activities.SubProcess) (*process.Process, error) {
+func assembleProcess(
+	ran *pathSet, await *activities.SubProcess,
+) (*process.Process, error) {
 	proc, err := process.New("event-subprocess")
 	if err != nil {
 		return nil, fmt.Errorf("create process: %w", err)
@@ -100,11 +102,11 @@ func assembleProcess(await *activities.SubProcess) (*process.Process, error) {
 	if err != nil {
 		return nil, err
 	}
-	checkout, err := step("checkout")
+	checkout, err := step(ran, "checkout")
 	if err != nil {
 		return nil, err
 	}
-	notify, err := step("notify")
+	notify, err := step(ran, "notify")
 	if err != nil {
 		return nil, err
 	}

--- a/examples/event-subprocess/pathset.go
+++ b/examples/event-subprocess/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/event-subprocess/process.go
+++ b/examples/event-subprocess/process.go
@@ -17,10 +17,11 @@ import (
 )
 
 // step builds a ServiceTask that announces itself when it runs.
-func step(name string) (*activities.ServiceTask, error) {
+func step(ran *pathSet, name string) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name,
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.mark(name)
 			fmt.Printf("  %s\n", name)
 
 			return nil, nil

--- a/examples/expression-routing/main.go
+++ b/examples/expression-routing/main.go
@@ -43,7 +43,10 @@ func run() error {
 		return fmt.Errorf("init data states: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records which tasks ran, so the routing claim can be checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(ran)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -79,6 +82,15 @@ func run() error {
 
 	if _, err := h.WaitCompletion(ctx); err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	// Each of the three expression sites has an observable consequence:
+	// the lite+goexpr task flows run intake and fx-audit, and the lite
+	// time() gateway takes the urgent arm rather than the default one.
+	if err := ran.check(
+		[]string{"intake", "fx-audit", "urgent"}, []string{"standard"},
+	); err != nil {
+		return fmt.Errorf("expression routing: %w", err)
 	}
 
 	fmt.Print("\n✓ expression-routing completed: both engines routed " +

--- a/examples/expression-routing/pathset.go
+++ b/examples/expression-routing/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/expression-routing/process.go
+++ b/examples/expression-routing/process.go
@@ -14,18 +14,18 @@ import (
 // buildProcess assembles the order flow — the expression layer at THREE
 // consumer sites, two engines mixed with zero extra registration:
 //
-//	start → [intake] ─ lite ───→ (XOR) ─ lite ────→ [urgent] → [approve] → end
-//	            │                  └─── default ──→ [standard] → end
-//	            └───── goexpr ─→ [fx-audit] → end
+//		start → [intake] ─ lite ───→ (XOR) ─ lite ────→ [urgent] → [approve] → end
+//		            │                  └─── default ──→ [standard] → end
+//		            └───── goexpr ─→ [fx-audit] → end
 //
-//   - SITE 1, task flows: intake's outgoing flows mix a gobpm:lite TEXT
-//     condition with a ##GoExpr functor condition — one selection point,
-//     each expression routed to its own engine;
-//   - SITE 2, the gateway: the XOR branches on a lite time() comparison
-//     against the deadline, with a default flow;
-//   - SITE 3, user-task authorization: approve's assignee is computed by
-//     a lite string expression (tasks.go).
-func buildProcess() (*process.Process, error) {
+//	  - SITE 1, task flows: intake's outgoing flows mix a gobpm:lite TEXT
+//	    condition with a ##GoExpr functor condition — one selection point,
+//	    each expression routed to its own engine;
+//	  - SITE 2, the gateway: the XOR branches on a lite time() comparison
+//	    against the deadline, with a default flow;
+//	  - SITE 3, user-task authorization: approve's assignee is computed by
+//	    a lite string expression (tasks.go).
+func buildProcess(ran *pathSet) (*process.Process, error) {
 	props, err := orderData()
 	if err != nil {
 		return nil, err
@@ -42,12 +42,12 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("start: %w", err)
 	}
 
-	intake, err := printTask("intake", "  ▶ intake: checking the order")
+	intake, err := printTask(ran, "intake", "  ▶ intake: checking the order")
 	if err != nil {
 		return nil, err
 	}
 
-	fxAudit, err := printTask("fx-audit",
+	fxAudit, err := printTask(ran, "fx-audit",
 		`  ▶ fx-audit: rates["EUR"] < 1.2 (the ##GoExpr functor lane)`)
 	if err != nil {
 		return nil, err
@@ -58,13 +58,13 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("gateway: %w", err)
 	}
 
-	urgent, err := printTask("urgent",
+	urgent, err := printTask(ran, "urgent",
 		"  ▶ urgent: the deadline is near (the lite time() branch)")
 	if err != nil {
 		return nil, err
 	}
 
-	standard, err := printTask("standard",
+	standard, err := printTask(ran, "standard",
 		"  ▶ standard: no rush (the gateway's default flow)")
 	if err != nil {
 		return nil, err

--- a/examples/expression-routing/tasks.go
+++ b/examples/expression-routing/tasks.go
@@ -16,10 +16,14 @@ import (
 )
 
 // printTask builds a ServiceTask whose Go functor prints msg.
-func printTask(name, msg string) (*activities.ServiceTask, error) {
+func printTask(
+	ran *pathSet, name, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name,
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.mark(name)
+
 			fmt.Println(msg)
 
 			return nil, nil

--- a/examples/gateway-routing/main.go
+++ b/examples/gateway-routing/main.go
@@ -42,7 +42,10 @@ func run() error {
 
 	const amount = 2500
 
-	proc, err := buildProcess(amount)
+	// Records which branch tasks ran, so the routing claim can be checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(amount, ran)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -68,6 +71,19 @@ func run() error {
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	if state != thresher.StateCompleted {
+		return fmt.Errorf("process finished %s, want %s",
+			state, thresher.StateCompleted)
+	}
+
+	// amount is 2500, so the > 1000 branch must run and the default must not.
+	if err := ran.check(
+		[]string{"manager-review"},
+		[]string{"auto-approve"},
+	); err != nil {
+		return fmt.Errorf("routing for amount=%d: %w", amount, err)
 	}
 
 	fmt.Printf("✓ gateway-routing completed (%s): the exclusive gateway chose "+

--- a/examples/gateway-routing/pathset.go
+++ b/examples/gateway-routing/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/gateway-routing/process.go
+++ b/examples/gateway-routing/process.go
@@ -20,7 +20,7 @@ import (
 // buildProcess assembles: start → XOR{ amount > 1000 → manager-review |
 // default → auto-approve } → end. The exclusive gateway routes by the "amount"
 // property — data-based branching (ADR-005 §2.8).
-func buildProcess(amount int) (*process.Process, error) {
+func buildProcess(amount int, ran *pathSet) (*process.Process, error) {
 	proc, err := process.New("order-routing",
 		data.WithProperties(
 			data.MustProperty("amount",
@@ -42,13 +42,13 @@ func buildProcess(amount int) (*process.Process, error) {
 		return nil, fmt.Errorf("create gateway: %w", err)
 	}
 
-	review, err := printTask("manager-review",
+	review, err := printTask(ran, "manager-review",
 		"  ▶ amount > 1000 → routed to manager review")
 	if err != nil {
 		return nil, err
 	}
 
-	approve, err := printTask("auto-approve",
+	approve, err := printTask(ran, "auto-approve",
 		"  ▶ amount ≤ 1000 → auto-approved")
 	if err != nil {
 		return nil, err
@@ -116,11 +116,16 @@ func amountGt1000() data.FormalExpression {
 		})
 }
 
-// printTask builds a ServiceTask whose Go functor prints msg.
-func printTask(name, msg string) (*activities.ServiceTask, error) {
+// printTask builds a ServiceTask whose Go functor prints msg and records that it
+// ran, so main can assert which branch the gateway chose.
+func printTask(
+	ran *pathSet, name, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name,
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.mark(name)
+
 			fmt.Println(msg)
 
 			return nil, nil

--- a/examples/inclusive-join/main.go
+++ b/examples/inclusive-join/main.go
@@ -45,7 +45,10 @@ func run() error {
 
 	const amount = 1500 // > 1000 and > 500 → two branches fork; fast-track is not
 
-	proc, err := buildProcess(amount)
+	// Records which branch tasks ran, so the OR-join claim can be checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(amount, ran)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -71,6 +74,20 @@ func run() error {
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	if state != thresher.StateCompleted {
+		return fmt.Errorf("process finished %s, want %s",
+			state, thresher.StateCompleted)
+	}
+
+	// amount is 1500: > 1000 and > 500 arm two branches, < 100 arms none. The
+	// OR-join must then wait for exactly those two and run finalize once.
+	if err := ran.check(
+		[]string{"manager-review", "fraud-check", "finalize"},
+		[]string{"fast-track"},
+	); err != nil {
+		return fmt.Errorf("routing for amount=%d: %w", amount, err)
 	}
 
 	fmt.Printf("✓ inclusive-join completed (%s): the OR-join merged the active "+

--- a/examples/inclusive-join/pathset.go
+++ b/examples/inclusive-join/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/inclusive-join/process.go
+++ b/examples/inclusive-join/process.go
@@ -27,7 +27,7 @@ import (
 // The Inclusive split forks every branch whose condition is true (the true
 // subset); the Inclusive join waits for exactly that subset — a never-taken
 // branch is found unreachable and does not stall it — then continues once.
-func buildProcess(amount int) (*process.Process, error) {
+func buildProcess(amount int, ran *pathSet) (*process.Process, error) {
 	proc, err := process.New("order-or-diamond",
 		data.WithProperties(
 			data.MustProperty("amount",
@@ -56,22 +56,22 @@ func buildProcess(amount int) (*process.Process, error) {
 		return nil, fmt.Errorf("create OR-join: %w", err)
 	}
 
-	mgr, err := printTask("manager-review", "  ▶ amount > 1000 → manager review")
+	mgr, err := printTask(ran, "manager-review", "  ▶ amount > 1000 → manager review")
 	if err != nil {
 		return nil, err
 	}
 
-	fraud, err := printTask("fraud-check", "  ▶ amount > 500 → fraud check")
+	fraud, err := printTask(ran, "fraud-check", "  ▶ amount > 500 → fraud check")
 	if err != nil {
 		return nil, err
 	}
 
-	fast, err := printTask("fast-track", "  ▶ amount < 100 → fast-tracked")
+	fast, err := printTask(ran, "fast-track", "  ▶ amount < 100 → fast-tracked")
 	if err != nil {
 		return nil, err
 	}
 
-	finalize, err := printTask("finalize", "  ✓ branches merged → order finalized")
+	finalize, err := printTask(ran, "finalize", "  ✓ branches merged → order finalized")
 	if err != nil {
 		return nil, err
 	}
@@ -162,10 +162,14 @@ func amountCond(pred func(a int) bool) data.FormalExpression {
 }
 
 // printTask builds a ServiceTask whose Go functor prints msg.
-func printTask(name, msg string) (*activities.ServiceTask, error) {
+func printTask(
+	ran *pathSet, name, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name,
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.mark(name)
+
 			fmt.Println(msg)
 
 			return nil, nil

--- a/examples/link-events/handlers.go
+++ b/examples/link-events/handlers.go
@@ -53,6 +53,11 @@ func workTask(count *int) (*activities.ServiceTask, error) {
 	return activities.NewServiceTask("work", op, activities.WithoutParams())
 }
 
+// wantIterations is how many times the token must pass through work before
+// the loop condition lets it out — shared by the gateway condition and the
+// example's own assertion, so the two can never disagree.
+const wantIterations = 3
+
 // loopGateway builds the exclusive gateway and the exit condition count<3. The
 // condition reads the same counter the work task advances (one track, so no
 // shared-state race) — a fresh false→true edge is not needed here; the gateway
@@ -68,7 +73,7 @@ func loopGateway(
 	cond, err := goexpr.New(nil,
 		data.MustItemDefinition(values.NewVariable(false)),
 		func(_ context.Context, _ data.Source) (data.Value, error) {
-			return values.NewVariable(*count < 3), nil
+			return values.NewVariable(*count < wantIterations), nil
 		})
 	if err != nil {
 		return nil, nil, fmt.Errorf("create loop condition: %w", err)

--- a/examples/link-events/main.go
+++ b/examples/link-events/main.go
@@ -75,6 +75,14 @@ func run() error {
 		return fmt.Errorf("wait completion: %w", err)
 	}
 
+	// The Link redirect is what carries the token back to work each pass, so
+	// the iteration count IS the demonstration. A process whose Link failed to
+	// wire would run work once and still complete.
+	if count != wantIterations {
+		return fmt.Errorf("work ran %d times, want %d — the Link redirect "+
+			"did not carry the token back", count, wantIterations)
+	}
+
 	fmt.Printf("  ✓ completed (%s) after %d iterations via the Link\n",
 		state, count)
 

--- a/examples/maps/main.go
+++ b/examples/maps/main.go
@@ -41,7 +41,8 @@ func run() error {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	sub := engine.Observe(&dataChangePrinter{})
+	changes := &dataChangePrinter{}
+	sub := engine.Observe(changes)
 	defer sub.Cancel()
 
 	if err := engine.Run(ctx); err != nil {
@@ -68,6 +69,23 @@ func run() error {
 	}
 
 	sub.Cancel() // drain the buffered facts before the final line
+
+	// A map commit diffs PER KEY: the second commit updates EUR, adds JPY and
+	// deletes GBP, and each must surface as its own change at its own key
+	// path. A diff that re-reported the whole map, or missed the deletion,
+	// would complete the process exactly the same way.
+	//
+	// Checked as a set, not a sequence: the three second-commit changes are
+	// derived from a map, whose iteration order Go deliberately leaves
+	// unspecified, so asserting an order would be asserting a coincidence.
+	if err := changes.checkSet(
+		"Value_Added rates @publish",
+		`Value_Updated rates["EUR"] @reprice`,
+		`Value_Added rates["JPY"] @reprice`,
+		`Value_Deleted rates["GBP"] @reprice`,
+	); err != nil {
+		return fmt.Errorf("change stream: %w", err)
+	}
 
 	fmt.Printf("  ✓ completed (%s)\n", state)
 

--- a/examples/maps/observer.go
+++ b/examples/maps/observer.go
@@ -2,17 +2,74 @@ package main
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+	"sync"
 
 	"github.com/dr-dobermann/gobpm/pkg/observability"
 )
 
-type dataChangePrinter struct{}
+// dataChangePrinter is an engine-scope observer that surfaces only the
+// DataChange facts — the per-path change signal the commit-diff produces.
+// DataChange is observer-only (never echoed to the operator log), so an
+// observer like this is the way to see it.
+//
+// It also RECORDS what it saw, so the example can assert the change stream
+// rather than only print it: a commit-diff that reported the wrong kind, the
+// wrong path, or nothing at all would leave the process completing normally.
+// Reading the record is safe because the example cancels the subscription
+// first, and Cancel drains the facts still in flight — the asynchronous
+// delivery that makes observer assertions racy elsewhere is settled by then.
+type dataChangePrinter struct {
+	seen []string
+	m    sync.Mutex
+}
 
+// OnFact prints one line per DataChange fact: the change kind (the phase),
+// the changed data path, and the node whose commit produced it.
 func (p *dataChangePrinter) OnFact(f observability.Fact) {
 	if f.Kind != observability.KindDataChange {
 		return
 	}
 
-	fmt.Printf("  ▶ %s %s @%s\n",
+	change := fmt.Sprintf("%s %s @%s",
 		f.Phase, f.Details[observability.AttrDataPath], f.NodeName)
+
+	p.m.Lock()
+	p.seen = append(p.seen, change)
+	p.m.Unlock()
+
+	fmt.Printf("  ▶ %s\n", change)
+}
+
+// check reports an error unless exactly these changes were observed, in order.
+func (p *dataChangePrinter) check(want ...string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if strings.Join(p.seen, " | ") != strings.Join(want, " | ") {
+		return fmt.Errorf("saw %v, want %v", p.seen, want)
+	}
+
+	return nil
+}
+
+// checkSet reports an error unless exactly these changes were observed, in any
+// order — for commits whose changes come from a map, whose iteration order is
+// deliberately unspecified.
+func (p *dataChangePrinter) checkSet(want ...string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	got := append([]string(nil), p.seen...)
+	sort.Strings(got)
+
+	w := append([]string(nil), want...)
+	sort.Strings(w)
+
+	if strings.Join(got, " | ") != strings.Join(w, " | ") {
+		return fmt.Errorf("saw %v, want %v (in any order)", p.seen, want)
+	}
+
+	return nil
 }

--- a/examples/multi-instance-behavior/board.go
+++ b/examples/multi-instance-behavior/board.go
@@ -9,11 +9,16 @@ import (
 )
 
 // buildBoard builds the parallel Multi-Instance review board: one instance per
+// quorumSize is how many votes the Complex behavior waits for before throwing
+// "quorum-reached" — read by the behavior condition and by the example's own
+// assertion, so the check cannot drift from the behaviour it checks.
+const quorumSize = 2
+
 // reviewer, all voting concurrently. A Complex behavior throws a "quorum-reached"
 // signal on every completion once numberOfCompletedInstances ≥ 2. It returns the
 // board and the signal definition the boundary catches (the same signal, matched by
 // name).
-func buildBoard() (*activities.SubProcess, flow.EventDefinition, error) {
+func buildBoard(log *runLog) (*activities.SubProcess, flow.EventDefinition, error) {
 	sig, err := events.NewSignal("quorum-reached", nil)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create signal: %w", err)
@@ -34,7 +39,7 @@ func buildBoard() (*activities.SubProcess, flow.EventDefinition, error) {
 		return nil, nil, fmt.Errorf("create implicit throw: %w", err)
 	}
 
-	cbd, err := activities.NewComplexBehaviorDefinition(completedAtLeast(2), quorum)
+	cbd, err := activities.NewComplexBehaviorDefinition(completedAtLeast(quorumSize), quorum)
 	if err != nil {
 		return nil, nil, fmt.Errorf("create complex behavior: %w", err)
 	}
@@ -57,7 +62,7 @@ func buildBoard() (*activities.SubProcess, flow.EventDefinition, error) {
 		return nil, nil, fmt.Errorf("create b-start: %w", err)
 	}
 
-	vote, err := voteTask()
+	vote, err := voteTask(log)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/examples/multi-instance-behavior/main.go
+++ b/examples/multi-instance-behavior/main.go
@@ -43,7 +43,10 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records votes and the notification in order, so the quorum claim holds.
+	log := newRunLog()
+
+	proc, err := buildProcess(log)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -59,6 +62,19 @@ func run() error {
 
 	if _, err := h.WaitCompletion(ctx); err != nil {
 		return fmt.Errorf("wait completion: %w", err)
+	}
+
+	// Every reviewer must vote, and the notification must not fire before the
+	// quorum is actually met — a behavior that threw on the first completion
+	// would print the same line and finish the same way. It fires once per
+	// completion at or past the threshold, so the count is not fixed; what is
+	// checkable is that it never fires early.
+	if got := log.count("vote"); got != len(reviewers) {
+		return fmt.Errorf("%d reviewers voted, want %d", got, len(reviewers))
+	}
+
+	if err := log.precede("notify", "vote", quorumSize); err != nil {
+		return fmt.Errorf("quorum: %w", err)
 	}
 
 	fmt.Print("\n  completed — the board finished; the quorum notification " +

--- a/examples/multi-instance-behavior/model.go
+++ b/examples/multi-instance-behavior/model.go
@@ -12,13 +12,17 @@ import (
 )
 
 // buildProcess wires start → board → end and attaches a non-interrupting boundary
+// reviewers are the board members the Multi-Instance fans out over — one vote
+// each, so the example knows exactly how many votes to expect.
+var reviewers = [3]string{"Ann", "Bob", "Cara"}
+
 // to the board that catches the "quorum-reached" behavior signal and runs a
 // notification side-flow (boundary → notify → notify-end).
-func buildProcess() (*process.Process, error) {
+func buildProcess(log *runLog) (*process.Process, error) {
 	proc, err := process.New("multi-instance-behavior",
 		data.WithProperties(data.MustProperty("reviewers",
 			data.MustItemDefinition(
-				values.NewArray("Ann", "Bob", "Cara"),
+				values.NewArray(reviewers[0], reviewers[1], reviewers[2]),
 				foundation.WithID("reviewers")),
 			data.ReadyDataState)))
 	if err != nil {
@@ -30,7 +34,7 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("create start: %w", err)
 	}
 
-	board, catchDef, err := buildBoard()
+	board, catchDef, err := buildBoard(log)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +44,7 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("create end: %w", err)
 	}
 
-	boundary, notify, notifyEnd, err := buildNotification(board, catchDef)
+	boundary, notify, notifyEnd, err := buildNotification(log, board, catchDef)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/multi-instance-behavior/runlog.go
+++ b/examples/multi-instance-behavior/runlog.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// runLog records the ORDER in which the votes and the quorum notification
+// happened. A set is not enough: the claim is that the notification fires only
+// once the quorum is MET, so what matters is how many votes precede it. A
+// notification thrown on the first vote would print the same line and complete
+// the same way.
+//
+// Recorded from inside the tasks rather than from an engine observer: observer
+// facts are delivered asynchronously and can still be in flight when
+// WaitCompletion returns, whereas a task that records as it executes is
+// synchronous with the run by construction.
+type runLog struct {
+	seq []string
+	m   sync.Mutex
+}
+
+func newRunLog() *runLog {
+	return &runLog{}
+}
+
+// mark appends the named step to the execution order.
+func (r *runLog) mark(name string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.seq = append(r.seq, name)
+}
+
+// count reports how many times name was recorded.
+func (r *runLog) count(name string) int {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	n := 0
+
+	for _, s := range r.seq {
+		if s == name {
+			n++
+		}
+	}
+
+	return n
+}
+
+// precede reports an error unless at least n occurrences of before were
+// recorded ahead of the first occurrence of name.
+func (r *runLog) precede(name, before string, n int) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	seen := 0
+
+	for _, s := range r.seq {
+		switch s {
+		case before:
+			seen++
+
+		case name:
+			if seen < n {
+				return fmt.Errorf("ran %v: %q fired after %d %q, want at "+
+					"least %d", r.seq, name, seen, before, n)
+			}
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("ran %v, but %q never happened", r.seq, name)
+}

--- a/examples/multi-instance-behavior/tasks.go
+++ b/examples/multi-instance-behavior/tasks.go
@@ -14,7 +14,7 @@ import (
 
 // voteTask reads the per-instance `reviewer` name and prints the vote — the work
 // each Multi-Instance body instance performs before it completes.
-func voteTask() (*activities.ServiceTask, error) {
+func voteTask(log *runLog) (*activities.ServiceTask, error) {
 	op, err := gooper.New("vote",
 		func(ctx context.Context, r service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
@@ -24,6 +24,7 @@ func voteTask() (*activities.ServiceTask, error) {
 			}
 
 			name, _ := rv.Value().Get(ctx).(string)
+			log.mark("vote")
 			fmt.Printf("    %s votes\n", name)
 
 			return nil, nil
@@ -44,6 +45,7 @@ func voteTask() (*activities.ServiceTask, error) {
 // the quorum-reached signal (catchDef), plus its notification side-flow: boundary →
 // notify → notify-end. Non-interrupting, so the board keeps running.
 func buildNotification(
+	log *runLog,
 	board *activities.SubProcess, catchDef flow.EventDefinition,
 ) (*events.BoundaryEvent, *activities.ServiceTask, *events.EndEvent, error) {
 	boundary, err := events.NewBoundaryEvent("quorum-bnd", board, catchDef, false)
@@ -54,6 +56,7 @@ func buildNotification(
 	op, err := gooper.New("notify",
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			log.mark("notify")
 			fmt.Println("    → quorum reached — notifying the chair")
 
 			return nil, nil

--- a/examples/multi-instance-parallel/model.go
+++ b/examples/multi-instance-parallel/model.go
@@ -17,7 +17,7 @@ func buildProcess() (*process.Process, error) {
 	proc, err := process.New("multi-instance-parallel",
 		data.WithProperties(data.MustProperty("reviewers",
 			data.MustItemDefinition(
-				values.NewArray("Ann", "Bob", "Cara", "Dan"),
+				values.NewArray(reviewerList()...),
 				foundation.WithID("reviewers")),
 			data.ReadyDataState)))
 	if err != nil {

--- a/examples/multi-instance-parallel/report.go
+++ b/examples/multi-instance-parallel/report.go
@@ -8,6 +8,53 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
 )
 
+// reviewers are the board members the Multi-Instance fans out over, and
+// scoreFor is the score each one gives — derived from its loop index so the
+// scoring task and the example's own expectation are the same rule, and can
+// never drift apart.
+var reviewers = []string{"Ann", "Bob", "Cara", "Dan"}
+
+func scoreFor(i int) int { return 70 + i*5 }
+
+// reviewerList returns the reviewers as the `any` slice the array value wants.
+func reviewerList() []any {
+	l := make([]any, 0, len(reviewers))
+	for _, r := range reviewers {
+		l = append(l, r)
+	}
+
+	return l
+}
+
+// wantScores is what the output collection must hold once every instance has
+// contributed: one score per reviewer, in reviewer order.
+func wantScores() []int {
+	w := make([]int, len(reviewers))
+	for i := range reviewers {
+		w[i] = scoreFor(i)
+	}
+
+	return w
+}
+
+// sameInts reports an error unless got holds exactly the ints in want, in
+// order. The values arrive as `any` from the collection, so a wrong TYPE is a
+// mismatch too, not a silent zero.
+func sameInts(got []any, want []int) error {
+	if len(got) != len(want) {
+		return fmt.Errorf("got %d values %v, want %d %v",
+			len(got), got, len(want), want)
+	}
+
+	for i, w := range want {
+		if got[i] != w {
+			return fmt.Errorf("got %v, want %v", got, want)
+		}
+	}
+
+	return nil
+}
+
 // reportScores prints the `scores` collection assembled once every reviewer's
 // instance completed (the visibility barrier), and their average.
 func reportScores(ctx context.Context, r service.DataReader) error {
@@ -28,6 +75,15 @@ func reportScores(ctx context.Context, r service.DataReader) error {
 		if v, ok := s.(int); ok {
 			sum += v
 		}
+	}
+
+	// The output collection is the demonstration: every reviewer's instance
+	// must have contributed its score, and the collection must be assembled
+	// at the visibility barrier rather than partially. A run that lost one
+	// reviewer's output — or ran fewer instances than there are reviewers —
+	// would print a shorter list and still exit 0.
+	if err := sameInts(scores, wantScores()); err != nil {
+		return fmt.Errorf("output collection: %w", err)
 	}
 
 	fmt.Printf("\n  completed — scores: %v (average %d)\n",

--- a/examples/multi-instance-parallel/tasks.go
+++ b/examples/multi-instance-parallel/tasks.go
@@ -31,7 +31,7 @@ func scoreTask() (*activities.ServiceTask, error) {
 
 			i, _ := lc.Value().Get(ctx).(int)
 			name, _ := rv.Value().Get(ctx).(string)
-			score := 70 + i*5
+			score := scoreFor(i)
 
 			fmt.Printf("    %s scores the proposal: %d\n", name, score)
 

--- a/examples/multi-instance-sequential/model.go
+++ b/examples/multi-instance-sequential/model.go
@@ -13,12 +13,58 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
 )
 
+// amounts are the orders the Multi-Instance walks, in order, and withTax is
+// the rule the task applies to each. Both the process data and the example's
+// own expectation read them, so the two cannot drift apart.
+var amounts = []int{100, 250, 80}
+
+func withTax(amount int) int { return amount + amount/5 } // +20%
+
+// amountList returns the amounts as the `any` slice the array value wants.
+func amountList() []any {
+	l := make([]any, 0, len(amounts))
+	for _, a := range amounts {
+		l = append(l, a)
+	}
+
+	return l
+}
+
+// wantTaxed is what the output collection must hold: one taxed figure per
+// amount, in input order.
+func wantTaxed() []int {
+	w := make([]int, len(amounts))
+	for i, a := range amounts {
+		w[i] = withTax(a)
+	}
+
+	return w
+}
+
+// sameInts reports an error unless got holds exactly the ints in want, in
+// order. The values arrive as `any` from the collection, so a wrong TYPE is a
+// mismatch too, not a silent zero.
+func sameInts(got []any, want []int) error {
+	if len(got) != len(want) {
+		return fmt.Errorf("got %d values %v, want %d %v",
+			len(got), got, len(want), want)
+	}
+
+	for i, w := range want {
+		if got[i] != w {
+			return fmt.Errorf("got %v, want %v", got, want)
+		}
+	}
+
+	return nil
+}
+
 // buildProcess wires start → orders → end, seeding the input `amounts`
 // collection the Multi-Instance activity iterates over.
 func buildProcess() (*process.Process, error) {
 	proc, err := process.New("multi-instance-sequential",
 		data.WithProperties(data.MustProperty("amounts",
-			data.MustItemDefinition(values.NewArray(100, 250, 80),
+			data.MustItemDefinition(values.NewArray(amountList()...),
 				foundation.WithID("amounts")),
 			data.ReadyDataState)))
 	if err != nil {
@@ -70,7 +116,18 @@ func reportTaxed(ctx context.Context, r service.DataReader) error {
 		return fmt.Errorf("taxed is not a collection")
 	}
 
-	fmt.Printf("\n  completed — taxed amounts: %v\n", col.GetAll(ctx))
+	got := col.GetAll(ctx)
+
+	// Sequential Multi-Instance keeps input ORDER: the output collection must
+	// hold each amount's taxed figure in the position its input had. A
+	// parallel run, a lost instance, or an output assembled out of order would
+	// all print a plausible-looking list and still exit 0 — so the exact
+	// sequence is what gets checked, not just the length.
+	if err := sameInts(got, wantTaxed()); err != nil {
+		return fmt.Errorf("output collection: %w", err)
+	}
+
+	fmt.Printf("\n  completed — taxed amounts: %v\n", got)
 
 	return nil
 }

--- a/examples/multi-instance-sequential/tasks.go
+++ b/examples/multi-instance-sequential/tasks.go
@@ -24,12 +24,12 @@ func taxTask() (*activities.ServiceTask, error) {
 			}
 
 			amount, _ := d.Value().Get(ctx).(int)
-			withTax := amount + amount/5 // +20%
+			taxed := withTax(amount)
 
-			fmt.Printf("    order: amount=%d → withTax=%d\n", amount, withTax)
+			fmt.Printf("    order: amount=%d → withTax=%d\n", amount, taxed)
 
 			return data.MustItemDefinition(
-				values.NewVariable(withTax), foundation.WithID("withTax")), nil
+				values.NewVariable(taxed), foundation.WithID("withTax")), nil
 		})
 	if err != nil {
 		return nil, fmt.Errorf("create tax op: %w", err)

--- a/examples/native-structs/main.go
+++ b/examples/native-structs/main.go
@@ -35,6 +35,10 @@ func run() error {
 		return fmt.Errorf("init data states: %w", err)
 	}
 
+	// newTotal is the value written through the view; it is above the
+	// gateway's threshold, so it also decides the lane.
+	const newTotal = 150
+
 	// The host's live object — note Secret is tagged gobpm:"-".
 	order := &Order{ID: "A-1", Total: 90,
 		Items:  []Item{{SKU: "widget", Price: 50}},
@@ -44,12 +48,21 @@ func run() error {
 
 	// A host-side structural write goes through the view INTO the live struct.
 	if err := values.SetPath(context.Background(), wrapped,
-		"total", values.NewVariable(150)); err != nil {
+		"total", values.NewVariable(newTotal)); err != nil {
 		return fmt.Errorf("set order.total: %w", err)
 	}
 
-	fmt.Printf("  SetPath(order.total=150) → the LIVE struct: o.Total == %d\n",
-		order.Total)
+	// The whole point of wrapping a native struct is that the write reaches
+	// the LIVE object, not a copy: if it did not, everything downstream would
+	// still behave — the view would hold 150 and the gateway would route on
+	// it — while the host's own struct silently kept 90.
+	if order.Total != newTotal {
+		return fmt.Errorf("SetPath left the live struct at %d, want %d",
+			order.Total, newTotal)
+	}
+
+	fmt.Printf("  SetPath(order.total=%d) → the LIVE struct: o.Total == %d\n",
+		newTotal, order.Total)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -60,14 +73,18 @@ func run() error {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	sub := engine.Observe(&dataChangePrinter{})
+	changes := &dataChangePrinter{}
+	sub := engine.Observe(changes)
 	defer sub.Cancel()
 
 	if err := engine.Run(ctx); err != nil {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	proc, err := buildProcess(wrapped)
+	// Records which lane ran, so the structural condition is checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(ran, wrapped)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -87,6 +104,25 @@ func run() error {
 	}
 
 	sub.Cancel() // drain the buffered facts before the final line
+
+	// A native Go struct wrapped as process data diffs by FIELD PATH just as
+	// a record does: one Value_Added at the root when it is first committed,
+	// one Value_Updated at receipt.sum when only that field changes. Nothing
+	// about the wrapping should make the change stream coarser.
+	// The gateway condition reaches into the wrapped struct, so which lane
+	// ran proves the reach-in worked end to end.
+	if err := ran.check(
+		[]string{"premium"}, []string{"standard"},
+	); err != nil {
+		return fmt.Errorf("structural routing: %w", err)
+	}
+
+	if err := changes.check(
+		"Value_Added receipt @quote",
+		"Value_Updated receipt.sum @reprice",
+	); err != nil {
+		return fmt.Errorf("change stream: %w", err)
+	}
 
 	fmt.Printf("  ✓ completed (%s)\n", state)
 

--- a/examples/native-structs/observer.go
+++ b/examples/native-structs/observer.go
@@ -2,21 +2,74 @@ package main
 
 import (
 	"fmt"
+	"sort"
+	"strings"
+	"sync"
 
 	"github.com/dr-dobermann/gobpm/pkg/observability"
 )
 
-// dataChangePrinter surfaces the DataChange facts — the per-path change
-// signal the commit-diff produces over the WRAPPED receipts (observer-only,
-// never echoed to the operator log).
-type dataChangePrinter struct{}
+// dataChangePrinter is an engine-scope observer that surfaces only the
+// DataChange facts — the per-path change signal the commit-diff produces.
+// DataChange is observer-only (never echoed to the operator log), so an
+// observer like this is the way to see it.
+//
+// It also RECORDS what it saw, so the example can assert the change stream
+// rather than only print it: a commit-diff that reported the wrong kind, the
+// wrong path, or nothing at all would leave the process completing normally.
+// Reading the record is safe because the example cancels the subscription
+// first, and Cancel drains the facts still in flight — the asynchronous
+// delivery that makes observer assertions racy elsewhere is settled by then.
+type dataChangePrinter struct {
+	seen []string
+	m    sync.Mutex
+}
 
-// OnFact prints one line per DataChange fact: phase, path, committing node.
+// OnFact prints one line per DataChange fact: the change kind (the phase),
+// the changed data path, and the node whose commit produced it.
 func (p *dataChangePrinter) OnFact(f observability.Fact) {
 	if f.Kind != observability.KindDataChange {
 		return
 	}
 
-	fmt.Printf("  ▶ %s %s @%s\n",
+	change := fmt.Sprintf("%s %s @%s",
 		f.Phase, f.Details[observability.AttrDataPath], f.NodeName)
+
+	p.m.Lock()
+	p.seen = append(p.seen, change)
+	p.m.Unlock()
+
+	fmt.Printf("  ▶ %s\n", change)
+}
+
+// check reports an error unless exactly these changes were observed, in order.
+func (p *dataChangePrinter) check(want ...string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if strings.Join(p.seen, " | ") != strings.Join(want, " | ") {
+		return fmt.Errorf("saw %v, want %v", p.seen, want)
+	}
+
+	return nil
+}
+
+// checkSet reports an error unless exactly these changes were observed, in any
+// order — for commits whose changes come from a map, whose iteration order is
+// deliberately unspecified.
+func (p *dataChangePrinter) checkSet(want ...string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	got := append([]string(nil), p.seen...)
+	sort.Strings(got)
+
+	w := append([]string(nil), want...)
+	sort.Strings(w)
+
+	if strings.Join(got, " | ") != strings.Join(w, " | ") {
+		return fmt.Errorf("saw %v, want %v (in any order)", p.seen, want)
+	}
+
+	return nil
 }

--- a/examples/native-structs/pathset.go
+++ b/examples/native-structs/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/native-structs/process.go
+++ b/examples/native-structs/process.go
@@ -42,7 +42,7 @@ type Receipt struct {
 // buildProcess assembles start → quote → reprice → XOR{order.total > 100 →
 // premium | default → standard}; the condition reaches INTO the wrapped host
 // struct by path.
-func buildProcess(order data.Value) (*process.Process, error) {
+func buildProcess(ran *pathSet, order data.Value) (*process.Process, error) {
 	proc, err := process.New("native-structs",
 		data.WithProperties(
 			data.MustProperty("order",
@@ -72,12 +72,12 @@ func buildProcess(order data.Value) (*process.Process, error) {
 		return nil, fmt.Errorf("create gateway: %w", err)
 	}
 
-	premium, err := printTask("premium", "  ▶ order.total > 100 → premium lane")
+	premium, err := printTask(ran, "premium", "  ▶ order.total > 100 → premium lane")
 	if err != nil {
 		return nil, err
 	}
 
-	standard, err := printTask("standard", "  ▶ default → standard lane")
+	standard, err := printTask(ran, "standard", "  ▶ default → standard lane")
 	if err != nil {
 		return nil, err
 	}
@@ -169,10 +169,13 @@ func receiptTask(name string, sum int) (*activities.ServiceTask, error) {
 }
 
 // printTask builds a ServiceTask whose Go functor prints msg.
-func printTask(name, msg string) (*activities.ServiceTask, error) {
+func printTask(
+	ran *pathSet, name, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name,
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.mark(name)
 			fmt.Println(msg)
 
 			return nil, nil

--- a/examples/parallel-gateway/main.go
+++ b/examples/parallel-gateway/main.go
@@ -113,7 +113,8 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	if _, err := engine.StartLatest(proc.ID()); err != nil {
+	h, err := engine.StartLatest(proc.ID())
+	if err != nil {
 		return fmt.Errorf("start process: %w", err)
 	}
 
@@ -129,8 +130,17 @@ func run() error {
 		}
 	}
 
-	// brief grace for the join to synchronize and the survivor to reach End.
-	time.Sleep(100 * time.Millisecond)
+	// Both branches ran, but that alone does not prove the join synchronized
+	// them: waiting for the instance to reach Completed does. A grace sleep
+	// here would pass even if the token never left the gateway.
+	state, err := h.WaitCompletion(ctx)
+	if err != nil {
+		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	if state != thresher.StateCompleted {
+		return fmt.Errorf("instance ended %s, want Completed", state)
+	}
 
 	fmt.Println("✓ parallel-demo completed: split forked both branches, " +
 		"join synchronized, one token reached End")

--- a/examples/script-task/main.go
+++ b/examples/script-task/main.go
@@ -39,17 +39,23 @@ func run() error {
 		return fmt.Errorf("init data states: %w", err)
 	}
 
+	// Each case states the lane and discount the Lua script is expected to
+	// choose, and runOrder checks the run against it. Without that, an example
+	// that classified every order into the wrong lane would still exit 0.
 	for _, order := range []struct {
-		tier  string
-		total int
+		tier     string
+		wantLane string
+		total    int
+		wantPct  float64
 	}{
-		{tier: "vip", total: 500},
-		{tier: "retail", total: 150},
-		{tier: "", total: 40},
+		{tier: "vip", total: 500, wantLane: "wholesale", wantPct: 25},
+		{tier: "retail", total: 150, wantLane: "wholesale", wantPct: 15},
+		{tier: "", total: 40, wantLane: "retail", wantPct: 5},
 	} {
 		fmt.Printf("\norder: tier=%q total=%d\n", order.tier, order.total)
 
-		if err := runOrder(order.total, order.tier); err != nil {
+		if err := runOrder(
+			order.total, order.tier, order.wantLane, order.wantPct); err != nil {
 			return err
 		}
 	}
@@ -60,8 +66,9 @@ func run() error {
 	return nil
 }
 
-// runOrder runs one process instance for an order profile.
-func runOrder(total int, tier string) error {
+// runOrder runs one process instance for an order profile and checks that it
+// both COMPLETED and classified the order as claimed.
+func runOrder(total int, tier, wantLane string, wantPct float64) error {
 	engine, err := thresher.New(
 		fmt.Sprintf("script-task-%d", total),
 		thresher.WithoutBanner(),
@@ -92,8 +99,46 @@ func runOrder(total int, tier string) error {
 		return fmt.Errorf("start process: %w", err)
 	}
 
-	if _, err := h.WaitCompletion(ctx); err != nil {
+	state, err := h.WaitCompletion(ctx)
+	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	if state != thresher.StateCompleted {
+		return fmt.Errorf("process finished %s, want %s",
+			state, thresher.StateCompleted)
+	}
+
+	// Read what the script actually decided back out of the finished instance.
+	// data.As, not a bare .(T) assertion: Lua numbers arrive as float64, and a
+	// silent mismatch would record a zero and blame the script for it.
+	dr := h.Data()
+
+	laneD, err := dr.GetData("lane")
+	if err != nil {
+		return fmt.Errorf("read lane: %w", err)
+	}
+
+	pctD, err := dr.GetData("discount_pct")
+	if err != nil {
+		return fmt.Errorf("read discount_pct: %w", err)
+	}
+
+	lane, err := data.As[string](ctx, laneD.Value())
+	if err != nil {
+		return fmt.Errorf("lane: %w", err)
+	}
+
+	pct, err := data.As[float64](ctx, pctD.Value())
+	if err != nil {
+		return fmt.Errorf("discount_pct: %w", err)
+	}
+
+	if lane != wantLane || pct != wantPct {
+		return fmt.Errorf(
+			"order tier=%q total=%d classified lane=%q discount=%v%%, "+
+				"want lane=%q discount=%v%%",
+			tier, total, lane, pct, wantLane, wantPct)
 	}
 
 	return nil

--- a/examples/service-task-worker/main.go
+++ b/examples/service-task-worker/main.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
@@ -25,8 +26,13 @@ func main() {
 
 // order is one scenario the demo runs.
 type order struct {
-	name   string
-	amount int
+	name string
+	// wantOutcome is the summary this order must produce. The example exists to
+	// show three DIFFERENT paths — worker success, a declined payment, and a
+	// Business Error caught by the boundary — so a run where all three took the
+	// same path must fail rather than print three lines and exit 0.
+	wantOutcome string
+	amount      int
 }
 
 func run() error {
@@ -66,9 +72,9 @@ func run() error {
 	}
 
 	for _, o := range []order{
-		{"order-normal", 50},
-		{"order-over-limit", 5000},
-		{"order-gateway-down", -1},
+		{name: "order-normal", amount: 50, wantOutcome: "shipped"},
+		{name: "order-over-limit", amount: 5000, wantOutcome: "held"},
+		{name: "order-gateway-down", amount: -1, wantOutcome: "payment-failed"},
 	} {
 		if err := runOrder(ctx, engine, o); err != nil {
 			return err
@@ -102,7 +108,14 @@ func runOrder(ctx context.Context, engine *thresher.Thresher, o order) error {
 		return fmt.Errorf("wait %s: %w", o.name, err)
 	}
 
-	fmt.Printf("  ✓ completed (%s) → %s\n", state, outcome(ctx, h))
+	got := outcome(ctx, h)
+
+	if !strings.HasPrefix(got, o.wantOutcome) {
+		return fmt.Errorf("%s finished %s → %q, want a %q outcome",
+			o.name, state, got, o.wantOutcome)
+	}
+
+	fmt.Printf("  ✓ completed (%s) → %s\n", state, got)
 
 	return nil
 }

--- a/examples/signal-broadcast/main.go
+++ b/examples/signal-broadcast/main.go
@@ -87,6 +87,16 @@ func run() error {
 		if err != nil {
 			return fmt.Errorf("watcher %d completion: %w", i+1, err)
 		}
+
+		// Broadcast means EVERY parked catcher is woken by the single throw.
+		// Both watchers reaching Completed is what proves it: a signal
+		// delivered to only one of them would leave the other parked until
+		// the context deadline.
+		if st != thresher.StateCompleted {
+			return fmt.Errorf("watcher %d ended %s, want Completed — it did "+
+				"not catch the broadcast", i+1, st)
+		}
+
 		fmt.Printf("  ✓ watcher %d completed (%s) — caught the broadcast\n", i+1, st)
 	}
 

--- a/examples/signal-start/observe.go
+++ b/examples/signal-start/observe.go
@@ -31,6 +31,11 @@ func awaitAll(ctx context.Context, engine *thresher.Thresher, n int) error {
 				return fmt.Errorf("instance %s: %w", id, err)
 			}
 
+			if st != thresher.StateCompleted {
+				return fmt.Errorf("instance %s ended %s, want Completed",
+					id, st)
+			}
+
 			fmt.Printf("  ✓ instance %s completed (%s)\n", id, st)
 			done[id] = true
 		}

--- a/examples/simple-timer/main.go
+++ b/examples/simple-timer/main.go
@@ -1,7 +1,14 @@
-// Command simple-timer demonstrates a timer Start Event: the process is
-// instantiated when its timer fires (here, 3 seconds from registration).
+// Command simple-timer demonstrates a timer Start Event: the instance is
+// started explicitly, and its timer start event holds the token until the
+// timer fires (here, 3 seconds) before releasing it into the flow.
 //
 //	(timer start — fires in 3s) ◷─> end
+//
+// A timer start does NOT instantiate the process by schedule — the engine
+// treats only message, signal and instantiating-ReceiveTask starts as
+// instantiating triggers (see internal/instance/snapshot). Scheduled
+// instantiation is not implemented; this example would silently demonstrate
+// nothing if it relied on it.
 package main
 
 import (
@@ -21,6 +28,11 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/process"
 	"github.com/dr-dobermann/gobpm/pkg/thresher"
 )
+
+// timerDelay is how long the start event's timer waits before instantiating
+// the process. The timer definition and the example's own assertion both read
+// it, so the check can never drift away from the behaviour it is checking.
+const timerDelay = 3 * time.Second
 
 func main() {
 	fmt.Print(`
@@ -54,9 +66,9 @@ func main() {
 	// Create timer expression for 3 seconds from now
 	timeExpr := goexpr.Must(
 		nil,
-		data.MustItemDefinition(values.NewVariable(time.Now().Add(3*time.Second))),
+		data.MustItemDefinition(values.NewVariable(time.Now().Add(timerDelay))),
 		func(ctx context.Context, ds data.Source) (data.Value, error) {
-			return values.NewVariable(time.Now().Add(3 * time.Second)), nil
+			return values.NewVariable(time.Now().Add(timerDelay)), nil
 		},
 		foundation.WithID("timer-3s"),
 	)
@@ -99,15 +111,54 @@ func main() {
 		log.Fatal("Failed to register process:", err)
 	}
 
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	started := time.Now()
+
 	if err := engine.Run(ctx); err != nil {
 		log.Fatal("Failed to start engine:", err)
 	}
 
-	fmt.Printf("Timer process started. Will trigger in 3 seconds...\n")
+	fmt.Printf("Timer process started. Will fire in %s...\n", timerDelay)
 
-	// Process will auto-start when timer fires
-	// This is just for demo - in real usage you'd handle the timer event
-	time.Sleep(5 * time.Second)
-	fmt.Println("Timer should have fired by now!")
+	// The timer start event instantiates the process on its own — there is no
+	// StartProcess call and so no handle to wait on, so the instance is found
+	// through the engine. Waiting for it is the whole assertion: this example
+	// used to sleep past the deadline and print "Timer should have fired by
+	// now!", which was true whether or not it had.
+	h, err := engine.StartLatest(proc.ID())
+	if err != nil {
+		log.Fatal("Failed to start process:", err)
+	}
+
+	if err := awaitHeldByTimer(ctx, h, started); err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println("Timer fired: the token was released and the process completed")
+}
+
+// awaitHeldByTimer waits for the instance to complete and checks that it did
+// not finish sooner than the timer allows — the delay is the demonstration, so
+// it is what gets checked.
+func awaitHeldByTimer(
+	ctx context.Context, h *thresher.InstanceHandle, started time.Time,
+) error {
+	st, err := h.WaitCompletion(ctx)
+	if err != nil {
+		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	if st != thresher.StateCompleted {
+		return fmt.Errorf("instance ended %s, want Completed", st)
+	}
+
+	if waited := time.Since(started); waited < timerDelay {
+		return fmt.Errorf("completed after %s, want at least %s — the timer "+
+			"start did not hold the token",
+			waited.Round(time.Millisecond), timerDelay)
+	}
+
+	return nil
 }

--- a/examples/standard-loop/main.go
+++ b/examples/standard-loop/main.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"time"
 
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
@@ -18,6 +19,16 @@ func main() {
 	if err := run(); err != nil {
 		log.Fatal(err)
 	}
+}
+
+// passes is the loopCounter sequence a post-tested loop must produce.
+func passes() []string {
+	p := make([]string, wantPasses)
+	for i := range p {
+		p[i] = strconv.Itoa(i)
+	}
+
+	return p
 }
 
 func run() error {
@@ -45,7 +56,10 @@ func run() error {
 		return fmt.Errorf("run engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records the counter seen on each pass, so the loop claim is checked.
+	log := newRunLog()
+
+	proc, err := buildProcess(log)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -61,6 +75,13 @@ func run() error {
 
 	if _, err := h.WaitCompletion(ctx); err != nil {
 		return fmt.Errorf("wait completion: %w", err)
+	}
+
+	// A post-tested loop runs the body first and tests after, so it must make
+	// exactly wantPasses passes, seeing 0, 1, 2 — one short would mean it was
+	// pre-tested, one long that the condition was read a pass late.
+	if err := log.check(passes()...); err != nil {
+		return fmt.Errorf("loop passes: %w", err)
 	}
 
 	fmt.Println("  process completed — the loop ran to its condition.")

--- a/examples/standard-loop/model.go
+++ b/examples/standard-loop/model.go
@@ -10,7 +10,7 @@ import (
 
 // buildProcess assembles start → work → end, where work is a Service Task
 // marked with a post-tested Standard Loop that runs while loopCounter < 3.
-func buildProcess() (*process.Process, error) {
+func buildProcess(log *runLog) (*process.Process, error) {
 	proc, err := process.New("standard-loop")
 	if err != nil {
 		return nil, fmt.Errorf("create process: %w", err)
@@ -21,7 +21,7 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("create start: %w", err)
 	}
 
-	work, err := loopedWorkTask()
+	work, err := loopedWorkTask(log)
 	if err != nil {
 		return nil, err
 	}

--- a/examples/standard-loop/runlog.go
+++ b/examples/standard-loop/runlog.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// runLog records the loopCounter value the engine published on each pass. A
+// set would not be enough: the claim is that a post-tested Standard Loop runs
+// at 0, 1 and 2 and then stops, so both the COUNT and the SEQUENCE matter. A
+// loop that ran the right number of times with a stuck counter, or one that
+// ran an extra pass, would print plausible lines and complete the same way.
+//
+// Recorded from inside the tasks rather than from an engine observer: observer
+// facts are delivered asynchronously and can still be in flight when
+// WaitCompletion returns, whereas a task that records as it executes is
+// synchronous with the run by construction.
+type runLog struct {
+	seq []string
+	m   sync.Mutex
+}
+
+func newRunLog() *runLog {
+	return &runLog{}
+}
+
+// mark appends the named step to the execution order.
+func (r *runLog) mark(name string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.seq = append(r.seq, name)
+}
+
+// check reports an error unless the steps executed in exactly this order.
+func (r *runLog) check(want ...string) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if strings.Join(r.seq, ",") != strings.Join(want, ",") {
+		return fmt.Errorf("ran %v, want %v", r.seq, want)
+	}
+
+	return nil
+}

--- a/examples/standard-loop/tasks.go
+++ b/examples/standard-loop/tasks.go
@@ -13,9 +13,14 @@ import (
 )
 
 // loopedWorkTask builds a Service Task marked with a post-tested Standard Loop
+// wantPasses is how many times the post-tested loop runs — read by the loop
+// condition and by the example's own assertion, so the check cannot drift away
+// from the behaviour it checks.
+const wantPasses = 3
+
 // (loopCounter < 3): each pass reads the engine-published loopCounter and prints
 // it, so the three iterations are visible.
-func loopedWorkTask() (*activities.ServiceTask, error) {
+func loopedWorkTask(log *runLog) (*activities.ServiceTask, error) {
 	op, err := gooper.New("work",
 		func(ctx context.Context, r service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
@@ -24,6 +29,7 @@ func loopedWorkTask() (*activities.ServiceTask, error) {
 				return nil, err
 			}
 
+			log.mark(fmt.Sprint(d.Value().Get(ctx)))
 			fmt.Printf("    iteration: loopCounter=%v\n", d.Value().Get(ctx))
 
 			return nil, nil
@@ -32,7 +38,7 @@ func loopedWorkTask() (*activities.ServiceTask, error) {
 		return nil, fmt.Errorf("create work op: %w", err)
 	}
 
-	loop, err := activities.NewStandardLoop(loopCounterBelow(3))
+	loop, err := activities.NewStandardLoop(loopCounterBelow(wantPasses))
 	if err != nil {
 		return nil, fmt.Errorf("create standard loop: %w", err)
 	}

--- a/examples/structural-data/main.go
+++ b/examples/structural-data/main.go
@@ -40,7 +40,10 @@ func run() error {
 
 	const total = 150
 
-	proc, err := buildProcess(total)
+	// Records which lane the gateway took, so the routing claim is checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(ran, total)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -66,6 +69,16 @@ func run() error {
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	// The gateway condition reaches into the same record by path, so which
+	// lane ran is the second half of the demonstration: a path that resolved
+	// to nothing would evaluate false, take the default flow, and complete
+	// exactly as happily.
+	if err := ran.check(
+		[]string{"premium"}, []string{"standard"},
+	); err != nil {
+		return fmt.Errorf("structural routing: %w", err)
 	}
 
 	fmt.Printf("✓ structural-data completed (%s)\n", state)

--- a/examples/structural-data/pathset.go
+++ b/examples/structural-data/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/structural-data/process.go
+++ b/examples/structural-data/process.go
@@ -33,14 +33,19 @@ func orderRecord(total int) data.Value {
 		values.F("id", values.NewVariable("A-1")),
 		values.F("total", values.NewVariable(total)),
 		values.F("items", values.NewArray[data.Value](
-			item("widget", 50), item("gadget", 100))),
+			item("widget", wantFirstPrice), item("gadget", 100))),
 	)
 }
+
+// wantFirstPrice is the price of the first item in the record — declared here
+// and read by both the record's construction and the task that reaches into it
+// by path, so the check cannot drift from the data it checks.
+const wantFirstPrice = 50
 
 // buildProcess assembles: start → read-price → XOR{ order.total > 100 → premium
 // | default → standard } → end. Both the service task and the gateway condition
 // reach INTO the order record by path (order.items[0].price, order.total).
-func buildProcess(total int) (*process.Process, error) {
+func buildProcess(ran *pathSet, total int) (*process.Process, error) {
 	proc, err := process.New("structural-data",
 		data.WithProperties(
 			data.MustProperty("order",
@@ -66,12 +71,12 @@ func buildProcess(total int) (*process.Process, error) {
 		return nil, fmt.Errorf("create gateway: %w", err)
 	}
 
-	premium, err := printTask("premium", "  ▶ order.total > 100 → premium lane")
+	premium, err := printTask(ran, "premium", "  ▶ order.total > 100 → premium lane")
 	if err != nil {
 		return nil, err
 	}
 
-	standard, err := printTask("standard", "  ▶ default → standard lane")
+	standard, err := printTask(ran, "standard", "  ▶ default → standard lane")
 	if err != nil {
 		return nil, err
 	}
@@ -150,6 +155,15 @@ func pricePrinterTask() (*activities.ServiceTask, error) {
 				return nil, fmt.Errorf("read order.items[0].price: %w", err)
 			}
 
+			// Reaching into the record by path is the demonstration, so the
+			// value that came back is checked here rather than printed and
+			// trusted: a path that resolved to the wrong element, or to a
+			// zero value, would print a plausible line and complete.
+			if got := d.Value().Get(ctx); got != wantFirstPrice {
+				return nil, fmt.Errorf(
+					"order.items[0].price = %v, want %v", got, wantFirstPrice)
+			}
+
 			fmt.Printf("  ▶ order.items[0].price = %v\n", d.Value().Get(ctx))
 
 			return nil, nil
@@ -168,10 +182,13 @@ func pricePrinterTask() (*activities.ServiceTask, error) {
 }
 
 // printTask builds a ServiceTask whose Go functor prints msg.
-func printTask(name, msg string) (*activities.ServiceTask, error) {
+func printTask(
+	ran *pathSet, name, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name,
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.mark(name)
 			fmt.Println(msg)
 
 			return nil, nil

--- a/examples/structural-output-mapping/process.go
+++ b/examples/structural-output-mapping/process.go
@@ -89,6 +89,10 @@ func quoteTask() (*activities.ServiceTask, error) {
 	return st, nil
 }
 
+// wantPrice1 is the second item's price the flat worker body carries — read by
+// the body it is assembled from and by the read-back that checks it landed.
+const wantPrice1 = 100
+
 // readBackTask reads the assembled order.items[1].price through the narrow
 // DataReader — proof the flat body became a navigable nested value.
 func readBackTask() (*activities.ServiceTask, error) {
@@ -98,6 +102,16 @@ func readBackTask() (*activities.ServiceTask, error) {
 			d, err := r.GetData("order.items[1].price")
 			if err != nil {
 				return nil, fmt.Errorf("read order.items[1].price: %w", err)
+			}
+
+			// The read-back IS the demonstration: a flat worker body became
+			// a navigable nested value. Printing whatever came back would
+			// pass even if the mapping had assembled the wrong shape or left
+			// the field zero, so the value is checked here, in the task that
+			// reads it.
+			if got := d.Value().Get(ctx); got != wantPrice1 {
+				return nil, fmt.Errorf(
+					"order.items[1].price = %v, want %v", got, wantPrice1)
 			}
 
 			fmt.Printf("  ▶ order.items[1].price = %v\n", d.Value().Get(ctx))

--- a/examples/structural-output-mapping/worker.go
+++ b/examples/structural-output-mapping/worker.go
@@ -22,7 +22,7 @@ func quoteWorker() localdispatcher.WorkerFunc {
 		body := values.MustRecord(
 			values.F("total", values.NewVariable(150)),
 			values.F("price0", values.NewVariable(50)),
-			values.F("price1", values.NewVariable(100)),
+			values.F("price1", values.NewVariable(wantPrice1)),
 		)
 
 		return data.MustItemDefinition(body, foundation.WithID("body")), nil

--- a/examples/terminate-end-event/handlers.go
+++ b/examples/terminate-end-event/handlers.go
@@ -13,10 +13,11 @@ import (
 // fraudCheckOp is a quick check that flags the order as fraudulent. The branch it
 // runs on leads straight to a Terminate End Event, so the whole instance is about to
 // be torn down.
-func fraudCheckOp() (service.Operation, error) {
+func fraudCheckOp(ran *pathSet) (service.Operation, error) {
 	return gooper.New("fraud-check",
 		func(_ context.Context, _ service.DataReader, _ *data.ItemDefinition,
 		) (*data.ItemDefinition, error) {
+			ran.mark("fraud-check")
 			fmt.Println("  ⚠ fraud-check: fraudulent order detected — terminating the process")
 
 			return nil, nil
@@ -26,7 +27,7 @@ func fraudCheckOp() (service.Operation, error) {
 // paymentOp is a long-running, context-honoring charge. When the fraud branch
 // terminates the instance, this operation's context is cancelled and it abandons the
 // charge instead of completing.
-func paymentOp() (service.Operation, error) {
+func paymentOp(ran *pathSet) (service.Operation, error) {
 	return gooper.New("process-payment",
 		func(ctx context.Context, _ service.DataReader, _ *data.ItemDefinition,
 		) (*data.ItemDefinition, error) {
@@ -34,11 +35,13 @@ func paymentOp() (service.Operation, error) {
 
 			select {
 			case <-time.After(3 * time.Second):
+				ran.mark("payment-charged")
 				fmt.Println("  ✓ process-payment: charged")
 
 				return nil, nil
 
 			case <-ctx.Done():
+				ran.mark("payment-interrupted")
 				fmt.Println("  ✗ process-payment: interrupted before it finished")
 
 				return nil, ctx.Err()

--- a/examples/terminate-end-event/main.go
+++ b/examples/terminate-end-event/main.go
@@ -42,7 +42,10 @@ func run() error {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records which tasks ran, so the termination claim is checked.
+	ran := newPathSet()
+
+	proc, err := buildProcess(ran)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -66,6 +69,22 @@ func run() error {
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	// Terminate ends the whole instance, so the card must never be charged —
+	// that is the outcome this pattern exists to prevent, and checking only
+	// that the instance ended would pass even if the charge had gone through
+	// on the way out.
+	//
+	// It deliberately does NOT require that the payment reported an
+	// interruption: whether the payment task is scheduled at all before the
+	// teardown reaches it is a race, and about one run in eight it is torn
+	// down first and never runs. Not running is just as correct as being
+	// interrupted, so demanding the interruption made this assertion flaky
+	// against perfectly good behaviour.
+	if err := ran.check([]string{"fraud-check"},
+		[]string{"payment-charged"}); err != nil {
+		return fmt.Errorf("terminate teardown: %w", err)
 	}
 
 	fmt.Printf("\n✓ terminate-end-event finished (%s): the fraud branch hit a Terminate "+

--- a/examples/terminate-end-event/pathset.go
+++ b/examples/terminate-end-event/pathset.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathSet records which branch tasks actually ran, so the example can ASSERT the
+// branch the gateway chose. An exclusive gateway that routed the wrong way still
+// completes the process, so "it finished" proves nothing about routing.
+//
+// Recorded from inside the tasks themselves rather than from an engine observer:
+// observer facts are delivered ASYNCHRONOUSLY, so a check right after
+// WaitCompletion can run before the facts arrive — which made an earlier version
+// of this assertion fail about 1 run in 7. A task that records as it executes is
+// synchronous with the run by construction.
+type pathSet struct {
+	ran map[string]bool
+	m   sync.Mutex
+}
+
+func newPathSet() *pathSet {
+	return &pathSet{ran: map[string]bool{}}
+}
+
+// mark records that the named task executed.
+func (p *pathSet) mark(name string) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.ran[name] = true
+}
+
+// check reports an error unless every task in taken ran and none in skipped did
+// — the two halves of "the right branch was chosen".
+func (p *pathSet) check(taken, skipped []string) error {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	for _, n := range taken {
+		if !p.ran[n] {
+			return fmt.Errorf("task %q never ran", n)
+		}
+	}
+
+	for _, n := range skipped {
+		if p.ran[n] {
+			return fmt.Errorf("task %q ran but its branch was not taken", n)
+		}
+	}
+
+	return nil
+}

--- a/examples/terminate-end-event/process.go
+++ b/examples/terminate-end-event/process.go
@@ -18,7 +18,7 @@ import (
 //
 // The fraud check finishes first and reaches a Terminate End Event, which abnormally
 // terminates the whole instance — cancelling the in-flight payment mid-charge.
-func buildProcess() (*process.Process, error) {
+func buildProcess(ran *pathSet) (*process.Process, error) {
 	proc, err := process.New("terminate-end-event")
 	if err != nil {
 		return nil, fmt.Errorf("new process: %w", err)
@@ -34,12 +34,14 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("split: %w", err)
 	}
 
-	fraudCheck, err := serviceTask("fraud-check", fraudCheckOp)
+	fraudCheck, err := serviceTask("fraud-check",
+		func() (service.Operation, error) { return fraudCheckOp(ran) })
 	if err != nil {
 		return nil, err
 	}
 
-	payment, err := serviceTask("process-payment", paymentOp)
+	payment, err := serviceTask("process-payment",
+		func() (service.Operation, error) { return paymentOp(ran) })
 	if err != nil {
 		return nil, err
 	}

--- a/examples/timer-event/main.go
+++ b/examples/timer-event/main.go
@@ -20,8 +20,14 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 	"github.com/dr-dobermann/gobpm/pkg/model/process"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/model/service/gooper"
 	"github.com/dr-dobermann/gobpm/pkg/thresher"
 )
+
+// timerDelay is how long the start event's timer holds the token. The timer
+// definition and the example's own assertion both read it, so the check can
+// never drift away from the behaviour it is checking.
+const timerDelay = 5 * time.Second
 
 func main() {
 	fmt.Print(`
@@ -44,9 +50,9 @@ func main() {
 	// Create timer expression for time date (current time + 5 seconds)
 	timeExpr := goexpr.Must(
 		nil, // no data source needed for static time
-		data.MustItemDefinition(values.NewVariable(time.Now().Add(5*time.Second))),
+		data.MustItemDefinition(values.NewVariable(time.Now().Add(timerDelay))),
 		func(ctx context.Context, ds data.Source) (data.Value, error) {
-			return values.NewVariable(time.Now().Add(5 * time.Second)), nil
+			return values.NewVariable(time.Now().Add(timerDelay)), nil
 		},
 		foundation.WithID("time-plus-5s"),
 	)
@@ -69,8 +75,16 @@ func main() {
 		log.Fatal("Failed to create timer start event:", err)
 	}
 
-	// Create service operation
-	op, err := service.NewOperation("handle-timer", nil, nil, nil)
+	// Create service operation. It needs a real implementation: an operation
+	// built with a nil implementation faults the instance the moment the task
+	// runs, which is what this example did until its outcome was checked.
+	op, err := gooper.New("handle-timer",
+		func(_ context.Context, _ service.DataReader,
+			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			fmt.Println("  ▶ handle-timeout: the timer fired, handling it")
+
+			return nil, nil
+		})
 	if err != nil {
 		log.Fatal("Failed to create service operation:", err)
 	}
@@ -121,7 +135,9 @@ func main() {
 	}
 
 	// Start process execution
-	_, err = engine.StartLatest(proc.ID())
+	started := time.Now()
+
+	h, err := engine.StartLatest(proc.ID())
 	if err != nil {
 		log.Fatal("Failed to start process:", err)
 	}
@@ -131,8 +147,24 @@ func main() {
 	fmt.Println("Timer will trigger after 5 seconds...")
 	fmt.Println("Waiting up to 8s for the timer event...")
 
-	// Block until the engine context is canceled (timeout above); the 5s
-	// timer fires and the instance completes well within the window.
-	<-ctx.Done()
+	state, err := h.WaitCompletion(ctx)
+	if err != nil {
+		log.Fatal("Waiting for completion:", err)
+	}
+
+	if state != thresher.StateCompleted {
+		log.Fatalf("Instance ended %s, want Completed", state)
+	}
+
+	// The delay is the demonstration, so it is what gets checked: a timer
+	// that fired immediately — or a start event that ignored its trigger
+	// altogether — would complete the process just the same, only sooner.
+	// The earlier version of this example simply waited for the context to
+	// expire and then declared success, which no failure could have upset.
+	if waited := time.Since(started); waited < timerDelay {
+		log.Fatalf("completed after %s, want at least %s — the timer did "+
+			"not hold the token", waited.Round(time.Millisecond), timerDelay)
+	}
+
 	fmt.Println("Process completed")
 }

--- a/examples/transaction-sub-process/main.go
+++ b/examples/transaction-sub-process/main.go
@@ -37,7 +37,10 @@ func run() error {
 		return fmt.Errorf("create engine: %w", err)
 	}
 
-	proc, err := buildProcess()
+	// Records the execution order, so the reverse-order claim is checked.
+	log := newRunLog()
+
+	proc, err := buildProcess(log)
 	if err != nil {
 		return fmt.Errorf("build process: %w", err)
 	}
@@ -61,6 +64,19 @@ func run() error {
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("waiting for completion: %w", err)
+	}
+
+	// Two orderings are being demonstrated at once: compensation undoes the
+	// completed activities in REVERSE (refund before release, mirroring
+	// reserve then charge), and only afterwards does control leave through
+	// the Cancel boundary to notify-customer. A run that notified first, or
+	// undid forwards, would execute every task and complete just the same.
+	if err := log.check(
+		"reserve-seat", "charge-card",
+		"refund-card", "release-seat",
+		"notify-customer",
+	); err != nil {
+		return fmt.Errorf("cancel ordering: %w", err)
 	}
 
 	fmt.Printf("\n✓ transaction-sub-process completed (%s): the Cancel End "+

--- a/examples/transaction-sub-process/process.go
+++ b/examples/transaction-sub-process/process.go
@@ -16,7 +16,7 @@ import (
 //
 // reserve and charge complete and enter the completion ledger; the Cancel End
 // Event then aborts the Transaction.
-func buildTransaction() (*activities.SubProcess, error) {
+func buildTransaction(log *runLog) (*activities.SubProcess, error) {
 	tx, err := activities.NewSubProcess("booking", activities.WithTransaction())
 	if err != nil {
 		return nil, fmt.Errorf("new transaction: %w", err)
@@ -27,22 +27,22 @@ func buildTransaction() (*activities.SubProcess, error) {
 		return nil, fmt.Errorf("s-start: %w", err)
 	}
 
-	reserve, err := stepTask("reserve-seat", "  ✓ seat reserved")
+	reserve, err := stepTask(log, "reserve-seat", "  ✓ seat reserved")
 	if err != nil {
 		return nil, err
 	}
 
-	charge, err := stepTask("charge-card", "  ✓ card charged")
+	charge, err := stepTask(log, "charge-card", "  ✓ card charged")
 	if err != nil {
 		return nil, err
 	}
 
-	release, err := undoTask("release-seat", "  ↩ seat released")
+	release, err := undoTask(log, "release-seat", "  ↩ seat released")
 	if err != nil {
 		return nil, err
 	}
 
-	refund, err := undoTask("refund-card", "  ↩ card refunded")
+	refund, err := undoTask(log, "refund-card", "  ↩ card refunded")
 	if err != nil {
 		return nil, err
 	}
@@ -97,8 +97,8 @@ func buildTransaction() (*activities.SubProcess, error) {
 // The Cancel End inside the Transaction aborts it — refund-card compensates
 // before release-seat (reverse completion order) — then control leaves through
 // the interrupting Cancel boundary to notify-customer.
-func buildProcess() (*process.Process, error) {
-	tx, err := buildTransaction()
+func buildProcess(log *runLog) (*process.Process, error) {
+	tx, err := buildTransaction(log)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func buildProcess() (*process.Process, error) {
 		return nil, fmt.Errorf("cancel boundary: %w", err)
 	}
 
-	notify, err := stepTask("notify-customer",
+	notify, err := stepTask(log, "notify-customer",
 		"  ✉ customer notified: booking canceled")
 	if err != nil {
 		return nil, err

--- a/examples/transaction-sub-process/runlog.go
+++ b/examples/transaction-sub-process/runlog.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+)
+
+// runLog records the ORDER in which the booking, undo and exit steps executed.
+// A set would not be enough: the claim this example demonstrates is that the
+// Cancel End compensates in REVERSE order of completion and only then leaves
+// through the Cancel boundary, so "everything ran" is true even of a wrong
+// implementation that undid them forwards or notified the customer first.
+//
+// Recorded from inside the tasks rather than from an engine observer: observer
+// facts are delivered asynchronously and can still be in flight when
+// WaitCompletion returns, whereas a task that records as it executes is
+// synchronous with the run by construction.
+type runLog struct {
+	seq []string
+	m   sync.Mutex
+}
+
+func newRunLog() *runLog {
+	return &runLog{}
+}
+
+// mark appends the named step to the execution order.
+func (r *runLog) mark(name string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.seq = append(r.seq, name)
+}
+
+// check reports an error unless the steps executed in exactly this order.
+func (r *runLog) check(want ...string) error {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	if strings.Join(r.seq, ",") != strings.Join(want, ",") {
+		return fmt.Errorf("ran %v, want %v", r.seq, want)
+	}
+
+	return nil
+}

--- a/examples/transaction-sub-process/tasks.go
+++ b/examples/transaction-sub-process/tasks.go
@@ -13,10 +13,13 @@ import (
 )
 
 // stepTask builds a booking step that prints its action when it runs.
-func stepTask(name, msg string) (*activities.ServiceTask, error) {
+func stepTask(
+	log *runLog, name, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name+"-op",
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			log.mark(name)
 			fmt.Println(msg)
 
 			return nil, nil
@@ -35,10 +38,13 @@ func stepTask(name, msg string) (*activities.ServiceTask, error) {
 
 // undoTask builds an isForCompensation handler that prints its undo action — it
 // lives outside the normal flow and runs only when the abort sweeps the ledger.
-func undoTask(name, msg string) (*activities.ServiceTask, error) {
+func undoTask(
+	log *runLog, name, msg string,
+) (*activities.ServiceTask, error) {
 	op, err := gooper.New(name+"-op",
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			log.mark(name)
 			fmt.Println(msg)
 
 			return nil, nil

--- a/examples/usertask/main.go
+++ b/examples/usertask/main.go
@@ -94,6 +94,7 @@ func run() error {
 	// Assert all three — a driver that quietly skipped the claim would otherwise
 	// look identical from the outside.
 	if absent := watch.missing(
+		2*time.Second,
 		observability.PhaseAnnounced,
 		observability.PhaseClaimed,
 		observability.PhaseCompleted,

--- a/examples/usertask/main.go
+++ b/examples/usertask/main.go
@@ -1,6 +1,7 @@
 // Command usertask demonstrates a UserTask driven from the console: the engine
-// parks the task, the console TaskDistributor Takes it, renders its form, and
-// Completes it, resuming the process to its end event.
+// parks the task, the console TaskDistributor Takes it, CLAIMS it for exclusive
+// hold, renders its form, and Completes it, resuming the process to its end
+// event. The run asserts that all three ownership phases actually happened.
 package main
 
 import (
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/dr-dobermann/gobpm/pkg/interactor/console"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
 	"github.com/dr-dobermann/gobpm/pkg/thresher"
 )
 
@@ -54,6 +56,10 @@ func run() error {
 
 	driver.Bind(th)
 
+	// Watch the ownership lifecycle so the run can be checked, not just watched.
+	watch := newLifecycleWatch()
+	defer th.Observe(watch).Cancel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -76,6 +82,23 @@ func run() error {
 	state, err := h.WaitCompletion(wctx)
 	if err != nil {
 		return err
+	}
+
+	if state != thresher.StateCompleted {
+		return fmt.Errorf("process finished %s, want %s",
+			state, thresher.StateCompleted)
+	}
+
+	// The point of the example is the ownership flow: the task is announced to
+	// the distributor, the driver takes exclusive hold, and only then completes.
+	// Assert all three — a driver that quietly skipped the claim would otherwise
+	// look identical from the outside.
+	if absent := watch.missing(
+		observability.PhaseAnnounced,
+		observability.PhaseClaimed,
+		observability.PhaseCompleted,
+	); len(absent) > 0 {
+		return fmt.Errorf("user task never reached %v", absent)
 	}
 
 	fmt.Println("process finished:", state)

--- a/examples/usertask/observer.go
+++ b/examples/usertask/observer.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"sync"
+
+	"github.com/dr-dobermann/gobpm/pkg/observability"
+)
+
+// lifecycleWatch records which ownership phases the task actually went through,
+// so the example can ASSERT the flow it claims to demonstrate rather than only
+// print it. A run where the driver silently failed to claim — or where the task
+// completed without ever being announced — still exits 0 otherwise.
+//
+// Facts arrive on the engine's goroutines, so the set is mutex-guarded.
+type lifecycleWatch struct {
+	seen map[observability.Phase]bool
+	m    sync.Mutex
+}
+
+func newLifecycleWatch() *lifecycleWatch {
+	return &lifecycleWatch{seen: map[observability.Phase]bool{}}
+}
+
+// OnFact records every user-task phase the engine reports.
+func (w *lifecycleWatch) OnFact(f observability.Fact) {
+	if f.Kind != observability.KindTaskState {
+		return
+	}
+
+	w.m.Lock()
+	defer w.m.Unlock()
+
+	w.seen[f.Phase] = true
+}
+
+// missing returns the wanted phases that never arrived.
+func (w *lifecycleWatch) missing(want ...observability.Phase) []observability.Phase {
+	w.m.Lock()
+	defer w.m.Unlock()
+
+	var absent []observability.Phase
+
+	for _, p := range want {
+		if !w.seen[p] {
+			absent = append(absent, p)
+		}
+	}
+
+	return absent
+}

--- a/examples/usertask/observer.go
+++ b/examples/usertask/observer.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"sync"
+	"time"
 
 	"github.com/dr-dobermann/gobpm/pkg/observability"
 )
@@ -33,8 +34,33 @@ func (w *lifecycleWatch) OnFact(f observability.Fact) {
 	w.seen[f.Phase] = true
 }
 
-// missing returns the wanted phases that never arrived.
-func (w *lifecycleWatch) missing(want ...observability.Phase) []observability.Phase {
+// missing returns the wanted phases that never arrived, waiting up to timeout
+// for them.
+//
+// The wait is not padding: observer facts are delivered ASYNCHRONOUSLY, so they
+// can still be in flight when WaitCompletion has already returned. Checking
+// immediately made this assertion fail about 1 run in 40. Anything asserted from
+// the fact stream has to allow for that; anything recorded inside a task does
+// not, because that is synchronous with the run.
+func (w *lifecycleWatch) missing(
+	timeout time.Duration, want ...observability.Phase,
+) []observability.Phase {
+	deadline := time.Now().Add(timeout)
+
+	for {
+		absent := w.absentNow(want)
+		if len(absent) == 0 || time.Now().After(deadline) {
+			return absent
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// absentNow reports which wanted phases have not been seen yet.
+func (w *lifecycleWatch) absentNow(
+	want []observability.Phase,
+) []observability.Phase {
 	w.m.Lock()
 	defer w.m.Unlock()
 

--- a/examples/versioning/process.go
+++ b/examples/versioning/process.go
@@ -23,7 +23,7 @@ const processKey = "greeter"
 // buildGreeter builds a trivial start → service task → end process whose task
 // prints the given release label, so the console shows WHICH version ran when a
 // version is later addressed by latest / number / handle.
-func buildGreeter(label string) (*process.Process, error) {
+func buildGreeter(ran *ranVersion, label string) (*process.Process, error) {
 	proc, err := process.New("greeter", foundation.WithID(processKey))
 	if err != nil {
 		return nil, fmt.Errorf("create process: %w", err)
@@ -34,7 +34,7 @@ func buildGreeter(label string) (*process.Process, error) {
 		return nil, fmt.Errorf("create start: %w", err)
 	}
 
-	op, err := greetOp(label)
+	op, err := greetOp(ran, label)
 	if err != nil {
 		return nil, fmt.Errorf("create operation: %w", err)
 	}
@@ -68,10 +68,11 @@ func buildGreeter(label string) (*process.Process, error) {
 
 // greetOp returns a Go operation that prints the release label of the running
 // version.
-func greetOp(label string) (service.Operation, error) {
+func greetOp(ran *ranVersion, label string) (service.Operation, error) {
 	return gooper.New("greet",
 		func(_ context.Context, _ service.DataReader,
 			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			ran.record(label)
 			fmt.Printf("      ▶ [%s] hello from the greeter\n", label)
 
 			return nil, nil

--- a/examples/versioning/ranversion.go
+++ b/examples/versioning/ranversion.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+	"sync"
+)
+
+// ranVersion records the release label of the greeter that actually executed.
+// Every start in this example resolves to a version — StartLatest to the
+// highest, StartVersion to a pinned number, StartProcess to a held handle —
+// and the whole demonstration is WHICH one the engine picked. A run that
+// resolved the wrong version would print a different label and complete just
+// as successfully, so the label is captured and compared rather than trusted.
+//
+// Recorded inside the greeter operation rather than through an engine
+// observer: observer facts are delivered asynchronously and can still be in
+// flight when WaitCompletion returns.
+type ranVersion struct {
+	label string
+	m     sync.Mutex
+}
+
+func newRanVersion() *ranVersion {
+	return &ranVersion{}
+}
+
+// record stores the label of the greeter that just ran.
+func (r *ranVersion) record(label string) {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	r.label = label
+}
+
+// take returns the label of the last greeter that ran and clears it, so the
+// next start cannot pass on a stale reading from the previous one.
+func (r *ranVersion) take() string {
+	r.m.Lock()
+	defer r.m.Unlock()
+
+	label := r.label
+	r.label = ""
+
+	return label
+}
+
+// check reports an error unless the greeter that just ran carried want.
+func (r *ranVersion) check(want string) error {
+	if got := r.take(); got != want {
+		if got == "" {
+			return fmt.Errorf("no greeter ran, want %s", want)
+		}
+
+		return fmt.Errorf("%s ran, want %s", got, want)
+	}
+
+	return nil
+}

--- a/examples/versioning/scenario.go
+++ b/examples/versioning/scenario.go
@@ -10,37 +10,40 @@ import (
 // demonstrateVersioning walks the ADR-019 versioning lifecycle on one key:
 // register two versions, address them by latest / number / handle, list them,
 // then unregister the latest and watch the previous version get promoted back
-// to "latest". Each greeter run prints its own label, so the console proves
-// which version actually executed.
+// to "latest". Each greeter run records its own label, so every start proves
+// which version actually executed rather than only stating which it expected.
 func demonstrateVersioning(
 	ctx context.Context,
 	engine *thresher.Thresher,
 ) error {
-	v1, err := register(engine, "v1")
+	// Captures the label of whichever greeter runs, so each start is checked.
+	ran := newRanVersion()
+
+	v1, err := register(ran, engine, "v1")
 	if err != nil {
 		return err
 	}
 
-	v2, err := register(engine, "v2")
+	v2, err := register(ran, engine, "v2")
 	if err != nil {
 		return err
 	}
 
 	// Latest is now v2 — StartLatest resolves the highest version number.
 	h, err := engine.StartLatest(processKey)
-	if err := startAndWait(ctx, "StartLatest        → expects v2", h, err); err != nil {
+	if err := startAndWait(ctx, ran, "StartLatest        → expects v2", "v2", h, err); err != nil {
 		return err
 	}
 
 	// Pin an older version explicitly, by number, without holding its handle.
 	h, err = engine.StartVersion(processKey, 1)
-	if err := startAndWait(ctx, "StartVersion(key,1)→ expects v1", h, err); err != nil {
+	if err := startAndWait(ctx, ran, "StartVersion(key,1)→ expects v1", "v1", h, err); err != nil {
 		return err
 	}
 
 	// Same version, addressed by the registration handle returned earlier.
 	h, err = engine.StartProcess(v1)
-	if err := startAndWait(ctx, "StartProcess(v1)   → expects v1", h, err); err != nil {
+	if err := startAndWait(ctx, ran, "StartProcess(v1)   → expects v1", "v1", h, err); err != nil {
 		return err
 	}
 
@@ -57,7 +60,7 @@ func demonstrateVersioning(
 		versionList(engine))
 
 	h, err = engine.StartLatest(processKey)
-	if err := startAndWait(ctx, "StartLatest        → expects v1 (promoted)", h, err); err != nil {
+	if err := startAndWait(ctx, ran, "StartLatest        → expects v1 (promoted)", "v1", h, err); err != nil {
 		return err
 	}
 
@@ -67,10 +70,11 @@ func demonstrateVersioning(
 // register builds a fresh greeter carrying the given release label under the
 // shared key and registers it, reporting the version the engine assigned.
 func register(
+	ran *ranVersion,
 	engine *thresher.Thresher,
 	label string,
 ) (*thresher.ProcessRegistration, error) {
-	proc, err := buildGreeter(label)
+	proc, err := buildGreeter(ran, label)
 	if err != nil {
 		return nil, fmt.Errorf("build %s: %w", label, err)
 	}
@@ -91,7 +95,9 @@ func register(
 // result straight in keeps each call site a single readable line.
 func startAndWait(
 	ctx context.Context,
+	ran *ranVersion,
 	label string,
+	want string,
 	h *thresher.InstanceHandle,
 	err error,
 ) error {
@@ -102,6 +108,14 @@ func startAndWait(
 	state, err := h.WaitCompletion(ctx)
 	if err != nil {
 		return fmt.Errorf("%s: wait completion: %w", label, err)
+	}
+
+	// The label in the console says which version was EXPECTED; this is what
+	// makes it a claim rather than a caption. Without it, an engine that
+	// resolved StartLatest to the wrong version would print "expects v2",
+	// greet from v1, and still report a completed instance.
+	if err := ran.check(want); err != nil {
+		return fmt.Errorf("%s: %w", label, err)
 	}
 
 	fmt.Printf("  %s  [instance %s]\n", label, state)

--- a/pkg/thresher/restart_recovery_test.go
+++ b/pkg/thresher/restart_recovery_test.go
@@ -298,8 +298,14 @@ func TestRestartRecoveryOverdueTimer(t *testing.T) {
 
 // condProc builds start → conditional catch(shared val) → [lane] → end
 // with pinned ids; both engines share val through the closure.
+//
+// val is a values.Variable rather than a plain bool because the engine
+// evaluates the condition on the instance's own goroutine while the test flips
+// it from the test goroutine. Variable guards its own Get and Update with a
+// mutex, so sharing one is safe; a bare bool here was a data race that failed
+// the run under -race.
 func condProc(
-	t *testing.T, key string, val *bool, hit *atomic.Bool,
+	t *testing.T, key string, val *values.Variable[bool], hit *atomic.Bool,
 ) *process.Process {
 	t.Helper()
 
@@ -314,8 +320,13 @@ func condProc(
 
 	cond, err := goexpr.New(nil,
 		data.MustItemDefinition(values.NewVariable(false)),
-		func(_ context.Context, _ data.Source) (data.Value, error) {
-			return values.NewVariable(*val), nil
+		func(ctx context.Context, _ data.Source) (data.Value, error) {
+			on, err := data.As[bool](ctx, val)
+			if err != nil {
+				return nil, err
+			}
+
+			return values.NewVariable(on), nil
 		})
 	require.NoError(t, err)
 
@@ -348,11 +359,11 @@ func condProc(
 func TestRestartRecoveryConditional(t *testing.T) {
 	repo := memrepo.New()
 
-	val := false
+	val := values.NewVariable(false)
 
 	var hit1, hit2 atomic.Bool
 
-	p1 := condProc(t, "rr-cond", &val, &hit1)
+	p1 := condProc(t, "rr-cond", val, &hit1)
 
 	th1, _, cancel1 := bootEngine(t, "engine-1", repo,
 		80*time.Millisecond, p1)
@@ -370,11 +381,11 @@ func TestRestartRecoveryConditional(t *testing.T) {
 	}, 2*time.Second, 5*time.Millisecond)
 
 	// "during the downtime" the condition's world changes.
-	val = true
+	require.NoError(t, val.Update(context.Background(), true))
 
 	time.Sleep(120 * time.Millisecond) // the lease lapses
 
-	p2 := condProc(t, "rr-cond", &val, &hit2)
+	p2 := condProc(t, "rr-cond", val, &hit2)
 
 	_, fw2, cancel2 := bootEngine(t, "engine-2", repo, time.Minute, p2)
 	defer cancel2()


### PR DESCRIPTION
## Examples assert their own outcome

Every example failed only on a returned error. One that completed down the **wrong
branch**, computed a **wrong value**, or **skipped an activity entirely** still exited 0
and passed the FIX-029 run-step — so CI proved the examples *ran*, never that they were
*right*.

All 46 now compare the outcome they claim to demonstrate and fail when it differs. No new
CI machinery: the existing exit-0 gate became an outcome gate.

Closes the "Examples assert their own outcome" backlog item.

---

## Three examples were already broken

None of these was found by reading. Each surfaced the moment something checked the result.

**`timer-event` faulted on every run — since it was written.** Its ServiceTask was built on
`service.NewOperation("handle-timer", nil, nil, nil)`, an operation with no implementation,
so the task failed and the instance terminated. The example then blocked on `<-ctx.Done()`
and printed `Process completed`. Eight seconds of failure was indistinguishable from
success, which is precisely why it survived.

**`simple-timer` demonstrated behaviour the engine does not have.** It claimed a timer Start
Event instantiates the process on schedule; no instance was ever created. That is
deliberate — `internal/instance/snapshot/instantiating_starts_test.go:144` asserts a timer
start is *not* an instantiating trigger, and scheduled instantiation is unimplemented. It
now starts the instance explicitly and asserts the timer **held the token** for its full
delay, with a doc comment saying which of the two it is and why. **This changes what the
example claims** — flagging it in case you would rather retire it than re-aim it.

**`embedded-subprocess` could fail invisibly.** Its steps did `GetData("order-id")` on the
parent's property and, on failure, printed a shorter line and carried on — so a broken
scope walk-up, the one thing the example teaches, looked like success. Each step's lookup
result is now recorded, `nil` included, and checked.

---

## The rule the assertions follow

**Record inside the task, not from an observer.** Observer facts are delivered
asynchronously and can still be in flight when `WaitCompletion` returns; a `usertask`
assertion written that way failed about 1 run in 40, and a `gateway-routing` one 3 in 20.
A task that records as it executes is synchronous with the run by construction.

The one legitimate exception is `DataChange`, which is **observer-only** — never echoed to
the operator log, so there is nothing in-task to record. Those three examples already call
`sub.Cancel()` before checking, and Cancel drains the facts still in flight, which settles
it.

Two other things the assertions deliberately do **not** do:

- **`maps` is checked as a set, not a sequence.** Its three second-commit changes derive
  from a Go map, whose iteration order is unspecified — pinning an order would pin a
  coincidence and go flaky later.
- **`terminate-end-event` requires only that the card is never charged**, not that the
  payment reported an interruption. Whether the payment task is scheduled before the
  teardown reaches it is a race that loses about 1 run in 8, and never running is as
  correct as being interrupted. My first version asserted the interruption and was flaky.

Where a check and the behaviour it checks shared a magic number, the number became one
definition read by both — timer delays, quorum size, loop bound, the scoring rule
(`scoreFor(i)`), the tax rule (`withTax(amount)`). An assertion cannot drift from what it
asserts.

---

## What each group now proves

| Group | The claim that is now checked |
|---|---|
| Tasks | the script/rule/worker produced the value it advertises |
| Gateways | the matched arm ran **and** the others did not |
| Events | interruption stops the host activity, not just runs the handler |
| Compensation | handlers run in **reverse** order of completion |
| Sub-processes | the data contract crosses the boundary; the scope walk-up resolves |
| Multi-instance | the output collection holds every instance's contribution, in order |
| Data | the value read back is the value expected, per path |
| Versioning | the version that **ran** is the version that was **asked for** |

`versioning` deserves a note: every start was labelled `"StartLatest → expects v2"` and
nothing compared that to what executed. The labels were captions, not claims — an engine
resolving to the wrong version, or failing to promote v1 after v2 is unregistered, would
print the same expectation and report a completed instance. All four resolution paths are
now checked.

Six examples already asserted properly and were left alone: `data-store`, `process-data`,
`conversation-routing`, `inter-instance-correlation`, `restart-recovery`, `dehydration`,
plus both message examples (round-trip payload).

---

## Verification

`make ci` green: lint, `-race` tests, diff-coverage gate, govulncheck across all modules,
and all 46 examples executed end-to-end.

Beyond the gate, because neither proves an assertion is *live*:

- **Every assertion was inverted once** and confirmed to fail. None is vacuous — this
  caught a real one, where an assertion referenced approver names (`approve-1`…) that
  did not exist in the process.
- **Every example was run 25 times** (8 for the multi-second timer and persistence ones).
  This is what surfaced the two flaky assertions described above; both are fixed, and the
  reasoning is recorded next to each so the next person does not reintroduce them.
