### PR TITLE
fix(docs-site): collapsible sidebar sections

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,12 @@ docs_dir: docs
 theme:
   name: material
   features:
-    - navigation.sections
+    # navigation.sections was dropped deliberately: it renders top-level
+    # sections as static always-expanded groups — a 40-entry design list
+    # cannot be folded away. Without it every section is collapsible.
+    # navigation.indexes makes a section's index.md the clickable section
+    # header instead of a duplicated child entry.
+    - navigation.indexes
     - navigation.top
     - search.suggest
     - content.code.copy


### PR DESCRIPTION
# Collapsible sidebar sections for the docs site

Follow-up polish to SRD-081's structured navigation: sections in the left
panel could not be folded — Material's `navigation.sections` feature renders
top-level sections as static, always-expanded groups, so the 40-entry
Design documents list dominated the sidebar; and each section's title
appeared twice (group header + its own `index.md` child).

Config-only change in `mkdocs.yml`: drop `navigation.sections` (every
section becomes a collapsible item), add `navigation.indexes` (a section's
`index.md` becomes the clickable section header — no duplicate child).

## Verification

- `mkdocs build --strict` green; the built sidebar carries collapse toggles
  and each section title appears exactly once.
- `make ci` green across modules.

## After merge

The site redeploys automatically; hard-refresh and check that Design
documents (and every section) folds, and that clicking a section header
opens its index page.
