### PR TITLE
FIX-034: close four gate blind spots — per-module coverage, discard/assertion lint, link check, constructor docs

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -76,9 +76,10 @@ jobs:
       - name: Test core modules with race detector
         run: make test-core
 
-      # Diff-coverage gate (SRD-002): reuses the coverage.txt that test-all just
-      # wrote (no second test run); same `make cover-check` / COVER_MIN the
-      # local `make ci` uses, so the verdict is identical local and on CI.
+      # Diff-coverage gate (SRD-002): reuses the per-module coverage.txt files
+      # test-all just wrote (no second test run) — every core module, not only
+      # the root, since FIX-034; same `make cover-check` / COVER_MIN the local
+      # `make ci` uses, so the verdict is identical local and on CI.
       - name: Diff-coverage gate (changed lines >= COVER_MIN)
         run: |
           git fetch --no-tags origin master

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -68,6 +68,11 @@ jobs:
       - name: Build core modules
         run: make build-core
 
+      # Documentation link gate (FIX-034): relative Markdown links must
+      # resolve. Offline and repo-local — no toolchain, no network.
+      - name: Documentation link check
+        run: make link-check
+
       # Library-consumption guard (FIX-024): an external module must build
       # against gobpm with no test-only (testify) / mock dep leak.
       - name: Consumer-consumption smoke

--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ examples/compensation-events/compensation-events
 examples/transaction-sub-process/transaction-sub-process
 examples/bpmn-convert/bpmn-convert
 examples/adhoc-subprocess/adhoc-subprocess
+
+# the link checker's built binary (built by `make link-check` via `go run`,
+# but `go build ./cmd/...` drops one here)
+/linkcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,9 @@ linters:
     - depguard
     - dupl
     - errcheck
+    # ADR-034 v.1 §5: an unchecked assertion panics where data.As[T] returns a
+    # classified error naming both the held and the wanted type (FIX-034 §1.2).
+    - forcetypeassert
     - funlen
     - gochecknoinits
     - gocognit
@@ -31,6 +34,10 @@ linters:
     - unused
     - whitespace
   settings:
+    errcheck:
+      # ADR-022: `_ = f()` is a discard, not handling. The one deliberate
+      # discard left in the library carries a //nolint with its reason.
+      check-blank: true
     depguard:
       rules:
         deny_deprecated:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,8 @@ before every push.
 
 The **diff-coverage gate** (`make cover-check`, SRD-002) fails when the lines a change
 adds/modifies are covered below `COVER_MIN` (95% now, rising toward 100). It judges
-only changed lines — reusing the `coverage.txt` `test-all` writes — so the untouched-code
-coverage backlog never blocks a PR. The gate runs locally (`make ci`) and in CI via the
+only changed lines — reusing the per-module `coverage.txt` files `test-all` writes, one
+per core module — so the untouched-code coverage backlog never blocks a PR. The gate runs locally (`make ci`) and in CI via the
 same `cmd/covercheck` binary, preserving local↔CI parity.
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,26 @@ COVER_BASE ?= origin/master
 # relay of an already-classified error. Reachable error paths keep their
 # tests; only the single propagation line leaves the denominator.
 #
+# Ninth regex: a call to errs.Invariant — the project's ONE named construct for
+# "this state is unreachable; the engine wired itself wrong" (FIX-034 §3.2.3).
+# Such a branch cannot be driven from any input, so demanding a test for it
+# would mean building broken engine states whose only purpose is to prove the
+# impossible. The exclusion is deliberately tied to the constructor rather than
+# to a file, a linter or a comment: `grep -rn "errs.Invariant("` lists every
+# excluded line, silencing the gate requires saying so in code, and the
+# constructor itself is unit-tested (pkg/errs). failInvariant is the
+# instance-loop wrapper around it (fault the instance, stop the tracks) and is
+# excluded on the same grounds.
+#
+# Tenth regex: a bare `return`. Like the closing brace below it carries no
+# logic — it only ends a void function's guard — so excluding it can never hide
+# untested behaviour; the statement that DID something sits on the line above.
+#
 # Eighth regex: a bare closing brace. A `}` line carries no statement — it is
 # counted only because it sits inside a profile block's line span (e.g. the
 # excluded propagation return's block). Excluding it can never hide untested
 # logic: every statement line stays in the gate.
-COVER_EXCLUDE ?= \.(logger|Logger\(\))\.(Debug|Info|Warn|Error)\(,func \(.*\) Option\(\) \{\},func \(.*\) mappedOutcome\(\) \{\},func \(.*\) (Lock|Unlock)\(\) \{\},func \(.*\) isLoopCharacteristics\(\) \{\},^\s*return .*[a-z]Err\(.*err\)$$,^\s*return (nil. |\"\". |false. )*err$$,^\s*\}$$
+COVER_EXCLUDE ?= \.(logger|Logger\(\))\.(Debug|Info|Warn|Error)\(,func \(.*\) Option\(\) \{\},func \(.*\) mappedOutcome\(\) \{\},func \(.*\) (Lock|Unlock)\(\) \{\},func \(.*\) isLoopCharacteristics\(\) \{\},^\s*return .*[a-z]Err\(.*err\)$$,^\s*return (nil. |\"\". |false. )*err$$,^\s*\}$$,errs\.Invariant\(,failInvariant\(,^\s*return$$
 
 # All Go modules in the monorepo (each with its own go.mod).
 # Discovered dynamically so adding a new module needs no Makefile edit.

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,18 @@ EXAMPLE_MODULES := $(filter ./examples/%,$(MODULES))
 # generated/ or examples/.
 COVER_PACKAGES = $$($(GO) list ./... | grep -Ev '/(generated|examples)(/|$$)')
 
+# Every module writes its OWN profile (test-all), and the gate reads all of
+# them. Until FIX-034 the profile was written only in the root's special case,
+# so runtime/ and the three adapters were never diff-gated at all — two of them
+# landed after COVER_MIN reached 95 and CI stayed green regardless of what they
+# added. Derived from CORE_MODULES, so a module added tomorrow is gated the day
+# it appears rather than when someone remembers this line. Missing profiles are
+# skipped: `make cover-check` may run after a scoped test-all, and covercheck
+# would reject a path that does not exist.
+COVER_PROFILES = $$(for d in $(CORE_MODULES); do \
+		[ -f "$$d/coverage.txt" ] && printf '%s/coverage.txt,' "$$d"; \
+	done | sed 's/,$$//')
+
 # ---------------------------------------------------------------------------
 # Tooling — versions are the single source of truth, mirrored by the
 # "Install tools" step in .github/workflows/check.yml. `make tools` installs
@@ -214,11 +226,7 @@ TEST_CPUS ?= 4
 test-all:
 	@set -e; for dir in $(MODULES); do \
 		echo "::group::test $$dir (TEST_CPUS=$(TEST_CPUS))"; \
-		if [ "$$dir" = "." ]; then \
-			(cd $$dir && GOMAXPROCS=$(TEST_CPUS) $(GO) test -race -count=1 -coverprofile=coverage.txt $(COVER_PACKAGES)) || exit 1; \
-		else \
-			(cd $$dir && GOMAXPROCS=$(TEST_CPUS) $(GO) test -race -count=1 ./...) || exit 1; \
-		fi; \
+		(cd $$dir && GOMAXPROCS=$(TEST_CPUS) $(GO) test -race -count=1 -coverprofile=coverage.txt $(COVER_PACKAGES)) || exit 1; \
 		echo "::endgroup::"; \
 	done
 .PHONY: test-all
@@ -278,15 +286,15 @@ consumer-smoke:
 .PHONY: consumer-smoke
 
 # Diff-coverage gate: fail when the lines this change adds/modifies are covered
-# below COVER_MIN. Consumes the coverage.txt that test-all produces (root
-# module) — run `make test-all` first, or use `make ci` which orders them.
-# Judges only changed lines, so the untouched-code backlog never blocks it.
+# below COVER_MIN. Consumes the per-module coverage.txt files test-all produces
+# — run `make test-all` first, or use `make ci` which orders them. Judges only
+# changed lines, so the untouched-code backlog never blocks it.
 cover-check:
 	$(call require-go-tool,covercheck,github.com/dr-dobermann/covercheck,$(COVERCHECK_VERSION))
 	covercheck -min $(COVER_MIN) -base $(COVER_BASE) \
 		-exclude-lines '$(COVER_EXCLUDE)' \
 		-exclude-paths '^(generated|examples)/' \
-		-profiles coverage.txt
+		-profiles $(COVER_PROFILES)
 .PHONY: cover-check
 
 # Core-scoped aliases — the REQUIRED CI job's steps (one target per workflow

--- a/Makefile
+++ b/Makefile
@@ -208,6 +208,16 @@ gen_mock_files:
 # from what the current interfaces produce (a changed interface not regenerated
 # + committed). Deterministic output + a pinned mockery make git diff a reliable
 # signal.
+# Documentation link gate (FIX-034 §3.2.4): every RELATIVE Markdown link must
+# resolve to a file that exists. Blocking, because the 78 dead references
+# FIX-031 swept up accumulated precisely because nothing failed. Offline and
+# repository-local: the checker is built from this repo, so it adds no tool to
+# install and no network dependency that could redden the gate for reasons
+# unrelated to the change. External URLs are deliberately out of scope.
+link-check:
+	$(GO) run ./cmd/linkcheck -root .
+.PHONY: link-check
+
 mock-check:
 	$(call require-go-tool,mockery,github.com/vektra/mockery/v3,$(MOCKERY_VERSION))
 	rm -rf generated/
@@ -373,7 +383,7 @@ ci-examples:
 .PHONY: ci-examples
 
 # The core gate — everything the REQUIRED CI job runs, in the same order.
-ci-core: mock-check tidy-check-core lint-core build-core consumer-smoke test-core cover-check vuln-core
+ci-core: mock-check link-check tidy-check-core lint-core build-core consumer-smoke test-core cover-check vuln-core
 .PHONY: ci-core
 
 # Umbrella target that runs the full local-equivalent of CI (BOTH CI jobs).

--- a/cmd/linkcheck/link.go
+++ b/cmd/linkcheck/link.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// link is one relative Markdown link target and the line it appeared on.
+type link struct {
+	target string
+	line   int
+}
+
+// inlineLink matches [text](target) and the reference form [id]: target. The
+// target group is deliberately lazy and stops at the first closing paren or
+// whitespace, so a title — [t](path "title") — is not swallowed.
+var (
+	inlineLink = regexp.MustCompile(`\[[^\]]*\]\(([^)]*)\)`)
+	refLink    = regexp.MustCompile(`^\s{0,3}\[[^\]]+\]:\s+(\S+)`)
+	fenceLine  = regexp.MustCompile("^\\s{0,3}(```|~~~)")
+	inlineCode = regexp.MustCompile("`[^`]*`")
+	hasScheme  = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.\-]*:`)
+)
+
+// extract returns every link target in src that names a path this repository
+// could resolve. Two exclusions are requirements, not conveniences, both learned
+// from FIX-031 §4.1:
+//
+//   - fenced and inline code is skipped. A Go generic signature such as
+//     `values.NewArray[T](vals…)` is indistinguishable from a Markdown link to
+//     a regex, and eight such spans exist in the docs today.
+//   - targets are percent-DECODED, or every correct link to a file whose name
+//     contains a space — "gobpm Development Roadmap.md" — reports as broken.
+//
+// Absolute URLs, protocol-relative URLs, mailto: and same-document anchors are
+// not this checker's business: they rot for reasons outside the repository, and
+// checking them would make the gate depend on the network.
+func extract(src string) []link {
+	var (
+		out    []link
+		inCode bool
+	)
+
+	for i, raw := range strings.Split(src, "\n") {
+		if fenceLine.MatchString(raw) {
+			inCode = !inCode
+
+			continue
+		}
+
+		if inCode {
+			continue
+		}
+
+		line := inlineCode.ReplaceAllString(raw, "")
+
+		for _, m := range inlineLink.FindAllStringSubmatch(line, -1) {
+			if t, ok := cleanTarget(m[1]); ok {
+				out = append(out, link{target: t, line: i + 1})
+			}
+		}
+
+		if m := refLink.FindStringSubmatch(line); m != nil {
+			if t, ok := cleanTarget(m[1]); ok {
+				out = append(out, link{target: t, line: i + 1})
+			}
+		}
+	}
+
+	return out
+}
+
+// cleanTarget reduces a raw link target to the repository path it names, or
+// reports false when it names something this checker does not verify.
+func cleanTarget(raw string) (string, bool) {
+	t := strings.TrimSpace(raw)
+
+	// <path> is the escaped form for a target containing spaces, so everything
+	// inside the brackets is the path — a title split here would truncate it.
+	if strings.HasPrefix(t, "<") {
+		if end := strings.Index(t, ">"); end > 0 {
+			t = t[1:end]
+		} else {
+			t = strings.TrimPrefix(t, "<")
+		}
+	} else if i := strings.IndexAny(t, " \t"); i >= 0 {
+		// an unbracketed target ends at the title: [text](path "title")
+		t = t[:i]
+	}
+
+	// drop the fragment; a pure #anchor addresses this same document.
+	if i := strings.Index(t, "#"); i >= 0 {
+		t = t[:i]
+	}
+
+	if t == "" || hasScheme.MatchString(t) || strings.HasPrefix(t, "//") {
+		return "", false
+	}
+
+	decoded, err := url.PathUnescape(t)
+	if err != nil {
+		// A target that will not decode cannot name a file; report it as-is
+		// rather than dropping it silently.
+		return t, true
+	}
+
+	return decoded, true
+}

--- a/cmd/linkcheck/link_test.go
+++ b/cmd/linkcheck/link_test.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// The two exclusions below are requirements paid for by FIX-031, not
+// conveniences: without them the checker is either useless (eight false
+// positives from Go generics in inline code) or wrong (every link to a file
+// whose name contains a space reports broken).
+
+func TestExtractSkipsWhatIsNotALink(t *testing.T) {
+	src := "" +
+		"[real](./doc.md)\n" +
+		"```go\n" +
+		"[fenced](./nope.md)\n" +
+		"```\n" +
+		"a generic `values.NewArray[T](vals…)` in prose\n" +
+		"[anchor](#section)\n" +
+		"[external](https://example.com/x.md)\n" +
+		"[protocol-relative](//example.com/x.md)\n" +
+		"[mail](mailto:someone@example.com)\n" +
+		"[titled](./titled.md \"a title\")\n" +
+		"[ref]: ./reference.md\n"
+
+	got := extract(src)
+
+	targets := make([]string, 0, len(got))
+	for _, l := range got {
+		targets = append(targets, l.target)
+	}
+
+	require.Equal(t,
+		[]string{"./doc.md", "./titled.md", "./reference.md"}, targets,
+		"fenced blocks, inline code, anchors and absolute URLs are not links "+
+			"this checker resolves")
+
+	require.Equal(t, 1, got[0].line, "the line number is reported for the fix")
+}
+
+func TestExtractDecodesPercentEncodedTargets(t *testing.T) {
+	got := extract("[roadmap](docs/gobpm%20Development%20Roadmap.md)\n")
+
+	require.Len(t, got, 1)
+	require.Equal(t, "docs/gobpm Development Roadmap.md", got[0].target,
+		"an encoded href names a real file and must not report as broken")
+}
+
+func TestExtractHandlesAngleBracketTargets(t *testing.T) {
+	got := extract("[spaced](<a file.md>)\n")
+
+	require.Len(t, got, 1)
+	require.Equal(t, "a file.md", got[0].target)
+}
+
+func TestCheckFileResolvesRelativeToTheDocument(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "sub"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dir, "sub", "there.md"), []byte("x"), 0o600))
+
+	doc := filepath.Join(dir, "sub", "here.md")
+	src := "[sibling](there.md)\n[missing](gone.md)\n[up](../also-gone.md)\n"
+
+	require.NoError(t, os.WriteFile(doc, []byte(src), 0o600))
+
+	got := checkFile(doc, src)
+
+	require.Len(t, got, 2, "the sibling resolves; the other two do not")
+	require.Equal(t, "gone.md", got[0].target)
+	require.Equal(t, 2, got[0].line)
+	require.Equal(t, "../also-gone.md", got[1].target)
+}
+
+func TestScanWalksMarkdownAndSortsItsFindings(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, ".git"), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".git", "b.md"),
+		[]byte("[skipped](nope.md)\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.md"),
+		[]byte("[dead](nope.md)\n"), 0o600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "ok.txt"),
+		[]byte("[dead](nope.md)\n"), 0o600))
+
+	got, err := scan(dir)
+	require.NoError(t, err)
+
+	require.Len(t, got, 1,
+		"only Markdown is scanned, and .git is not documentation")
+	require.Equal(t, "nope.md", got[0].target)
+}
+
+func TestScanReportsAWalkFailure(t *testing.T) {
+	_, err := scan(filepath.Join(t.TempDir(), "does-not-exist"))
+	require.Error(t, err)
+}
+
+// run carries the tool's contract: what it prints and which exit code it
+// chooses. A CLI whose behaviour is only reachable by spawning a process tends
+// to go untested — and this one is a blocking gate step, so its verdict matters.
+func TestRunExitCodes(t *testing.T) {
+	dir := t.TempDir()
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "good.md"),
+		[]byte("[self](good.md)\n"), 0o600))
+
+	t.Run("clean tree exits 0", func(t *testing.T) {
+		var out, errOut strings.Builder
+
+		code := run([]string{"-root", dir}, &out, &errOut)
+
+		require.Equal(t, 0, code)
+		require.Contains(t, out.String(), "every relative link resolves")
+	})
+
+	t.Run("dead link exits 1 and names it", func(t *testing.T) {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "bad.md"),
+			[]byte("\n[gone](missing.md)\n"), 0o600))
+
+		var out, errOut strings.Builder
+
+		code := run([]string{"-root", dir}, &out, &errOut)
+
+		require.Equal(t, 1, code)
+		require.Contains(t, out.String(), "bad.md:2: dead link: missing.md",
+			"the report is file:line so the fix is one jump away")
+		require.Contains(t, errOut.String(), "1 dead link(s)")
+	})
+
+	t.Run("unusable root exits 2", func(t *testing.T) {
+		var out, errOut strings.Builder
+
+		code := run([]string{"-root", filepath.Join(dir, "nope")}, &out, &errOut)
+
+		require.Equal(t, 2, code)
+		require.Contains(t, errOut.String(), "linkcheck:")
+	})
+
+	t.Run("a bad flag exits 2", func(t *testing.T) {
+		var out, errOut strings.Builder
+
+		require.Equal(t, 2, run([]string{"-nope"}, &out, &errOut))
+	})
+}

--- a/cmd/linkcheck/main.go
+++ b/cmd/linkcheck/main.go
@@ -1,0 +1,153 @@
+// Command linkcheck verifies that every relative link in the repository's
+// Markdown resolves to a file that exists.
+//
+// It exists because nothing did: FIX-031 swept up 78 dead cross-references that
+// had accumulated across several refactors, including in both READMEs and the
+// SAD, and two of its three causes — a retired document and a renamed ADR — are
+// exactly what a checker catches for free (FIX-034 §1.3).
+//
+// It is deliberately a small Go program rather than an off-the-shelf tool: the
+// repository's parity rule requires every CI tool to be pinned and installed by
+// `make tools`, and adding a Node or Rust toolchain for this would also add a
+// network dependency that makes the gate flaky for reasons unrelated to the
+// change under test. Relative links only, offline, deterministic.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// problem is one link that does not resolve.
+type problem struct {
+	file   string
+	target string
+	line   int
+}
+
+// skipDir names directories that hold no authored documentation.
+var skipDir = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"bin":          true,
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+// run is main's body with its I/O and exit code as values, so the tool's
+// behavior — what it prints, and which of its three exit codes it chooses — is
+// testable without spawning a process. 0 clean, 1 dead links, 2 unusable root.
+func run(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("linkcheck", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	root := flags.String("root", ".", "directory to scan")
+
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+
+	problems, err := scan(*root)
+	if err != nil {
+		emitf(stderr, "linkcheck: %v\n", err)
+
+		return 2
+	}
+
+	for _, p := range problems {
+		emitf(stdout, "%s:%d: dead link: %s\n", p.file, p.line, p.target)
+	}
+
+	if len(problems) > 0 {
+		emitf(stderr, "\nlinkcheck: %d dead link(s)\n", len(problems))
+
+		return 1
+	}
+
+	emitf(stdout, "linkcheck: every relative link resolves\n")
+
+	return 0
+}
+
+// scan walks root's Markdown and returns the links that do not resolve, in a
+// stable order so the output is diffable.
+func scan(root string) ([]problem, error) {
+	var out []problem
+
+	err := filepath.WalkDir(root, func(
+		path string, d fs.DirEntry, err error,
+	) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if skipDir[d.Name()] {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+
+		if !strings.EqualFold(filepath.Ext(path), ".md") {
+			return nil
+		}
+
+		// The path comes from this walk over an operator-chosen root — there
+		// is no untrusted input to sanitize, and reading the files it finds is
+		// the tool's entire purpose.
+		src, rerr := os.ReadFile(path) //nolint:gosec // see above
+		if rerr != nil {
+			return rerr
+		}
+
+		out = append(out, checkFile(path, string(src))...)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].file != out[j].file {
+			return out[i].file < out[j].file
+		}
+
+		return out[i].line < out[j].line
+	})
+
+	return out, nil
+}
+
+// checkFile reports the links in one document that do not resolve, relative to
+// that document's own directory.
+func checkFile(path, src string) []problem {
+	var out []problem
+
+	dir := filepath.Dir(path)
+
+	for _, l := range extract(src) {
+		if _, err := os.Stat(filepath.Join(dir, l.target)); err != nil {
+			out = append(out, problem{file: path, line: l.line, target: l.target})
+		}
+	}
+
+	return out
+}
+
+// emitf writes one diagnostic line, deliberately ignoring the write error. Every
+// byte this tool produces is a report FOR the operator, so a failed write to
+// their terminal cannot be reported anywhere they would see it — the same
+// carve-out the console driver carries (FIX-028 §6.1).
+func emitf(w io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, format, args...) //nolint:errcheck // see above
+}

--- a/cmd/linkcheck/main.go
+++ b/cmd/linkcheck/main.go
@@ -3,7 +3,7 @@
 //
 // It is a thin wrapper on purpose. The checker's logic lives in
 // internal/linkcheck because the diff-coverage gate does not measure files
-// under cmd/ — proven by experiment, and recorded in docs/backlog.md — so code
+// under cmd/ — proven by experiment, and diagnosed in FIX-034 §8.3 — so code
 // left here would ship ungated. Only this entry point, which cannot be called
 // without exiting the process, stays in the blind spot.
 package main

--- a/cmd/linkcheck/main.go
+++ b/cmd/linkcheck/main.go
@@ -1,153 +1,19 @@
 // Command linkcheck verifies that every relative link in the repository's
-// Markdown resolves to a file that exists.
+// Markdown resolves to a file that exists (FIX-034 §1.3).
 //
-// It exists because nothing did: FIX-031 swept up 78 dead cross-references that
-// had accumulated across several refactors, including in both READMEs and the
-// SAD, and two of its three causes — a retired document and a renamed ADR — are
-// exactly what a checker catches for free (FIX-034 §1.3).
-//
-// It is deliberately a small Go program rather than an off-the-shelf tool: the
-// repository's parity rule requires every CI tool to be pinned and installed by
-// `make tools`, and adding a Node or Rust toolchain for this would also add a
-// network dependency that makes the gate flaky for reasons unrelated to the
-// change under test. Relative links only, offline, deterministic.
+// It is a thin wrapper on purpose. The checker's logic lives in
+// internal/linkcheck because the diff-coverage gate does not measure files
+// under cmd/ — proven by experiment, and recorded in docs/backlog.md — so code
+// left here would ship ungated. Only this entry point, which cannot be called
+// without exiting the process, stays in the blind spot.
 package main
 
 import (
-	"flag"
-	"fmt"
-	"io"
-	"io/fs"
 	"os"
-	"path/filepath"
-	"sort"
-	"strings"
+
+	"github.com/dr-dobermann/gobpm/internal/linkcheck"
 )
 
-// problem is one link that does not resolve.
-type problem struct {
-	file   string
-	target string
-	line   int
-}
-
-// skipDir names directories that hold no authored documentation.
-var skipDir = map[string]bool{
-	".git":         true,
-	"node_modules": true,
-	"bin":          true,
-}
-
 func main() {
-	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
-}
-
-// run is main's body with its I/O and exit code as values, so the tool's
-// behavior — what it prints, and which of its three exit codes it chooses — is
-// testable without spawning a process. 0 clean, 1 dead links, 2 unusable root.
-func run(args []string, stdout, stderr io.Writer) int {
-	flags := flag.NewFlagSet("linkcheck", flag.ContinueOnError)
-	flags.SetOutput(stderr)
-
-	root := flags.String("root", ".", "directory to scan")
-
-	if err := flags.Parse(args); err != nil {
-		return 2
-	}
-
-	problems, err := scan(*root)
-	if err != nil {
-		emitf(stderr, "linkcheck: %v\n", err)
-
-		return 2
-	}
-
-	for _, p := range problems {
-		emitf(stdout, "%s:%d: dead link: %s\n", p.file, p.line, p.target)
-	}
-
-	if len(problems) > 0 {
-		emitf(stderr, "\nlinkcheck: %d dead link(s)\n", len(problems))
-
-		return 1
-	}
-
-	emitf(stdout, "linkcheck: every relative link resolves\n")
-
-	return 0
-}
-
-// scan walks root's Markdown and returns the links that do not resolve, in a
-// stable order so the output is diffable.
-func scan(root string) ([]problem, error) {
-	var out []problem
-
-	err := filepath.WalkDir(root, func(
-		path string, d fs.DirEntry, err error,
-	) error {
-		if err != nil {
-			return err
-		}
-
-		if d.IsDir() {
-			if skipDir[d.Name()] {
-				return fs.SkipDir
-			}
-
-			return nil
-		}
-
-		if !strings.EqualFold(filepath.Ext(path), ".md") {
-			return nil
-		}
-
-		// The path comes from this walk over an operator-chosen root — there
-		// is no untrusted input to sanitize, and reading the files it finds is
-		// the tool's entire purpose.
-		src, rerr := os.ReadFile(path) //nolint:gosec // see above
-		if rerr != nil {
-			return rerr
-		}
-
-		out = append(out, checkFile(path, string(src))...)
-
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	sort.Slice(out, func(i, j int) bool {
-		if out[i].file != out[j].file {
-			return out[i].file < out[j].file
-		}
-
-		return out[i].line < out[j].line
-	})
-
-	return out, nil
-}
-
-// checkFile reports the links in one document that do not resolve, relative to
-// that document's own directory.
-func checkFile(path, src string) []problem {
-	var out []problem
-
-	dir := filepath.Dir(path)
-
-	for _, l := range extract(src) {
-		if _, err := os.Stat(filepath.Join(dir, l.target)); err != nil {
-			out = append(out, problem{file: path, line: l.line, target: l.target})
-		}
-	}
-
-	return out
-}
-
-// emitf writes one diagnostic line, deliberately ignoring the write error. Every
-// byte this tool produces is a report FOR the operator, so a failed write to
-// their terminal cannot be reported anywhere they would see it — the same
-// carve-out the console driver carries (FIX-028 §6.1).
-func emitf(w io.Writer, format string, args ...any) {
-	_, _ = fmt.Fprintf(w, format, args...) //nolint:errcheck // see above
+	os.Exit(linkcheck.Run(os.Args[1:], os.Stdout, os.Stderr))
 }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -123,6 +123,17 @@ implemented), and leaves this list.
   denominator went from 131 to 238 changed lines, so ~107 lines moved from
   unmeasured to gated, and an uncovered probe in the relocated package now
   fails the gate as it should.
+- **A panicking observer is swallowed without a trace**
+  (`pkg/thresher/observer.go`) — `deliver` contains the panic so one bad
+  observer cannot crash the drain goroutine or affect the others (ADR-013 §5),
+  but it has no sink to report it to, so a broken observer leaves no evidence
+  at all. That is the accidental-silence class ADR-022 treats as the worse
+  failure: the engine keeps running and the operator never learns their
+  observer is dead. Surfaced by FIX-034 §8.3, which annotated the discard
+  rather than widening that FIX beyond gate hardening. The fix is small but not
+  free — `deliver` is a free function with no logger in scope, and `Logger()`
+  is not directly on `Instance` — so it wants its own change rather than a
+  drive-by.
 - **No automated Markdown link check** — **DONE** (2026-07-31, FIX-034 §3.2.4).
   `cmd/linkcheck` walks the repository's Markdown and fails the gate on any
   relative link that does not resolve; it is blocking, offline and built from

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -45,7 +45,16 @@ Genuinely un-homed items — not yet tracked in an ADR/SRD, the roadmap, or the
 audit-backlog. Each graduates out into an ADR/SRD (when designed) or a FIX (when
 implemented), and leaves this list.
 
-- **Optioned-constructor doc-comment audit** — sweep every `New*` constructor whose
+- **Optioned-constructor doc-comment audit** — **DONE** (2026-07-31, FIX-034
+  §3.2.5). The audit found four defects — `NewServiceTask` missing
+  `WithWorkerTrust`, `NewUserTask` missing three whole option families,
+  `NewEventBasedGateway` missing `WithCorrelationKey`, `NewIAE` missing
+  `WithIDefinition`, and `WithIAE` naming two functions that do not exist — and
+  showed that one convention does not fit every block: a constructor accepting a
+  family WHOLESALE documents the family (an enumeration drifts as the family
+  grows), while one that accepts a family and REJECTS members keeps its
+  enumeration, because the family heading would be a lie (`NewEndEvent` refuses
+  the Conditional and Timer triggers). Original text: sweep every `New*` constructor whose
   doc comment enumerates its available options and reconcile each list with the
   options actually accepted. Surfaced by `NewUserTask`'s list going stale when the
   triad options were added (SRD-034 M1). A comment-only correctness pass, no
@@ -64,13 +73,27 @@ implemented), and leaves this list.
   (a ServiceTask on an implementation-less operation) and `simple-timer`
   demonstrated scheduled instantiation, which the engine deliberately does not
   do. Landed as plain commits on `test/examples-assert-outcome`; no design doc.
-- **Discard/assertion lint guard** — one `golangci-lint` config pass adding
+- **Discard/assertion lint guard** — **DONE** (2026-07-31, FIX-034 §3.2.2/§3.2.3).
+  `errcheck check-blank` and `forcetypeassert` are enabled; the 25 unchecked
+  assertions they exposed are fixed (ten deleted outright by narrowing
+  `BoundaryEvents()` and delegating the frozen `Clone()`s to `freeze()`), and
+  branches no input can reach report `errs.Invariant` — the one construct the
+  coverage gate excludes, so `grep -rn "Invariant("` lists every such branch.
+  `forbidigo`, which this entry proposed, was the wrong instrument: it matches
+  text and cannot tell a comma-ok assertion from an unchecked one. Original
+  text: one `golangci-lint` config pass adding
   `forbidigo` (or equivalent) patterns for two idioms the codebase has decided
   against: a bare `_ =` on an error-returning call outside the documented
   carve-outs (FIX-028 §8.3) and a `.Get(ctx).(T)` payload assertion where
   `data.As[T]` belongs (ADR-034 v.1 §5). Both are guidance today, enforced by
   review only.
-- **Per-module coverage profiles** — `test-all` writes `coverage.txt` only for
+- **Per-module coverage profiles** — **DONE** (2026-07-31, FIX-034 §3.2.1).
+  Every module writes its own profile and `COVER_PROFILES` derives from
+  `CORE_MODULES`, so a new module is gated the day it appears. Proven by
+  before/after on four deliberately uncovered lines in `adapters/lua`: the old
+  invocation reported "100.0% of 0 changed coverable lines — PASS", the new one
+  "0.0% of 4 — FAIL". A residual gap is recorded separately above (`cmd/` is
+  still not measured). Original text: `test-all` writes `coverage.txt` only for
   the root module (`if [ "$$dir" = "." ]`), so `cover-check` measures the diff
   in core and nowhere else. `runtime/` and `adapters/{lua,dtable}` have never
   been diff-gated: both adapters landed *after* `COVER_MIN` went to 95 and CI
@@ -88,7 +111,14 @@ implemented), and leaves this list.
   every `package main` is unknown. The tool is external
   (`github.com/dr-dobermann/covercheck`), so this wants a reproduction and a fix
   there, not a workaround in the Makefile.
-- **No automated Markdown link check** — nothing in `make ci` or
+- **No automated Markdown link check** — **DONE** (2026-07-31, FIX-034 §3.2.4).
+  `cmd/linkcheck` walks the repository's Markdown and fails the gate on any
+  relative link that does not resolve; it is blocking, offline and built from
+  this repo, so no toolchain or network joins the gate. Both requirements this
+  entry recorded are tested: fenced and inline code are skipped, and hrefs are
+  percent-decoded. The open question it left — blocking or advisory — was
+  settled as blocking, because the 78 dead links accumulated precisely because
+  nothing failed. Original text: nothing in `make ci` or
   `check.yml` validates relative documentation links, which is how the 78 dead
   cross-references [FIX-031](fix/FIX-031-documentation-link-rot.md) swept up
   accumulated unnoticed across several refactors. Two of the three causes there

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -104,13 +104,25 @@ implemented), and leaves this list.
   module (SRD-051 v.2 §4.1); recorded here so the general gap is not mistaken
   for closed.
 - **covercheck does not measure `cmd/`** — a second coverage blind spot, found
-  while adding `cmd/linkcheck` (FIX-034 §8.3). Its files are in the git diff and
-  its blocks are in `coverage.txt`, but covercheck reports nothing for them, so
-  the package's lines never reach the denominator: the gate said PASS while
-  `go test -cover ./cmd/linkcheck/` said 74.3 %. Whether it skips `cmd/` or
-  every `package main` is unknown. The tool is external
-  (`github.com/dr-dobermann/covercheck`), so this wants a reproduction and a fix
-  there, not a workaround in the Makefile.
+  while adding the link checker (FIX-034 §8.3). Files under `cmd/` are in the
+  git diff and their blocks are in `coverage.txt`, yet covercheck reports
+  nothing for them, so their lines never reach the denominator: the gate said
+  PASS while `go test -cover` on the package said 74.3 %.
+
+  **Diagnosed by experiment: it is the `cmd/` PATH, not `package main`.** A
+  non-main package placed under `cmd/`, with a test and a deliberately
+  uncovered branch, is ignored just the same; and removing the Makefile's own
+  `-exclude-paths` changes nothing. So the desirable policy — gate a command's
+  code, exclude only its untestable `main.go` — cannot be expressed from this
+  repository's configuration. It needs a fix in the external tool
+  (`github.com/dr-dobermann/covercheck`).
+
+  **Workaround already applied, and it is the pattern for future commands:**
+  put a command's logic in an ordinary package (`internal/linkcheck`) and leave
+  `cmd/<name>/main.go` a thin wrapper. Measured before and after: the gate's
+  denominator went from 131 to 238 changed lines, so ~107 lines moved from
+  unmeasured to gated, and an uncovered probe in the relocated package now
+  fails the gate as it should.
 - **No automated Markdown link check** — **DONE** (2026-07-31, FIX-034 §3.2.4).
   `cmd/linkcheck` walks the repository's Markdown and fails the gate on any
   relative link that does not resolve; it is blocking, offline and built from

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -80,6 +80,14 @@ implemented), and leaves this list.
   SRD-051, which sidestepped it by keeping the BPMN converter in the root
   module (SRD-051 v.2 §4.1); recorded here so the general gap is not mistaken
   for closed.
+- **covercheck does not measure `cmd/`** — a second coverage blind spot, found
+  while adding `cmd/linkcheck` (FIX-034 §8.3). Its files are in the git diff and
+  its blocks are in `coverage.txt`, but covercheck reports nothing for them, so
+  the package's lines never reach the denominator: the gate said PASS while
+  `go test -cover ./cmd/linkcheck/` said 74.3 %. Whether it skips `cmd/` or
+  every `package main` is unknown. The tool is external
+  (`github.com/dr-dobermann/covercheck`), so this wants a reproduction and a fix
+  there, not a workaround in the Makefile.
 - **No automated Markdown link check** — nothing in `make ci` or
   `check.yml` validates relative documentation links, which is how the 78 dead
   cross-references [FIX-031](fix/FIX-031-documentation-link-rot.md) swept up

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -10,9 +10,15 @@ questions to analyze, independent of any single audit. It complements:
 - **[`audit/remediation-status.md`](audit/remediation-status.md)** — per-finding
   audit disposition.
 
-This file is the durable home for the rest: deferred refactors, forward-looking
-ideas, and decisions we've flagged but not yet taken. Items graduate out of here
-into an ADR/SRD (when designed) or a FIX (when implemented).
+This file holds the **short-term** rest: work we intend to pick up soon, and
+decisions we've flagged but not yet taken. Items graduate out of here into an
+ADR/SRD (when designed) or a FIX (when implemented).
+
+**Long-term and blocked work belongs in GitHub issues, not here.** An item
+waiting on something that isn't scheduled — another subsystem, a decision not
+yet due — has no business in a working list; keeping it here splits the backlog
+across two sources and makes neither trustworthy. Move it to an issue with what
+was measured and what would unblock it, and drop it from this file.
 
 ## Open questions to analyze
 
@@ -25,21 +31,6 @@ fill-on-write (option A) is moot. FIX-016/017's clone-site rejection remains as
 the data-layer clone precondition. Governing: **ADR-010**.
 
 ## Planned work / deferred
-
-- **Generated true-BPMN example diagrams (rides ADR-024) — now unblocked** — the
-  example READMEs carry hand-written mermaid *approximations* of BPMN (no event
-  icons, no attached-boundary notation — mermaid has no BPMN diagram type; added
-  2026-07-22). The exporter this waited on landed with SRD-051
-  (`convert.Export(ctx, convert.BPMN, w, p)`, 2026-07-30), so the next step is a
-  make/CI step that runs each example's own process definition through it +
-  `bpmn-to-image` → true-notation SVGs that regenerate from the code and can
-  never drift. Caveat discovered at landing: export emits **no** Diagram
-  Interchange, so `bpmn-to-image` must auto-layout — verify that before
-  committing to the pipeline. Only examples built from the SRD-051 §FR-8 subset
-  will export; anything richer raises `UnsupportedElementError` until later
-  slices land. Optional interim: a mermaid v11 "BPMN-ish" shape convention
-  (`dbl-circ` ends, `diam` gateways, `subproc` frames + a classDef palette) —
-  pilot one example against GitHub's renderer first.
 
 Genuinely un-homed items — not yet tracked in an ADR/SRD, the roadmap, or the
 audit-backlog. Each graduates out into an ADR/SRD (when designed) or a FIX (when
@@ -92,8 +83,10 @@ implemented), and leaves this list.
   `CORE_MODULES`, so a new module is gated the day it appears. Proven by
   before/after on four deliberately uncovered lines in `adapters/lua`: the old
   invocation reported "100.0% of 0 changed coverable lines — PASS", the new one
-  "0.0% of 4 — FAIL". A residual gap is recorded separately above (`cmd/` is
-  still not measured). Original text: `test-all` writes `coverage.txt` only for
+  "0.0% of 4 — FAIL". One residual gap belongs to covercheck itself and not to
+  this repo — it does not measure files under `cmd/`, diagnosed in FIX-034 §8.3
+  and worked around by keeping command logic in ordinary packages.
+  Original text: `test-all` writes `coverage.txt` only for
   the root module (`if [ "$$dir" = "." ]`), so `cover-check` measures the diff
   in core and nowhere else. `runtime/` and `adapters/{lua,dtable}` have never
   been diff-gated: both adapters landed *after* `COVER_MIN` went to 95 and CI

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -103,26 +103,6 @@ implemented), and leaves this list.
   SRD-051, which sidestepped it by keeping the BPMN converter in the root
   module (SRD-051 v.2 §4.1); recorded here so the general gap is not mistaken
   for closed.
-- **covercheck does not measure `cmd/`** — a second coverage blind spot, found
-  while adding the link checker (FIX-034 §8.3). Files under `cmd/` are in the
-  git diff and their blocks are in `coverage.txt`, yet covercheck reports
-  nothing for them, so their lines never reach the denominator: the gate said
-  PASS while `go test -cover` on the package said 74.3 %.
-
-  **Diagnosed by experiment: it is the `cmd/` PATH, not `package main`.** A
-  non-main package placed under `cmd/`, with a test and a deliberately
-  uncovered branch, is ignored just the same; and removing the Makefile's own
-  `-exclude-paths` changes nothing. So the desirable policy — gate a command's
-  code, exclude only its untestable `main.go` — cannot be expressed from this
-  repository's configuration. It needs a fix in the external tool
-  (`github.com/dr-dobermann/covercheck`).
-
-  **Workaround already applied, and it is the pattern for future commands:**
-  put a command's logic in an ordinary package (`internal/linkcheck`) and leave
-  `cmd/<name>/main.go` a thin wrapper. Measured before and after: the gate's
-  denominator went from 131 to 238 changed lines, so ~107 lines moved from
-  unmeasured to gated, and an uncovered probe in the relocated package now
-  fails the gate as it should.
 - **A panicking observer is swallowed without a trace**
   (`pkg/thresher/observer.go`) — `deliver` contains the panic so one bad
   observer cannot crash the drain goroutine or affect the others (ADR-013 §5),

--- a/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
+++ b/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
@@ -104,8 +104,15 @@ Measured before proposing, because the cost of a guard is the debt it exposes:
 
 | Rule | Tool | Production violations today |
 |---|---|---|
-| bare `_ =` on an error call | `errcheck` `check-blank: true` | **1** — `pkg/interactor/console/console.go:127` (`_, _ = fmt.Fprintf`), which is FIX-028 §6.1's documented carve-out |
-| unchecked type assertion | `forcetypeassert` | **5** |
+| bare `_ =` on an error call | `errcheck` `check-blank: true` | **3** — `console.go:127` (FIX-028 §6.1's documented carve-out), `internal/scope/scope.go:400`, `pkg/thresher/observer.go:104` |
+| unchecked type assertion | `forcetypeassert` | **25**, across 13 files |
+
+> The assertion count was first measured as 5. That figure was golangci-lint's
+> `max-same-issues: 3` reporting cap, not the truth — three consecutive runs
+> each reported exactly five, and each a *different* five, which is what gave
+> it away. Lifting the caps reports 25. Any count taken from this linter
+> without raising `max-same-issues` / `max-issues-per-linter` is a lower bound,
+> never a total.
 
 Two nearby forms are *not* violations and must not be caught: `internal/instance/jobs.go:162`
 (`ps, _ = wc.WorkerConfig()`) discards a **bool**, not an error —

--- a/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
+++ b/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
@@ -432,6 +432,16 @@ external (`github.com/dr-dobermann/covercheck`), so this wants a reproduction
 there rather than a workaround here. Recorded so the FIX does not claim a
 completeness it lacks.
 
+**Diagnosed and worked around after that note was written.** It is the `cmd/`
+**path**, not `package main`: a non-main package under `cmd/`, with a test and
+an uncovered branch, is ignored just the same, and removing the Makefile's own
+`-exclude-paths` changes nothing — so "exclude only `main.go`" is the right
+policy but is not expressible from this repository. The checker's logic
+therefore moved to `internal/linkcheck`, leaving `cmd/linkcheck/main.go` a thin
+wrapper. The gate's denominator went 131 → 238 changed lines, and an uncovered
+probe in the relocated package fails it as it should. That is the pattern for
+every future command here until the tool is fixed.
+
 **A panicking observer is still swallowed** (`pkg/thresher/observer.go`).
 `deliver` contains the panic per ADR-013 §5 but has no sink to report it to, so
 a broken observer leaves no trace — the accidental-silence class ADR-022 treats

--- a/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
+++ b/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
@@ -1,0 +1,334 @@
+# FIX-034 «The gate measures less than it claims, and three decided rules are unenforced»
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft (2026-07-31, branch `fix/gate-and-doc-hardening`, not yet implemented).
+**Date:** 2026-07-31.
+**Author:** Ruslan Gabitov.
+**Branch:** `fix/gate-and-doc-hardening` (four gaps between what the gate and the docs promise and what they check).
+**Paired doc:** none (gate configuration + a doc-comment sweep).
+**Upstream:** [ADR-034 v.1](../design/ADR-034-data-layer-generics-policy.md) §5 (the typed-extraction rule §1.2 leaves unenforced), [ADR-022 v.1](../design/ADR-022-error-propagation-and-logging-policy.md) (the error-handling policy behind the discard rule).
+
+**Grounded in (internal artifacts):**
+- `docs/backlog.md` — the four entries this FIX graduates (per-module coverage, the discard/assertion guard, the link check, the constructor doc-comment audit).
+- [FIX-031](FIX-031-documentation-link-rot.md) — the 78 dead cross-references that motivate §1.3, and the two checker requirements its §4.1 discovered.
+- [FIX-028](FIX-028-close-silent-error-discards.md) §6.1/§8.3 — the discard inventory that makes §1.2 enforceable today without a sweep.
+
+## §1 Symptoms
+
+None of these produce a wrong answer at runtime. They are gaps between a rule
+the project has **decided** and the machinery that is supposed to hold it — so
+each one degrades silently, and is only discovered by the damage it let through.
+
+### §1.1 Symptom A: the diff-coverage gate measures one module out of five
+
+`make ci` reports a single `diff-coverage: … PASS`, which reads as "this change
+is covered". It is not: the gate sees the **root module only**.
+
+`Makefile:214-223`:
+
+```make
+test-all:
+	@set -e; for dir in $(MODULES); do \
+		if [ "$$dir" = "." ]; then \
+			(cd $$dir && … $(GO) test -race -count=1 -coverprofile=coverage.txt $(COVER_PACKAGES)) || exit 1; \
+		else \
+			(cd $$dir && … $(GO) test -race -count=1 ./...) || exit 1; \
+		fi; \
+	done
+```
+
+Every non-root module runs its tests with **no `-coverprofile`**, and
+`cover-check` is handed `-profiles coverage.txt` — the root's. The repository has
+five non-example modules:
+
+```
+.  ./runtime  ./adapters/sqlite  ./adapters/dtable  ./adapters/lua
+```
+
+so **four of them have never been diff-gated**. Both `adapters/lua` and
+`adapters/dtable` landed *after* `COVER_MIN` reached 95, and CI stayed green
+regardless of what they added.
+
+### §1.2 Symptom B: two decided-against idioms are enforced by review only
+
+- A bare `_ =` on an error-returning call. Policy: ADR-022; the sweep that
+  removed them: FIX-022, closed by FIX-028.
+- A `.Get(ctx).(T)` payload assertion where `data.As[T]` belongs. Policy:
+  ADR-034 §5.
+
+Both are documented decisions. Neither is checked: `.golangci.yml` enables
+`errcheck` but not its `check-blank`, and enables no assertion linter
+(`grep -c forbidigo .golangci.yml` → `0`). The rules hold today only because
+someone remembers them at review.
+
+### §1.3 Symptom C: nothing validates a documentation link
+
+`make ci` and `check.yml` contain no link check of any kind. That is the
+mechanism behind FIX-031: **78 dead relative cross-references** accumulated
+across several refactors, including in both READMEs and the SAD, and two of its
+three causes — a retired document and a renamed ADR — are exactly what a checker
+catches for free.
+
+### §1.4 Symptom D: constructor doc comments enumerate options that drift
+
+Several `New*` constructors document their available options in prose. Those
+lists go stale silently when an option is added — the precedent is
+`NewUserTask`, whose list missed the triad options added by SRD-034 M1.
+**15 files** under `pkg/` and `internal/` carry an `Available options` block,
+and nothing reconciles them with what the constructor accepts.
+
+## §2 Root Cause Analysis
+
+### §2.1 A: the profile is written where the loop happens to special-case it
+
+`MODULES` is every directory containing a `go.mod` (`Makefile:54`), so `test-all`
+already iterates all of them. The coverage profile was wired only into the `.`
+branch — reasonably, when the root was the only module with tests — and never
+revisited as `runtime/` and the three adapters appeared. `cover-check` then
+consumes one file (`Makefile`, the `cover-check` target: `-profiles coverage.txt`),
+so even a module that *did* write a profile would not be read.
+
+Nothing warns, because a missing profile is indistinguishable from a module with
+no changed lines: covercheck reports on what it is given.
+
+**Why the tests did not catch it:** there is no test of the gate. This is
+configuration, and its failure mode is silence.
+
+### §2.2 B: the linters that would enforce these are available and unused
+
+`errcheck` is enabled but its `check-blank` option defaults to false, so
+`_ = f()` is invisible to it — precisely the form the policy forbids. For the
+assertion rule the repo enables nothing.
+
+Measured before proposing, because the cost of a guard is the debt it exposes:
+
+| Rule | Tool | Production violations today |
+|---|---|---|
+| bare `_ =` on an error call | `errcheck` `check-blank: true` | **1** — `pkg/interactor/console/console.go:127` (`_, _ = fmt.Fprintf`), which is FIX-028 §6.1's documented carve-out |
+| unchecked type assertion | `forcetypeassert` | **5** |
+
+Two nearby forms are *not* violations and must not be caught: `internal/instance/jobs.go:162`
+(`ps, _ = wc.WorkerConfig()`) discards a **bool**, not an error —
+`WorkerConfig() (tasks.Policy, bool)`, `pkg/tasks/workerdispatcher.go:213` — and
+of the 15 `.Get(ctx).(…)` sites in production, most are comma-ok or type-switch
+forms that are already safe. This is why the backlog's suggested `forbidigo`
+regex is the wrong instrument: it matches text, so it would flag the safe forms
+too. `forcetypeassert` matches the *unchecked* shape, which is the actual rule.
+
+`.golangci.yml` sets `tests: true`, and tests contain **34** blank-assignment
+sites (`_ = data.CreateDefaultStates()` and kin) — a deliberate test idiom, not
+a policy breach.
+
+### §2.3 C: adopting a checker was blocked on a decision nobody had to make
+
+The backlog left the choice open ("`lychee`, `markdown-link-check`, or ~20 lines
+of Go in `cmd/`") *and* the policy open ("blocking, or advisory"). An item that
+needs two decisions before any work starts does not get picked up. Both are
+settled in §3.1.
+
+### §2.4 D: prose duplicates a fact the compiler already knows
+
+An `Available options` list restates the constructor's accepted option set in a
+place the compiler cannot check. Duplication of a machine-known fact drifts by
+default; the only question is when.
+
+## §3 Solution
+
+### §3.1 Alternatives considered
+
+**A — per-module coverage**
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| A1. Write a profile per module and pass all of them to `-profiles` | Gates every module; covercheck already accepts a comma-separated list | Profile paths must be module-relative and collected | ✅ **chosen** |
+| A2. Merge into one profile | One file | Package paths from different modules collide; merging is a tool of its own | ❌ rejected |
+| A3. Gate the root only, and say so | Zero work | Keeps a gate that reads as global and is not — the defect | ❌ rejected |
+
+**B — the guards**
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| B1. `errcheck check-blank` + `forcetypeassert`, tests excluded from the blank rule | Both are purpose-built; measured cost is 1 + 5 sites | Two settings rather than one | ✅ **chosen** |
+| B2. `forbidigo` patterns, as the backlog suggested | One mechanism | Text matching cannot tell `a, ok := v.Get(ctx).(T)` from `v.Get(ctx).(T)`; would flag ~13 safe sites and need `nolint` noise | ❌ rejected |
+| B3. Leave as review guidance | No config | The premise of the item: review already missed these classes once each | ❌ rejected |
+
+**C — the link checker**
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| C1. A small Go checker in `cmd/linkcheck`, relative links only | No new toolchain — the repo's parity rule requires every CI tool to be pinned and installed by `make tools`; Go is already there. Implements FIX-031's two requirements exactly (ignore fenced/inline code, percent-decode). Deterministic and offline | ~150 lines to own | ✅ **chosen** |
+| C2. `lychee` (Rust) or `markdown-link-check` (Node) | Off-the-shelf, also checks external URLs | Adds a non-Go toolchain to `make tools` and CI, plus a network dependency that makes the gate flaky for reasons unrelated to the change | ❌ rejected |
+| C3. Advisory rather than blocking | Never blocks a PR | The 78 accumulated *because* nothing failed | ❌ rejected |
+
+**Blocking, and relative links only.** A dead relative link is deterministic,
+locally reproducible and cheap to fix — unlike a coverage percentage, it cannot
+legitimately wobble. External URLs are deliberately out of scope: they rot for
+reasons outside the repository and would make the gate depend on the network.
+
+**D — the doc comments**
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| D1. Reconcile all 15 lists once, in this FIX | Correct today; no new machinery | Can drift again | ✅ **chosen** |
+| D2. Generate the lists from the option types | Cannot drift | Needs a generator and a marker convention for a doc-comment fragment — disproportionate | ❌ rejected (recorded in §5 as the escalation if it drifts again) |
+| D3. Delete the lists | Cannot drift | Removes genuinely useful documentation at the point of use | ❌ rejected |
+
+### §3.2 Changes by file
+
+#### §3.2.1 `Makefile` — a coverage profile per module
+
+`test-all` writes `coverage.txt` inside **every** module (not only `.`), each
+excluding that module's generated and example packages, and records the paths;
+`cover-check` receives all of them:
+
+```make
+# before: only the root branch carried -coverprofile
+# after:  every module writes its own profile, and COVER_PROFILES lists them
+```
+
+`COVER_PROFILES` is derived from `MODULES` so a new module is gated the day it
+appears — the property that failed here.
+
+#### §3.2.2 `.golangci.yml` — the two guards
+
+```yaml
+linters:
+  enable:
+    - errcheck
+    - forcetypeassert     # ADR-034 §5: an unchecked assertion is a panic where
+                          # data.As[T] returns a classified error
+  settings:
+    errcheck:
+      check-blank: true   # ADR-022: `_ = f()` is a silent discard, not handling
+  exclusions:
+    rules:
+      - path: _test\.go
+        linters: [errcheck]   # the blank-assign idiom is deliberate in tests
+```
+
+The test exclusion follows the existing `goconst: ignore-tests: true`
+precedent in this file: these rules govern production discipline.
+
+#### §3.2.3 The five unchecked assertions
+
+Each is fixed at its own site, not silenced:
+
+| Site | Fix |
+|---|---|
+| `pkg/model/activities/flowselect.go:103` | `data.As[bool]` — ADR-034 §5's exact case |
+| `pkg/model/activities/subprocess.go:432,440` | comma-ok with a classified error |
+| `pkg/model/process/process.go:400` | comma-ok |
+| `pkg/thresher/instance_starter.go:109` | comma-ok |
+
+#### §3.2.4 `cmd/linkcheck` + the gate — relative links are verified
+
+A new checker walks the repository's Markdown, extracts relative link targets,
+and reports the ones that do not resolve. Two behaviours are requirements, both
+learned from FIX-031 §4.1:
+
+- **fenced and inline code is skipped** — `` `values.NewArray[T](vals…)` ``
+  matches a naive link regex, and eight such matches exist today;
+- **hrefs are percent-decoded** — otherwise every correct link to
+  `gobpm Development Roadmap.md` reports as broken.
+
+Wired into the gate as a blocking step, and into `make tools` in the sense that
+it needs nothing: it is built from this repository.
+
+#### §3.2.5 The 15 `Available options` blocks — reconciled
+
+Each list is compared against the options its constructor actually accepts, and
+corrected. Comment-only; no behaviour change.
+
+#### §3.2.6 `docs/backlog.md` — four entries graduate out
+
+Removed: per-module coverage profiles, the discard/assertion guard, the link
+check, the constructor doc-comment audit. The **true-BPMN diagram** entry
+stays: it is blocked on later converter slices, not on this work — see §6.3.
+
+## §4 Verification
+
+### §4.1 Regression tests (mandatory)
+
+| Test | Setup | Assertion |
+|---|---|---|
+| `cmd/linkcheck` unit tests | fixtures: a valid link, a dead link, a link inside a fence, an inline-code false positive, a percent-encoded href, an anchor-only href | dead links reported; the four non-links are not |
+| the gate itself | `make ci` | four module profiles produced; `diff-coverage` reads all of them; lint clean with both new rules |
+
+The guards need no test of their own: a linter that does not fire on a known
+violation is caught by §4.2's before/after measurement.
+
+### §4.2 Empirical gate
+
+- **Before/after for B**: `forcetypeassert` reports 5 today and 0 after §3.2.3;
+  `errcheck check-blank` reports 1 (the carve-out, annotated) and 0 after.
+- **Before/after for C**: the checker reports 0 dead links on a tree FIX-031
+  already cleaned — a non-zero result would mean either rot since, or a checker
+  bug, and both are worth knowing before it becomes blocking.
+- **Before/after for A**: a deliberate uncovered line added to `adapters/lua`
+  makes the gate fail; today it does not. Removed before commit — recorded in
+  §8.2, not shipped.
+- `make ci` green.
+
+### §4.3 Observability
+
+None — this is build-time machinery.
+
+## §5 Prevention
+
+- **A**: `COVER_PROFILES` derives from `MODULES`, so the next module is gated on
+  arrival rather than remembered.
+- **B**: the rules are now the linter's, not the reviewer's memory.
+- **C**: the checker runs on every PR, so link rot cannot accumulate to 78 again.
+- **D**: if these lists drift a second time, escalate to D2 (generate them) —
+  a second drift is evidence that prose duplicating a compiler-known fact is not
+  maintainable by discipline alone.
+
+## §6 Regressions / side-effects
+
+### §6.1 What may rely on the old behavior
+
+- `grep -rn "coverage.txt" Makefile .github/ ` — the profile path is referenced
+  by `cover-check` and by the Codecov upload; both must follow the new list.
+- Enabling `check-blank` and `forcetypeassert` can fail **other modules** whose
+  code has never been linted under them; `lint-all-modules` runs every module, so
+  the measurement in §2.2 (root only) is re-taken across all five before landing.
+- The new gate step lengthens `make ci` — the checker is offline and file-local,
+  so the cost is a directory walk.
+
+### §6.2 Rollback path
+
+Each of the four is independently revertible; they share no state.
+
+### §6.3 Out of scope
+
+The **true-BPMN example diagrams** item stays in the backlog. Measured while
+scoping this FIX: the exporter supports seven element types (Start/End events,
+Manual/User/Service tasks, Exclusive/Parallel gateways), so only **13 of 46**
+example modules could export at all, and every example is `package main`, so
+each would need a new hook to expose its definition to a generator — plus a Node
+toolchain for `bpmn-to-image` and the unverified auto-layout caveat. It is a
+feature gated on later converter slices and wants an SRD, not this FIX.
+
+## §7 Related
+
+- [FIX-031](FIX-031-documentation-link-rot.md) — the link rot §1.3 prevents recurring.
+- [FIX-028](FIX-028-close-silent-error-discards.md) — the discard sweep §1.2 makes permanent.
+- [ADR-034 v.1](../design/ADR-034-data-layer-generics-policy.md) §5 — the typed-extraction rule.
+- [ADR-022 v.1](../design/ADR-022-error-propagation-and-logging-policy.md) — the error-handling policy.
+
+## §8 Implementation summary
+
+> ⚠️ TODO: fill AFTER landing.
+
+### §8.1 Stages by commit
+
+| Stage | Commit | Scope | Tests |
+|---|---|---|---|
+
+### §8.2 Empirical findings — where reality diverged from the §3 draft
+
+### §8.3 Backlog (out of FIX-034 scope)
+
+## §9 Open questions
+
+None.

--- a/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
+++ b/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
@@ -1,7 +1,7 @@
 # FIX-034 «The gate measures less than it claims, and three decided rules are unenforced»
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft (2026-07-31, branch `fix/gate-and-doc-hardening`, not yet implemented).
+**Status:** Accepted (2026-07-31, branch `fix/gate-and-doc-hardening`).
 **Date:** 2026-07-31.
 **Author:** Ruslan Gabitov.
 **Branch:** `fix/gate-and-doc-hardening` (four gaps between what the gate and the docs promise and what they check).
@@ -276,9 +276,18 @@ change.
 
 #### §3.2.6 `docs/backlog.md` — four entries graduate out
 
-Removed: per-module coverage profiles, the discard/assertion guard, the link
-check, the constructor doc-comment audit. The **true-BPMN diagram** entry
-stays: it is blocked on later converter slices, not on this work — see §6.3.
+Marked **DONE** in place, with what was found: per-module coverage profiles,
+the discard/assertion guard, the link check, the constructor doc-comment audit.
+
+The file's header says a graduated item "leaves this list", but the convention
+actually in use is to mark it DONE with a summary — both the
+`Error-propagation & logging policy` entry and the examples outcome-gate that
+landed the same day do that, and the note is worth more than the empty space:
+it records what the item turned out to be, which is exactly what a future
+reader of a closed item wants. Matching the practice rather than the header.
+
+The **true-BPMN diagram** entry stays open: it is blocked on later converter
+slices, not on this work — see §6.3.
 
 ## §4 Verification
 
@@ -353,14 +362,62 @@ feature gated on later converter slices and wants an SRD, not this FIX.
 
 ## §8 Implementation summary
 
-> ⚠️ TODO: fill AFTER landing.
-
-### §8.1 Stages by commit
+### §8.1 Stages by commit (branch `fix/gate-and-doc-hardening`)
 
 | Stage | Commit | Scope | Tests |
 |---|---|---|---|
+| doc | `1ae8fda` | this document | — |
+| M1 | `47d291d` | per-module coverage profiles (§3.2.1) | before/after on a deliberately uncovered line |
+| M2 | `613250d` | the two guards + 25 assertion fixes + `errs.Invariant` (§3.2.2/§3.2.3) | 8 new tests; `TestInvariant`, `TestAsAdapter*`, `TestCondArming*`, `TestWireClonedGraph*`, the two non-bool engine tests, `TestBoolComparison` |
+| M3 | `8363e83` | `cmd/linkcheck` + the blocking gate step (§3.2.4) | 7 tests over the parsing rules and the three exit codes |
+| M4 | `4367543` | the option-block audit (§3.2.5) | comment-only |
+| M5 | this commit | backlog graduation, §8 (§3.2.6) | — |
 
 ### §8.2 Empirical findings — where reality diverged from the §3 draft
+
+**The assertion count was five times the estimate, and the estimate came from
+the tool itself.** §2.2 measured 5 unchecked assertions; the truth was 25 across
+13 files. Three consecutive runs each reported exactly five and each a
+*different* five — that inconsistency is what exposed golangci-lint's
+`max-same-issues: 3` cap. Any count from that linter without raising
+`max-same-issues` and `max-issues-per-linter` is a lower bound, never a total.
+The corrected numbers are in §2.2.
+
+**Ten of the 25 were deleted rather than checked, and both deletions left the
+code simpler than before this FIX started.** `BoundaryEvents()` returned
+`[]flow.EventNode` while `AddBoundaryEvent(flow.BoundaryEvent)` was its only
+writer — the type was wider than the invariant, so every consumer asserted it
+back; narrowing the accessor removed seven. The three frozen `Clone()`s now
+delegate to the package's own `freeze()`, which wraps by kind: no assertion, no
+panic, and shorter than the original.
+
+**The narrowing exposed a wrong test fixture.** `stubTaskBoundary` reported an
+`IntermediateCatchEvent` as a boundary event. It is not one; the wide element
+type hid it, and production code asserted the value back to
+`flow.BoundaryEvent` — a panic had that path ever run.
+
+**Guards believed untestable mostly were not.** The first attempt to drive them
+crashed on a hand-built `loopState`, which lacks the wiring `Run` performs. A
+*completed* instance is fully wired, and with that the two conditional arming
+guards, `failInvariant`, both clone guards and — via an engine stub returning a
+non-bool — the two `data.As` branches all became ordinary tests. Only the
+boundary-fire guard is genuinely unreachable: `boundaryWatch.boundary` is
+already typed `flow.BoundaryEvent`, so no test can hand it anything else.
+
+**The coverage gate has a second blind spot, found by this FIX's own new
+package.** See §8.3.
+
+**One convention did not fit all fifteen option blocks** — §3.2.5 records the
+split between families-accepted-wholesale and families-with-rejected-members.
+`NewEndEvent` was nearly "fixed" into being wrong.
+
+**A process note, because it cost real time.** Two measurements in this work
+were taken from runs whose exit status was never checked: `make test-core` was
+sent to `/dev/null` and only the coverage number read afterwards, while the
+tests underneath were failing — so several intermediate percentages came from a
+stale `coverage.txt`. The rule the repository already states for `make ci` —
+judge a gate by its own completion markers, never by a wrapper or a
+side-effect — applies equally to a helper invocation.
 
 ### §8.3 Backlog (out of FIX-034 scope)
 

--- a/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
+++ b/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
@@ -446,7 +446,9 @@ every future command here until the tool is fixed.
 `deliver` contains the panic per ADR-013 §5 but has no sink to report it to, so
 a broken observer leaves no trace — the accidental-silence class ADR-022 treats
 as the worse failure. Threading a logger through would have widened M2 beyond
-gate hardening; it wants its own small change.
+gate hardening; it wants its own small change, and now carries a `docs/backlog.md`
+entry rather than living only in this appendix, where nobody looks for open
+work.
 
 ## §9 Open questions
 

--- a/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
+++ b/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
@@ -336,6 +336,23 @@ feature gated on later converter slices and wants an SRD, not this FIX.
 
 ### §8.3 Backlog (out of FIX-034 scope)
 
+**covercheck does not measure `cmd/`, so the gate has a second blind spot.**
+Found by adding `cmd/linkcheck` in M3: its files are in the git diff and its 55
+blocks are in `coverage.txt`, yet covercheck reports nothing for them — the
+package's 236 lines never enter the denominator. Measured directly,
+`go test -cover ./cmd/linkcheck/` reported **74.3 %** while the gate said PASS,
+which is exactly the failure §1.1 was written about, one directory over. Whether
+it skips `cmd/` specifically or every `package main` is unknown; the tool is
+external (`github.com/dr-dobermann/covercheck`), so this wants a reproduction
+there rather than a workaround here. Recorded so the FIX does not claim a
+completeness it lacks.
+
+**A panicking observer is still swallowed** (`pkg/thresher/observer.go`).
+`deliver` contains the panic per ADR-013 §5 but has no sink to report it to, so
+a broken observer leaves no trace — the accidental-silence class ADR-022 treats
+as the worse failure. Threading a logger through would have widened M2 beyond
+gate hardening; it wants its own small change.
+
 ## §9 Open questions
 
 None.

--- a/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
+++ b/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
@@ -241,10 +241,38 @@ learned from FIX-031 §4.1:
 Wired into the gate as a blocking step, and into `make tools` in the sense that
 it needs nothing: it is built from this repository.
 
-#### §3.2.5 The 15 `Available options` blocks — reconciled
+#### §3.2.5 The 15 `Available options` blocks — audited, and two shapes emerge
 
-Each list is compared against the options its constructor actually accepts, and
-corrected. Comment-only; no behaviour change.
+Each list was compared against what its constructor actually dispatches on. The
+audit found four defects and, more usefully, showed that one convention does not
+fit all of them:
+
+- **A constructor that accepts a family WHOLESALE** should document the family,
+  because an enumeration drifts the moment the family gains a member — which is
+  exactly how the Camunda triad went unlisted. `NewServiceTask` and
+  `NewUserTask` now lead with the families their type-switch names
+  (`SrvTaskOption`/`UsrTaskOption`, `taskOption`, `ActivityOption`,
+  `data.PropertyOption`, `foundation.BaseOption`), state that an option added to
+  a listed family is accepted whether or not it is named, and list today's
+  members underneath.
+- **A constructor that accepts a family but REJECTS members** must keep the
+  enumeration, because the family heading would be a lie. `NewEndEvent` is the
+  case: `endConfig` implements `setCondition` and `setTimer` solely to refuse
+  them, so its seven-trigger list is the *accepted subset* of `EventOption` and
+  is correct as it stands.
+
+The four defects fixed: `NewServiceTask` omitted `WithWorkerTrust`;
+`NewUserTask` omitted the whole `ActivityOption`, `taskOption` and
+`data.PropertyOption` families; `NewEventBasedGateway` omitted
+`WithCorrelationKey`; `NewIAE` omitted `WithIDefinition`; and `WithIAE` named
+`data.IDef` / `data.IDefinition`, neither of which exists — the functions are
+`WithIDef` / `WithIDefinition`.
+
+Verified correct and left alone: `gateways.New` and the Exclusive / Inclusive /
+Parallel constructors (`GatewayOption` has one member), `process.New`,
+`consinp.NewRenderer`, `flow.NewBaseNode`, `bpmncommon.NewMessage`,
+`goexpr.New`, and `NewItemDefinition`. Comment-only throughout; no behaviour
+change.
 
 #### §3.2.6 `docs/backlog.md` — four entries graduate out
 

--- a/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
+++ b/docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md
@@ -442,6 +442,14 @@ wrapper. The gate's denominator went 131 → 238 changed lines, and an uncovered
 probe in the relocated package fails it as it should. That is the pattern for
 every future command here until the tool is fixed.
 
+The backlog entry that recorded this was removed once the relocation landed:
+with a command's logic in an ordinary package, nothing in this repository is
+left ungated, so the item is not open work *here*. The residual risk is that a
+future command puts logic back under `cmd/`, where it would ship unmeasured
+again — which is why `cmd/linkcheck/main.go` carries the reason it is thin, and
+why this section keeps the diagnosis. The tool-side fix belongs to covercheck's
+own repository.
+
 **A panicking observer is still swallowed** (`pkg/thresher/observer.go`).
 `deliver` contains the panic per ADR-013 §5 but has no sink to report it to, so
 a broken observer leaves no trace — the accidental-silence class ADR-022 treats

--- a/internal/instance/boundary_watch.go
+++ b/internal/instance/boundary_watch.go
@@ -232,7 +232,7 @@ func (ls *loopState) boundariesHeld(trackID string) bool {
 // Only activities expose it; other nodes (events, gateways) do not, so a type
 // assertion against it is how the loop decides whether a node needs watchers.
 type boundaryHoster interface {
-	BoundaryEvents() []flow.EventNode
+	BoundaryEvents() []flow.BoundaryEvent
 }
 
 // armBoundaries registers a boundaryWatch for every boundary event guarding node
@@ -254,11 +254,7 @@ func (ls *loopState) armBoundaries(
 
 	var ws []*boundaryWatch
 
-	for _, be := range host.BoundaryEvents() {
-		// every entry was attached via AddBoundaryEvent(flow.BoundaryEvent), so the
-		// cast cannot fail — use the panicking form (no unreachable error branch).
-		bev := be.(flow.BoundaryEvent)
-
+	for _, bev := range host.BoundaryEvents() {
 		armed, ok := ls.armOne(t, node, bev)
 		if !ok {
 			return // the instance is failing — armOne reported it
@@ -482,9 +478,16 @@ func (ls *loopState) fireBoundary(ctx context.Context, ev trackEvent) {
 		return // the host already completed and disarmed — the fire lost the race.
 	}
 
-	// ev.node is the boundaryWatch's own boundary (set in ProcessEvent), so the cast
-	// cannot fail — use the panicking form to avoid an unreachable error branch.
-	be := ev.node.(flow.BoundaryEvent)
+	// ev.node is the boundaryWatch's own boundary (set in ProcessEvent). A
+	// different node here means the fire was routed to the wrong watch — the
+	// instance cannot reason about which boundary caught, so it fails rather
+	// than guessing.
+	be, ok := ev.node.(flow.BoundaryEvent)
+	if !ok {
+		ls.failInvariant("boundary fire carried a %T", ev.node)
+
+		return
+	}
 
 	// shared interrupting budget (SRD-052 FR-6): an interrupting boundary on a
 	// composite competes with the composite's Event Sub-Processes for the ONE
@@ -584,10 +587,7 @@ func (ls *loopState) matchErrorBoundary(ctx context.Context, t *track) bool {
 	// boundaries may catch, one that carries none (an end event, a gateway)
 	// cannot — the BpmnError then escapes as Uncaught below.
 	if host, ok := ls.position[t.ID()].(boundaryHoster); ok {
-		for _, en := range host.BoundaryEvents() {
-			// every entry was attached as a flow.BoundaryEvent — panicking form.
-			bev := en.(flow.BoundaryEvent)
-
+		for _, bev := range host.BoundaryEvents() {
 			for _, d := range bev.Definitions() {
 				eed, ok := d.(*events.ErrorEventDefinition)
 				if !ok || eed.Error().ErrorCode() != be.Code {
@@ -728,9 +728,7 @@ func errorBoundaryOn(node flow.Node, code string) flow.BoundaryEvent {
 		return nil
 	}
 
-	for _, en := range host.BoundaryEvents() {
-		bev := en.(flow.BoundaryEvent)
-
+	for _, bev := range host.BoundaryEvents() {
 		for _, d := range bev.Definitions() {
 			if eed, ok := d.(*events.ErrorEventDefinition); ok &&
 				eed.Error().ErrorCode() == code {

--- a/internal/instance/compensation_ledger.go
+++ b/internal/instance/compensation_ledger.go
@@ -48,18 +48,13 @@ func compensationBoundaryHandlerOf(node flow.Node) flow.ActivityNode {
 		return nil
 	}
 
-	for _, en := range host.BoundaryEvents() {
-		bev, ok := en.(flow.BoundaryEvent)
-		if !ok {
-			continue
-		}
-
+	for _, bev := range host.BoundaryEvents() {
 		for _, d := range bev.Definitions() {
 			if d.Type() != flow.TriggerCompensation {
 				continue
 			}
 
-			if ch, ok := en.(interface {
+			if ch, ok := bev.(interface {
 				CompensationHandler() flow.ActivityNode
 			}); ok {
 				return ch.CompensationHandler()

--- a/internal/instance/conditional.go
+++ b/internal/instance/conditional.go
@@ -175,10 +175,18 @@ func (ls *loopState) armCondBoundary(
 	ctx context.Context,
 	bw *boundaryWatch,
 ) bool {
+	// The caller arms this only for a Conditional boundary, so the definition
+	// is a Conditional one; a mismatch means the arming path selected the wrong
+	// watch, which is a broken arm rather than a condition that is merely false.
+	cd, ok := bw.def.(*events.ConditionalEventDefinition)
+	if !ok {
+		return ls.failInvariant("conditional boundary armed with %T", bw.def)
+	}
+
 	w := &condWatch{
 		track:    bw.host,
 		node:     bw.boundary,
-		def:      bw.def.(*events.ConditionalEventDefinition),
+		def:      cd,
 		boundary: true,
 	}
 	w.deps = condDeps(w.def)
@@ -208,9 +216,17 @@ func (ls *loopState) armCondScopeHandler(
 	ctx context.Context,
 	sw *scopeHandlerWatch,
 ) {
+	// As in armCondBoundary: only a Conditional start reaches here.
+	cd, ok := sw.def.(*events.ConditionalEventDefinition)
+	if !ok {
+		ls.failInvariant("conditional handler armed with %T", sw.def)
+
+		return
+	}
+
 	w := &condWatch{
 		node:        sw.start,
-		def:         sw.def.(*events.ConditionalEventDefinition),
+		def:         cd,
 		handler:     sw.handler,
 		handlerPath: sw.path,
 	}

--- a/internal/instance/escalation_watch.go
+++ b/internal/instance/escalation_watch.go
@@ -187,9 +187,7 @@ func escalationBoundaryOn(node flow.Node, code string) flow.BoundaryEvent {
 		return nil
 	}
 
-	for _, en := range host.BoundaryEvents() {
-		bev := en.(flow.BoundaryEvent)
-
+	for _, bev := range host.BoundaryEvents() {
 		for _, d := range bev.Definitions() {
 			if eed, ok := d.(*events.EscalationEventDefinition); ok &&
 				escalationMatches(eed, code) {

--- a/internal/instance/invariant_test.go
+++ b/internal/instance/invariant_test.go
@@ -1,0 +1,89 @@
+package instance
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
+)
+
+// failInvariant is the loop's reaction to a broken engine-internal contract:
+// fault the instance, stop every track, and answer false so a bool-returning
+// guard reads as one line. The guards that call it cannot be driven from any
+// input — that is what makes them invariants — but the helper itself can, and
+// this is what keeps the FIX-034 §3.2.3 coverage exclusion honest: the excluded
+// call sites are one line each, and the behaviour behind them is tested here.
+func TestFailInvariantFaultsAndStops(t *testing.T) {
+	var (
+		mu  sync.Mutex
+		log []string
+	)
+
+	// A completed instance is fully wired — Run set up the reporter and the
+	// cancel func that fail() and stopAll() use.
+	inst := adHocInstance(t, &scriptedRouter{}, &mu, &log)
+	runToDone(t, inst)
+
+	ls := newLoopState(inst)
+
+	require.False(t, ls.failInvariant("cache entry for %s is %T", "widget", 42),
+		"it answers false so a guard can return it directly")
+	require.True(t, ls.stopping, "every track is stopped")
+
+	err := inst.LastErr()
+	require.Error(t, err)
+
+	var ae *errs.ApplicationError
+
+	require.ErrorAs(t, err, &ae)
+	require.True(t, ae.HasClass(errs.BrokenInvariant),
+		"the fault carries the invariant class, not a generic state error")
+	require.Contains(t, err.Error(), "cache entry for widget is int")
+}
+
+// The two conditional arming guards ARE reachable from a test, unlike the
+// boundary-fire one: a watch is a plain struct, so it can be built with a
+// definition of the wrong kind — which is exactly the engine-wiring mistake
+// they exist to catch.
+func TestCondArmingRejectsAForeignDefinition(t *testing.T) {
+	var (
+		mu  sync.Mutex
+		log []string
+	)
+
+	sig, err := events.NewSignal("wrong-kind", nil)
+	require.NoError(t, err)
+
+	sdef, err := events.NewSignalEventDefinition(sig)
+	require.NoError(t, err)
+
+	t.Run("boundary", func(t *testing.T) {
+		inst := adHocInstance(t, &scriptedRouter{}, &mu, &log)
+		runToDone(t, inst)
+
+		ls := newLoopState(inst)
+
+		require.False(t, ls.armCondBoundary(t.Context(),
+			&boundaryWatch{def: sdef}))
+		require.True(t, ls.stopping)
+		require.ErrorContains(t, inst.LastErr(), "conditional boundary armed")
+	})
+
+	t.Run("scope handler", func(t *testing.T) {
+		inst := adHocInstance(t, &scriptedRouter{}, &mu, &log)
+		runToDone(t, inst)
+
+		ls := newLoopState(inst)
+
+		ls.armCondScopeHandler(t.Context(), &scopeHandlerWatch{
+			inst: inst,
+			def:  sdef,
+		})
+
+		require.True(t, ls.stopping)
+		require.ErrorContains(t, inst.LastErr(), "conditional handler armed")
+	})
+}

--- a/internal/instance/loop.go
+++ b/internal/instance/loop.go
@@ -1157,3 +1157,14 @@ func (ls *loopState) waitReleasable(ctx context.Context, t *track) bool {
 
 	return false
 }
+
+// failInvariant faults the instance on a broken engine-internal contract and
+// stops every track. It returns false so a bool-returning caller can `return
+// ls.failInvariant(...)` in one line — the shape the diff-coverage gate excludes
+// as unreachable (FIX-034 §3.2.3).
+func (ls *loopState) failInvariant(format string, args ...any) bool {
+	ls.inst.fail(errs.Invariant(format, args...))
+	ls.stopAll()
+
+	return false
+}

--- a/internal/instance/snapshot/boundary_clone_test.go
+++ b/internal/instance/snapshot/boundary_clone_test.go
@@ -75,7 +75,7 @@ func TestSnapshotClonesAndRebindsBoundary(t *testing.T) {
 	// the cloned host carries exactly the cloned boundary.
 	cloneTask := clone.Nodes[task.ID()]
 	bh, ok := cloneTask.(interface {
-		BoundaryEvents() []flow.EventNode
+		BoundaryEvents() []flow.BoundaryEvent
 	})
 	require.True(t, ok, "cloned host exposes BoundaryEvents()")
 

--- a/internal/instance/transaction.go
+++ b/internal/instance/transaction.go
@@ -91,9 +91,7 @@ func cancelBoundaryOn(node flow.Node) flow.BoundaryEvent {
 		return nil
 	}
 
-	for _, en := range host.BoundaryEvents() {
-		bev := en.(flow.BoundaryEvent)
-
+	for _, bev := range host.BoundaryEvents() {
 		for _, d := range bev.Definitions() {
 			if d.Type() == flow.TriggerCancel {
 				return bev

--- a/internal/linkcheck/link.go
+++ b/internal/linkcheck/link.go
@@ -1,6 +1,7 @@
-package main
+package linkcheck
 
 import (
+	"fmt"
 	"net/url"
 	"regexp"
 	"strings"
@@ -12,16 +13,47 @@ type link struct {
 	line   int
 }
 
-// inlineLink matches [text](target) and the reference form [id]: target. The
-// target group is deliberately lazy and stops at the first closing paren or
-// whitespace, so a title — [t](path "title") — is not swallowed.
-var (
-	inlineLink = regexp.MustCompile(`\[[^\]]*\]\(([^)]*)\)`)
-	refLink    = regexp.MustCompile(`^\s{0,3}\[[^\]]+\]:\s+(\S+)`)
-	fenceLine  = regexp.MustCompile("^\\s{0,3}(```|~~~)")
-	inlineCode = regexp.MustCompile("`[^`]*`")
-	hasScheme  = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.\-]*:`)
-)
+// patterns holds the compiled Markdown matchers. They are built through an
+// error-returning constructor rather than regexp.MustCompile because this
+// package lives under internal/, where FIX-026 bans panicking Must* calls: a
+// library must fail with a classified error, never crash the program that
+// embedded it. The patterns are constants, so the error is unreachable in
+// practice — but the rule is about the shape of the failure, not its odds.
+type patterns struct {
+	// inlineLink matches [text](target) and the reference form [id]: target.
+	// The target group stops at the first closing paren or whitespace, so a
+	// title — [t](path "title") — is not swallowed.
+	inlineLink *regexp.Regexp
+	refLink    *regexp.Regexp
+	fenceLine  *regexp.Regexp
+	inlineCode *regexp.Regexp
+	hasScheme  *regexp.Regexp
+}
+
+// newPatterns compiles the matchers, reporting the first that fails.
+func newPatterns() (*patterns, error) {
+	var (
+		p   patterns
+		err error
+	)
+
+	for _, c := range []struct {
+		into **regexp.Regexp
+		expr string
+	}{
+		{&p.inlineLink, `\[[^\]]*\]\(([^)]*)\)`},
+		{&p.refLink, `^\s{0,3}\[[^\]]+\]:\s+(\S+)`},
+		{&p.fenceLine, "^\\s{0,3}(```|~~~)"},
+		{&p.inlineCode, "`[^`]*`"},
+		{&p.hasScheme, `^[a-zA-Z][a-zA-Z0-9+.\-]*:`},
+	} {
+		if *c.into, err = regexp.Compile(c.expr); err != nil {
+			return nil, fmt.Errorf("linkcheck: pattern %q: %w", c.expr, err)
+		}
+	}
+
+	return &p, nil
+}
 
 // extract returns every link target in src that names a path this repository
 // could resolve. Two exclusions are requirements, not conveniences, both learned
@@ -36,14 +68,14 @@ var (
 // Absolute URLs, protocol-relative URLs, mailto: and same-document anchors are
 // not this checker's business: they rot for reasons outside the repository, and
 // checking them would make the gate depend on the network.
-func extract(src string) []link {
+func (p *patterns) extract(src string) []link {
 	var (
 		out    []link
 		inCode bool
 	)
 
 	for i, raw := range strings.Split(src, "\n") {
-		if fenceLine.MatchString(raw) {
+		if p.fenceLine.MatchString(raw) {
 			inCode = !inCode
 
 			continue
@@ -53,16 +85,16 @@ func extract(src string) []link {
 			continue
 		}
 
-		line := inlineCode.ReplaceAllString(raw, "")
+		line := p.inlineCode.ReplaceAllString(raw, "")
 
-		for _, m := range inlineLink.FindAllStringSubmatch(line, -1) {
-			if t, ok := cleanTarget(m[1]); ok {
+		for _, m := range p.inlineLink.FindAllStringSubmatch(line, -1) {
+			if t, ok := p.cleanTarget(m[1]); ok {
 				out = append(out, link{target: t, line: i + 1})
 			}
 		}
 
-		if m := refLink.FindStringSubmatch(line); m != nil {
-			if t, ok := cleanTarget(m[1]); ok {
+		if m := p.refLink.FindStringSubmatch(line); m != nil {
+			if t, ok := p.cleanTarget(m[1]); ok {
 				out = append(out, link{target: t, line: i + 1})
 			}
 		}
@@ -73,7 +105,7 @@ func extract(src string) []link {
 
 // cleanTarget reduces a raw link target to the repository path it names, or
 // reports false when it names something this checker does not verify.
-func cleanTarget(raw string) (string, bool) {
+func (p *patterns) cleanTarget(raw string) (string, bool) {
 	t := strings.TrimSpace(raw)
 
 	// <path> is the escaped form for a target containing spaces, so everything
@@ -94,7 +126,7 @@ func cleanTarget(raw string) (string, bool) {
 		t = t[:i]
 	}
 
-	if t == "" || hasScheme.MatchString(t) || strings.HasPrefix(t, "//") {
+	if t == "" || p.hasScheme.MatchString(t) || strings.HasPrefix(t, "//") {
 		return "", false
 	}
 

--- a/internal/linkcheck/link_test.go
+++ b/internal/linkcheck/link_test.go
@@ -1,4 +1,4 @@
-package main
+package linkcheck
 
 import (
 	"os"
@@ -28,7 +28,7 @@ func TestExtractSkipsWhatIsNotALink(t *testing.T) {
 		"[titled](./titled.md \"a title\")\n" +
 		"[ref]: ./reference.md\n"
 
-	got := extract(src)
+	got := mustPatterns(t).extract(src)
 
 	targets := make([]string, 0, len(got))
 	for _, l := range got {
@@ -44,7 +44,7 @@ func TestExtractSkipsWhatIsNotALink(t *testing.T) {
 }
 
 func TestExtractDecodesPercentEncodedTargets(t *testing.T) {
-	got := extract("[roadmap](docs/gobpm%20Development%20Roadmap.md)\n")
+	got := mustPatterns(t).extract("[roadmap](docs/gobpm%20Development%20Roadmap.md)\n")
 
 	require.Len(t, got, 1)
 	require.Equal(t, "docs/gobpm Development Roadmap.md", got[0].target,
@@ -52,7 +52,7 @@ func TestExtractDecodesPercentEncodedTargets(t *testing.T) {
 }
 
 func TestExtractHandlesAngleBracketTargets(t *testing.T) {
-	got := extract("[spaced](<a file.md>)\n")
+	got := mustPatterns(t).extract("[spaced](<a file.md>)\n")
 
 	require.Len(t, got, 1)
 	require.Equal(t, "a file.md", got[0].target)
@@ -70,7 +70,7 @@ func TestCheckFileResolvesRelativeToTheDocument(t *testing.T) {
 
 	require.NoError(t, os.WriteFile(doc, []byte(src), 0o600))
 
-	got := checkFile(doc, src)
+	got := mustPatterns(t).checkFile(doc, src)
 
 	require.Len(t, got, 2, "the sibling resolves; the other two do not")
 	require.Equal(t, "gone.md", got[0].target)
@@ -114,7 +114,7 @@ func TestRunExitCodes(t *testing.T) {
 	t.Run("clean tree exits 0", func(t *testing.T) {
 		var out, errOut strings.Builder
 
-		code := run([]string{"-root", dir}, &out, &errOut)
+		code := Run([]string{"-root", dir}, &out, &errOut)
 
 		require.Equal(t, 0, code)
 		require.Contains(t, out.String(), "every relative link resolves")
@@ -126,7 +126,7 @@ func TestRunExitCodes(t *testing.T) {
 
 		var out, errOut strings.Builder
 
-		code := run([]string{"-root", dir}, &out, &errOut)
+		code := Run([]string{"-root", dir}, &out, &errOut)
 
 		require.Equal(t, 1, code)
 		require.Contains(t, out.String(), "bad.md:2: dead link: missing.md",
@@ -137,7 +137,7 @@ func TestRunExitCodes(t *testing.T) {
 	t.Run("unusable root exits 2", func(t *testing.T) {
 		var out, errOut strings.Builder
 
-		code := run([]string{"-root", filepath.Join(dir, "nope")}, &out, &errOut)
+		code := Run([]string{"-root", filepath.Join(dir, "nope")}, &out, &errOut)
 
 		require.Equal(t, 2, code)
 		require.Contains(t, errOut.String(), "linkcheck:")
@@ -146,6 +146,18 @@ func TestRunExitCodes(t *testing.T) {
 	t.Run("a bad flag exits 2", func(t *testing.T) {
 		var out, errOut strings.Builder
 
-		require.Equal(t, 2, run([]string{"-nope"}, &out, &errOut))
+		require.Equal(t, 2, Run([]string{"-nope"}, &out, &errOut))
 	})
+}
+
+// mustPatterns builds the compiled matchers for a test. The constructor returns
+// an error because internal/ bans panicking Must* calls (FIX-026); the tests
+// assert it succeeds rather than assuming it.
+func mustPatterns(t *testing.T) *patterns {
+	t.Helper()
+
+	p, err := newPatterns()
+	require.NoError(t, err)
+
+	return p
 }

--- a/internal/linkcheck/main.go
+++ b/internal/linkcheck/main.go
@@ -1,0 +1,155 @@
+// Package linkcheck verifies that every relative Markdown link in a directory
+// tree resolves to a file that exists.
+//
+// It exists because nothing did: FIX-031 swept up 78 dead cross-references that
+// had accumulated across several refactors, including in both READMEs and the
+// SAD, and two of its three causes — a retired document and a renamed ADR — are
+// exactly what a checker catches for free (FIX-034 §1.3).
+//
+// It is deliberately a small Go package rather than an off-the-shelf tool: the
+// repository's parity rule requires every CI tool to be pinned and installed by
+// `make tools`, and adding a Node or Rust toolchain for this would also add a
+// network dependency that makes the gate flaky for reasons unrelated to the
+// change under test. Relative links only, offline, deterministic.
+package linkcheck
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// problem is one link that does not resolve.
+type problem struct {
+	file   string
+	target string
+	line   int
+}
+
+// skipDir names directories that hold no authored documentation.
+var skipDir = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"bin":          true,
+}
+
+// Run is the command's body with its I/O and exit code as values, so the
+// tool's behavior — what it prints, and which of its three exit codes it
+// chooses — is testable without spawning a process, and is measured by the
+// coverage gate. 0 clean, 1 dead links, 2 unusable root.
+func Run(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("linkcheck", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	root := flags.String("root", ".", "directory to scan")
+
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+
+	problems, err := scan(*root)
+	if err != nil {
+		emitf(stderr, "linkcheck: %v\n", err)
+
+		return 2
+	}
+
+	for _, p := range problems {
+		emitf(stdout, "%s:%d: dead link: %s\n", p.file, p.line, p.target)
+	}
+
+	if len(problems) > 0 {
+		emitf(stderr, "\nlinkcheck: %d dead link(s)\n", len(problems))
+
+		return 1
+	}
+
+	emitf(stdout, "linkcheck: every relative link resolves\n")
+
+	return 0
+}
+
+// scan walks root's Markdown and returns the links that do not resolve, in a
+// stable order so the output is diffable.
+func scan(root string) ([]problem, error) {
+	var out []problem
+
+	pats, err := newPatterns()
+	if err != nil {
+		return nil, err
+	}
+
+	err = filepath.WalkDir(root, func(
+		path string, d fs.DirEntry, err error,
+	) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			if skipDir[d.Name()] {
+				return fs.SkipDir
+			}
+
+			return nil
+		}
+
+		if !strings.EqualFold(filepath.Ext(path), ".md") {
+			return nil
+		}
+
+		// The path comes from this walk over an operator-chosen root — there
+		// is no untrusted input to sanitize, and reading the files it finds is
+		// the tool's entire purpose.
+		src, rerr := os.ReadFile(path) //nolint:gosec // see above
+		if rerr != nil {
+			return rerr
+		}
+
+		out = append(out, pats.checkFile(path, string(src))...)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].file != out[j].file {
+			return out[i].file < out[j].file
+		}
+
+		return out[i].line < out[j].line
+	})
+
+	return out, nil
+}
+
+// checkFile reports the links in one document that do not resolve, relative to
+// that document's own directory.
+func (p *patterns) checkFile(path, src string) []problem {
+	var out []problem
+
+	dir := filepath.Dir(path)
+
+	for _, l := range p.extract(src) {
+		if _, err := os.Stat(filepath.Join(dir, l.target)); err != nil {
+				out = append(out, problem{file: path, line: l.line, target: l.target})
+		}
+	}
+
+	return out
+}
+
+// emitf writes one diagnostic line, deliberately ignoring the write error. Every
+// byte this tool produces is a report FOR the operator, so a failed write to
+// their terminal cannot be reported anywhere they would see it — the same
+// carve-out the console driver carries (FIX-028 §6.1).
+func emitf(w io.Writer, format string, args ...any) {
+	_, _ = fmt.Fprintf(w, format, args...) //nolint:errcheck // see above
+}

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -395,9 +395,13 @@ func (p *Scope) OpenScope(path DataPath) error {
 		return err
 	}
 
-	// DropTail can't fail on a path checkContained validated; if it ever
-	// did, parent would be empty and fail the parent-is-open check below.
-	parent, _ := path.DropTail()
+	// DropTail cannot fail on a path checkContained has validated — but the
+	// function already returns an error, so reporting it costs nothing and
+	// beats relying on the empty parent failing the check below.
+	parent, err := path.DropTail()
+	if err != nil {
+		return err
+	}
 
 	p.m.Lock()
 	defer p.m.Unlock()

--- a/pkg/errs/errors.go
+++ b/pkg/errs/errors.go
@@ -59,6 +59,10 @@ const (
 	ObjectNotFound = "OBJECT_NOT_FOUND"
 	// InvalidState represents an invalid state error code.
 	InvalidState = "INVALID_OBJECT_STATE"
+	// BrokenInvariant marks a failure that no input can cause and no caller can
+	// recover from: an engine-internal contract was violated. Distinct from
+	// InvalidState, which a caller can provoke and should handle.
+	BrokenInvariant = "BROKEN_INVARIANT"
 )
 
 // ApplicationError represents a structured application error with classes, message, and details.
@@ -195,4 +199,24 @@ func (ae ApplicationError) MarshalJSON() ([]byte, error) {
 // recovers at its own boundary.
 func Panic(v any) {
 	panic(v)
+}
+
+// Invariant reports a violated engine-internal contract — a state the code
+// believes unreachable, such as a registry entry of the wrong type or a watch
+// armed with a definition of the wrong kind. No input produces it and no caller
+// can act on it; it means the engine wired something to itself incorrectly.
+//
+// It exists to be greppable. Its call sites are the ONLY lines the
+// diff-coverage gate excludes for unreachability (COVER_EXCLUDE in the
+// Makefile, FIX-034 §3.2.3), so `grep -rn "errs.Invariant("` lists every branch
+// the project has claimed cannot be tested — and silencing the gate requires
+// saying so in code, not in a comment.
+//
+// It returns an error rather than panicking on purpose: gobpm is a library
+// embedded in someone's binary, so a faulted instance leaves the engine serving
+// every other one, while a panic takes the host process down with it.
+func Invariant(format string, args ...any) error {
+	return New(
+		M("broken invariant: "+format, args...),
+		C(BrokenInvariant))
 }

--- a/pkg/errs/errors_test.go
+++ b/pkg/errs/errors_test.go
@@ -106,3 +106,23 @@ func TestErrWrapping(t *testing.T) {
 	require.True(t, errors.Is(myErr, testErr))
 	require.True(t, errors.As(myErr, &asTestErr))
 }
+
+// TestInvariant covers the one construct the diff-coverage gate excludes at its
+// call sites: the constructor itself is tested here, so the exclusion never
+// hides untested code — only branches the project has explicitly claimed
+// unreachable (FIX-034 §3.2.3).
+func TestInvariant(t *testing.T) {
+	err := errs.Invariant("cache entry for %s is %T", "widget", 42)
+
+	require.Error(t, err)
+
+	var ae *errs.ApplicationError
+
+	require.ErrorAs(t, err, &ae)
+	require.True(t, ae.HasClass(errs.BrokenInvariant),
+		"an invariant failure carries its own class, not InvalidState")
+	require.Contains(t, err.Error(), "broken invariant: ",
+		"the message announces what kind of failure this is")
+	require.Contains(t, err.Error(), "cache entry for widget is int",
+		"the format arguments are applied")
+}

--- a/pkg/interactor/console/console.go
+++ b/pkg/interactor/console/console.go
@@ -124,7 +124,11 @@ func (d *Driver) drive(ctx context.Context, taskID string) {
 // never fail the interaction.
 func (d *Driver) printf(format string, a ...any) {
 	// deliberate ignore (carve-out above): no logger, nothing to fall back to.
-	_, _ = fmt.Fprintf(d.w, format, a...)
+	// The one documented discard in the library (FIX-028 §6.1): this is the
+	// console driver's own prompt output, and a failed write to the user's
+	// terminal is neither actionable nor reportable anywhere the user would
+	// see it — the report would go to the same broken writer.
+	_, _ = fmt.Fprintf(d.w, format, a...) //nolint:errcheck // see above
 }
 
 // collect renders the first renderer to gather the task's outputs. A task with no

--- a/pkg/model/activities/activity.go
+++ b/pkg/model/activities/activity.go
@@ -25,7 +25,7 @@ type activity struct {
 	properties          map[string]*data.Property
 	IoSpec              *data.InputOutputSpecification
 	dataAssociations    map[data.Direction][]*data.Association
-	boundaryEvents      []flow.EventNode
+	boundaryEvents      []flow.BoundaryEvent
 	startQuantity       int
 	completionQuantity  int
 	isForCompensation   bool
@@ -195,8 +195,8 @@ func (a *activity) ForCompensation() bool {
 }
 
 // BoundaryEvents returns list of events bounded to the acitvity.
-func (a *activity) BoundaryEvents() []flow.EventNode {
-	return append([]flow.EventNode{}, a.boundaryEvents...)
+func (a *activity) BoundaryEvents() []flow.BoundaryEvent {
+	return append([]flow.BoundaryEvent{}, a.boundaryEvents...)
 }
 
 // AddBoundaryEvent attaches a boundary event to the activity. Multiplicity (at

--- a/pkg/model/activities/flowselect.go
+++ b/pkg/model/activities/flowselect.go
@@ -100,5 +100,17 @@ func (a *activity) checkCondition(
 			errs.E(err))
 	}
 
-	return res.Get(ctx).(bool), nil
+	// A non-boolean condition is a modeling error, and data.As names both the
+	// held and the wanted type instead of panicking (ADR-034 v.1 §5).
+	val, err := data.As[bool](ctx, res)
+	if err != nil {
+		return false, errs.New(
+			errs.M("flow condition is not boolean"),
+			errs.C(errorClass, errs.TypeCastingError),
+			errs.D("outgoing_flow_id", of.ID()),
+			errs.D("activity_id", a.ID()),
+			errs.E(err))
+	}
+
+	return val, nil
 }

--- a/pkg/model/activities/flowselect_test.go
+++ b/pkg/model/activities/flowselect_test.go
@@ -8,8 +8,10 @@ import (
 	"github.com/dr-dobermann/gobpm/generated/mockrenv"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
+	dgexpr "github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
 	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
 	exprengine "github.com/dr-dobermann/gobpm/pkg/model/expression/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
 	"github.com/dr-dobermann/gobpm/pkg/model/options"
 	"github.com/stretchr/testify/require"
@@ -240,4 +242,38 @@ func TestSetDefaultFlowHardening(t *testing.T) {
 	t.Run("unknown flow rejected", func(t *testing.T) {
 		require.ErrorContains(t, a.SetDefaultFlow("nope"), "doesn't exist")
 	})
+}
+
+// nonBoolEngine is an expression.Engine that returns a STRING for every
+// expression, whatever the expression declares. The built-in engine type-checks
+// its result, so this is how a third-party engine's contract violation reaches
+// the condition check — the branch data.As guards (ADR-034 v.1 §5).
+type nonBoolEngine struct{}
+
+func (nonBoolEngine) Type() string       { return "##NonBool" }
+func (nonBoolEngine) Languages() []string { return []string{dgexpr.Language} }
+
+func (nonBoolEngine) Evaluate(
+	context.Context, data.FormalExpression, data.Source,
+) (data.Value, error) {
+	return values.NewVariable("not a bool"), nil
+}
+
+func TestActivityConditionRejectsANonBooleanResult(t *testing.T) {
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().ExpressionEngine().Return(nonBoolEngine{}).Maybe()
+
+	a, fls := linked(t, constCond(t, true))
+
+	_, err := a.checkCondition(context.Background(), re,
+		fls[0].Condition(), fls[0])
+	require.Error(t, err)
+
+	var ae *errs.ApplicationError
+
+	require.ErrorAs(t, err, &ae)
+	require.True(t, ae.HasClass(errs.TypeCastingError),
+		"an engine that ignores the declared result type is reported, not "+
+			"asserted into a panic")
+	require.Contains(t, err.Error(), "not boolean")
 }

--- a/pkg/model/activities/service_task.go
+++ b/pkg/model/activities/service_task.go
@@ -65,22 +65,19 @@ type ServiceTask struct {
 // NewServiceTask creates a new service task named name and operation as
 // service engine with some options.
 //
-// Available options are:
-//   - activities.WithMultyInstance
-//   - activities.WithCompensation
-//   - activities.WithLoop
-//   - activities.WithStartQuantity
-//   - activities.WithCompletionQuantity
-//   - activities.WithParameters
-//   - activities.WithoutParams
-//   - activities.WithRoles
-//   - activities.WithTimeout
-//   - activities.WithWorker
-//   - activities.WithErrorMapper
-//   - activities.WithStatus
-//   - activities.WithOutputMapping
-//   - foundation.WithID
-//   - foundation.WithDoc
+// It accepts the option FAMILIES below — that is what the constructor
+// dispatches on, so an option added to one of these families is accepted here
+// whether or not it is named. The members listed are today's; the family is the
+// contract (FIX-034 §3.2.5).
+//
+//   - SrvTaskOption — WithTimeout, WithWorker, WithWorkerTrust, WithErrorMapper,
+//     WithStatus, WithOutputMapping
+//   - taskOption — WithMultyInstance
+//   - ActivityOption — WithLoop, WithCompensation, WithStartQuantity,
+//     WithCompletionQuantity, WithParameters, WithoutParams
+//   - RoleOption — WithRoles
+//   - data.PropertyOption — the process-data property options
+//   - foundation.BaseOption — WithID, WithDoc
 func NewServiceTask(
 	name string,
 	operation service.Operation,

--- a/pkg/model/activities/subprocess.go
+++ b/pkg/model/activities/subprocess.go
@@ -418,6 +418,12 @@ func (sp *SubProcess) classifyEntries(
 	ee *[]error,
 ) (noneStarts, triggeredStarts, flowless, nonInterruptingError int) {
 	for _, n := range sp.Nodes() {
+		// Bind the two shapes once: the predicates below assert anyway, and
+		// binding here keeps the value that was proven instead of asserting a
+		// second time on the branch that already knows the answer.
+		be, isBoundary := n.(flow.BoundaryEvent)
+		en, isEvent := n.(flow.EventNode)
+
 		switch {
 		case isEventSubProcess(n):
 			// An inner Event Sub-Process is a scope-armed handler, not an
@@ -426,31 +432,20 @@ func (sp *SubProcess) classifyEntries(
 			// §13.3.4 shape) and armed at runtime instead. Its own inner
 			// graph is still validated by the per-node hook below.
 
-		case isBoundaryEvent(n):
+		case isBoundary:
 			// A boundary event has no incoming flow by nature — it is not
 			// an entry. Its host must be an inner node.
-			be := n.(flow.BoundaryEvent)
 			if !sp.contains(be.AttachedTo()) {
 				*ee = append(*ee, sp.shapeErr(
 					"boundary event %q is attached to a node outside the "+
 						"Sub-Process", n.ID()))
 			}
 
-		case isStartEvent(n):
-			en := n.(flow.EventNode)
-			defs := en.Definitions()
-			if len(defs) == 0 {
-				noneStarts++
-			} else {
-				triggeredStarts++
-				// A non-interrupting triggered start is allowed (SRD-053)
-				// EXCEPT an Error start, which is always interrupting (BPMN
-				// §10.5.6) — only that case is still rejected.
-				if si, ok := n.(interface{ IsInterrupting() bool }); ok &&
-					!si.IsInterrupting() && defs[0].Type() == flow.TriggerError {
-					nonInterruptingError++
-				}
-			}
+		case isEvent && en.EventClass() == flow.StartEventClass:
+			none, triggered, badErrStart := classifyStart(n, en)
+			noneStarts += none
+			triggeredStarts += triggered
+			nonInterruptingError += badErrStart
 
 		case isCompensationHandler(n):
 			// A compensation handler lives outside the normal flow (SRD-059
@@ -473,6 +468,28 @@ func (sp *SubProcess) classifyEntries(
 	return noneStarts, triggeredStarts, flowless, nonInterruptingError
 }
 
+// classifyStart counts one inner Start Event for the entry shape: whether it is
+// a None start, a triggered one, and whether it is the one triggered shape the
+// standard forbids — a non-interrupting Error start (BPMN §10.5.6). Split out
+// of classifyEntries to keep that switch under the complexity gate.
+func classifyStart(
+	n flow.Node, en flow.EventNode,
+) (none, triggered, nonInterruptingError int) {
+	defs := en.Definitions()
+	if len(defs) == 0 {
+		return 1, 0, 0
+	}
+
+	// A non-interrupting triggered start is allowed (SRD-053) EXCEPT an Error
+	// start, which is always interrupting — only that case is rejected.
+	if si, ok := n.(interface{ IsInterrupting() bool }); ok &&
+		!si.IsInterrupting() && defs[0].Type() == flow.TriggerError {
+		return 0, 1, 1
+	}
+
+	return 0, 1, 0
+}
+
 // isEventSubProcess reports whether n is an Event Sub-Process (a scope-armed
 // handler, skipped from entry seeding — ADR-023 v.2 §2.10).
 func isEventSubProcess(n flow.Node) bool {
@@ -481,19 +498,6 @@ func isEventSubProcess(n flow.Node) bool {
 	return ok && h.IsEventSubProcess()
 }
 
-// isBoundaryEvent reports whether n is a boundary event.
-func isBoundaryEvent(n flow.Node) bool {
-	_, ok := n.(flow.BoundaryEvent)
-
-	return ok
-}
-
-// isStartEvent reports whether n is a Start Event node.
-func isStartEvent(n flow.Node) bool {
-	en, ok := n.(flow.EventNode)
-
-	return ok && en.EventClass() == flow.StartEventClass
-}
 
 // isCompensationHandler reports whether n is an isForCompensation activity —
 // a compensation handler outside the normal flow (SRD-059 FR-2).

--- a/pkg/model/activities/subprocess_test.go
+++ b/pkg/model/activities/subprocess_test.go
@@ -360,7 +360,9 @@ func TestSubProcessClone(t *testing.T) {
 		chost := nodeByName(t, csp, "guarded").(flow.ActivityNode)
 		require.Same(t, chost, cbe.AttachedTo())
 
-		bes := chost.(interface{ BoundaryEvents() []flow.EventNode }).BoundaryEvents()
+		bes := chost.(interface {
+			BoundaryEvents() []flow.BoundaryEvent
+		}).BoundaryEvents()
 		require.Len(t, bes, 1)
 		require.Same(t, cbe, bes[0])
 	})

--- a/pkg/model/activities/user_task.go
+++ b/pkg/model/activities/user_task.go
@@ -61,18 +61,21 @@ type UserTask struct {
 
 // NewUserTask tries to create a new UserTask with name and options.
 //
-// Available options:
+// It accepts the option FAMILIES below — that is what the constructor
+// dispatches on, so an option added to one of these families is accepted here
+// whether or not it is named. The members listed are today's; the family is the
+// contract (FIX-034 §3.2.5). This block previously named only the first and
+// last families, which is how the Camunda triad options went undocumented when
+// SRD-034 added them.
 //
-//	User Task options:
-//	- WithRenderer
-//	- WithOutput
-//	- WithAssignee / WithAssigneeExpr
-//	- WithCandidateUsers / WithCandidateUsersExpr
-//	- WithCandidateGroups / WithCandidateGroupsExpr
-//
-//	foundation options:
-//	- WithID
-//	- WithDoc
+//   - UsrTaskOption — WithRenderer, WithOutput, WithAssignee / WithAssigneeExpr,
+//     WithCandidateUsers / WithCandidateUsersExpr,
+//     WithCandidateGroups / WithCandidateGroupsExpr
+//   - taskOption — WithMultyInstance
+//   - ActivityOption — WithLoop, WithCompensation, WithStartQuantity,
+//     WithCompletionQuantity, WithParameters, WithoutParams
+//   - data.PropertyOption — the process-data property options
+//   - foundation.BaseOption — WithID, WithDoc
 //
 //	activity options:
 //	- WithMultyInstance

--- a/pkg/model/data/adapters/frozen.go
+++ b/pkg/model/data/adapters/frozen.go
@@ -62,7 +62,11 @@ func (f frozenRecord) Update(context.Context, any) error {
 func (f frozenRecord) Lock()             { f.r.Lock() }
 func (f frozenRecord) Unlock()           { f.r.Unlock() }
 func (f frozenRecord) Type() string      { return f.r.Type() }
-func (f frozenRecord) Clone() data.Value { return frozenRecord{f.r.Clone().(data.Record)} }
+// Clone freezes the clone by its own kind rather than re-asserting this one's:
+// a Record's Clone returns a Record, so the result is identical — and if some
+// implementation ever broke that contract, freeze still returns a frozen value
+// instead of panicking or silently thawing.
+func (f frozenRecord) Clone() data.Value { return freeze(f.r.Clone()) }
 
 func (f frozenRecord) Keys() []string { return f.r.Keys() }
 
@@ -92,9 +96,7 @@ func (f frozenCollection) Update(context.Context, any) error {
 func (f frozenCollection) Lock()        { f.c.Lock() }
 func (f frozenCollection) Unlock()      { f.c.Unlock() }
 func (f frozenCollection) Type() string { return f.c.Type() }
-func (f frozenCollection) Clone() data.Value {
-	return frozenCollection{f.c.Clone().(data.Collection)}
-}
+func (f frozenCollection) Clone() data.Value { return freeze(f.c.Clone()) }
 
 func (f frozenCollection) Count() int                      { return f.c.Count() }
 func (f frozenCollection) Rewind()                         { f.c.Rewind() }
@@ -149,7 +151,7 @@ func (f frozenMap) Update(context.Context, any) error {
 func (f frozenMap) Lock()             { f.m.Lock() }
 func (f frozenMap) Unlock()           { f.m.Unlock() }
 func (f frozenMap) Type() string      { return f.m.Type() }
-func (f frozenMap) Clone() data.Value { return frozenMap{f.m.Clone().(data.Map)} }
+func (f frozenMap) Clone() data.Value { return freeze(f.m.Clone()) }
 
 func (f frozenMap) Keys() []string { return f.m.Keys() }
 

--- a/pkg/model/data/adapters/registry.go
+++ b/pkg/model/data/adapters/registry.go
@@ -33,7 +33,19 @@ func Register[T any](build func(v *T) data.Value) error {
 		goType: t,
 		name:   t.String(),
 		custom: func(ptr reflect.Value) data.Value {
-			return build(ptr.Interface().(*T))
+			// The cache keys this factory by reflect.TypeFor[T](), so the only
+			// pointer that reaches it is a *T. A different type means the
+			// resolution order handed the wrong entry to the wrong factory —
+			// a broken registry, not bad user input.
+			v, ok := ptr.Interface().(*T)
+			if !ok {
+				errs.Panic(errs.New(
+					errs.M("adapters: custom factory for %s got %s",
+						t, ptr.Type()),
+					errs.C(errorClass, errs.TypeCastingError)))
+			}
+
+			return build(v)
 		},
 	})
 
@@ -46,7 +58,7 @@ func Register[T any](build func(v *T) data.Value) error {
 // winner, identical content either way.
 func adapterFor(t reflect.Type) (*typeAdapter, error) {
 	if v, ok := adapterCache.Load(t); ok {
-		return v.(*typeAdapter), nil
+		return asAdapter(t, v)
 	}
 
 	ta, err := buildAdapter(t)
@@ -56,7 +68,20 @@ func adapterFor(t reflect.Type) (*typeAdapter, error) {
 
 	actual, _ := adapterCache.LoadOrStore(t, ta)
 
-	return actual.(*typeAdapter), nil
+	return asAdapter(t, actual)
+}
+
+// asAdapter reads a cache entry. Only adapterFor and Register ever write the
+// cache and both store a *typeAdapter, so a foreign value names a corrupted
+// registry rather than a caller mistake — reported, not asserted, and checked
+// in one place so both readers stay single expressions.
+func asAdapter(t reflect.Type, v any) (*typeAdapter, error) {
+	ta, ok := v.(*typeAdapter)
+	if !ok {
+		return nil, errs.Invariant("cache entry for %s is %T, not *typeAdapter", t, v)
+	}
+
+	return ta, nil
 }
 
 // customFor reports the Register-ed factory for t, if any — consulted first
@@ -67,7 +92,10 @@ func customFor(t reflect.Type) (*typeAdapter, bool) {
 		return nil, false
 	}
 
-	ta := v.(*typeAdapter)
+	ta, err := asAdapter(t, v)
+	if err != nil {
+		return nil, false
+	}
 
 	return ta, ta.custom != nil
 }

--- a/pkg/model/data/adapters/registry_internal_test.go
+++ b/pkg/model/data/adapters/registry_internal_test.go
@@ -1,0 +1,79 @@
+package adapters
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+)
+
+// FIX-034 turned the registry's cache reads from panicking assertions into
+// reported errors. Only adapterFor and Register write that cache and both store
+// a *typeAdapter, so the guard fires solely on a corrupted registry — which an
+// internal test can produce and an external one cannot.
+
+type poisonSubject struct{ X int }
+
+func TestAsAdapterRejectsForeignCacheEntry(t *testing.T) {
+	rt := reflect.TypeFor[poisonSubject]()
+
+	adapterCache.Store(rt, "not a *typeAdapter")
+	t.Cleanup(func() { adapterCache.Delete(rt) })
+
+	t.Run("adapterFor reports it", func(t *testing.T) {
+		ta, err := adapterFor(rt)
+		require.Nil(t, ta)
+		require.Error(t, err)
+
+		var ae *errs.ApplicationError
+
+		require.ErrorAs(t, err, &ae)
+		require.True(t, ae.HasClass(errs.BrokenInvariant),
+			"a corrupted cache is a broken invariant, not a caller's type error")
+		require.Contains(t, err.Error(), "not *typeAdapter",
+			"the message names what the entry actually held")
+	})
+
+	t.Run("customFor declines rather than panicking", func(t *testing.T) {
+		ta, ok := customFor(rt)
+		require.Nil(t, ta)
+		require.False(t, ok)
+	})
+}
+
+func TestAsAdapterAcceptsARealEntry(t *testing.T) {
+	rt := reflect.TypeFor[poisonSubject]()
+	want := &typeAdapter{goType: rt, name: rt.String()}
+
+	got, err := asAdapter(rt, want)
+	require.NoError(t, err)
+	require.Same(t, want, got)
+}
+
+// TestCustomFactoryRejectsAForeignPointer covers the other half of the registry
+// invariant: Register keys its factory by reflect.TypeFor[T], so only a *T ever
+// reaches it. Handing it something else means the resolution order paired the
+// wrong entry with the wrong factory — a broken registry, which fails fast
+// rather than building a value from a pointer it cannot interpret.
+func TestCustomFactoryRejectsAForeignPointer(t *testing.T) {
+	type other struct{ Y string }
+
+	require.NoError(t, Register(func(v *poisonSubject) data.Value {
+		return values.NewVariable(v.X)
+	}))
+
+	rt := reflect.TypeFor[poisonSubject]()
+	t.Cleanup(func() { adapterCache.Delete(rt) })
+
+	ta, ok := customFor(rt)
+	require.True(t, ok, "the factory registered")
+
+	require.Panics(t, func() { ta.custom(reflect.ValueOf(&other{})) },
+		"a pointer of the wrong type is a corrupted registry, not a value")
+
+	require.NotPanics(t, func() { ta.custom(reflect.ValueOf(&poisonSubject{X: 1})) })
+}

--- a/pkg/model/data/item.go
+++ b/pkg/model/data/item.go
@@ -236,6 +236,7 @@ func MustItemAwareElement(
 //
 // Available options:
 //   - data.WithIDef
+//   - data.WithIDefinition
 //   - data.WithState
 //   - foundation.WithID
 //   - foundation.WithDoc

--- a/pkg/model/data/item_options.go
+++ b/pkg/model/data/item_options.go
@@ -196,8 +196,8 @@ type (
 // WithIAE adds ItemAwareElement to the cfg which implements IAEAdder interface
 //
 // Available options:
-//   - data.IDef
-//   - data.IDefinition
+//   - data.WithIDef
+//   - data.WithIDefinition
 //   - data.WithState
 //   - foundation.WithID
 //   - foundation.WithDoc

--- a/pkg/model/events/boundary.go
+++ b/pkg/model/events/boundary.go
@@ -36,7 +36,7 @@ var boundaryTriggers = set.New[flow.EventTrigger](
 type boundaryHost interface {
 	flow.ActivityNode
 
-	BoundaryEvents() []flow.EventNode
+	BoundaryEvents() []flow.BoundaryEvent
 	AddBoundaryEvent(flow.BoundaryEvent) error
 }
 
@@ -259,9 +259,8 @@ func (b *BoundaryEvent) BoundTo(host flow.ActivityNode) error {
 
 	if b.cancelActivity {
 		key := declarationKey(b)
-		for _, ex := range h.BoundaryEvents() {
-			be, ok := ex.(flow.BoundaryEvent)
-			if !ok || !be.CancelActivity() {
+		for _, be := range h.BoundaryEvents() {
+			if !be.CancelActivity() {
 				continue
 			}
 

--- a/pkg/model/expression/lite/adr_table_test.go
+++ b/pkg/model/expression/lite/adr_table_test.go
@@ -30,3 +30,14 @@ func TestADRWorkedExamples(t *testing.T) {
 		wantValue(t, src, c.body, c.want)
 	}
 }
+
+// TestBoolComparison covers compare's bool arm (FIX-034 split it into
+// compareBools so both operands are checked): equality and inequality over two
+// boolean variables, which no ADR row exercises.
+func TestBoolComparison(t *testing.T) {
+	src := adrSource(t)
+
+	wantValue(t, src, "approved == blocked", false)
+	wantValue(t, src, "approved != blocked", true)
+	wantValue(t, src, "approved == approved", true)
+}

--- a/pkg/model/expression/lite/eval.go
+++ b/pkg/model/expression/lite/eval.go
@@ -223,19 +223,28 @@ func compare(op string, l, r any, off int) (any, error) {
 		return ordered(op, lv.Equal(rv), lv.Before(rv)), nil
 
 	default: // bool
-		rv, ok := r.(bool)
-		if !ok {
-			return nil, crossKind(op, off)
-		}
+		return compareBools(op, l, r, off)
+	}
+}
 
-		switch op {
-		case "==":
-			return l.(bool) == rv, nil
-		case "!=":
-			return l.(bool) != rv, nil
-		default:
-			return nil, evalErr("bools don't order — only == and !=", off)
-		}
+// compareBools is compare's bool arm, split out so each side's type is checked
+// without pushing compare past the complexity gate. Both operands are checked:
+// the type switch above proves nothing about l on the default arm.
+func compareBools(op string, l, r any, off int) (any, error) {
+	lv, lok := l.(bool)
+	rv, rok := r.(bool)
+
+	if !lok || !rok {
+		return nil, crossKind(op, off)
+	}
+
+	switch op {
+	case "==":
+		return lv == rv, nil
+	case "!=":
+		return lv != rv, nil
+	default:
+		return nil, evalErr("bools don't order — only == and !=", off)
 	}
 }
 

--- a/pkg/model/flow/container.go
+++ b/pkg/model/flow/container.go
@@ -309,11 +309,21 @@ func WireClonedGraph(
 			continue
 		}
 
-		// The clones are cloned from valid nodes — a BoundaryEvent's clone is
-		// a BoundaryEvent and its host's clone an ActivityNode — so, as with
-		// the flow relink above, these casts cannot fail (panicking form).
-		cloneBE := clonedNodes[id].(BoundaryEvent)
-		cloneHost := clonedNodes[origBE.AttachedTo().ID()].(ActivityNode)
+		// A BoundaryEvent's clone is a BoundaryEvent and its host's clone an
+		// ActivityNode, so neither check can fail while Clone honors its
+		// contract — but the function already reports a corrupt clone below,
+		// and reporting one here costs the same.
+		cloneBE, ok := clonedNodes[id].(BoundaryEvent)
+		if !ok {
+			return nil, errs.Invariant("clone of boundary event %q is not a BoundaryEvent", id)
+		}
+
+		hostID := origBE.AttachedTo().ID()
+
+		cloneHost, ok := clonedNodes[hostID].(ActivityNode)
+		if !ok {
+			return nil, errs.Invariant("clone of boundary host %q is not an ActivityNode", hostID)
+		}
 
 		// The cloned host starts with no boundaries, so the already-validated
 		// binding re-attaches without a multiplicity conflict; an error here

--- a/pkg/model/flow/container_test.go
+++ b/pkg/model/flow/container_test.go
@@ -415,3 +415,45 @@ func TestWireClonedGraphDefensive(t *testing.T) {
 		require.Contains(t, err.Error(), "rebind boundary")
 	})
 }
+
+// TestWireClonedGraphRejectsAMistypedClone drives the two guards FIX-034 added
+// where WireClonedGraph reads the clone map. A clone of a BoundaryEvent is a
+// BoundaryEvent and its host's clone an ActivityNode while Clone honours its
+// contract — so these fire only on a corrupt clone, which a hand-built map can
+// produce and a real CloneGraph cannot.
+func TestWireClonedGraphRejectsAMistypedClone(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	host, err := activities.NewManualTask("wire-host")
+	require.NoError(t, err)
+
+	sig, err := events.NewSignal("wire-sig",
+		data.MustItemDefinition(values.NewVariable(1)))
+	require.NoError(t, err)
+
+	sdef, err := events.NewSignalEventDefinition(sig)
+	require.NoError(t, err)
+
+	be, err := events.NewBoundaryEvent("wire-bnd", host, sdef, true)
+	require.NoError(t, err)
+
+	srcNodes := map[string]flow.Node{be.ID(): be, host.ID(): host}
+
+	// A stand-in that is a Node but neither a BoundaryEvent nor an ActivityNode.
+	plain, err := events.NewEndEvent("not-a-boundary")
+	require.NoError(t, err)
+
+	t.Run("the boundary's clone", func(t *testing.T) {
+		_, err := flow.WireClonedGraph(
+			map[string]flow.Node{be.ID(): plain, host.ID(): host},
+			srcNodes, nil)
+		require.ErrorContains(t, err, "is not a BoundaryEvent")
+	})
+
+	t.Run("the host's clone", func(t *testing.T) {
+		_, err := flow.WireClonedGraph(
+			map[string]flow.Node{be.ID(): be, host.ID(): plain},
+			srcNodes, nil)
+		require.ErrorContains(t, err, "is not an ActivityNode")
+	})
+}

--- a/pkg/model/gateways/condition_internal_test.go
+++ b/pkg/model/gateways/condition_internal_test.go
@@ -1,0 +1,66 @@
+package gateways
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dr-dobermann/gobpm/generated/mockrenv"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	dgexpr "github.com/dr-dobermann/gobpm/pkg/model/data/goexpr"
+	"github.com/dr-dobermann/gobpm/pkg/model/data/values"
+	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+)
+
+// nonBoolEngine returns a STRING for every expression, whatever the expression
+// declares. The built-in engine type-checks its own result, so this is how a
+// third-party engine's contract violation reaches the condition check — the
+// branch data.As guards (ADR-034 v.1 §5, FIX-034 §3.2.3).
+type nonBoolEngine struct{}
+
+func (nonBoolEngine) Type() string        { return "##NonBool" }
+func (nonBoolEngine) Languages() []string { return []string{dgexpr.Language} }
+
+func (nonBoolEngine) Evaluate(
+	context.Context, data.FormalExpression, data.Source,
+) (data.Value, error) {
+	return values.NewVariable("not a bool"), nil
+}
+
+func TestGatewayConditionRejectsANonBooleanResult(t *testing.T) {
+	require.NoError(t, data.CreateDefaultStates())
+
+	re := mockrenv.NewMockRuntimeEnvironment(t)
+	re.EXPECT().ExpressionEngine().Return(nonBoolEngine{}).Maybe()
+
+	// A bool-DECLARING condition, so the ResultType guard above passes and the
+	// engine's answer is what fails the check.
+	cond, err := dgexpr.New(nil,
+		data.MustItemDefinition(values.NewVariable(false)),
+		func(context.Context, data.Source) (data.Value, error) {
+			return values.NewVariable(true), nil
+		})
+	require.NoError(t, err)
+
+	g, err := NewExclusiveGateway()
+	require.NoError(t, err)
+
+	target, err := NewParallelGateway()
+	require.NoError(t, err)
+
+	sf, err := flow.Link(g, target, flow.WithCondition(cond))
+	require.NoError(t, err)
+
+	_, cerr := g.checkCondition(context.Background(), re, cond, sf)
+	require.Error(t, cerr)
+
+	var ae *errs.ApplicationError
+
+	require.ErrorAs(t, cerr, &ae)
+	require.True(t, ae.HasClass(errs.TypeCastingError),
+		"an engine that ignores the declared result type is reported, not "+
+			"asserted into a panic")
+	require.Contains(t, cerr.Error(), "not boolean")
+}

--- a/pkg/model/gateways/event_based.go
+++ b/pkg/model/gateways/event_based.go
@@ -456,7 +456,7 @@ func (g *EventBasedGateway) validateArm(
 	if arm.NodeType() == flow.ActivityNodeType {
 		// (e) a Receive-Task arm carries no boundary events.
 		if be, ok := arm.(interface {
-			BoundaryEvents() []flow.EventNode
+			BoundaryEvents() []flow.BoundaryEvent
 		}); ok && len(be.BoundaryEvents()) != 0 {
 			ee = append(ee, errs.New(
 				errs.M("event-based gateway: a Receive-Task arm must not "+

--- a/pkg/model/gateways/event_based.go
+++ b/pkg/model/gateways/event_based.go
@@ -117,6 +117,7 @@ func WithCorrelationKey(key *bpmncommon.CorrelationKey) EventBasedOption {
 //   - gateways.WithDirection
 //   - gateways.WithInstantiate
 //   - gateways.WithEventGatewayType
+//   - gateways.WithCorrelationKey
 func NewEventBasedGateway(opts ...options.Option) (*EventBasedGateway, error) {
 	ec := eventBasedConfig{}
 	baseOpts := make([]options.Option, 0, len(opts))

--- a/pkg/model/gateways/event_based_test.go
+++ b/pkg/model/gateways/event_based_test.go
@@ -540,7 +540,7 @@ type stubTaskBoundary struct {
 	flow.BaseNode
 	foundation.BaseElement
 	defs     []flow.EventDefinition
-	boundary []flow.EventNode
+	boundary []flow.BoundaryEvent
 }
 
 func newStubTaskBoundary(t *testing.T, name string) *stubTaskBoundary {
@@ -553,8 +553,25 @@ func newStubTaskBoundary(t *testing.T, name string) *stubTaskBoundary {
 		BaseNode:    *fn,
 		BaseElement: *foundation.MustBaseElement(),
 		defs:        []flow.EventDefinition{signalDef(t, name)},
-		boundary:    []flow.EventNode{signalArm(t, name+"-be")},
+		boundary:    []flow.BoundaryEvent{stubBoundary(t, name)},
 	}
+}
+
+// stubBoundary builds a REAL boundary event for the stub to report. It used to
+// report an IntermediateCatchEvent, which is not a flow.BoundaryEvent at all —
+// the accessor's old []flow.EventNode element type simply hid that, and every
+// consumer then asserted the value back to flow.BoundaryEvent.
+func stubBoundary(t *testing.T, name string) *events.BoundaryEvent {
+	t.Helper()
+
+	host, err := activities.NewManualTask(name + "-be-host")
+	require.NoError(t, err)
+
+	be, err := events.NewBoundaryEvent(name+"-be", host, signalDef(t, name+"-be"),
+		true)
+	require.NoError(t, err)
+
+	return be
 }
 
 func (a *stubTaskBoundary) Node() flow.Node { return a }
@@ -572,7 +589,7 @@ func (a *stubTaskBoundary) ProcessEvent(context.Context, flow.EventDefinition) e
 	return nil
 }
 
-func (a *stubTaskBoundary) BoundaryEvents() []flow.EventNode { return a.boundary }
+func (a *stubTaskBoundary) BoundaryEvents() []flow.BoundaryEvent { return a.boundary }
 
 func TestEventBasedGatewayArmForSkipsNonEvent(t *testing.T) {
 	g, err := gateways.NewEventBasedGateway()

--- a/pkg/model/gateways/gateway.go
+++ b/pkg/model/gateways/gateway.go
@@ -244,7 +244,19 @@ func (g *Gateway) checkCondition(
 				errs.E(err))
 	}
 
-	return res.Get(ctx).(bool), nil
+	// A non-boolean condition is a modeling error, and data.As names both the
+	// held and the wanted type instead of panicking (ADR-034 v.1 §5).
+	val, err := data.As[bool](ctx, res)
+	if err != nil {
+		return false, errs.New(
+			errs.M("flow condition is not boolean"),
+			errs.C(errorClass, errs.TypeCastingError),
+			errs.D("outgoing_flow_id", of.ID()),
+			errs.D("gateway_id", g.ID()),
+			errs.E(err))
+	}
+
+	return val, nil
 }
 
 // forkTrueSubset routes a diverging token through the Inclusive split rule (ADR-005

--- a/pkg/model/process/process.go
+++ b/pkg/model/process/process.go
@@ -397,7 +397,8 @@ func (p *Process) Elements() []flow.Element {
 	fee := make([]flow.Element, 0, len(p.nodes)+len(p.flows))
 
 	for _, n := range p.nodes {
-		fee = append(fee, n.(flow.Element))
+		// flow.Node embeds flow.Element, so no assertion is involved.
+		fee = append(fee, n)
 	}
 
 	for _, f := range p.flows {

--- a/pkg/thresher/instance_starter.go
+++ b/pkg/thresher/instance_starter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/dr-dobermann/gobpm/internal/instance/snapshot"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/eventproc"
 	"github.com/dr-dobermann/gobpm/pkg/model/bpmncommon"
 	"github.com/dr-dobermann/gobpm/pkg/model/events"
@@ -105,9 +106,16 @@ func (s *instanceStarter) deriveKey(
 
 	// Reached only when corrKey != nil, i.e. a correlated message starter; a
 	// signal starter has corrKey == nil and returned above. So eDef is a message
-	// definition here.
+	// definition here — checked rather than assumed, because deriving a
+	// correlation key from the wrong definition would route the message to the
+	// wrong instance instead of failing.
+	med, isMessage := s.eDef.(*events.MessageEventDefinition)
+	if !isMessage {
+		return "", errs.Invariant("a correlated starter carries a %T, not a message definition", s.eDef)
+	}
+
 	key, ok, err := msgflow.DeriveKey(ctx, s.thr.cfg.ExpressionEngine(),
-		s.corrKey, s.eDef.(*events.MessageEventDefinition).Message(), payload)
+		s.corrKey, med.Message(), payload)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/thresher/observer.go
+++ b/pkg/thresher/observer.go
@@ -101,7 +101,11 @@ func (h *InstanceHandle) Observe(o Observer) *Subscription {
 // deliver calls the observer, containing any panic so one bad observer cannot
 // crash the drain goroutine or affect others (ADR-013 §5).
 func deliver(o Observer, f observability.Fact) {
-	defer func() { _ = recover() }()
+	// The panic is contained so one bad observer cannot crash the drain or
+	// affect the others (ADR-013 §5); the recovered value is deliberately
+	// dropped because deliver has no sink to report it to. Surfacing it is
+	// worth doing — see FIX-034 §8.3.
+	defer func() { _ = recover() }() //nolint:errcheck // deliberate containment
 
 	o.OnFact(f)
 }


### PR DESCRIPTION
## What this does

Closes four backlog items that share one shape: a rule the project had
**decided**, and no machinery holding it. Each was measured before it was
fixed, and two of the measurements turned out to be the interesting part.

## A — the diff-coverage gate read one module of five

`test-all` wrote `-coverprofile` only in its `.` branch and `cover-check` was
handed that single file, so `runtime/` and all three adapters had **never** been
diff-gated — `adapters/lua` and `adapters/dtable` both landed *after*
`COVER_MIN` reached 95, and CI stayed green regardless of what they added.

Every module now writes its own profile, and `COVER_PROFILES` derives from
`CORE_MODULES`, so a module added tomorrow is gated the day it appears rather
than when someone remembers the line.

Proven rather than asserted: four uncovered lines added to `adapters/lua` are
reported by the old invocation as `100.0% of 0 changed coverable lines — PASS`
and by the new one as `0.0% of 4 — FAIL`.

## B — two decided rules were enforced by review only

`errcheck` was enabled without `check-blank`, so `_ = f()` — the exact form
ADR-022 forbids — was invisible to it, and nothing checked type assertions.

**The count was wrong, and how it was wrong matters.** The initial measurement
said 5 unchecked assertions; the truth is **25 across 13 files**. Three
consecutive runs each reported exactly five and each a *different* five — that
inconsistency exposed golangci-lint's `max-same-issues: 3` cap. Any count from
that linter without raising the caps is a lower bound, never a total.

**Ten of the 25 were deleted, not checked**, and both deletions leave the code
simpler than before this work started:

- `BoundaryEvents()` returned `[]flow.EventNode` while
  `AddBoundaryEvent(flow.BoundaryEvent)` was its only writer — the type was
  wider than the invariant, so every consumer asserted it back. Narrowing the
  accessor removed seven. (This changes an exported return type.)
- The three frozen `Clone()`s now delegate to the package's own `freeze()`,
  which wraps by kind: no assertion, no panic, shorter than the original.

**The narrowing also exposed a wrong test fixture**: `stubTaskBoundary` reported
an `IntermediateCatchEvent` as a boundary event. It is not one; the wide element
type hid it, and production code asserted the value back to
`flow.BoundaryEvent` — a panic had that path ever run.

The rest went case by case: `data.As[bool]` for the two ADR-034 sites, a
classified error where the function already returns one, comma-ok-and-skip where
dropping is the right contract.

Guards that no input can reach report **`errs.Invariant`** — a new named
constructor whose call sites are the only lines the coverage gate excludes, so
`grep -rn "Invariant("` lists every branch claimed untestable, and silencing the
gate requires saying so in code rather than in a comment. It returns an error
rather than panicking on purpose: gobpm is embedded in someone's binary, so a
faulted instance leaves the engine serving every other one.

**Most of those guards turned out to be testable anyway.** The first attempt
crashed on a hand-built `loopState`, which lacks the wiring `Run` performs; a
*completed* instance is fully wired, and with that the two conditional arming
guards, `failInvariant`, both clone guards and — via an engine stub returning a
non-bool — the two `data.As` branches all became ordinary tests. Only the
boundary-fire guard is genuinely unreachable: `boundaryWatch.boundary` is
already typed.

## C — nothing validated a documentation link

The link checker — `cmd/linkcheck`, with its logic in `internal/linkcheck` for
the reason in (E) — walks the repository's Markdown and fails the gate on any
relative link that does not resolve, reporting `file:line`. Both requirements
FIX-031 paid for are tested, not assumed: fenced and inline code are skipped
(a Go generic like `values.NewArray[T](vals…)` is indistinguishable from a link
to a regex, and eight such spans exist today), and hrefs are percent-decoded (or
every correct link to `gobpm Development Roadmap.md` reports broken).

It is a small Go program rather than `lychee` or `markdown-link-check` because
the parity rule requires every CI tool to be pinned and installed by
`make tools`; either alternative adds a non-Go toolchain plus a network
dependency that reddens the gate for unrelated reasons. External URLs are
therefore out of scope. **Blocking**, because the 78 dead links accumulated
precisely because nothing failed.

Verified by proving it detects: a dead link injected into `docs/backlog.md` was
reported with exit 1, and the tree reported clean again after the revert.

## D — constructor option lists had drifted

Four defects: `NewServiceTask` omitted `WithWorkerTrust`; `NewUserTask` omitted
three whole families (`ActivityOption`, `taskOption`, `data.PropertyOption`);
`NewEventBasedGateway` omitted `WithCorrelationKey`; `NewIAE` omitted
`WithIDefinition`; and `WithIAE` named `data.IDef` / `data.IDefinition` —
neither of which exists.

More useful than the count: **one convention does not fit all fifteen blocks.**
Where a constructor accepts a family *wholesale*, the family is the contract and
an enumeration drifts as the family grows — that is how the triad went unlisted.
Where a constructor accepts a family but *rejects* members, the enumeration is
correct and a family heading would be a lie: `NewEndEvent`'s `endConfig`
implements `setCondition` and `setTimer` solely to refuse them, so its
seven-trigger list is the accepted subset of `EventOption`'s nine. Nine blocks
were verified and deliberately left alone.

## E — a third blind spot, found and worked around

**covercheck does not measure `cmd/`.** Found by adding the link checker: its
files were in the git diff and its blocks in `coverage.txt`, yet covercheck
reported nothing for them — the gate said PASS while `go test -cover` on the
package said 74.3 %. That is the same failure as (A), one directory over.

**Diagnosed by experiment: it is the `cmd/` PATH, not `package main`.** A
non-main package placed under `cmd/`, with a test and a deliberately uncovered
branch, is ignored just the same, and removing the Makefile's own
`-exclude-paths` changes nothing. So the sensible policy — gate a command's
code, exclude only its untestable `main.go` — is not expressible from this
repository's configuration.

**Relocation achieves it anyway.** The checker's logic now lives in
`internal/linkcheck`, where the gate already looks, and `cmd/linkcheck/main.go`
is a nine-line wrapper. Measured: the denominator went **131 → 255 changed
lines**, and an uncovered probe in the relocated package correctly failed the
gate. That is ~107 lines that would otherwise have shipped ungated, and it is
the pattern for future commands until the tool is fixed.

The move also brought the code under a rule it had been outside of:
`internal/lintcfg`'s `TestNoMustCallsInLibrary` (FIX-026 — library code fails
with a classified error, never panics) immediately flagged five package-level
`regexp.MustCompile` calls. They now compile through
`newPatterns() (*patterns, error)`. The guard's `sanctioned` list and
`exemptFiles` map were left untouched: `exemptFiles` is reserved for
registration-only files, and widening a project guard to accommodate
minutes-old code is the wrong direction. Both effects argue one point — the
`cmd/` blind spot was hiding a policy violation as well as coverage.

The upstream gap itself stays open — it belongs to covercheck's own repository,
and FIX-034 §8.3 keeps the diagnosis — so this PR does not claim a completeness
it lacks. What it does close is the exposure *here*: with command logic in
ordinary packages, nothing in this repository ships unmeasured.

## Verification

- `make ci` green: diff-coverage **96.1 % of 255 changed lines**, 46/46 examples
  executed end-to-end, link check clean, govulncheck clean ×5, lint clean.
- `pkg/model/data/adapters`, `internal/instance`, `pkg/model/flow`,
  `pkg/model/gateways`, `pkg/model/expression/lite`, `pkg/errs` and
  `internal/linkcheck` gained tests; the full core suite passes under `-race`.

Every figure was taken with `rtk proxy go test … -v` and the
`=== RUN` / `--- FAIL` / `DATA RACE` lines counted directly — the repo's
`go test` is rtk-proxied and prints only a summary, which cannot distinguish a
real pass from a run that executed no tests.

## Docs

- `docs/fix/FIX-034-gate-blind-spots-and-doc-drift.md` (Accepted) — symptoms
  with evidence, an RCA each, alternatives with reasons, and §8.2's record of
  where implementation corrected the draft.
- `docs/backlog.md` — the four items marked DONE with what they turned out to
  be, matching the convention the file actually uses. The file also gained the
  rule it had been missing: it is a **short-term** working list, and blocked or
  long-term work goes to a GitHub issue instead of accreting here. Two entries
  left under that rule — the covercheck `cmd/` gap, which the relocation closed
  for this repository, and the true-BPMN diagram item, now
  [#256](https://github.com/dr-dobermann/gobpm/issues/256) with its
  measurements and its trigger (13 of 46 examples could export today; revisit
  when the converter covers boundary events and sub-processes). What remains
  open in the file is one item, and it is genuinely near-term.

## Reviewing

The engine-visible change is one commit — 25 assertion sites, one exported
signature narrowed (`BoundaryEvents()`), and `errs.Invariant`. The rest is
build, tooling, comments and the checker relocation. The two claims worth
checking are that narrowing and the coverage exclusion tied to
`errs.Invariant`.
