### PR TITLE
fix(thresher): the engine's lifecycle bookkeeping — FIX-036

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`Thresher.UpdateState` now validates the TRANSITION, not just the value**
+  (FIX-036). It accepted any legal `State` member and stored it, so a host could
+  put a never-run engine into `Started` — after which `RegisterEvent`'s
+  `State() != Started` guard admitted registrations to a hub that was never
+  started. It now admits only the operator transitions, `Started ↔ Paused`, and
+  refuses anything else with a classified `InvalidState` error naming both
+  states; starting and stopping remain the compare-and-swap ladder's alone, in
+  `Run` and `Shutdown`. A lost race re-reads and re-judges rather than failing,
+  so a concurrent pause/resume is not spuriously rejected while a concurrent
+  `Shutdown` is reported with the state it actually left behind. **Callers that
+  used `UpdateState` to start an engine must call `Run`**; the pause/resume use
+  is unaffected.
+
 - **Timer construction errors now name the rule they broke.** The three
   rejections — attributes that are mutually exclusive, a recurrence missing its
   interval, and nothing set at all — previously shared one message
@@ -128,6 +141,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The engine's lifecycle bookkeeping: a data race, reservations with no
+  owner, and host code with no containment** (FIX-036 — the remediation of an
+  external audit of `pkg/thresher`; eight defects, one shape: bookkeeping
+  maintained by convention rather than by machinery).
+  - **A repeat business key could never start a process again.** An
+    event-started instance reserved its correlation key and nothing released it
+    when the instance finished, so a later message carrying that key was
+    answered "joined existing instance" and **silently dropped** — there was no
+    instance to join. Order `ORD-42` handled today meant `ORD-42` could never
+    start a process again, and the map grew for the engine's lifetime. A
+    reservation now records *whose* it is and is taken over once that
+    conversation is gone. Its mirror image is fixed with it: a conversation
+    recovered from a checkpoint — a cold restart or a wake — used to come back
+    **unreserved**, so the next message carrying its key started a duplicate
+    beside it.
+  - **The engine context was written without synchronization.** `Run` assigned
+    the context and its cancel with no lock while `Shutdown` read them under
+    one, which is a data race, not synchronization — a `Shutdown` could cancel
+    nothing and still report `Stopped`. Both are now published as one immutable
+    pair through an `atomic.Pointer`, and a launch on an engine that never ran
+    is a classified error rather than a nil-context panic.
+  - **A held subscription could outlive its own release.** The hub registration
+    and the release-path record were written in two unguarded steps, so a
+    `ReleaseWaits` racing the arm — an interrupting boundary, an Event-Based
+    gateway's losing arm — withdrew nothing and left a subscription registered
+    forever, able to wake an instance for a wait nobody was waiting on.
+  - **A panic in the host's observability policy killed a business process.**
+    `ObservationFilter.FilterObservation` and `LogRedactor.RedactLog` are host
+    code called on the reporting goroutine — an instance's execution loop — with
+    no recover around either. Both are now contained and **fall closed** (the
+    recipient is denied, the record suppressed), counted, and logged once at
+    `Warn`. Both interfaces now also state the obligations they always relied
+    on: cheap, non-blocking, no call back into the engine.
+  - **`Shutdown` left instances running.** It snapshotted the instance registry
+    *before* cancelling the engine context and awaited only that snapshot, so an
+    instance born in the window — an event-triggered start, a Call Activity
+    child — was abandoned. It now re-reads the registry until a pass adds
+    nothing, and a timeout names the instances that did not settle instead of
+    reporting only that something did not finish.
+  - **A process registered while the engine was starting could be wired twice.**
+    `RegisterProcess` and `Run`'s startup sweep both wire the latest version's
+    instance-starters and are not mutually exclusive, so one message could spawn
+    two instances. Wiring is now claimed per registration.
 - **Scope snapshots rejected Properties and DataObjects.** `SnapshotAt`'s
   value-copy (the compensation ledger's and now the incident snapshot's
   machinery) asserted one `Clone` shape, but `Property` and `DataObject`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     child — was abandoned. It now re-reads the registry until a pass adds
     nothing, and a timeout names the instances that did not settle instead of
     reporting only that something did not finish.
+  - **`Forget` leaked a context per instance it reaped.** Every launch path
+    derives the instance's context from the engine's and retains the cancel, but
+    nothing ever called it — so the child stayed attached to the engine context
+    for the engine's whole lifetime, and the one method whose stated purpose is
+    "so a long-running engine doesn't accumulate finished instances" released
+    everything about an instance except its context.
   - **A process registered while the engine was starting could be wired twice.**
     `RegisterProcess` and `Run`'s startup sweep both wire the latest version's
     instance-starters and are not mutually exclusive, so one message could spawn

--- a/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
+++ b/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
@@ -117,6 +117,15 @@ Event-Based gateway's losing arm) returns having withdrawn nothing, the
 subscription stays registered, and the map entry materialises afterwards —
 a leaked holder that can still wake an instance for a wait nobody is waiting on.
 
+The arm has **two** unguarded sides, which is why simply swapping the order is
+not the fix. Recording first makes the hold visible to a concurrent release,
+but that release then calls `UnregisterEvent` on a holder the hub does not know
+yet: the call fails `ObjectNotFound` (`eventhub.go:401-410`), the registration
+that follows succeeds, and the subscription is again live with no record —
+the same leak reached from the other side. The hold must therefore be recorded
+**before** the arm so a release can see it, and **confirmed still recorded**
+after the arm so a release that could not reach the hub is honoured.
+
 ### 1.5 The host's observation filter runs under the producer lock, uncontained
 
 ```go
@@ -232,10 +241,19 @@ restart is reserved exactly as one that never stopped.
 `Forget` deletes the instance's `settled` channel and any correlation
 reservation it holds, alongside the registration.
 
-#### 3.2.4 `pkg/thresher/subscription_holder.go` — record, then arm
+#### 3.2.4 `pkg/thresher/subscription_holder.go` — record, arm, confirm
 
-`HoldSubscription` writes `t.subs` first and registers on the hub second,
-removing the entry if registration fails.
+`HoldSubscription` writes `t.subs` first, registers on the hub second, and then
+re-reads the record: if it no longer names this holder, a release took it while
+the arm ran and could not withdraw it from the hub, so the hold withdraws
+itself. A refused registration removes the entry — conditionally, so a rollback
+never clobbers a record a later arm has put there. A hold withdrawn by a
+concurrent release returns **no error**: the release is authoritative, and the
+caller's wait is gone either way.
+
+`ReleaseWaits`' per-holder hub call moves into a shared `withdraw` helper, since
+the confirm path needs exactly the same "unregister, log a failure at Debug"
+behaviour — a missing waiter is an idempotent condition, not an error.
 
 #### 3.2.5 `pkg/thresher/producer.go` — the filter is host code
 
@@ -280,7 +298,8 @@ runs first wires and the other is a no-op.
 | T-2 | `TestCorrelationKeyReleasedAfterInstanceEnds` | a second message with the same key after the first instance terminated starts a NEW instance, not a silent join (§1.2) |
 | T-2a | `TestRecoveredConversationKeepsItsKey` | engine A parks a conversation and is fenced out; engine B recovers it from the checkpoint and the reservation names the recovered instance — without the rebind the key comes back free and the next message duplicates the conversation (§1.2, restart half) |
 | T-3 | `TestForgetReleasesKeyAndSettled` | after `Forget`, `seenKeys` and `settled` no longer hold the id (§1.2, §1.3) |
-| T-4 | `TestReleaseWaitsSeesHoldImmediately` | a `ReleaseWaits` racing `HoldSubscription` withdraws the hold — the hub carries no leftover subscription (§1.4) |
+| T-4 | `TestReleaseWaitsDuringArmWithdrawsTheHold` | a `ReleaseWaits` driven into the MIDDLE of `HoldSubscription` (a hub wrapper fires it from inside `RegisterEvent`) leaves neither a record nor a hub subscription — and the withdrawal is counted at the hub, so removing either half of the fix fails it (§1.4) |
+| T-4a | `TestHoldSubscriptionRollsBackOnArmFailure` | a refused arm leaves nothing recorded — the record exists only to make an ARMED hold releasable (§1.4) |
 | T-5 | `TestPanickingObservationFilterContained` | a filter that panics denies its recipient, is counted and logged once, and never reaches `Report`'s caller (§1.5) |
 | T-6 | `TestUpdateStateRejectsLifecycleJumps` | `Started` on a never-run engine is refused; `Started ↔ Paused` is admitted (§1.6) |
 | T-7 | `TestShutdownAwaitsInstanceBornDuringCancel` | an instance created in the snapshot→cancel window is awaited; the timeout error names the unsettled (§1.7) |

--- a/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
+++ b/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
@@ -1,0 +1,324 @@
+# FIX-036 — the engine's lifecycle bookkeeping: unsynchronized state, reservations that are never released, and foreign code under a lock
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft.
+**Date:** 2026-08-05.
+**Author:** Ruslan Gabitov.
+**Branch:** `fix/thresher-audit` — the remediation of an external audit of `pkg/thresher` (2026-08-05).
+**Upstream:** [ADR-002 v.2](../design/ADR-002-extension-architecture.md) §4.2 (bounded in-memory defaults — the principle the two unbounded maps break), [ADR-013 v.2](../design/ADR-013-instance-observability.md) §5 (contain observer failures — the containment the filter path skips), [ADR-015 v.1](../design/ADR-015-event-triggered-instantiation.md) (event-triggered instantiation and its correlation-key reservation), [ADR-019 v.1](../design/ADR-019-definition-versioning.md) §2.5 (latest-supersedes — the starter wiring both paths perform), [ADR-033 v.3](../design/ADR-033-persistence-and-state.md) §2.4/§2.5 (the wait-holder model whose subscription half publishes out of order).
+
+**Grounded in (internal artifacts, verified at `36d9751`):**
+- `pkg/thresher/thresher.go:535` — `Run` assigns `t.ctx`/`t.engineCancel` with no lock; `:707` — `Shutdown` reads `t.engineCancel` under `t.m`.
+- `pkg/thresher/thresher.go:1118,1128` — the correlation-key reservation and its **only** release.
+- `pkg/thresher/locked.go:241` — `settled` written; `pkg/thresher/discovery.go:82-84` — `Forget` deletes from `instances` alone.
+- `pkg/thresher/subscription_holder.go:95,100` — the hub registration precedes the `t.subs` record; `:114-126` — `ReleaseWaits` scans `t.subs`.
+- `pkg/thresher/producer.go:84-105` — `p.mu` spans `FilterObservation`; `pkg/thresher/observer.go:163` — the containment the sibling delivery path has.
+- `pkg/thresher/thresher.go:456` — `UpdateState` stores any valid enum value; `:520,680` — the CAS ladder it bypasses.
+- `pkg/thresher/thresher.go:1088` — `registerAllStarters` wires without the per-key lock `:862` takes.
+
+---
+
+## 1 Symptoms
+
+An audit of `pkg/thresher` reported seven flags and five edge cases. Each was
+re-checked against the code at `36d9751`; **eight are real**, three are
+documented design (§7). They are not one bug, but they are one *shape*: the
+engine's own bookkeeping — its context, its reservations, its state — is
+maintained by convention, and every place the convention is not machinery is a
+place it has already slipped.
+
+### 1.1 The engine context is written without synchronization
+
+`Run` derives and stores the engine context:
+
+```go
+// thresher.go:535
+t.ctx, t.engineCancel = context.WithCancel(ctx)
+```
+
+No lock. `Shutdown` reads the same field **under `t.m`**:
+
+```go
+// thresher.go:701-708
+t.m.Lock()
+…
+cancel := t.engineCancel
+t.m.Unlock()
+```
+
+A mutex on one side of a shared write is not synchronization — under the Go
+memory model this is a data race, and the reader may observe a nil or stale
+`engineCancel`, i.e. a `Shutdown` that cancels nothing while reporting
+`Stopped`. Five further readers take no lock at all: `launchInstance`
+(`:1171`), `launchInstanceFromEvent` (`:1346`), `invoker.go:76`,
+`recovery.go:103`, `wake.go:114,146`. `Run`'s own comment concedes the field is
+reassigned on a retry — it solves that for the hub goroutine (by capturing
+`runCtx`) and for nobody else.
+
+### 1.2 A finished conversation's correlation key is reserved forever
+
+An event-started process reserves its namespaced correlation key so two
+concurrent messages cannot both instantiate:
+
+```go
+// thresher.go:1118-1131
+if !t.reserveKeyLocked(nsKey) {
+    return nil // an instance already exists for this key: join, no duplicate
+}
+if err := t.launchInstanceFromEvent(…); err != nil {
+    t.releaseKeyLocked(nsKey)   // the ONLY release in the package
+    return err
+}
+```
+
+The reservation is released **only when the launch fails**. Nothing releases it
+when the instance finishes. Two consequences, the second worse than the first:
+
+- `seenKeys` grows for the engine's lifetime — one entry per correlation value
+  ever seen, against ADR-002 §4.2's bounded-defaults principle;
+- once that instance is gone, a later message carrying the same business key is
+  answered `"joined existing instance (key seen)"` and **silently dropped** —
+  there is no instance to join. Order `ORD-42` handled today means order
+  `ORD-42` can never start a process again.
+
+`Forget` — documented as the path so "a long-running engine doesn't accumulate
+finished instances" — does not release keys.
+
+### 1.3 `settled` is never deleted
+
+`settledFor` mints one terminal-signal channel per instance id and stores it
+(`locked.go:241`); the map is read on rebuild so a waiter survives dehydration
+(`:254`). There is no `delete(t.settled, …)` anywhere in the package. `Forget`
+removes the instance registration (`discovery.go:83`) and leaves the channel.
+
+### 1.4 A held subscription reaches the hub before it reaches the release path
+
+```go
+// subscription_holder.go:95-101
+if err := t.RegisterEvent(h, eDef); err != nil { return err }
+
+t.subMu.Lock()
+t.subs[subKey{instanceID, trackID, eDef.ID()}] = h
+t.subMu.Unlock()
+```
+
+`ReleaseWaits` withdraws holds by scanning `t.subs` (`:114-126`). Between the
+two statements the holder is live on the hub and invisible to the release: a
+concurrent `ReleaseWaits` for that track (an interrupting boundary, an
+Event-Based gateway's losing arm) returns having withdrawn nothing, the
+subscription stays registered, and the map entry materialises afterwards —
+a leaked holder that can still wake an instance for a wait nobody is waiting on.
+
+### 1.5 The host's observation filter runs under the producer lock, uncontained
+
+```go
+// producer.go:84-97
+p.mu.Lock()
+defer p.mu.Unlock()
+
+for _, s := range p.subs {
+    if p.filter != nil {
+        filtered, ok := p.filter.FilterObservation(s.obs, ev)
+```
+
+`ObservationFilter` is host-supplied (`pkg/observability/visibility.go:19`).
+The sibling delivery path contains a panicking host observer
+(`observer.go:163` → `deliver`'s recover); this path does not. A panicking
+filter therefore propagates out of `Report` into **its caller** — which is an
+instance's loop goroutine — and a merely slow filter serializes every `Report`
+in the engine behind one host call.
+
+### 1.6 `UpdateState` bypasses the lifecycle ladder it exists beside
+
+`Run` claims its transition with a CAS (`:520`), `Shutdown` likewise (`:680`).
+`UpdateState` (`:456`) validates that the value is a legal enum member and
+stores it. A host may set `Started` on an engine that never ran — after which
+`RegisterEvent`'s `State() != Started` guard (`:745`) admits registrations to a
+hub that was never started. The method is not dead API: `Paused` is a real
+state (`Shutdown` accepts `Started, Paused` at `:679`), so the defect is the
+absence of a transition rule, not the method's existence.
+
+### 1.7 `Shutdown` waits only for the instances that existed before the cancel
+
+The snapshot is taken under `t.m` (`:701-705`), *then* the engine context is
+cancelled (`:712`), *then* the snapshot is awaited (`:717`). An instance born in
+that window — an event-triggered start, a Call Activity child — is never
+awaited. Independently: the deferred publish (`:696`) stores `Stopped` on
+**every** exit path, including the timeout return at `:721`, so the engine
+reports itself stopped while instances are still running.
+
+### 1.8 Starter wiring races between `RegisterProcess` and `Run`
+
+`RegisterProcess` holds the per-key lock (`:862`) across the registry mutation
+(`:871`) and the hub wiring, which it performs only `if t.State() == Started`
+(`:888`). `Run`'s `registerAllStarters` (`:1088`) reads
+`t.latestStartersLocked()` and wires everything it finds — **without** the
+per-key lock. The two paths are therefore not mutually exclusive: a version
+appended while `Run` is between its read and its wiring can be registered by
+both (duplicate starters on one event definition) or, with the opposite
+interleaving, by neither.
+
+## 2 Root cause analysis
+
+**One rule, four unenforced halves.** The package's central discipline —
+recorded at `thresher.go:135` and in every `…Locked` helper — is *never hold
+`t.m` across a subsystem call*. It is enforced by comments. §1.1, §1.4, §1.5
+and §1.8 are each the same failure: a place where correctness depends on an
+ordering or a scope that nothing checks. The state field escaped `t.m`
+deliberately (it is atomic, and that is why `State()` is callable under the
+lock); the *context* escaped by omission and kept the same "not guarded by
+`t.m`" shape without the atomic that makes it safe.
+
+**Reservations without a lifecycle.** §1.2 and §1.3 share a cause: both maps
+are written on the way in and have no owner on the way out. `Forget` is the
+package's only reaping path and it reaps one of the three maps. The
+correlation reservation additionally conflates two questions — *is a start in
+flight for this key?* and *does an instance for this key exist?* — and answers
+the second with the first's data, which is why an expired reservation reads as
+a live conversation.
+
+**Containment applied once.** §1.5 is FIX-035's fix, applied to one of the two
+call sites. FIX-035 §3.2.2 records the producer path as the "second call site"
+for the *panic sink*; the filter call beside it was never brought under the
+same rule.
+
+## 3 Solution
+
+### 3.1 Alternatives considered
+
+| # | Decision | Alternatives | Chosen |
+|---|---|---|---|
+| 1 | §1.1 the engine context | (a) take `t.m` for every read and the write — puts the engine lock on the hot launch path and invites the RC2 lock-ordering hazard the package forbids; (b) an `atomic.Pointer` to an immutable `{ctx, cancel}` pair — lock-free reads, single writer, and the same shape `state` already uses | **(b)** |
+| 2 | §1.2 the key reservation | (a) release in `Forget` only — still wrong for an engine that never calls it; (b) a watcher goroutine per reservation — a goroutine per conversation, the cost ADR-007 exists to avoid; (c) record `nsKey → instanceID` and re-take the reservation when the recorded instance is unknown or terminal — self-healing, O(1), no goroutine | **(c)** + release in `Forget` so the map also shrinks |
+| 3 | §1.4 the hold ordering | (a) hold `subMu` across `RegisterEvent` — an engine lock across a subsystem call, the forbidden shape; (b) record in `t.subs` first and roll the entry back if registration fails — the release path can then always see it, and the hub's `UnregisterEvent` is already idempotent for an unknown definition (`eventhub.go:401-409`) | **(b)** |
+| 4 | §1.5 the filter | (a) snapshot subscribers, unlock, then filter and send — breaks the documented fence that lets `unsubscribe` close a channel with no in-flight send, and buys nothing the contract cannot state; (b) contain the filter call the way `deliver` contains an observer, and make the cheapness the lock demands an explicit term of the `ObservationFilter` contract | **(b)** — the panic is the defect and is fixed; the serialization is a **property of a lock-fenced fan-out, decided here as a contract obligation on the host**, exactly as the observer stream already requires a fast, non-blocking observer. Lifting the fence (epoch counter or send-side refcount) would change the observation contract itself — an ADR question, and one nothing has asked: no measurement shows a filter cost worth redesigning for |
+| 5 | §1.6 `UpdateState` | (a) remove the method — breaks a public API and a real feature (`Paused`); (b) validate the *transition*, not just the value | **(b)** |
+| 6 | §1.7 shutdown | (a) refuse new instances once `Stopping` — a larger contract change (what does a start return then?); (b) re-snapshot after the cancel until the set stops growing, and name the unsettled instances on timeout | **(b)** |
+| 7 | §1.8 starter wiring | (a) take the per-key lock in `registerAllStarters` — closes this window but leaves the invariant order-dependent; (b) make wiring idempotent per registration with a flag both paths check under `t.m` | **(b)** |
+
+### 3.2 Changes by file
+
+#### 3.2.1 `pkg/thresher/thresher.go` — the engine context becomes atomic
+
+`t.ctx`/`t.engineCancel` are replaced by one `atomic.Pointer[engineCtx]` over
+an immutable pair. `Run` stores it before the hub start; every reader loads it
+(`launchInstance`, `launchInstanceFromEvent`, `invoker`, `recovery`, `wake`),
+and a nil load — an engine that never ran — is a classified error rather than
+a nil-context panic.
+
+#### 3.2.2 `pkg/thresher/locked.go`, `thresher.go` — the reservation knows whose it is
+
+`seenKeys map[string]struct{}` becomes `map[string]string` (nsKey →
+instanceID). `reserveKeyLocked` returns true when the key is free **or** when
+the instance holding it is no longer live (absent from `instances`, or present
+and terminal), taking the reservation over in that case. The join path keeps
+its existing semantics for a live instance.
+
+#### 3.2.3 `pkg/thresher/discovery.go` — `Forget` forgets everything
+
+`Forget` deletes the instance's `settled` channel and any correlation
+reservation it holds, alongside the registration.
+
+#### 3.2.4 `pkg/thresher/subscription_holder.go` — record, then arm
+
+`HoldSubscription` writes `t.subs` first and registers on the hub second,
+removing the entry if registration fails.
+
+#### 3.2.5 `pkg/thresher/producer.go` — the filter is host code
+
+The `FilterObservation` call is wrapped in the same containment `deliver`
+provides: a panic is recovered, counted and logged once, and the event is
+treated as denied for that recipient rather than propagating into the engine.
+
+#### 3.2.6 `pkg/observability/visibility.go` — the filter's obligations, stated
+
+`ObservationFilter`'s doc comment gains the two terms the implementation has
+always relied on and never wrote down: the filter is called **on the
+reporter's goroutine, under the producer's dispatch lock**, so it must be
+cheap and must not block; and a panic is contained (the event is treated as
+denied for that recipient) rather than propagated. This is the same contract
+`Observer` carries, and stating it is what turns §1.5's remaining
+serialization from an unexamined hazard into a declared cost.
+
+#### 3.2.7 `pkg/thresher/thresher.go` — `UpdateState` validates the transition
+
+A transition table admits the operator transitions (`Started ↔ Paused`) and
+refuses everything else with `errs.InvalidState`, naming both states. The
+lifecycle transitions stay the CAS ladder's alone.
+
+#### 3.2.8 `pkg/thresher/thresher.go` — `Shutdown` drains what it started
+
+After the cancel, the instance set is re-snapshotted and awaited until no new
+ids appear; the timeout error names the instances that did not settle.
+
+#### 3.2.9 `pkg/thresher/thresher.go` — starter wiring is idempotent
+
+`instanceReg`/the version record gains a `startersWired` flag set under `t.m`;
+both `RegisterProcess` and `registerAllStarters` check-and-set it, so whichever
+runs first wires and the other is a no-op.
+
+## 4 Verification
+
+### 4.1 Regression tests
+
+| # | Test | Asserts |
+|---|---|---|
+| T-1 | `TestEngineContextIsRaceFree` | concurrent `Run`/`Shutdown`/launch under `-race` — no race on the engine context; a `Shutdown` after a completed `Run` always cancels (§1.1) |
+| T-2 | `TestCorrelationKeyReleasedAfterInstanceEnds` | a second message with the same key after the first instance terminated starts a NEW instance, not a silent join (§1.2) |
+| T-3 | `TestForgetReleasesKeyAndSettled` | after `Forget`, `seenKeys` and `settled` no longer hold the id (§1.2, §1.3) |
+| T-4 | `TestReleaseWaitsSeesHoldImmediately` | a `ReleaseWaits` racing `HoldSubscription` withdraws the hold — the hub carries no leftover subscription (§1.4) |
+| T-5 | `TestPanickingObservationFilterContained` | a filter that panics denies its recipient, is counted and logged once, and never reaches `Report`'s caller (§1.5) |
+| T-6 | `TestUpdateStateRejectsLifecycleJumps` | `Started` on a never-run engine is refused; `Started ↔ Paused` is admitted (§1.6) |
+| T-7 | `TestShutdownAwaitsInstanceBornDuringCancel` | an instance created in the snapshot→cancel window is awaited; the timeout error names the unsettled (§1.7) |
+| T-8 | `TestStartersWiredExactlyOnce` | a registration racing `Run` yields exactly one hub registration per starter (§1.8) |
+
+### 4.2 Gate
+
+`make ci` green end to end, `-race` included; diff-coverage ≥95% on the touched
+lines (`COVER_MIN`).
+
+## 5 Prevention
+
+- The `…Locked` convention gains the one piece of machinery it can have: every
+  field that is deliberately *not* guarded by `t.m` is now an atomic (state,
+  engine context), so "unguarded" and "unsafe" stop being the same shape.
+- The two maps with a lifecycle are reaped by the one path that already exists
+  for reaping, `Forget`, and the correlation reservation additionally
+  self-heals — a leak now requires both mechanisms to fail.
+- Host code called from inside the engine is contained at both call sites, and
+  the `ObservationFilter` contract states the constraint the lock imposes.
+
+## 6 Regressions and side effects
+
+- `seenKeys`'s value type changes; it is package-private, so no API moves.
+- `UpdateState` becomes stricter: a host that today sets an arbitrary state
+  gets a classified error. This is the point of the fix, but it is a
+  behavioural change to a public method and is called out in the CHANGELOG.
+- `Shutdown` may now wait marginally longer — it awaits instances it previously
+  abandoned — bounded by the caller's context exactly as before.
+
+## 7 Related
+
+Three audit findings are **documented design, not defects**, and are recorded
+here so a later reader does not re-open them:
+
+- **Recovery does not retry a missing pinned version** (`recovery.go:84`) —
+  deployment parity is the operator's contract (ADR-033 v.3 §2.8); the engine
+  reports and stops rather than guessing.
+- **`fireDue` scans all holds per tick** (`timer_service.go`) — the O(1)
+  goroutine cost was bought with an O(n) scan, deliberately.
+- **`Forget` is all-or-nothing** — stated in its own doc comment
+  (`discovery.go:57-61`).
+
+Prior art: [FIX-035](FIX-035-observer-silence-and-attribute-vocabulary.md)
+(the containment rule §1.5 completes), [FIX-013](FIX-013-thresher-registry-starter-lifecycle.md)
+(the per-key lock §1.8 extends), [FIX-002](FIX-002-event-start-registration-lifecycle.md)
+(the RC2 rule every alternative in §3.1 is measured against).
+
+## 8 Implementation summary
+
+_To be filled after the milestones land._
+
+## 9 Open questions
+
+None.

--- a/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
+++ b/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
@@ -465,7 +465,7 @@ Prior art: [FIX-035](FIX-035-observer-silence-and-attribute-vocabulary.md)
 | M5 | `9f9298c` | §1.6, §1.7 — `UpdateState`'s transition rule; `Shutdown` drains what it started (§3.2.7, §3.2.8) |
 | M6 | `8799afb` | §1.8 — starter wiring is idempotent per registration (§3.2.9) |
 | M7 | `d247464` | the branches the fix added, covered; four duplicated guards folded into one; `TestRestartRecoveryBoundaryDeadline` hardened |
-| M8 | _this commit_ | the three findings of the independent pre-merge review (§8.2) |
+| M8 | `786176d` | the three findings of the independent pre-merge review (§8.2) |
 
 ### 8.2 Findings the implementation added to the design
 

--- a/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
+++ b/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
@@ -145,6 +145,21 @@ filter therefore propagates out of `Report` into **its caller** — which is an
 instance's loop goroutine — and a merely slow filter serializes every `Report`
 in the engine behind one host call.
 
+`LogRedactor` — the producer's *other* host-supplied hook — has exactly the
+same shape and the same gap:
+
+```go
+// producer.go:67-75
+if p.redactor != nil {
+    redacted, ok := p.redactor.RedactLog(ev)
+```
+
+It is the same interface family (`visibility.go:9`), asserted off the same
+authorizer, called on the same reporting goroutine, with no recover either. It
+is repaired with the filter rather than left for a second pass: they are one
+defect reached through two entry points, and containing only the one the audit
+happened to name would leave the identical crash reachable through the other.
+
 ### 1.6 `UpdateState` bypasses the lifecycle ladder it exists beside
 
 `Run` claims its transition with a CAS (`:520`), `Shutdown` likewise (`:680`).
@@ -255,21 +270,29 @@ caller's wait is gone either way.
 the confirm path needs exactly the same "unregister, log a failure at Debug"
 behaviour — a missing waiter is an idempotent condition, not an error.
 
-#### 3.2.5 `pkg/thresher/producer.go` — the filter is host code
+#### 3.2.5 `pkg/thresher/producer.go` — the two hooks are host code
 
-The `FilterObservation` call is wrapped in the same containment `deliver`
-provides: a panic is recovered, counted and logged once, and the event is
-treated as denied for that recipient rather than propagating into the engine.
+`FilterObservation` and `RedactLog` are both wrapped in the containment
+`deliver` provides, through one shared `callHostHook` helper: the panic is
+recovered, counted per hook, and logged once at Warn with a stack (Debug
+thereafter, since ADR-022 v.1 §2.4 forbids a per-event record above it).
 
-#### 3.2.6 `pkg/observability/visibility.go` — the filter's obligations, stated
+Both **fall closed**. A panicking filter denies its recipient; a panicking
+redactor suppresses the log record. The alternative — treating a failed hook as
+pass-through — would make a crash in the host's policy code the one condition
+under which the engine emits what that policy exists to withhold, which is the
+worst possible moment to fail open.
 
-`ObservationFilter`'s doc comment gains the two terms the implementation has
-always relied on and never wrote down: the filter is called **on the
-reporter's goroutine, under the producer's dispatch lock**, so it must be
-cheap and must not block; and a panic is contained (the event is treated as
-denied for that recipient) rather than propagated. This is the same contract
-`Observer` carries, and stating it is what turns §1.5's remaining
-serialization from an unexamined hazard into a declared cost.
+#### 3.2.6 `pkg/observability/visibility.go` — the hooks' obligations, stated
+
+Both interfaces' doc comments gain the terms the implementation has always
+relied on and never wrote down: each hook is called **on the reporter's
+goroutine** — and the filter additionally **under the producer's dispatch
+lock**, once per registered observer — so it must be cheap and must not block
+or call back into the engine; and a panic is contained, falling closed, rather
+than propagated. This is the same contract `Observer` carries, and stating it
+is what turns §1.5's remaining serialization from an unexamined hazard into a
+declared cost.
 
 #### 3.2.7 `pkg/thresher/thresher.go` — `UpdateState` validates the transition
 
@@ -300,7 +323,8 @@ runs first wires and the other is a no-op.
 | T-3 | `TestForgetReleasesKeyAndSettled` | after `Forget`, `seenKeys` and `settled` no longer hold the id (§1.2, §1.3) |
 | T-4 | `TestReleaseWaitsDuringArmWithdrawsTheHold` | a `ReleaseWaits` driven into the MIDDLE of `HoldSubscription` (a hub wrapper fires it from inside `RegisterEvent`) leaves neither a record nor a hub subscription — and the withdrawal is counted at the hub, so removing either half of the fix fails it (§1.4) |
 | T-4a | `TestHoldSubscriptionRollsBackOnArmFailure` | a refused arm leaves nothing recorded — the record exists only to make an ARMED hold releasable (§1.4) |
-| T-5 | `TestPanickingObservationFilterContained` | a filter that panics denies its recipient, is counted and logged once, and never reaches `Report`'s caller (§1.5) |
+| T-5 | `TestPanickingObservationFilterContained` | a filter that panics denies its recipient, is counted, is logged once at Warn and at Debug thereafter, and never reaches `Report`'s caller (§1.5) |
+| T-5a | `TestPanickingLogRedactorContained` | a redactor that panics suppresses the record rather than echoing it unredacted, and leaves the observer stream — which is not the redactor's to deny — untouched (§1.5) |
 | T-6 | `TestUpdateStateRejectsLifecycleJumps` | `Started` on a never-run engine is refused; `Started ↔ Paused` is admitted (§1.6) |
 | T-7 | `TestShutdownAwaitsInstanceBornDuringCancel` | an instance created in the snapshot→cancel window is awaited; the timeout error names the unsettled (§1.7) |
 | T-8 | `TestStartersWiredExactlyOnce` | a registration racing `Run` yields exactly one hub registration per starter (§1.8) |
@@ -329,6 +353,22 @@ lines (`COVER_MIN`).
   behavioural change to a public method and is called out in the CHANGELOG.
 - `Shutdown` may now wait marginally longer — it awaits instances it previously
   abandoned — bounded by the caller's context exactly as before.
+- **`TestCorrelationDedup` is re-pinned to a live conversation.** It asserted
+  ADR-016 v.1 §2.3's join rule using the start→end process, so its "existing
+  instance" completed the moment it was created; §1.2's release then let the
+  repeat key legitimately start a third instance whenever the message lost the
+  race against that completion, and the test failed roughly one run in six.
+  The join rule is unchanged and still pinned — the test now uses the parking
+  process, which is what makes the existing instance *joinable* at all. The
+  finished-conversation half is owned by its own test
+  (`TestCorrelationKeyReleasedAfterInstanceEnds`, T-2), which waits for the
+  completion instead of racing it.
+
+  This is the only pre-existing test whose behaviour this landing changes, and
+  it is worth saying why it is a re-pin and not a weakening: joining a finished
+  instance cannot deliver the message anywhere — no receiver is parked on it —
+  so the old reservation did not preserve the join rule, it discarded the
+  business message that the rule exists to route.
 
 ## 7 Related
 

--- a/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
+++ b/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
@@ -320,9 +320,27 @@ neither claims the stop was orderly.
 
 #### 3.2.9 `pkg/thresher/thresher.go` — starter wiring is idempotent
 
-`instanceReg`/the version record gains a `startersWired` flag set under `t.m`;
-both `RegisterProcess` and `registerAllStarters` check-and-set it, so whichever
-runs first wires and the other is a no-op.
+`ProcessRegistration` gains a `wired` flag guarded by `t.m`; both
+`RegisterProcess` and `registerAllStarters` check-and-set it, so whichever runs
+first wires and the other is a no-op.
+
+Only the double-wiring interleaving is reachable, and it is worth saying why the
+opposite one is not: `Run` stores `Started` *before* it sweeps, so a
+`RegisterProcess` whose state read returns not-started is ordered before that
+store, hence before the sweep's registry read — its version is therefore always
+visible to the sweep. The two paths can both wire; they cannot both skip.
+
+**A claim must be released whenever it does not result in a live subscription.**
+`registerStarters` is all-or-nothing (FIX-013 §1.3), so a failed call leaves
+nothing on the hub, and `Run` rolls the whole start back on one — a claim kept
+across that rollback would make the RETRY find every version already marked
+wired and wire nothing, starting a clean engine with no auto-start at all. That
+is a worse failure than the double-wiring the flag exists to prevent, and
+`TestRunRollsBackWhenStarterRegistrationFails` catches it. The claim is
+therefore handed back on every failure path, and the flag tracks the hub in both
+directions: `RegisterProcess` releases the superseded version's claim as it tears
+its starters down, and promote-on-removal takes the claim for the version it
+promotes.
 
 ## 4 Verification
 
@@ -340,7 +358,8 @@ runs first wires and the other is a no-op.
 | T-5a | `TestPanickingLogRedactorContained` | a redactor that panics suppresses the record rather than echoing it unredacted, and leaves the observer stream — which is not the redactor's to deny — untouched (§1.5) |
 | T-6 | `TestUpdateStateRejectsLifecycleJumps` | `Started` on a never-run engine is refused; `Started ↔ Paused` is admitted (§1.6) |
 | T-7 | `TestShutdownAwaitsInstanceBornDuringCancel` | an instance created in the snapshot→cancel window is awaited; the timeout error names the unsettled (§1.7) |
-| T-8 | `TestStartersWiredExactlyOnce` | a registration racing `Run` yields exactly one hub registration per starter (§1.8) |
+| T-8 | `TestStartersWiredExactlyOnce` | a registration racing `Run` yields exactly one hub registration per starter — counted at the hub, so a second arm fails it (§1.8) |
+| T-8a | `TestFailedSweepReleasesItsClaims` | a sweep that wired nothing claims nothing, so `Run`'s rollback stays retryable (§1.8) |
 
 ### 4.2 Gate
 

--- a/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
+++ b/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
@@ -1,7 +1,7 @@
 # FIX-036 — the engine's lifecycle bookkeeping: unsynchronized state, reservations that are never released, and foreign code under a lock
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft.
+**Status:** Accepted.
 **Date:** 2026-08-05.
 **Author:** Ruslan Gabitov.
 **Branch:** `fix/thresher-audit` — the remediation of an external audit of `pkg/thresher` (2026-08-05).
@@ -75,7 +75,7 @@ The reservation is released **only when the launch fails**. Nothing releases it
 when the instance finishes. Two consequences, the second worse than the first:
 
 - `seenKeys` grows for the engine's lifetime — one entry per correlation value
-  ever seen, against ADR-002 §4.2's bounded-defaults principle;
+  ever seen, against ADR-002 v.2 §4.2's bounded-defaults principle;
 - once that instance is gone, a later message carrying the same business key is
   answered `"joined existing instance (key seen)"` and **silently dropped** —
   there is no instance to join. Order `ORD-42` handled today means order
@@ -120,7 +120,7 @@ a leaked holder that can still wake an instance for a wait nobody is waiting on.
 The arm has **two** unguarded sides, which is why simply swapping the order is
 not the fix. Recording first makes the hold visible to a concurrent release,
 but that release then calls `UnregisterEvent` on a holder the hub does not know
-yet: the call fails `ObjectNotFound` (`eventhub.go:401-410`), the registration
+yet: the call fails `ObjectNotFound` (`eventhub.go:401-409`), the registration
 that follows succeeds, and the subscription is again live with no record —
 the same leak reached from the other side. The hold must therefore be recorded
 **before** the arm so a release can see it, and **confirmed still recorded**
@@ -221,7 +221,7 @@ same rule.
 | # | Decision | Alternatives | Chosen |
 |---|---|---|---|
 | 1 | §1.1 the engine context | (a) take `t.m` for every read and the write — puts the engine lock on the hot launch path and invites the RC2 lock-ordering hazard the package forbids; (b) an `atomic.Pointer` to an immutable `{ctx, cancel}` pair — lock-free reads, single writer, and the same shape `state` already uses | **(b)** |
-| 2 | §1.2 the key reservation | (a) release in `Forget` only — still wrong for an engine that never calls it; (b) a watcher goroutine per reservation — a goroutine per conversation, the cost ADR-007 exists to avoid; (c) record `nsKey → instanceID` and re-take the reservation when the recorded instance is unknown or terminal — self-healing, O(1), no goroutine | **(c)** + release in `Forget` so the map also shrinks |
+| 2 | §1.2 the key reservation | (a) release in `Forget` only — still wrong for an engine that never calls it; (b) a watcher goroutine per reservation — a goroutine per conversation, the cost ADR-007 v.2.1 exists to avoid; (c) record `nsKey → instanceID` and re-take the reservation when the recorded instance is unknown or terminal — self-healing, O(1), no goroutine | **(c)** + release in `Forget` so the map also shrinks |
 | 3 | §1.4 the hold ordering | (a) hold `subMu` across `RegisterEvent` — an engine lock across a subsystem call, the forbidden shape; (b) record in `t.subs` first and roll the entry back if registration fails — the release path can then always see it, and the hub's `UnregisterEvent` is already idempotent for an unknown definition (`eventhub.go:401-409`) | **(b)** |
 | 4 | §1.5 the filter | (a) snapshot subscribers, unlock, then filter and send — breaks the documented fence that lets `unsubscribe` close a channel with no in-flight send, and buys nothing the contract cannot state; (b) contain the filter call the way `deliver` contains an observer, and make the cheapness the lock demands an explicit term of the `ObservationFilter` contract | **(b)** — the panic is the defect and is fixed; the serialization is a **property of a lock-fenced fan-out, decided here as a contract obligation on the host**, exactly as the observer stream already requires a fast, non-blocking observer. Lifting the fence (epoch counter or send-side refcount) would change the observation contract itself — an ADR question, and one nothing has asked: no measurement shows a filter cost worth redesigning for |
 | 5 | §1.6 `UpdateState` | (a) remove the method — breaks a public API and a real feature (`Paused`); (b) validate the *transition*, not just the value | **(b)** |
@@ -247,7 +247,7 @@ and terminal), taking the reservation over in that case. The join path keeps
 its existing semantics for a live instance.
 
 A rebuilt conversation re-takes its reservation: `recoverOne` and
-`rebuildAndContinue` bind the keys the checkpoint carries (ADR-033 §2.1's
+`rebuildAndContinue` bind the keys the checkpoint carries (ADR-033 v.3 §2.1's
 `ConvKeys`) to the instance they just tracked, so a conversation that crossed a
 restart is reserved exactly as one that never stopped.
 
@@ -275,7 +275,7 @@ behaviour — a missing waiter is an idempotent condition, not an error.
 `FilterObservation` and `RedactLog` are both wrapped in the containment
 `deliver` provides, through one shared `callHostHook` helper: the panic is
 recovered, counted per hook, and logged once at Warn with a stack (Debug
-thereafter, since ADR-022 v.1 §2.4 forbids a per-event record above it).
+thereafter, since ADR-022 v.2 §2.4 forbids a per-event record above it).
 
 Both **fall closed**. A panicking filter denies its recipient; a panicking
 redactor suppresses the log record. The alternative — treating a failed hook as
@@ -411,11 +411,25 @@ lines (`COVER_MIN`).
   (`TestCorrelationKeyReleasedAfterInstanceEnds`, T-2), which waits for the
   completion instead of racing it.
 
-  This is the only pre-existing test whose behaviour this landing changes, and
-  it is worth saying why it is a re-pin and not a weakening: joining a finished
-  instance cannot deliver the message anywhere — no receiver is parked on it —
-  so the old reservation did not preserve the join rule, it discarded the
-  business message that the rule exists to route.
+  This is the only pre-existing test whose asserted CONTRACT this landing
+  changes, and it is worth saying why it is a re-pin and not a weakening:
+  joining a finished instance cannot deliver the message anywhere — no receiver
+  is parked on it — so the old reservation did not preserve the join rule, it
+  discarded the business message that the rule exists to route.
+- **`TestRestartRecoveryBoundaryDeadline` is hardened, not re-pinned.** It
+  asserts exactly what it did before — a recovered boundary fires at its
+  RECORDED deadline rather than a re-evaluated one — but it failed once in a
+  full parallel `go test ./...` sweep and never in isolation. Engine-1 is
+  abandoned by lease rather than stopped, so it keeps running with its own timer
+  armed: if the crash-and-recover sequence did not finish inside the 700 ms
+  deadline, engine-1 fired the boundary and completed the instance, leaving
+  engine-2 nothing in flight to recover. The deadline widens to 2.5 s, which
+  costs nothing in assertion strength because an overdue restored deadline fires
+  immediately (`TestRestartRecoveryOverdueTimer` pins that) — the test proves
+  the same thing whether the deadline is still ahead or already behind at
+  recovery time. Its crash gate also now waits for the checkpoint to carry the
+  armed BOUNDARY rather than only `StatusActive`, the same race
+  `waitParkedRecord` closes for the track's own wait.
 
 ## 7 Related
 
@@ -437,7 +451,60 @@ Prior art: [FIX-035](FIX-035-observer-silence-and-attribute-vocabulary.md)
 
 ## 8 Implementation summary
 
-_To be filled after the milestones land._
+### 8.1 Milestones
+
+| # | Commit | Scope |
+|---|---|---|
+| — | `acd305b` | this document |
+| M1 | `0fd8592` | §1.1 — the engine context becomes an `atomic.Pointer` to an immutable `{ctx, cancel}` pair (§3.2.1) |
+| M2 | `455aedb` | §1.2, §1.3 — the reservation records its owner and self-heals; `recoverOne`/`rebuildAndContinue` rebind a recovered conversation's keys; `Forget` reaps `settled` and the reservations (§3.2.2, §3.2.3) |
+| M3 | `aa8acc4` | §1.4 — `HoldSubscription` records, arms, then confirms (§3.2.4) |
+| M4 | `0a768c0` | §1.5 — both host hooks contained and their obligations stated; `TestCorrelationDedup` re-pinned (§3.2.5, §3.2.6) |
+| — | `87a4b10` | `gofmt` on three test files the lint scope never saw |
+| M5 | `9f9298c` | §1.6, §1.7 — `UpdateState`'s transition rule; `Shutdown` drains what it started (§3.2.7, §3.2.8) |
+| M6 | `8799afb` | §1.8 — starter wiring is idempotent per registration (§3.2.9) |
+| M7 | `d247464` | the branches the fix added, covered; four duplicated guards folded into one; `TestRestartRecoveryBoundaryDeadline` hardened |
+
+### 8.2 Findings the implementation added to the design
+
+Three things the doc did not foresee, each recorded where it belongs and
+repeated here because they are the parts a later reader is most likely to
+re-derive:
+
+- **§1.4 has two sides, not one.** The prescription — "record, then arm" — closes
+  the window the audit named and opens its mirror: a release landing between the
+  record and the arm unregisters a holder the hub does not know yet, the arm
+  then succeeds, and the subscription is live with no record. Recording first is
+  necessary but not sufficient; the arm must also *confirm* it still owns the
+  record. Writing T-4 is what surfaced this — the doc-as-written version fails it
+  on "the holder must actually leave the hub, not just the map".
+- **§1.5's defect has two entry points.** `LogRedactor` is the same interface
+  family, asserted off the same authorizer, called on the same goroutine, with
+  the same missing recover. It is repaired with the filter rather than left for a
+  second pass.
+- **§1.8's flag needs a release, not just a claim.** `registerStarters` is
+  all-or-nothing and `Run` rolls the whole start back when it fails, so a claim
+  kept across that rollback makes the retry wire *nothing* — an engine that
+  starts cleanly with no auto-start at all, strictly worse than the double-wiring
+  the flag exists to prevent. `TestRunRollsBackWhenStarterRegistrationFails`
+  caught it.
+
+### 8.3 Gate
+
+`make ci` green end to end at `d247464`, verified by its own completion markers
+rather than an exit code:
+
+- `diff-coverage: 100.0% of 298 changed coverable lines (min 95%) — PASS`
+- `No vulnerabilities found.` on every module
+- `consumer-smoke … ✓`, `linkcheck: every relative link resolves`, mock-check
+  regenerated clean, `tidy` across all example modules, every example run
+- no `*** [<target>] Error N` anywhere in the log
+
+The lines that remain uncovered are the three `if err != nil` propagations at
+`instanceContext`'s gated call sites (`InvokeProcess`, `launchInstanceFromEvent`,
+recovery), which no caller can reach because all three refuse on a non-started
+engine long before they get there. The guard itself is pinned by
+`TestEngineContextRefusedBeforeRun`.
 
 ## 9 Open questions
 

--- a/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
+++ b/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
@@ -84,6 +84,14 @@ when the instance finishes. Two consequences, the second worse than the first:
 `Forget` — documented as the path so "a long-running engine doesn't accumulate
 finished instances" — does not release keys.
 
+**And the mirror image, found while fixing the above** (not in the audit): the
+map is in-memory only, so it does not survive the process. An engine that
+recovers a live conversation from its checkpoint — a cold restart
+(`recovery.go`) or a wake (`wake.go`) — brings the instance back **unreserved**,
+and the next message carrying its key starts a *duplicate* conversation beside
+it. The two halves are one defect seen from both ends: the reservation's
+lifetime is not tied to the conversation's.
+
 ### 1.3 `settled` is never deleted
 
 `settledFor` mints one terminal-signal channel per instance id and stores it
@@ -214,6 +222,11 @@ the instance holding it is no longer live (absent from `instances`, or present
 and terminal), taking the reservation over in that case. The join path keeps
 its existing semantics for a live instance.
 
+A rebuilt conversation re-takes its reservation: `recoverOne` and
+`rebuildAndContinue` bind the keys the checkpoint carries (ADR-033 §2.1's
+`ConvKeys`) to the instance they just tracked, so a conversation that crossed a
+restart is reserved exactly as one that never stopped.
+
 #### 3.2.3 `pkg/thresher/discovery.go` — `Forget` forgets everything
 
 `Forget` deletes the instance's `settled` channel and any correlation
@@ -265,6 +278,7 @@ runs first wires and the other is a no-op.
 |---|---|---|
 | T-1 | `TestEngineContextIsRaceFree` | concurrent `Run`/`Shutdown`/launch under `-race` — no race on the engine context; a `Shutdown` after a completed `Run` always cancels (§1.1) |
 | T-2 | `TestCorrelationKeyReleasedAfterInstanceEnds` | a second message with the same key after the first instance terminated starts a NEW instance, not a silent join (§1.2) |
+| T-2a | `TestRecoveredConversationKeepsItsKey` | engine A parks a conversation and is fenced out; engine B recovers it from the checkpoint and the reservation names the recovered instance — without the rebind the key comes back free and the next message duplicates the conversation (§1.2, restart half) |
 | T-3 | `TestForgetReleasesKeyAndSettled` | after `Forget`, `seenKeys` and `settled` no longer hold the id (§1.2, §1.3) |
 | T-4 | `TestReleaseWaitsSeesHoldImmediately` | a `ReleaseWaits` racing `HoldSubscription` withdraws the hold — the hub carries no leftover subscription (§1.4) |
 | T-5 | `TestPanickingObservationFilterContained` | a filter that panics denies its recipient, is counted and logged once, and never reaches `Report`'s caller (§1.5) |

--- a/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
+++ b/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
@@ -302,8 +302,21 @@ lifecycle transitions stay the CAS ladder's alone.
 
 #### 3.2.8 `pkg/thresher/thresher.go` — `Shutdown` drains what it started
 
-After the cancel, the instance set is re-snapshotted and awaited until no new
-ids appear; the timeout error names the instances that did not settle.
+The snapshot moves BELOW the cancel and becomes a loop: `drainInstances`
+re-reads the registry after each pass and awaits whatever is new, ending at the
+fixed point where a pass adds nothing. Births stop once the cancel propagates,
+so the loop terminates; `ctx` bounds it regardless. The timeout error names the
+instances that did not settle, sorted, so it reads the same way twice.
+
+On §1.7's second half — the deferred publish marking `Stopped` even on the
+timeout path — the state **stays** `Stopped`. The engine's context is cancelled
+and its hub is being torn down, so it must go on rejecting new work; leaving it
+`Stopping` would make it neither usable nor shut down, and `Shutdown`'s own
+idempotence rule (`case Stopping: return nil`) would then refuse the retry. What
+was wrong is not the state but letting an abandoned shutdown read as a clean
+one, so the timeout additionally logs a `Warn` naming the instances left
+running. The returned error and the operator log now say the same thing, and
+neither claims the stop was orderly.
 
 #### 3.2.9 `pkg/thresher/thresher.go` — starter wiring is idempotent
 
@@ -351,6 +364,21 @@ lines (`COVER_MIN`).
 - `UpdateState` becomes stricter: a host that today sets an arbitrary state
   gets a classified error. This is the point of the fix, but it is a
   behavioural change to a public method and is called out in the CHANGELOG.
+  Three existing tests drove it in ways the rule now refuses, and each is
+  re-pinned rather than relaxed:
+  - `TestThresher_StateManagement/update state success` asserted that a
+    never-run engine could be moved to `Started` by hand — it encoded §1.6's
+    defect as the expected behaviour, so it now asserts the refusal. The
+    legitimate pause/resume pair keeps its coverage in the same file's
+    `run and pause workflow`, which runs the engine first.
+  - `TestEngineStatePausedAndSupersede` reached `Paused` from `NotStarted`
+    purely to emit the fact; it now runs the engine first, which is what
+    pausing means.
+  - The same test's `UpdateState(NotStarted)` line existed to exercise
+    `reportEngineState`'s no-phase early return. That state is no longer
+    reachable through the public API, so the early return is pinned directly by
+    `TestUnmappedEngineStateReportsNothing` — moved to the reporter rather than
+    dropped, since the Run rollback still reaches it internally.
 - `Shutdown` may now wait marginally longer — it awaits instances it previously
   abandoned — bounded by the caller's context exactly as before.
 - **`TestCorrelationDedup` is re-pinned to a live conversation.** It asserted

--- a/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
+++ b/docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md
@@ -360,6 +360,7 @@ promotes.
 | T-7 | `TestShutdownAwaitsInstanceBornDuringCancel` | an instance created in the snapshot→cancel window is awaited; the timeout error names the unsettled (§1.7) |
 | T-8 | `TestStartersWiredExactlyOnce` | a registration racing `Run` yields exactly one hub registration per starter — counted at the hub, so a second arm fails it (§1.8) |
 | T-8a | `TestFailedSweepReleasesItsClaims` | a sweep that wired nothing claims nothing, so `Run`'s rollback stays retryable (§1.8) |
+| T-9 | `TestForgetCancelsInstanceContext` | `Forget` releases the instance's retained context-cancel, not only its registration — the reaping path stops leaking a `cancelCtx` per reaped instance (§8.2) |
 
 ### 4.2 Gate
 
@@ -464,6 +465,7 @@ Prior art: [FIX-035](FIX-035-observer-silence-and-attribute-vocabulary.md)
 | M5 | `9f9298c` | §1.6, §1.7 — `UpdateState`'s transition rule; `Shutdown` drains what it started (§3.2.7, §3.2.8) |
 | M6 | `8799afb` | §1.8 — starter wiring is idempotent per registration (§3.2.9) |
 | M7 | `d247464` | the branches the fix added, covered; four duplicated guards folded into one; `TestRestartRecoveryBoundaryDeadline` hardened |
+| M8 | _this commit_ | the three findings of the independent pre-merge review (§8.2) |
 
 ### 8.2 Findings the implementation added to the design
 
@@ -488,6 +490,47 @@ re-derive:
   starts cleanly with no auto-start at all, strictly worse than the double-wiring
   the flag exists to prevent. `TestRunRollsBackWhenStarterRegistrationFails`
   caught it.
+
+**And three the self-review chain could not have found.** After `/check-srd`
+passed at 0 🔴 / 0 🟡 and the gate was green, the branch diff was reviewed by an
+**external agent** (Antigravity / `agy`, `gemini-3.1-pro-high`) across three
+lenses, doc-blind. Every lens returned exactly one note; all three verified as
+real, and all three are fixed in M8:
+
+- **`instanceReg.stop` was never called — anywhere.** Every launch path derives
+  the instance's context from the engine's with `context.WithCancel` and retains
+  the cancel; three separate comments describe it as "retained for later
+  teardown (engine stop / instance cleanup)", and no teardown ever used it. The
+  child therefore stayed attached to the engine context's children for the
+  engine's whole lifetime, and `Forget` — whose doc comment says it exists "so a
+  long-running engine doesn't accumulate finished instances" — reaped the
+  registration, the terminal signal and the reservation while leaving the
+  context behind. `Shutdown` masked it by cancelling the parent, so the leak was
+  bounded only by engine lifetime, which for a server is unbounded. `Forget` now
+  collects the retained cancels under `t.m` and invokes them after the unlock
+  (the `…Locked` convention), pinned by `TestForgetCancelsInstanceContext`.
+- **`Fact` is shared, and §3.2.6 did not say so.** `Fact.Details` is a
+  `map[string]string` — a reference. A redactor or filter that edits it in
+  place, the allocation-free reflex, corrupts the event for the log echo and
+  every later observer; for a *per-recipient* filter that is precisely
+  backwards. M4 documented what those hooks owe the engine and missed this one;
+  both doc comments now state that `ev` is read-only and that a modification
+  must be returned as a copy. No defensive copy in the engine: that would be a
+  per-event allocation on the hot path, which is the cost ADR-022 v.2 §2.4's
+  hot-path corollary exists to avoid.
+- **T-1 could pass for the shape it exists to catch.** `Run` is non-blocking, so
+  without a start barrier the writer goroutine could finish before the runtime
+  scheduled a single reader — and the race detector only reports accesses that
+  actually overlap. Since the engine pair is now atomic the detector has nothing
+  to say either way; the test's entire value is as a canary for someone
+  reverting to plain fields, and that value needed the overlap it did not
+  guarantee. All nine goroutines now block on one channel and fire together.
+
+The point is not the three findings but their shape: none is a doc-vs-code
+mismatch, so `/check-srd` was not built to see them, and none is a house-rule
+violation, so `/check-style` was not either. Both are the author checking the
+author. This is why the independent review became a step of its own
+(`/pr-review`, `/sdd-fix` step 14a) rather than a one-off.
 
 ### 8.3 Gate
 

--- a/internal/instance/incident_test.go
+++ b/internal/instance/incident_test.go
@@ -637,7 +637,7 @@ func TestIncidentRetryInternalEdges(t *testing.T) {
 
 	t.Run("a past deadline arms an immediate fire", func(t *testing.T) {
 		inst.incidents["past"] = &incident{id: "past",
-			state: incidentRetryScheduled,
+			state:   incidentRetryScheduled,
 			retryAt: inst.now().Add(-time.Minute)}
 		ls.rearmIncidentRetryTimer()
 		require.NotNil(t, ls.retryC)

--- a/internal/scope/snapshot_test.go
+++ b/internal/scope/snapshot_test.go
@@ -265,7 +265,6 @@ type brokenDatum struct{ data.Data }
 
 func (brokenDatum) Name() string { return "broken" }
 
-
 func TestOwnDataUnclonable(t *testing.T) {
 	root := mustPath(t, "/proc")
 

--- a/pkg/observability/visibility.go
+++ b/pkg/observability/visibility.go
@@ -11,6 +11,12 @@ package observability
 // execution loop — once per observable event, so it must be cheap and MUST NOT
 // block: whatever it waits for, the process being reported on waits for too.
 //
+// ev is SHARED. Fact is a struct, but its Details map is a reference, so
+// redacting in place — the allocation-free reflex — mutates the very event the
+// observer stream is about to fan out, and every observer sees the redaction
+// the log was supposed to get. Return a modified COPY (clone Details before
+// writing to it); treat the argument as read-only.
+//
 // A panic is contained and the record is SUPPRESSED, as though the redactor had
 // returned ok=false: a redactor exists to keep detail out of the log, so one
 // that fails to run cannot be read as having permitted the record. The engine
@@ -33,6 +39,13 @@ type LogRedactor interface {
 // block or call back into the engine: a slow filter serializes every reporter
 // behind it, and a blocking one stalls them all. Decide from the arguments;
 // do the expensive part in the observer.
+//
+// ev is SHARED, and here the sharing is per-recipient: the same Fact is passed
+// to every registered observer in turn, and its Details map is a reference.
+// Filtering in place therefore leaks one recipient's view into all the others
+// and into the log echo — the exact opposite of what a per-recipient filter is
+// for. Return a modified COPY (clone Details before writing to it); treat the
+// argument as read-only.
 //
 // A panic is contained and the event is DENIED to that recipient, as though the
 // filter had returned ok=false — a policy that failed to run cannot be read as

--- a/pkg/observability/visibility.go
+++ b/pkg/observability/visibility.go
@@ -6,6 +6,16 @@ package observability
 // start; an authorizer that does not implement it leaves the log echo
 // pass-through (the ADR default), and no per-event assertion is paid. ok=false
 // suppresses the log record entirely.
+//
+// RedactLog is called ON THE REPORTING GOROUTINE — usually an instance's
+// execution loop — once per observable event, so it must be cheap and MUST NOT
+// block: whatever it waits for, the process being reported on waits for too.
+//
+// A panic is contained and the record is SUPPRESSED, as though the redactor had
+// returned ok=false: a redactor exists to keep detail out of the log, so one
+// that fails to run cannot be read as having permitted the record. The engine
+// logs the first panic at Warn with a stack and later ones at Debug, and keeps
+// running.
 type LogRedactor interface {
 	RedactLog(ev Fact) (Fact, bool)
 }
@@ -16,6 +26,18 @@ type LogRedactor interface {
 // absent ⇒ pass-through. observer is the registering observer (opaque here — the
 // policy decides what it means). ok=false denies delivery to that recipient: a
 // policy denial, distinct from a counted buffer drop.
+//
+// FilterObservation is called ON THE REPORTING GOROUTINE, once per event PER
+// REGISTERED OBSERVER, under the producer's dispatch lock — the one every
+// Report in the engine passes through. It must therefore be cheap and MUST NOT
+// block or call back into the engine: a slow filter serializes every reporter
+// behind it, and a blocking one stalls them all. Decide from the arguments;
+// do the expensive part in the observer.
+//
+// A panic is contained and the event is DENIED to that recipient, as though the
+// filter had returned ok=false — a policy that failed to run cannot be read as
+// having permitted delivery. The engine logs the first panic at Warn with a
+// stack and later ones at Debug, and keeps running.
 type ObservationFilter interface {
 	FilterObservation(observer any, ev Fact) (Fact, bool)
 }

--- a/pkg/thresher/boundary_recovery_test.go
+++ b/pkg/thresher/boundary_recovery_test.go
@@ -96,9 +96,16 @@ func TestRestartRecoveryBoundaryDeadline(t *testing.T) {
 	dist1 := &annCollector{}
 	dist2 := &annCollector{}
 
-	// far enough out that the instance parks and checkpoints first, near
-	// enough that a RESTORED deadline lands inside the test.
-	deadline := time.Now().Add(700 * time.Millisecond)
+	// Far enough out that engine-1 cannot fire the boundary — and complete the
+	// instance, leaving engine-2 nothing in flight to recover — before the
+	// crash-and-recover sequence finishes. Engine-1 is abandoned by lease, not
+	// stopped, so it keeps running and its own timer stays armed; at 700ms this
+	// test lost that race about once in a full parallel `go test ./...` sweep.
+	// The margin costs nothing in assertion strength: an overdue RESTORED
+	// deadline fires immediately (TestRestartRecoveryOverdueTimer pins that),
+	// so the test proves the same thing whether the deadline is still ahead at
+	// recovery time or already behind.
+	deadline := time.Now().Add(2500 * time.Millisecond)
 
 	var esc1, esc2 atomic.Bool
 
@@ -115,13 +122,22 @@ func TestRestartRecoveryBoundaryDeadline(t *testing.T) {
 		2*time.Second, 5*time.Millisecond,
 		"the guarded task must park and be announced")
 
-	// the park checkpoint must exist before the crash — it is what carries
-	// the boundary's recorded deadline.
+	// The park checkpoint must carry the ARMED BOUNDARY before the crash — it
+	// is what holds the recorded deadline. Gating on Status alone raced the
+	// checkpoint that adds the boundary, and the assertions below would then
+	// fail on a record that was merely young (the same gap waitParkedRecord
+	// closes for the track's own wait).
 	require.Eventually(t, func() bool {
 		rec, ok, _ := repo.Load(context.Background(), instID)
+		if !ok || rec.Status != repository.StatusActive {
+			return false
+		}
 
-		return ok && rec.Status == repository.StatusActive
-	}, 2*time.Second, 5*time.Millisecond)
+		d, uerr := checkpoint.Unmarshal(rec.Payload)
+
+		return uerr == nil && len(d.Boundaries) > 0 && d.Boundaries[0].Timer != nil
+	}, 2*time.Second, 5*time.Millisecond,
+		"the park checkpoint must record the armed boundary")
 
 	rec, ok, err := repo.Load(context.Background(), instID)
 	require.NoError(t, err)
@@ -147,7 +163,7 @@ func TestRestartRecoveryBoundaryDeadline(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return esc2.Load()
-	}, 3*time.Second, 5*time.Millisecond,
+	}, 6*time.Second, 5*time.Millisecond,
 		"the recovered boundary must fire at its RECORDED deadline — a "+
 			"re-evaluated one would have restarted the escalation clock")
 }

--- a/pkg/thresher/discovery.go
+++ b/pkg/thresher/discovery.go
@@ -81,6 +81,14 @@ func (t *Thresher) Forget(ids ...string) error {
 
 	for _, id := range ids {
 		delete(t.instances, id)
+
+		// Forget everything the engine holds for the instance, not just its
+		// registration (FIX-036 §1.2/§1.3): its terminal signal and any
+		// correlation reservation it owns. Both are safe here precisely
+		// because the loop above proved the instance terminal — nothing can
+		// rebuild it and wait on a channel we dropped.
+		delete(t.settled, id)
+		t.releaseKeysOfLocked(id)
 	}
 
 	return nil

--- a/pkg/thresher/discovery.go
+++ b/pkg/thresher/discovery.go
@@ -2,7 +2,6 @@ package thresher
 
 import (
 	"github.com/dr-dobermann/gobpm/internal/instance"
-	"github.com/dr-dobermann/gobpm/pkg/errs"
 )
 
 // InstanceFilter selects which tracked instances Instances returns (SRD-019).
@@ -60,35 +59,19 @@ func (t *Thresher) Instances(filter InstanceFilter) []string {
 // unknown or still-live id none are removed and an error naming it is returned.
 // Forget(Instances(InstancesCompleted)...) sweeps all finished instances.
 func (t *Thresher) Forget(ids ...string) error {
-	t.m.Lock()
-	defer t.m.Unlock()
-
-	for _, id := range ids {
-		reg, ok := t.instances[id]
-		if !ok {
-			return errs.New(
-				errs.M("unknown instance %q", id),
-				errs.C(errorClass, errs.ObjectNotFound))
-		}
-
-		if st := reg.inst.State(); !instanceTerminal(st) {
-			return errs.New(
-				errs.M("instance %q is still live (%s); cancel it before forgetting",
-					id, st.String()),
-				errs.C(errorClass, errs.InvalidState))
-		}
+	stops, err := t.forgetLocked(ids)
+	if err != nil {
+		return err
 	}
 
-	for _, id := range ids {
-		delete(t.instances, id)
-
-		// Forget everything the engine holds for the instance, not just its
-		// registration (FIX-036 §1.2/§1.3): its terminal signal and any
-		// correlation reservation it owns. Both are safe here precisely
-		// because the loop above proved the instance terminal — nothing can
-		// rebuild it and wait on a channel we dropped.
-		delete(t.settled, id)
-		t.releaseKeysOfLocked(id)
+	// Release each instance's context OUTSIDE t.m. Every launch path derives
+	// the instance's context from the engine's and retains the cancel here, so
+	// until it is called the child stays attached to the engine context's
+	// children — for the engine's whole lifetime. Forget is the reaping path;
+	// reaping the registration and leaving the context behind is exactly the
+	// accumulation this method exists to prevent (FIX-036 §8.2).
+	for _, stop := range stops {
+		stop()
 	}
 
 	return nil

--- a/pkg/thresher/engine_facts_test.go
+++ b/pkg/thresher/engine_facts_test.go
@@ -102,11 +102,16 @@ func TestEngineStatePausedAndSupersede(t *testing.T) {
 
 	// Paused is set via UpdateState (no code drives it yet — the reserved-but-
 	// reachable path); done last so it doesn't perturb the registry above.
+	// The engine must be RUNNING first: pausing is an operator transition out
+	// of Started, and UpdateState no longer lets a host jump the lifecycle
+	// ladder to reach it (FIX-036 §1.6). The no-phase early return that the
+	// removed UpdateState(NotStarted) line used to exercise is no longer
+	// reachable through the public API and is pinned directly instead, by
+	// TestUnmappedEngineStateReportsNothing.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
 	require.NoError(t, th.UpdateState(thresher.Paused))
-
-	// An unmapped state (NotStarted) reports nothing — exercises the
-	// no-phase early return.
-	require.NoError(t, th.UpdateState(thresher.NotStarted))
 
 	sub.Cancel() // drains the buffered facts so the asserts see them
 

--- a/pkg/thresher/incident_boundary_test.go
+++ b/pkg/thresher/incident_boundary_test.go
@@ -204,4 +204,3 @@ func TestInterruptingBoundaryOvertakesIncident(t *testing.T) {
 	require.Equal(t, "overtaken", incs[0].State)
 	require.Zero(t, h.OpenIncidents())
 }
-

--- a/pkg/thresher/instance_starter_internal_test.go
+++ b/pkg/thresher/instance_starter_internal_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 	"github.com/dr-dobermann/gobpm/pkg/model/options"
 	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/dr-dobermann/gobpm/pkg/repository"
+	"github.com/dr-dobermann/gobpm/pkg/repository/memrepo"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -551,6 +553,78 @@ func corrStartProcess(t *testing.T, name, msgName, refName string) *process.Proc
 	return proc
 }
 
+// corrWaitProcess is corrStartProcess with a PARKING node between the start and
+// the end: the conversation stays live — and therefore recoverable from its
+// checkpoint — instead of completing the moment it starts.
+func corrWaitProcess(t *testing.T, name, msgName string) *process.Process {
+	t.Helper()
+
+	require.NoError(t, data.CreateDefaultStates())
+
+	mp := goexpr.Must(nil,
+		data.MustItemDefinition(values.NewVariable("")),
+		func(ctx context.Context, ds data.Source) (data.Value, error) {
+			d, err := ds.Find(ctx, "order_in")
+			if err != nil {
+				return nil, err
+			}
+
+			return values.NewVariable(fmt.Sprint(d.Value().Get(ctx))), nil
+		})
+
+	re, err := bpmncommon.NewCorrelationPropertyRetrievalExpression(mp,
+		bpmncommon.MustMessage(msgName, data.MustItemDefinition(
+			values.NewVariable(""), foundation.WithID("order_in"))))
+	require.NoError(t, err)
+
+	prop, err := bpmncommon.NewCorrelationProperty("orderId", "string",
+		[]bpmncommon.CorrelationPropertyRetrievalExpression{*re})
+	require.NoError(t, err)
+
+	key, err := bpmncommon.NewCorrelationKey("orderKey",
+		[]bpmncommon.CorrelationProperty{*prop})
+	require.NoError(t, err)
+
+	// Every id is pinned: recovery resolves the recorded node ids against the
+	// second engine's registration (the ADR-033 §2.8 deployment-parity rule).
+	proc, err := process.New(name, foundation.WithID(name))
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start",
+		events.WithMessageTrigger(events.MustMessageEventDefinition(
+			bpmncommon.MustMessage(msgName, data.MustItemDefinition(
+				values.NewVariable(""), foundation.WithID("order_in"))), nil)),
+		events.WithCorrelationKey(key),
+		foundation.WithID(name+"-start"))
+	require.NoError(t, err)
+
+	when := time.Now().Add(time.Hour)
+	tdef, err := events.NewTimerEventDefinition(
+		goexpr.Must(nil, data.MustItemDefinition(values.NewVariable(time.Time{})),
+			func(_ context.Context, _ data.Source) (data.Value, error) {
+				return values.NewVariable(when), nil
+			}), nil, nil)
+	require.NoError(t, err)
+
+	wait, err := events.NewIntermediateCatchEvent("wait", tdef,
+		foundation.WithID(name+"-wait"))
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end", foundation.WithID(name+"-end"))
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{start, wait, end} {
+		require.NoError(t, proc.Add(e))
+	}
+
+	_, err = flow.Link(start, wait)
+	require.NoError(t, err)
+	_, err = flow.Link(wait, end)
+	require.NoError(t, err)
+
+	return proc
+}
+
 func instanceCount(th *Thresher) int {
 	th.m.Lock()
 	defer th.m.Unlock()
@@ -704,4 +778,188 @@ func TestStarterGuardHelpers(t *testing.T) {
 	end, err := events.NewEndEvent("e")
 	require.NoError(t, err)
 	require.False(t, parallelStart(end))
+}
+
+// TestCorrelationKeyReleasedAfterInstanceEnds is FIX-036 T-2: the reservation
+// belongs to a CONVERSATION, not to the key forever. While the first instance
+// lives, a repeat key joins it (no duplicate — TestCorrelationDedup's rule);
+// once it has finished, the same business key must start a NEW instance rather
+// than being answered "joined existing instance" against an instance that no
+// longer exists, which silently dropped the message.
+func TestCorrelationKeyReleasedAfterInstanceEnds(t *testing.T) {
+	broker := membroker.New()
+
+	th, err := New("corr-reuse", WithMessageBroker(broker), WithoutBanner())
+	require.NoError(t, err)
+
+	proc := corrStartProcess(t, "p-corr-reuse", "order placed", "order placed")
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	require.NoError(t, broker.Publish(ctx,
+		messaging.Envelope{Name: "order placed", Payload: "ORD-42"}))
+
+	require.Eventually(t, func() bool { return instanceCount(th) == 1 },
+		3*time.Second, 10*time.Millisecond)
+
+	// the first conversation runs to its end (the process is start → end).
+	require.Eventually(t, func() bool {
+		return len(th.Instances(InstancesCompleted)) == 1
+	}, 3*time.Second, 10*time.Millisecond, "the first instance must finish")
+
+	// the SAME key again: a finished conversation is not a conversation.
+	require.NoError(t, broker.Publish(ctx,
+		messaging.Envelope{Name: "order placed", Payload: "ORD-42"}))
+
+	require.Eventually(t, func() bool { return instanceCount(th) == 2 },
+		3*time.Second, 10*time.Millisecond,
+		"a repeat business key must start a new instance once the first ended")
+
+	// and the reservation now names the SECOND instance, not the first.
+	th.m.Lock()
+	owner := th.seenKeys[nsKeyFor(proc.ID(), "ORD-42")]
+	th.m.Unlock()
+
+	require.NotEmpty(t, owner)
+	require.NotEqual(t, keyInFlight, owner)
+}
+
+// TestForgetReleasesKeyAndSettled is FIX-036 T-3: Forget is the package's
+// reaping path and now reaps everything the engine holds for the instance —
+// its registration, its terminal signal and its correlation reservation — so
+// neither map grows for the engine's lifetime.
+func TestForgetReleasesKeyAndSettled(t *testing.T) {
+	broker := membroker.New()
+
+	th, err := New("corr-forget", WithMessageBroker(broker), WithoutBanner())
+	require.NoError(t, err)
+
+	proc := corrStartProcess(t, "p-corr-forget", "order placed", "order placed")
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	require.NoError(t, broker.Publish(ctx,
+		messaging.Envelope{Name: "order placed", Payload: "ORD-7"}))
+
+	require.Eventually(t, func() bool { return instanceCount(th) == 1 },
+		3*time.Second, 10*time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		return len(th.Instances(InstancesCompleted)) == 1
+	}, 3*time.Second, 10*time.Millisecond)
+
+	ids := th.Instances(InstancesCompleted)
+	require.Len(t, ids, 1)
+
+	id := ids[0]
+
+	th.m.Lock()
+	_, hadSettled := th.settled[id]
+	th.m.Unlock()
+	require.True(t, hadSettled, "the terminal signal is minted per instance")
+
+	require.NoError(t, th.Forget(id))
+
+	th.m.Lock()
+	defer th.m.Unlock()
+
+	require.NotContains(t, th.instances, id)
+	require.NotContains(t, th.settled, id)
+	require.NotContains(t, th.seenKeys, nsKeyFor(proc.ID(), "ORD-7"))
+}
+
+// TestRecoveredConversationKeepsItsKey is FIX-036 §1.2's restart half. The
+// reservation map is in-memory, so an engine that rebuilds a live conversation
+// from its checkpoint must re-take that conversation's correlation key.
+// Without it the recovered instance is unreserved and the very next message
+// carrying its key starts a DUPLICATE conversation beside it.
+func TestRecoveredConversationKeepsItsKey(t *testing.T) {
+	repo := memrepo.New()
+	broker := membroker.New()
+
+	proc := corrWaitProcess(t, "p-corr-rec", "order placed")
+
+	// Engine A: starts the conversation, which parks on its timer and is
+	// checkpointed with its ConvKeys — then is abandoned, not shut down.
+	thA, err := New("corr-rec", WithoutBanner(), WithRepository(repo),
+		WithMessageBroker(broker), WithLeaseTTL(50*time.Millisecond))
+	require.NoError(t, err)
+
+	_, err = thA.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	ctxA, cancelA := context.WithCancel(context.Background())
+	require.NoError(t, thA.Run(ctxA))
+
+	require.NoError(t, broker.Publish(ctxA,
+		messaging.Envelope{Name: "order placed", Payload: "ORD-9"}))
+
+	require.Eventually(t, func() bool { return instanceCount(thA) == 1 },
+		3*time.Second, 10*time.Millisecond)
+
+	var instID string
+
+	thA.m.Lock()
+	for id := range thA.instances {
+		instID = id
+	}
+	thA.m.Unlock()
+
+	require.Eventually(t, func() bool {
+		rec, ok, lerr := repo.Load(context.Background(), instID)
+
+		return lerr == nil && ok && len(rec.Payload) > 0
+	}, 3*time.Second, 10*time.Millisecond, "the parked conversation must checkpoint")
+
+	// "Crash" engine A the way the restart-recovery tests do: fence it out
+	// with a foreign, already-expired claim so its terminal write on cancel is
+	// CAS-rejected and the record stays Active — an abandoned conversation,
+	// which is what the next engine recovers.
+	rec, ok, err := repo.Load(context.Background(), instID)
+	require.True(t, ok)
+	require.NoError(t, err)
+
+	rec.Lease = repository.Lease{
+		Owner:       "crash-sim",
+		Incarnation: rec.Lease.Incarnation + 1,
+		Expiry:      time.Now().Add(-time.Second),
+	}
+	require.NoError(t, repo.Save(context.Background(), rec))
+
+	cancelA()
+
+	time.Sleep(80 * time.Millisecond)
+
+	// Engine B recovers it. Its reservation map starts empty — the map never
+	// crosses a process boundary, which is the whole defect.
+	thB, err := New("corr-rec", WithoutBanner(), WithRepository(repo),
+		WithMessageBroker(membroker.New()))
+	require.NoError(t, err)
+
+	_, err = thB.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	ctxB, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+	require.NoError(t, thB.Run(ctxB))
+
+	require.Eventually(t, func() bool { return instanceCount(thB) == 1 },
+		3*time.Second, 10*time.Millisecond, "engine B must recover the instance")
+
+	thB.m.Lock()
+	owner, reserved := thB.seenKeys[nsKeyFor(proc.ID(), "ORD-9")]
+	thB.m.Unlock()
+
+	require.True(t, reserved,
+		"the recovered conversation must own its correlation key again")
+	require.Equal(t, instID, owner,
+		"and the reservation must name the recovered instance")
 }

--- a/pkg/thresher/instance_starter_internal_test.go
+++ b/pkg/thresher/instance_starter_internal_test.go
@@ -635,13 +635,22 @@ func instanceCount(th *Thresher) int {
 // TestCorrelationDedup is ADR-016 v.1 §2.3 / SRD-015 V6: messages with distinct
 // derived keys spawn distinct instances; a repeat of a seen key joins the
 // existing instance (no duplicate).
+//
+// The conversations must be LIVE for that to be the question under test, so
+// this uses the PARKING process rather than the start→end one. With a process
+// that completes the moment it starts, the repeat key raced its own instance's
+// end: joining won only when the message beat the completion, and once a
+// finished conversation stopped reserving its key (FIX-036 §1.2) the repeat
+// legitimately started a third instance instead — a real contract, wrongly
+// reached, which showed up as an intermittent failure of this test rather than
+// of the one that owns it (TestCorrelationKeyReleasedAfterInstanceEnds).
 func TestCorrelationDedup(t *testing.T) {
 	broker := membroker.New()
 
 	th, err := New("corr", WithMessageBroker(broker))
 	require.NoError(t, err)
 
-	proc := corrStartProcess(t, "p-corr", "order placed", "order placed")
+	proc := corrWaitProcess(t, "p-corr", "order placed")
 	_, err = th.RegisterProcess(proc)
 	require.NoError(t, err)
 

--- a/pkg/thresher/instance_starter_internal_test.go
+++ b/pkg/thresher/instance_starter_internal_test.go
@@ -3,6 +3,7 @@ package thresher
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -841,6 +842,58 @@ func TestCorrelationKeyReleasedAfterInstanceEnds(t *testing.T) {
 // reaping path and now reaps everything the engine holds for the instance —
 // its registration, its terminal signal and its correlation reservation — so
 // neither map grows for the engine's lifetime.
+// TestForgetCancelsInstanceContext is FIX-036 M8 (found by the independent
+// pre-merge review, §8.2): every launch path derives the instance's context
+// from the engine's and retains the cancel in instanceReg.stop. Nothing in the
+// package ever called it — three comments claimed it was "retained for later
+// teardown" and no teardown used it — so each launched instance left a
+// cancelCtx attached to the engine context's children for the engine's whole
+// lifetime. Forget is the reaping path, and reaping the registration while
+// leaving the context behind is exactly the accumulation it exists to prevent.
+func TestForgetCancelsInstanceContext(t *testing.T) {
+	broker := membroker.New()
+
+	th, err := New("corr-forget-ctx", WithMessageBroker(broker), WithoutBanner())
+	require.NoError(t, err)
+
+	proc := corrStartProcess(t, "p-forget-ctx", "order placed", "order placed")
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	require.NoError(t, broker.Publish(ctx,
+		messaging.Envelope{Name: "order placed", Payload: "ORD-CTX"}))
+
+	require.Eventually(t, func() bool {
+		return len(th.Instances(InstancesCompleted)) == 1
+	}, 3*time.Second, 10*time.Millisecond, "the instance must finish")
+
+	id := th.Instances(InstancesCompleted)[0]
+
+	// Wrap the retained cancel so the test can see whether Forget invokes it.
+	var cancelled atomic.Bool
+
+	th.m.Lock()
+	reg := th.instances[id]
+	inner := reg.stop
+	require.NotNil(t, inner, "the launch retained a cancel")
+
+	reg.stop = func() {
+		cancelled.Store(true)
+		inner()
+	}
+	th.instances[id] = reg
+	th.m.Unlock()
+
+	require.NoError(t, th.Forget(id))
+
+	require.True(t, cancelled.Load(),
+		"Forget must release the instance's context, not only its registration")
+}
+
 func TestForgetReleasesKeyAndSettled(t *testing.T) {
 	broker := membroker.New()
 

--- a/pkg/thresher/invoker.go
+++ b/pkg/thresher/invoker.go
@@ -74,12 +74,10 @@ func (t *Thresher) InvokeProcess(
 	// instanceReg.stop for teardown. It must NOT be deferred — Run is
 	// non-blocking (launchInstance's rationale). The engine pair is loaded
 	// atomically (FIX-036 §1.1).
-	engCtx, running := t.engineContext()
-	if !running {
-		return nil, t.errEngineNotRunning("InvokeProcess")
+	ctx, cancel, err := t.instanceContext("InvokeProcess")
+	if err != nil {
+		return nil, err
 	}
-
-	ctx, cancel := context.WithCancel(engCtx)
 	if err = inst.Run(ctx); err != nil {
 		cancel()
 

--- a/pkg/thresher/invoker.go
+++ b/pkg/thresher/invoker.go
@@ -72,8 +72,14 @@ func (t *Thresher) InvokeProcess(
 
 	// The child owns this context for its lifetime; cancel is retained in
 	// instanceReg.stop for teardown. It must NOT be deferred — Run is
-	// non-blocking (launchInstance's rationale).
-	ctx, cancel := context.WithCancel(t.ctx)
+	// non-blocking (launchInstance's rationale). The engine pair is loaded
+	// atomically (FIX-036 §1.1).
+	engCtx, running := t.engineContext()
+	if !running {
+		return nil, t.errEngineNotRunning("InvokeProcess")
+	}
+
+	ctx, cancel := context.WithCancel(engCtx)
 	if err = inst.Run(ctx); err != nil {
 		cancel()
 

--- a/pkg/thresher/lifecycle_internal_test.go
+++ b/pkg/thresher/lifecycle_internal_test.go
@@ -222,10 +222,21 @@ func TestEngineContextIsRaceFree(t *testing.T) {
 
 	// One writer (Run) against many readers — the shape the race detector
 	// needs to see. Readers use the same accessor every launch path uses.
+	//
+	// The barrier is load-bearing: Run is NON-blocking, so without one the
+	// writer goroutine could finish before the runtime schedules a single
+	// reader, and the detector only reports accesses that actually overlap.
+	// The test would then pass for the racy shape it exists to catch — its
+	// whole value is as a canary for someone reverting the atomic pair back
+	// to plain fields.
+	start := make(chan struct{})
+
 	wg.Add(1)
 
 	go func() {
 		defer wg.Done()
+
+		<-start
 
 		_ = th.Run(context.Background())
 	}()
@@ -236,6 +247,8 @@ func TestEngineContextIsRaceFree(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
+			<-start
+
 			for range 50 {
 				if ctx, ok := th.engineContext(); ok {
 					_ = ctx.Err()
@@ -243,6 +256,8 @@ func TestEngineContextIsRaceFree(t *testing.T) {
 			}
 		}()
 	}
+
+	close(start) // fire all nine together
 
 	wg.Wait()
 

--- a/pkg/thresher/lifecycle_internal_test.go
+++ b/pkg/thresher/lifecycle_internal_test.go
@@ -269,6 +269,28 @@ func TestEngineContextRefusedBeforeRun(t *testing.T) {
 	err = th.errEngineNotRunning("probe")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "isn't running")
+
+	// Every launch path derives its instance context through one helper, so
+	// the refusal is pinned once: a launch on an engine that never ran returns
+	// a classified error naming the caller instead of dereferencing the absent
+	// pair. The other three callers (InvokeProcess, launchInstanceFromEvent,
+	// recovery) are all gated on a started engine long before they get here.
+	entered, release := make(chan struct{}), make(chan struct{})
+	defer close(release)
+
+	proc := blockingTaskProcess(t, "p-unrun", entered, release)
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	snap := th.latestSnapshotLocked(proc.ID())
+	require.NotNil(t, snap)
+
+	_, err = th.launchInstance(snap)
+	require.ErrorContains(t, err, "launchInstance")
+	require.ErrorContains(t, err, "isn't running")
+
+	_, _, err = th.instanceContext("probe-op")
+	require.ErrorContains(t, err, "probe-op")
 }
 
 // TestUpdateStateRejectsLifecycleJumps is FIX-036 T-6: UpdateState is the

--- a/pkg/thresher/lifecycle_internal_test.go
+++ b/pkg/thresher/lifecycle_internal_test.go
@@ -3,6 +3,7 @@ package thresher
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -200,4 +201,66 @@ func TestRunRollsBackOnHubStartFailure(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "couldn't start eventHub")
 	require.Equal(t, NotStarted, th.State())
+}
+
+// TestEngineContextIsRaceFree is FIX-036 T-1: the engine context is published
+// and read as one atomic pair, so a Run racing a Shutdown (and the launch
+// paths reading between them) carries no data race — the defect was a field
+// written unlocked by Run and read under m by Shutdown, which is a race
+// however well the reader locks.
+func TestEngineContextIsRaceFree(t *testing.T) {
+	th, err := New("lc-engine-ctx", WithoutBanner())
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+
+	// One writer (Run) against many readers — the shape the race detector
+	// needs to see. Readers use the same accessor every launch path uses.
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		_ = th.Run(context.Background())
+	}()
+
+	for range 8 {
+		wg.Add(1)
+
+		go func() {
+			defer wg.Done()
+
+			for range 50 {
+				if ctx, ok := th.engineContext(); ok {
+					_ = ctx.Err()
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// A Shutdown after a completed Run must cancel what Run published —
+	// the failure mode of the racy read was a nil cancel that tore down
+	// nothing while reporting Stopped.
+	ec := th.engine.Load()
+	require.NotNil(t, ec, "Run must publish the engine pair")
+
+	require.NoError(t, th.Shutdown(context.Background()))
+	require.Error(t, ec.ctx.Err(), "Shutdown must cancel the published context")
+}
+
+// TestEngineContextRefusedBeforeRun is FIX-036 T-1's sibling: before Run there
+// is no engine lifetime to hang work on, so the accessor says so and the launch
+// paths turn that into a classified error instead of dereferencing nil.
+func TestEngineContextRefusedBeforeRun(t *testing.T) {
+	th, err := New("lc-engine-ctx-unrun")
+	require.NoError(t, err)
+
+	_, ok := th.engineContext()
+	require.False(t, ok)
+
+	err = th.errEngineNotRunning("probe")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "isn't running")
 }

--- a/pkg/thresher/lifecycle_internal_test.go
+++ b/pkg/thresher/lifecycle_internal_test.go
@@ -8,7 +8,13 @@ import (
 	"time"
 
 	"github.com/dr-dobermann/gobpm/internal/eventproc"
+	"github.com/dr-dobermann/gobpm/pkg/model/activities"
+	"github.com/dr-dobermann/gobpm/pkg/model/data"
+	"github.com/dr-dobermann/gobpm/pkg/model/events"
 	"github.com/dr-dobermann/gobpm/pkg/model/flow"
+	"github.com/dr-dobermann/gobpm/pkg/model/process"
+	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/model/service/gooper"
 	"github.com/stretchr/testify/require"
 )
 
@@ -263,4 +269,163 @@ func TestEngineContextRefusedBeforeRun(t *testing.T) {
 	err = th.errEngineNotRunning("probe")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "isn't running")
+}
+
+// TestUpdateStateRejectsLifecycleJumps is FIX-036 T-6: UpdateState is the
+// OPERATOR's door (pause/resume), not a second way into the lifecycle ladder
+// Run and Shutdown claim with a CAS. It used to accept any legal enum member,
+// so a host could store Started on an engine that never ran — after which
+// RegisterEvent's `State() != Started` guard admitted registrations to a hub
+// that was never started.
+func TestUpdateStateRejectsLifecycleJumps(t *testing.T) {
+	th, err := New("engine-transitions", WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	require.Equal(t, NotStarted, th.State())
+
+	for _, ns := range []State{Started, Starting, Stopping, Stopped, Paused} {
+		require.Error(t, th.UpdateState(ns),
+			"a never-run engine may not be moved to %q by hand", ns)
+		require.Equal(t, NotStarted, th.State(),
+			"a refused transition leaves the state untouched")
+	}
+
+	// an out-of-range value is still refused by the enum check, ahead of the
+	// transition rule.
+	require.Error(t, th.UpdateState(State(200)))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	// the operator pair, both ways.
+	require.NoError(t, th.UpdateState(Paused))
+	require.Equal(t, Paused, th.State())
+	require.NoError(t, th.UpdateState(Started))
+	require.Equal(t, Started, th.State())
+
+	// but not the lifecycle transitions, even from a legal running state.
+	for _, ns := range []State{Stopped, Stopping, Starting, NotStarted} {
+		require.Error(t, th.UpdateState(ns))
+		require.Equal(t, Started, th.State())
+	}
+}
+
+// blockingTaskProcess builds start → service task → end, where the task
+// signals that it has been ENTERED and then blocks until release is closed —
+// ignoring its context on purpose, so the instance cannot settle on its own.
+func blockingTaskProcess(
+	t *testing.T, name string, entered chan<- struct{}, release <-chan struct{},
+) *process.Process {
+	t.Helper()
+
+	require.NoError(t, data.CreateDefaultStates())
+
+	op, err := gooper.New(name,
+		func(_ context.Context, _ service.DataReader,
+			_ *data.ItemDefinition) (*data.ItemDefinition, error) {
+			close(entered)
+			<-release
+
+			return nil, nil
+		})
+	require.NoError(t, err)
+
+	st, err := activities.NewServiceTask(name, op, activities.WithoutParams())
+	require.NoError(t, err)
+
+	proc, err := process.New(name)
+	require.NoError(t, err)
+
+	start, err := events.NewStartEvent("start")
+	require.NoError(t, err)
+
+	end, err := events.NewEndEvent("end")
+	require.NoError(t, err)
+
+	for _, e := range []flow.Element{start, st, end} {
+		require.NoError(t, proc.Add(e))
+	}
+
+	_, err = flow.Link(start, st)
+	require.NoError(t, err)
+	_, err = flow.Link(st, end)
+	require.NoError(t, err)
+
+	return proc
+}
+
+// TestShutdownAwaitsInstanceBornDuringCancel is FIX-036 T-7: Shutdown used to
+// snapshot the instance registry BEFORE cancelling the engine context and then
+// await only that snapshot, so an instance born in the window between the two —
+// an event-triggered start the hub was already dispatching, a Call Activity
+// child its parent was already creating — was left running.
+//
+// The window is reproduced exactly rather than approximately: the engine's own
+// published context/cancel pair is replaced with one whose cancel launches an
+// instance first. That is the seam Shutdown reads, so the birth lands precisely
+// between the snapshot and the cancel.
+func TestShutdownAwaitsInstanceBornDuringCancel(t *testing.T) {
+	entered, release := make(chan struct{}), make(chan struct{})
+	defer close(release)
+
+	th, err := New("engine-shutdown-window",
+		WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	proc := blockingTaskProcess(t, "p-block", entered, release)
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	ec := th.engine.Load()
+	require.NotNil(t, ec)
+
+	var bornID string
+
+	th.engine.Store(&engineCtx{ctx: ec.ctx, cancel: func() {
+		h, lerr := th.launchInstance(th.latestSnapshotLocked(proc.ID()))
+		if lerr == nil {
+			bornID = h.ID()
+			<-entered // it is inside the blocking task, so it cannot settle
+		}
+
+		ec.cancel()
+	}})
+
+	sctx, scancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer scancel()
+
+	err = th.Shutdown(sctx)
+
+	require.Error(t, err,
+		"an instance born in the cancel window must still be awaited")
+	require.ErrorContains(t, err, "1 instance(s) settled")
+	require.ErrorContains(t, err, bornID,
+		"the timeout names what did not settle")
+}
+
+// TestUnmappedEngineStateReportsNothing pins reportEngineState's no-phase early
+// return. A state with no observable phase — NotStarted, which Run's rollback
+// stores — reports nothing; a mapped one reports. This used to be driven
+// through UpdateState(NotStarted), which the transition rule now refuses
+// (FIX-036 §1.6), so it is pinned at the reporter instead of through a door
+// that no longer opens.
+func TestUnmappedEngineStateReportsNothing(t *testing.T) {
+	th, err := New("engine-unmapped", WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	o := &recObserver{}
+	sub := th.Observe(o)
+
+	th.reportEngineState(NotStarted)
+	th.reportEngineState(Invalid)
+	th.reportEngineState(Paused)
+
+	sub.Cancel()
+
+	require.Equal(t, 1, o.count(), "only the mapped state reports")
 }

--- a/pkg/thresher/locked.go
+++ b/pkg/thresher/locked.go
@@ -2,6 +2,7 @@ package thresher
 
 import (
 	"context"
+	"sort"
 
 	"github.com/dr-dobermann/gobpm/internal/instance"
 	"github.com/dr-dobermann/gobpm/internal/instance/snapshot"
@@ -231,6 +232,45 @@ func (t *Thresher) releaseKeysOfLocked(instanceID string) {
 			delete(t.seenKeys, nsKey)
 		}
 	}
+}
+
+// pendingInstancesLocked returns the tracked instances whose ids are NOT in
+// settled — the work one Shutdown drain pass still has to await. A fresh call
+// picks up anything born since the previous pass (FIX-036 §1.7).
+func (t *Thresher) pendingInstancesLocked(
+	settled map[string]struct{},
+) []instanceReg {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	pending := make([]instanceReg, 0, len(t.instances))
+
+	for id, r := range t.instances {
+		if _, done := settled[id]; !done {
+			pending = append(pending, r)
+		}
+	}
+
+	return pending
+}
+
+// unsettledIDsLocked names the tracked instances that never settled, sorted so
+// a timeout error reads the same way twice.
+func (t *Thresher) unsettledIDsLocked(settled map[string]struct{}) []string {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	ids := make([]string, 0, len(t.instances))
+
+	for id := range t.instances {
+		if _, done := settled[id]; !done {
+			ids = append(ids, id)
+		}
+	}
+
+	sort.Strings(ids)
+
+	return ids
 }
 
 // latestSnapshotLocked returns the snapshot of the latest registered version of

--- a/pkg/thresher/locked.go
+++ b/pkg/thresher/locked.go
@@ -117,21 +117,70 @@ func (t *Thresher) removeKeyLocked(
 	return liveStarters, true
 }
 
-// latestStartersLocked collects the instance-starters of the latest version of
-// every registered key — the set Run wires onto the hub at startup (only the
-// latest auto-starts; latest-supersedes).
-func (t *Thresher) latestStartersLocked() []*instanceStarter {
+// claimLatestRegistrationsLocked claims the hub wiring of the latest version of
+// every registered key — the set Run wires at startup (only the latest
+// auto-starts; latest-supersedes) — and returns the registrations it claimed,
+// so a caller that fails can give every one of them back.
+//
+// The claim is what makes the two wiring paths idempotent against each other
+// (FIX-036 §1.8). Run publishes Started before it sweeps, so a RegisterProcess
+// that lands in between sees a started engine and wires its own starters, while
+// the sweep still finds that version in the registry and would wire them a
+// second time. Whichever arrives first claims; the other skips that key.
+func (t *Thresher) claimLatestRegistrationsLocked() []*ProcessRegistration {
 	t.m.Lock()
 	defer t.m.Unlock()
 
-	var all []*instanceStarter
+	var claimed []*ProcessRegistration
+
 	for _, regs := range t.registrations {
-		if n := len(regs); n > 0 {
-			all = append(all, regs[n-1].starters...)
+		n := len(regs)
+		if n == 0 || regs[n-1].wired {
+			continue
 		}
+
+		regs[n-1].wired = true
+
+		claimed = append(claimed, regs[n-1])
 	}
 
-	return all
+	return claimed
+}
+
+// claimWiringLocked claims the hub wiring of reg's starters, returning false if
+// they are already claimed — the RegisterProcess half of the same handshake.
+func (t *Thresher) claimWiringLocked(reg *ProcessRegistration) bool {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	if reg.wired {
+		return false
+	}
+
+	reg.wired = true
+
+	return true
+}
+
+// releaseWiringLocked records that reg's starters have left the hub, so a later
+// promotion — or a retry after a failed registration — can wire them again.
+func (t *Thresher) releaseWiringLocked(reg *ProcessRegistration) {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	reg.wired = false
+}
+
+// setLatestWiredLocked records whether key's latest registration owns the live
+// starter set. It is how promote-on-removal claims the wiring for the version
+// it just promoted, whose registration the remover does not hold.
+func (t *Thresher) setLatestWiredLocked(key string, wired bool) {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	if regs := t.registrations[key]; len(regs) > 0 {
+		regs[len(regs)-1].wired = wired
+	}
 }
 
 // keyInFlight is the reservation's value while its instance is being launched:

--- a/pkg/thresher/locked.go
+++ b/pkg/thresher/locked.go
@@ -133,21 +133,57 @@ func (t *Thresher) latestStartersLocked() []*instanceStarter {
 	return all
 }
 
-// reserveKeyLocked records the correlation key nsKey as seen, returning true if
-// it was newly reserved or false if an instance already claimed it (a join, no
-// duplicate). The check-and-record is atomic so two concurrent same-key starts
+// keyInFlight is the reservation's value while its instance is being launched:
+// the key is claimed (a concurrent same-key start must not create a second
+// instance) but no instance owns it yet. bindKeyLocked replaces it with the id.
+const keyInFlight = ""
+
+// reserveKeyLocked claims the correlation key nsKey for a NEW instance,
+// returning false when the key belongs to a conversation that is still going —
+// a live instance (join, no duplicate) or a start already in flight.
+//
+// A reservation whose instance has finished is NOT such a conversation: it is
+// taken over, so a later message carrying the same business key starts a new
+// process instead of joining an instance that no longer exists (FIX-036 §1.2).
+// The check-and-record is atomic, so two concurrent same-key starts still
 // cannot both create an instance.
 func (t *Thresher) reserveKeyLocked(nsKey string) bool {
 	t.m.Lock()
 	defer t.m.Unlock()
 
-	if _, seen := t.seenKeys[nsKey]; seen {
+	if owner, seen := t.seenKeys[nsKey]; seen && t.keyOwnerLiveLocked(owner) {
 		return false
 	}
 
-	t.seenKeys[nsKey] = struct{}{}
+	t.seenKeys[nsKey] = keyInFlight
 
 	return true
+}
+
+// keyOwnerLiveLocked reports whether a reservation still names a conversation
+// nothing may duplicate: a start in flight, or a tracked instance that has not
+// reached a terminal state. An id the registry no longer knows — forgotten, or
+// lost with the engine that ran it — is not live. Caller holds m.
+func (t *Thresher) keyOwnerLiveLocked(owner string) bool {
+	if owner == keyInFlight {
+		return true
+	}
+
+	reg, tracked := t.instances[owner]
+	if !tracked {
+		return false
+	}
+
+	return !instanceTerminal(reg.inst.State())
+}
+
+// bindKeyLocked names the instance that owns a reservation, once its launch has
+// succeeded (FIX-036 §1.2).
+func (t *Thresher) bindKeyLocked(nsKey, instanceID string) {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	t.seenKeys[nsKey] = instanceID
 }
 
 // releaseKeyLocked drops a correlation-key reservation, letting a later message
@@ -157,6 +193,44 @@ func (t *Thresher) releaseKeyLocked(nsKey string) {
 	defer t.m.Unlock()
 
 	delete(t.seenKeys, nsKey)
+}
+
+// rebindKeysLocked re-establishes the correlation reservations of an instance
+// the engine has just rebuilt from its checkpoint — a cold restart recovery or
+// a wake (FIX-036 §1.2). seenKeys is in-memory bookkeeping, so without this a
+// live conversation comes back unreserved and the next message carrying its key
+// starts a DUPLICATE instance beside it. The keys are the conversation values
+// the checkpoint carries (ADR-033 §2.1's ConvKeys), which are the same values
+// the instance-starter reserved when it first created the conversation.
+func (t *Thresher) rebindKeysLocked(
+	processID, instanceID string,
+	convKeys map[string]string,
+) {
+	if len(convKeys) == 0 {
+		return
+	}
+
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	for _, v := range convKeys {
+		if v == "" {
+			continue
+		}
+
+		t.seenKeys[nsKeyFor(processID, v)] = instanceID
+	}
+}
+
+// releaseKeysOfLocked drops every reservation owned by instanceID — the
+// forgetting half of §1.2, so the map shrinks with the instances it tracks
+// rather than growing for the engine's lifetime. Caller holds m.
+func (t *Thresher) releaseKeysOfLocked(instanceID string) {
+	for nsKey, owner := range t.seenKeys {
+		if owner == instanceID {
+			delete(t.seenKeys, nsKey)
+		}
+	}
 }
 
 // latestSnapshotLocked returns the snapshot of the latest registered version of

--- a/pkg/thresher/locked.go
+++ b/pkg/thresher/locked.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/dr-dobermann/gobpm/internal/instance"
 	"github.com/dr-dobermann/gobpm/internal/instance/snapshot"
+	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/foundation"
 )
 
@@ -320,6 +321,55 @@ func (t *Thresher) unsettledIDsLocked(settled map[string]struct{}) []string {
 	sort.Strings(ids)
 
 	return ids
+}
+
+// forgetLocked validates and removes the listed terminal instances, returning
+// the retained context-cancels of the ones it removed so the CALLER can invoke
+// them outside t.m — the same shape every other helper here follows.
+//
+// All-or-nothing: every id is validated first (known AND terminal); on any
+// unknown or still-live id nothing is removed and an error naming it comes back.
+func (t *Thresher) forgetLocked(
+	ids []string,
+) ([]context.CancelFunc, error) {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	for _, id := range ids {
+		reg, ok := t.instances[id]
+		if !ok {
+			return nil, errs.New(
+				errs.M("unknown instance %q", id),
+				errs.C(errorClass, errs.ObjectNotFound))
+		}
+
+		if st := reg.inst.State(); !instanceTerminal(st) {
+			return nil, errs.New(
+				errs.M("instance %q is still live (%s); cancel it before forgetting",
+					id, st.String()),
+				errs.C(errorClass, errs.InvalidState))
+		}
+	}
+
+	stops := make([]context.CancelFunc, 0, len(ids))
+
+	for _, id := range ids {
+		if reg := t.instances[id]; reg.stop != nil {
+			stops = append(stops, reg.stop)
+		}
+
+		delete(t.instances, id)
+
+		// Forget everything the engine holds for the instance, not just its
+		// registration (FIX-036 §1.2/§1.3): its terminal signal and any
+		// correlation reservation it owns. Both are safe here precisely
+		// because the loop above proved the instance terminal — nothing can
+		// rebuild it and wait on a channel we dropped.
+		delete(t.settled, id)
+		t.releaseKeysOfLocked(id)
+	}
+
+	return stops, nil
 }
 
 // latestSnapshotLocked returns the snapshot of the latest registered version of

--- a/pkg/thresher/locked_internal_test.go
+++ b/pkg/thresher/locked_internal_test.go
@@ -106,3 +106,71 @@ func TestReserveReleaseKeyLocked(t *testing.T) {
 	th.releaseKeyLocked("k")
 	require.True(t, th.reserveKeyLocked("k"))
 }
+
+// TestWiringClaimIsExclusive pins the claim handshake directly (FIX-036 §1.8).
+// Its losing side — a second claim on an already-wired version — only happens
+// when RegisterProcess and Run's sweep reach the same registration, which is a
+// race no test can schedule; the primitive that decides it is pinned here
+// instead, and T-8 pins the behaviour it produces.
+func TestWiringClaimIsExclusive(t *testing.T) {
+	th, err := New("claim", WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	reg := &ProcessRegistration{key: "k", id: "r1", version: 1}
+
+	require.True(t, th.claimWiringLocked(reg), "the first claim wins")
+	require.False(t, th.claimWiringLocked(reg),
+		"a second claim finds the wiring already owned")
+
+	th.releaseWiringLocked(reg)
+	require.True(t, th.claimWiringLocked(reg),
+		"a released claim can be taken again — promote-on-removal depends on it")
+
+	// the sweep skips a version already claimed, and claims one that is not.
+	th.registrations["k"] = []*ProcessRegistration{reg}
+	require.Empty(t, th.claimLatestRegistrationsLocked(),
+		"the sweep leaves an already-wired version alone")
+
+	th.setLatestWiredLocked("k", false)
+	require.Len(t, th.claimLatestRegistrationsLocked(), 1)
+
+	// an unknown key is a no-op, not a panic.
+	th.setLatestWiredLocked("absent", true)
+}
+
+// TestReservationIgnoresAnUntrackedOwner covers the takeover rule's other
+// branch (FIX-036 §1.2): a reservation naming an id the registry no longer
+// knows — forgotten, or lost with the engine that ran it — is not a live
+// conversation, so the key is free.
+func TestReservationIgnoresAnUntrackedOwner(t *testing.T) {
+	th, err := New("ghost", WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	th.m.Lock()
+	th.seenKeys["p\x1fORD-1"] = "an-instance-this-engine-never-heard-of"
+	th.m.Unlock()
+
+	require.True(t, th.reserveKeyLocked("p\x1fORD-1"),
+		"a reservation whose owner is gone must not block a new conversation")
+}
+
+// TestRebindSkipsEmptyKeyValues: a checkpoint may carry a declared conversation
+// key that was never derived (ADR-033 §2.1 records the map, not only the
+// populated entries). An empty value identifies no conversation, so rebinding
+// it would reserve the namespaced key "" for the instance and swallow the next
+// unkeyed start.
+func TestRebindSkipsEmptyKeyValues(t *testing.T) {
+	th, err := New("rebind", WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	th.rebindKeysLocked("p", "i-1", map[string]string{
+		"orderKey": "",
+		"caseKey":  "C-9",
+	})
+
+	th.m.Lock()
+	defer th.m.Unlock()
+
+	require.Equal(t, map[string]string{nsKeyFor("p", "C-9"): "i-1"}, th.seenKeys,
+		"only the derived key is reserved")
+}

--- a/pkg/thresher/producer.go
+++ b/pkg/thresher/producer.go
@@ -150,7 +150,7 @@ func callHostHook[T any](
 }
 
 // reportHookPanic counts and logs one contained host-hook panic, bounded the
-// way an observer panic is (ADR-022 v.1 §2.4): the FIRST one Warns with a
+// way an observer panic is (ADR-022 v.2 §2.4): the FIRST one Warns with a
 // stack — degraded but continuing, never Error, since no engine state was
 // affected — and every one after it is a Debug, because the hot-path corollary
 // forbids a per-event record above Debug.

--- a/pkg/thresher/producer.go
+++ b/pkg/thresher/producer.go
@@ -1,6 +1,8 @@
 package thresher
 
 import (
+	"fmt"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 
@@ -20,6 +22,10 @@ type producer struct {
 	subs     map[uint64]*engineSub
 	mu       sync.Mutex
 	nextID   uint64
+	// panics contained in the two host-supplied hooks, counted separately so
+	// each gets its own one-shot Warn (FIX-036 §1.5).
+	redactorPanicked atomic.Uint64
+	filterPanicked   atomic.Uint64
 }
 
 // engineSub is one engine-scope observer registration: its buffered channel, the
@@ -66,7 +72,7 @@ func (p *producer) Report(ev observability.Fact) {
 // Echo itself skips the stream-only kinds and picks the level.
 func (p *producer) echo(ev observability.Fact) {
 	if p.redactor != nil {
-		redacted, ok := p.redactor.RedactLog(ev)
+		redacted, ok := p.redact(ev)
 		if !ok {
 			return
 		}
@@ -75,6 +81,96 @@ func (p *producer) echo(ev observability.Fact) {
 	}
 
 	observability.Echo(p.log, ev)
+}
+
+// redact applies the host's LogRedactor under containment. A panicking redactor
+// SUPPRESSES the record: a redactor exists to keep detail out of the log, so
+// its failure must fall closed rather than echo an unredacted event.
+func (p *producer) redact(
+	ev observability.Fact,
+) (observability.Fact, bool) {
+	out, ok, r, stack := callHostHook(
+		func() (observability.Fact, bool) { return p.redactor.RedactLog(ev) },
+		p.redactorPanicked.Load() == 0)
+	if r != nil {
+		p.reportHookPanic("log redactor", &p.redactorPanicked, r, stack)
+
+		return ev, false
+	}
+
+	return out, ok
+}
+
+// filtered applies the host's ObservationFilter for one recipient under
+// containment. A panicking filter DENIES that recipient, for the same reason a
+// panicking redactor suppresses: a policy that failed to run must not be
+// treated as having permitted anything.
+func (p *producer) filtered(
+	obs Observer, ev observability.Fact,
+) (observability.Fact, bool) {
+	out, ok, r, stack := callHostHook(
+		func() (observability.Fact, bool) {
+			return p.filter.FilterObservation(obs, ev)
+		},
+		p.filterPanicked.Load() == 0)
+	if r != nil {
+		p.reportHookPanic("observation filter", &p.filterPanicked, r, stack)
+
+		return ev, false
+	}
+
+	return out, ok
+}
+
+// callHostHook runs one host-supplied observability hook under panic
+// containment. Both hooks are AuthorizationProvider methods called on the
+// REPORTER's goroutine — an instance's loop — so an escaping panic there would
+// take down the run of a process for a fault in the host's policy code. A
+// broken policy must degrade its own event and nothing else.
+//
+// It mirrors deliver's shape: the recovered value and, for the first panic
+// only, its stack come back to the caller, which owns counting and logging.
+func callHostHook[T any](
+	hook func() (T, bool), wantStack bool,
+) (out T, ok bool, recovered any, stack []byte) {
+	defer func() {
+		if r := recover(); r != nil {
+			recovered = r
+			ok = false
+
+			if wantStack {
+				stack = debug.Stack()
+			}
+		}
+	}()
+
+	out, ok = hook()
+
+	return out, ok, nil, nil
+}
+
+// reportHookPanic counts and logs one contained host-hook panic, bounded the
+// way an observer panic is (ADR-022 v.1 §2.4): the FIRST one Warns with a
+// stack — degraded but continuing, never Error, since no engine state was
+// affected — and every one after it is a Debug, because the hot-path corollary
+// forbids a per-event record above Debug.
+func (p *producer) reportHookPanic(
+	hook string, counter *atomic.Uint64, r any, stack []byte,
+) {
+	// the identity pair, plus the stack pair the Warn branch appends.
+	args := make([]any, 0, 4)
+	args = append(args, observability.AttrError, fmt.Sprint(r))
+
+	// Add, not Load: two reporters can panic concurrently, and exactly one of
+	// them must own the Warn.
+	if counter.Add(1) != 1 {
+		p.log.Debug(hook+" panicked", args...)
+
+		return
+	}
+
+	p.log.Warn(hook+" panicked; its events are degraded until it is fixed",
+		append(args, "stack", string(stack))...)
 }
 
 // fanout delivers ev to every engine-scope observer, applying the
@@ -88,7 +184,7 @@ func (p *producer) fanout(ev observability.Fact) {
 	for _, s := range p.subs {
 		out := ev
 		if p.filter != nil {
-			filtered, ok := p.filter.FilterObservation(s.obs, ev)
+			filtered, ok := p.filtered(s.obs, ev)
 			if !ok {
 				continue // policy-denied — not a counted drop
 			}

--- a/pkg/thresher/producer_internal_test.go
+++ b/pkg/thresher/producer_internal_test.go
@@ -1,6 +1,7 @@
 package thresher
 
 import (
+	"strings"
 	"sync"
 	"testing"
 
@@ -34,19 +35,46 @@ func (r *recLogger) count() int {
 	return len(r.msgs)
 }
 
+// countWith returns how many recorded records contain sub — used to separate
+// one specific record from the ordinary echo traffic sharing the logger.
+func (r *recLogger) countWith(sub string) int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	n := 0
+
+	for _, m := range r.msgs {
+		if strings.Contains(m, sub) {
+			n++
+		}
+	}
+
+	return n
+}
+
 // capAuthz is an allow-all authorizer that also carries the two optional
 // visibility capabilities, letting one double drive both channels.
 type capAuthz struct {
 	auth.AuthorizationProvider
 	suppressLog bool
 	denyObserve bool
+	panicLog    bool
+	panicObs    bool
 }
 
 func (a capAuthz) RedactLog(ev observability.Fact) (observability.Fact, bool) {
+	if a.panicLog {
+		panic("the host's redactor is broken")
+	}
+
 	return ev, !a.suppressLog
 }
 
 func (a capAuthz) FilterObservation(_ any, ev observability.Fact) (observability.Fact, bool) {
+	if a.panicObs {
+		panic("the host's filter is broken")
+	}
+
 	return ev, !a.denyObserve
 }
 
@@ -189,3 +217,66 @@ func TestProducerDropsWhenBufferFull(t *testing.T) {
 type blockingRecObserver struct{ release chan struct{} }
 
 func (b *blockingRecObserver) OnFact(observability.Fact) { <-b.release }
+
+// TestPanickingObservationFilterContained is FIX-036 T-5: the ObservationFilter
+// is host code called on the REPORTER's goroutine — an instance's execution
+// loop — so a panic in it used to propagate out of Report and kill the run of a
+// process for a fault in the host's policy. It is now contained: the recipient
+// is denied (a policy that failed to run has not permitted anything), the panic
+// is counted, and it is logged once at Warn rather than per event.
+func TestPanickingObservationFilterContained(t *testing.T) {
+	log := &recLogger{}
+	p := newProducer(log, capAuthz{
+		AuthorizationProvider: allowall.New(),
+		panicObs:              true,
+	})
+
+	o := &recObserver{}
+	sub := p.subscribe(o)
+
+	require.NotPanics(t, func() {
+		p.Report(lifecycleEvent())
+		p.Report(lifecycleEvent())
+	}, "a broken filter must not reach Report's caller")
+
+	sub.Cancel()
+
+	require.Zero(t, o.count(),
+		"a filter that failed to run denies its recipient")
+	require.Zero(t, sub.Dropped(),
+		"a contained panic is a policy denial, not a buffer drop")
+	require.Equal(t, uint64(2), p.filterPanicked.Load(),
+		"every panic is counted")
+	require.Equal(t, 1, log.countWith("WARN:observation filter panicked"),
+		"the Warn is one per engine, not one per event")
+	require.Equal(t, 1, log.countWith("DEBUG:observation filter panicked"),
+		"later panics stay at Debug — the hot path carries no Warn")
+}
+
+// TestPanickingLogRedactorContained is T-5's other half: RedactLog is the same
+// kind of host code on the same goroutine. A panic suppresses the record — a
+// redactor exists to keep detail OUT of the log, so its failure must not be
+// read as permission to echo the event unredacted — and the observer stream,
+// which the redactor has no say over, is unaffected.
+func TestPanickingLogRedactorContained(t *testing.T) {
+	log := &recLogger{}
+	p := newProducer(log, capAuthz{
+		AuthorizationProvider: allowall.New(),
+		panicLog:              true,
+	})
+
+	o := &recObserver{}
+	sub := p.subscribe(o)
+
+	require.NotPanics(t, func() { p.Report(lifecycleEvent()) },
+		"a broken redactor must not reach Report's caller")
+
+	sub.Cancel()
+
+	require.Equal(t, uint64(1), p.redactorPanicked.Load())
+	require.Equal(t, 1, log.countWith("WARN:log redactor panicked"))
+	require.Equal(t, 1, log.count(),
+		"only the Warn — the unredacted record is suppressed, not echoed")
+	require.Equal(t, 1, o.count(),
+		"the observer stream is not the redactor's to deny")
+}

--- a/pkg/thresher/recovery.go
+++ b/pkg/thresher/recovery.go
@@ -100,12 +100,10 @@ func (t *Thresher) recoverOne(ctx context.Context, id string) error {
 		return recoveryErr("the instance doesn't restore", err)
 	}
 
-	engCtx, running := t.engineContext()
-	if !running {
-		return recoveryErr("the engine context is gone", nil)
+	runCtx, cancel, err := t.instanceContext("recovery")
+	if err != nil {
+		return recoveryErr("the engine context is gone", err)
 	}
-
-	runCtx, cancel := context.WithCancel(engCtx)
 	if err := inst.Run(runCtx); err != nil {
 		cancel()
 

--- a/pkg/thresher/recovery.go
+++ b/pkg/thresher/recovery.go
@@ -114,6 +114,12 @@ func (t *Thresher) recoverOne(ctx context.Context, id string) error {
 
 	t.trackInstanceLocked(inst, cancel, t.settledFor(id))
 
+	// A recovered conversation re-takes its correlation reservation (FIX-036
+	// §1.2): the reservation map does not survive the process, so without this
+	// the next message carrying this instance's key would start a duplicate
+	// beside the one just recovered.
+	t.rebindKeysLocked(doc.ProcessID, id, doc.ConvKeys)
+
 	inst.Report(observability.Fact{
 		Kind:  observability.KindInstanceState,
 		Phase: observability.PhaseRecovered,

--- a/pkg/thresher/recovery.go
+++ b/pkg/thresher/recovery.go
@@ -100,7 +100,12 @@ func (t *Thresher) recoverOne(ctx context.Context, id string) error {
 		return recoveryErr("the instance doesn't restore", err)
 	}
 
-	runCtx, cancel := context.WithCancel(t.ctx)
+	engCtx, running := t.engineContext()
+	if !running {
+		return recoveryErr("the engine context is gone", nil)
+	}
+
+	runCtx, cancel := context.WithCancel(engCtx)
 	if err := inst.Run(runCtx); err != nil {
 		cancel()
 

--- a/pkg/thresher/registration.go
+++ b/pkg/thresher/registration.go
@@ -14,6 +14,11 @@ type ProcessRegistration struct {
 	starters []*instanceStarter // auto-start starters of this version (nil in manual mode)
 	version  int                // 1-based, increments per key in registration order
 	manual   bool               // registered WithManualStart
+	// wired records whether this version's starters are currently on the hub.
+	// Guarded by Thresher.m. Two paths wire starters — RegisterProcess and
+	// Run's one-time sweep — and they are not mutually exclusive, so the flag
+	// is what lets whichever arrives first claim the work (FIX-036 §1.8).
+	wired bool
 }
 
 // Key returns the versioning key — the process id shared by every version of

--- a/pkg/thresher/subscription_holder.go
+++ b/pkg/thresher/subscription_holder.go
@@ -92,15 +92,57 @@ func (t *Thresher) HoldSubscription(
 		convKeys:    append([]string{}, convKeys...),
 	}
 
+	// The arm is not atomic, so a ReleaseWaits for this track — an interrupting
+	// boundary, an Event-Based gateway's losing arm — can land in the middle of
+	// it. Recording first makes the hold VISIBLE to that release; confirming
+	// afterwards makes it EFFECTIVE. Neither half suffices alone (FIX-036
+	// §1.4): arm-then-record leaves a release scanning an empty map while the
+	// holder is already live on the hub, and record-then-arm alone leaves the
+	// release unregistering a holder the hub does not know yet — both end with
+	// a subscription registered forever, able to wake an instance for a wait
+	// nobody is waiting on.
+	key := subKey{instanceID, trackID, eDef.ID()}
+
+	t.subMu.Lock()
+	t.subs[key] = h
+	t.subMu.Unlock()
+
 	if err := t.RegisterEvent(h, eDef); err != nil {
+		t.dropHold(key, h)
+
 		return err
 	}
 
-	t.subMu.Lock()
-	t.subs[subKey{instanceID, trackID, eDef.ID()}] = h
-	t.subMu.Unlock()
+	// The confirm: if the record is no longer ours, a release took it while the
+	// arm ran and its own withdrawal could not reach the hub. Withdraw here —
+	// the release is authoritative, so this is a success, not a failed hold.
+	if !t.holdStillRecorded(key, h) {
+		t.withdraw(instanceID, trackID, h)
+	}
 
 	return nil
+}
+
+// holdStillRecorded reports whether key still names h — false once a
+// ReleaseWaits has withdrawn the track's holds.
+func (t *Thresher) holdStillRecorded(key subKey, h *subHolder) bool {
+	t.subMu.Lock()
+	defer t.subMu.Unlock()
+
+	cur, ok := t.subs[key]
+
+	return ok && cur == h
+}
+
+// dropHold removes key iff it still names h, so a rollback never clobbers a
+// record some other arm has since put there.
+func (t *Thresher) dropHold(key subKey, h *subHolder) {
+	t.subMu.Lock()
+	defer t.subMu.Unlock()
+
+	if cur, ok := t.subs[key]; ok && cur == h {
+		delete(t.subs, key)
+	}
 }
 
 // ReleaseWaits implements exec.WaitHolders: withdraw EVERY hold taken for a
@@ -128,11 +170,18 @@ func (t *Thresher) ReleaseWaits(instanceID, trackID string) {
 	// unregister outside the lock: the hub is an independent subsystem and must
 	// never be touched under an engine lock (the FIX-002 RC2 rule).
 	for _, h := range dropped {
-		if err := t.UnregisterEvent(h, h.eDef.ID()); err != nil {
-			t.cfg.logger.Debug("releasing a held subscription",
-				observability.AttrInstanceID, instanceID, observability.AttrTrackID, trackID,
-				observability.AttrEventDefinitionID, h.eDef.ID(), observability.AttrError, err.Error())
-		}
+		t.withdraw(instanceID, trackID, h)
+	}
+}
+
+// withdraw takes one holder off the hub. A failure is a Debug fact, never an
+// error: the waiter may already be gone (a fired timer self-removes), and there
+// is nothing a caller could do with it.
+func (t *Thresher) withdraw(instanceID, trackID string, h *subHolder) {
+	if err := t.UnregisterEvent(h, h.eDef.ID()); err != nil {
+		t.cfg.logger.Debug("releasing a held subscription",
+			observability.AttrInstanceID, instanceID, observability.AttrTrackID, trackID,
+			observability.AttrEventDefinitionID, h.eDef.ID(), observability.AttrError, err.Error())
 	}
 }
 

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -499,10 +499,52 @@ func (t *Thresher) UpdateState(ns State) error {
 			errs.E(err))
 	}
 
-	t.state.Store(uint32(ns))
+	cur := t.State()
+	if !operatorTransitions[stateChange{from: cur, to: ns}] {
+		return errs.New(
+			errs.M("couldn't move the Thresher from %q to %q: UpdateState"+
+				" admits only the operator transitions (Started↔Paused);"+
+				" starting and stopping belong to Run and Shutdown",
+				cur.String(), ns.String()),
+			errs.C(errorClass, errs.InvalidState))
+	}
+
+	// CAS, not Store, for the same reason Run and Shutdown claim their
+	// transitions with one: between the read above and the write, a concurrent
+	// Shutdown may have moved the engine on, and a plain Store would resurrect
+	// the state it left behind.
+	if !t.state.CompareAndSwap(uint32(cur), uint32(ns)) {
+		return errs.New(
+			errs.M("couldn't move the Thresher from %q to %q: its state"+
+				" changed concurrently (now %q)",
+				cur.String(), ns.String(), t.State().String()),
+			errs.C(errorClass, errs.InvalidState))
+	}
+
 	t.reportEngineState(ns)
 
 	return nil
+}
+
+// stateChange is one from→to pair of the engine lifecycle.
+type stateChange struct {
+	from State
+	to   State
+}
+
+// operatorTransitions are the ONLY changes UpdateState admits: pausing a
+// running engine and resuming a paused one (FIX-036 §1.6).
+//
+// Everything else belongs to the CAS ladder in Run and Shutdown. The method
+// used to accept any legal enum MEMBER, which is a different question from
+// whether the engine may go there from where it is: storing Started on an
+// engine that never ran opened RegisterEvent's `State() != Started` guard onto
+// a hub that was never started. Paused is a real operator state — Shutdown
+// accepts it as a live one — so the defect was the absence of a transition
+// rule, not the existence of the method.
+var operatorTransitions = map[stateChange]bool{
+	{from: Started, to: Paused}: true,
+	{from: Paused, to: Started}: true,
 }
 
 // enginePhase maps a Thresher state to its observable phase (SRD-041 §3.4). A
@@ -745,13 +787,6 @@ func (t *Thresher) Shutdown(ctx context.Context) error {
 		t.reportEngineState(Stopped)
 	}()
 
-	t.m.Lock()
-	regs := make([]instanceReg, 0, len(t.instances))
-	for _, r := range t.instances {
-		regs = append(regs, r)
-	}
-	t.m.Unlock()
-
 	// The engine pair is atomic, never guarded by m (FIX-036 §1.1): loading it
 	// here — outside the registry lock — is both correct and the only way to
 	// read what Run published without racing it.
@@ -766,20 +801,68 @@ func (t *Thresher) Shutdown(ctx context.Context) error {
 		cancel()
 	}
 
-	// Settle each running instance, bounded by ctx.
-	for _, r := range regs {
-		select {
-		case <-r.inst.Done():
-		case <-ctx.Done():
-			return errs.New(
-				errs.M("thresher shutdown timed out before instances settled"),
-				errs.C(errorClass, errs.OperationFailed),
-				errs.E(ctx.Err()))
-		}
+	if err := t.drainInstances(ctx); err != nil {
+		return err
 	}
 
 	// Drain the event machinery: stop waiters and wait for their goroutines.
 	return t.eventHub.Shutdown(ctx)
+}
+
+// drainInstances awaits every instance the engine tracks, bounded by ctx.
+//
+// It RE-SNAPSHOTS after each pass (FIX-036 §1.7). A single snapshot taken
+// before the cancel misses every instance born in the window between the two —
+// an event-triggered start the hub was already dispatching, a Call Activity
+// child its parent was already creating — and Shutdown would return leaving
+// them running. Births stop once the cancel above propagates, so a pass that
+// adds nothing new is the fixed point that ends the loop.
+func (t *Thresher) drainInstances(ctx context.Context) error {
+	settled := map[string]struct{}{}
+
+	for {
+		pending := t.pendingInstancesLocked(settled)
+		if len(pending) == 0 {
+			return nil
+		}
+
+		for _, r := range pending {
+			select {
+			case <-r.inst.Done():
+				settled[r.inst.ID()] = struct{}{}
+
+			case <-ctx.Done():
+				return t.errShutdownTimeout(ctx, settled)
+			}
+		}
+	}
+}
+
+// errShutdownTimeout builds the timeout refusal, NAMING the instances that did
+// not settle so an operator can find them rather than being told only that
+// something did not finish.
+//
+// The deferred publish still marks the engine Stopped: its context is canceled
+// and its hub is being torn down, so it must go on rejecting new work — the
+// state is right even though the stop was not clean. What would be wrong is
+// letting that read as a NORMAL stop, so the abandonment is stated in the
+// operator log too, not only in the returned error.
+func (t *Thresher) errShutdownTimeout(
+	ctx context.Context, settled map[string]struct{},
+) error {
+	unsettled := t.unsettledIDsLocked(settled)
+
+	t.cfg.logger.Warn(
+		"thresher shutdown timed out; marking it stopped with instances"+
+			" still running",
+		observability.AttrInstanceID, strings.Join(unsettled, ","),
+		observability.AttrError, ctx.Err().Error())
+
+	return errs.New(
+		errs.M("thresher shutdown timed out before %d instance(s) settled: %s",
+			len(unsettled), strings.Join(unsettled, ", ")),
+		errs.C(errorClass, errs.OperationFailed),
+		errs.E(ctx.Err()))
 }
 
 // ------------------ EventProducer interface ----------------------------------

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -1021,17 +1021,31 @@ func (t *Thresher) RegisterProcess(
 	// holding the engine lock across an engine-subsystem call is the deadlock
 	// class FIX-002 RC2 warns about. Before Run the hub isn't started yet, so
 	// registration is deferred to Run (registerAllStarters wires latest-only).
-	if t.State() == Started {
+	//
+	// The claim makes this path and Run's sweep idempotent against each other:
+	// Run publishes Started before it sweeps, so a registration landing between
+	// the two is visible to both, and without the claim both would wire it
+	// (FIX-036 §1.8).
+	if t.State() == Started && t.claimWiringLocked(reg) {
 		// Latest-supersedes (ADR-019 §2.5): the new version takes over auto-start,
 		// so the previous latest's starters stop firing. A superseded version only
 		// finishes its already-running instances.
 		if prevLatest != nil {
 			if err := t.unregisterStarters(prevLatest.starters); err != nil {
+				t.releaseWiringLocked(reg)
+
 				return nil, err
 			}
+
+			t.releaseWiringLocked(prevLatest)
 		}
 
 		if err := t.registerStarters(starters); err != nil {
+			// registerStarters is all-or-nothing (FIX-013 §1.3), so nothing of
+			// this version reached the hub: give the claim back rather than
+			// leave a version marked wired that is not.
+			t.releaseWiringLocked(reg)
+
 			return nil, err
 		}
 	}
@@ -1096,10 +1110,17 @@ func (t *Thresher) UnregisterVersion(reg *ProcessRegistration) error {
 			return err
 		}
 
+		t.setLatestWiredLocked(reg.key, false)
+
 		// promote the now-newest remaining version to live auto-start (empty for
 		// a manual-start version or when the key had a single version).
 		if len(promote) > 0 {
-			return t.registerStarters(promote)
+			if err := t.registerStarters(promote); err != nil {
+				return err
+			}
+
+			// the promoted version now owns the live starter set.
+			t.setLatestWiredLocked(reg.key, true)
 		}
 	}
 
@@ -1222,7 +1243,27 @@ func (t *Thresher) unregisterStarters(starters []*instanceStarter) error {
 // version of every process registered before Run (only the latest auto-starts —
 // latest-supersedes; the hub accepts registrations once Started).
 func (t *Thresher) registerAllStarters() error {
-	return t.registerStarters(t.latestStartersLocked())
+	claimed := t.claimLatestRegistrationsLocked()
+
+	var starters []*instanceStarter
+	for _, reg := range claimed {
+		starters = append(starters, reg.starters...)
+	}
+
+	if err := t.registerStarters(starters); err != nil {
+		// Give every claim back. registerStarters is all-or-nothing (FIX-013
+		// §1.3) and Run rolls the whole start back, so leaving these versions
+		// marked wired would make the RETRY wire nothing — an engine that
+		// starts cleanly with no auto-start at all, which is worse than the
+		// double-wiring the claim exists to prevent.
+		for _, reg := range claimed {
+			t.releaseWiringLocked(reg)
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 // resolveAndLaunch performs the create-or-route-or-join decision per correlation

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -152,8 +152,13 @@ type instanceReg struct {
 //     per-key lock, never under m). State() never takes a per-key lock, so it
 //     adds no RC2 vector.
 type Thresher struct {
-	ctx           context.Context
-	engineCancel  context.CancelFunc
+	// engine holds the engine's own context and its cancel as ONE immutable
+	// pair, published atomically by Run and loaded by every user (FIX-036
+	// §1.1). It is deliberately NOT guarded by m — like state, and for the
+	// same reason: the launch paths read it while m may be held elsewhere,
+	// and a mutex taken on only one side of a shared write is not
+	// synchronization at all, which is what this replaces.
+	engine        atomic.Pointer[engineCtx]
 	eventHub      eventproc.EventHub
 	registrations map[string][]*ProcessRegistration
 	nextVersion   map[string]int
@@ -443,6 +448,34 @@ func (t *Thresher) logStartupConfig() {
 	}
 }
 
+// engineCtx is the engine's derived context and the cancel that ends it — one
+// immutable value so a reader can never see a context from one Run paired with
+// the cancel of another (FIX-036 §1.1). Replaced wholesale on every Run.
+type engineCtx struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// engineContext returns the context every instance is launched under. ok is
+// false before the first Run — the engine has no lifetime to hang work on yet,
+// and callers turn that into a classified error instead of dereferencing nil.
+func (t *Thresher) engineContext() (context.Context, bool) {
+	ec := t.engine.Load()
+	if ec == nil {
+		return nil, false
+	}
+
+	return ec.ctx, true
+}
+
+// errEngineNotRunning is the classified refusal for work that needs the engine
+// context before Run established one.
+func (t *Thresher) errEngineNotRunning(op string) error {
+	return errs.New(
+		errs.M("%s: the thresher isn't running (state %q)", op, t.State()),
+		errs.C(errorClass, errs.InvalidState))
+}
+
 // State returns current state of the Threasher. It is lock-free (atomic load),
 // so it is safe to call while t.m is held — the property that removes the
 // FIX-002 RC2 re-entrant self-deadlock.
@@ -532,8 +565,17 @@ func (t *Thresher) Run(ctx context.Context) error {
 	// their ctx still propagates here.
 	// engineCancel is stored on the Thresher and called by Shutdown (and both Run
 	// rollbacks) — the engine context lives for the engine's lifetime (SRD-019).
-	t.ctx, t.engineCancel = context.WithCancel(ctx)
-	runCtx := t.ctx
+	// Published as one immutable pair (FIX-036 §1.1); the rollbacks below use
+	// the local `ec` rather than re-loading, so a retry that has already
+	// replaced the pair can never cancel the newer engine.
+	//nolint:gosec // G118: the cancel is retained in the engine pair below and
+	// called by Shutdown and by every Run rollback — it outlives this scope by
+	// design, which is what an engine-lifetime context means.
+	engCtx, engCancel := context.WithCancel(ctx)
+	ec := &engineCtx{ctx: engCtx, cancel: engCancel}
+	t.engine.Store(ec)
+
+	runCtx := ec.ctx
 
 	// Synchronously initialize the EventHub so that any subsequent
 	// RegisterEvent / UnregisterEvent / PropagateEvent call sees a fully
@@ -542,11 +584,11 @@ func (t *Thresher) Run(ctx context.Context) error {
 	// FIX-001 for the race this replaces (previously the hub was spun up
 	// in a goroutine guarded only by a 1ms sleep, which is not a memory
 	// barrier under the Go memory model).
-	if err := t.eventHub.Start(t.ctx); err != nil {
+	if err := t.eventHub.Start(runCtx); err != nil {
 		// The start failed: cancel the engine context we just derived (it is
 		// otherwise abandoned — a retry Run reassigns t.ctx/engineCancel) and roll
 		// the claim back to NotStarted so a retry stays possible.
-		t.engineCancel()
+		ec.cancel()
 		t.state.Store(uint32(NotStarted))
 
 		return errs.New(
@@ -584,7 +626,7 @@ func (t *Thresher) Run(ctx context.Context) error {
 		// engine context is canceled to stop the live hub goroutine and the
 		// state returns to NotStarted. registerStarters is all-or-nothing
 		// (FIX-013 §1.3), so no partial subscriptions linger to unwind here.
-		t.engineCancel()
+		ec.cancel()
 		t.state.Store(uint32(NotStarted))
 
 		return errs.New(
@@ -601,7 +643,7 @@ func (t *Thresher) Run(ctx context.Context) error {
 	if t.cfg.repoSet {
 		if m, ok := t.cfg.Repository().(renv.Migrator); ok {
 			if err := m.Migrate(runCtx); err != nil {
-				t.engineCancel()
+				ec.cancel()
 				t.state.Store(uint32(NotStarted))
 
 				return errs.New(
@@ -619,7 +661,7 @@ func (t *Thresher) Run(ctx context.Context) error {
 	// Repository: a volatile engine writes no records.
 	if t.cfg.repoSet {
 		if err := t.ensureGroup(runCtx); err != nil {
-			t.engineCancel()
+			ec.cancel()
 			t.state.Store(uint32(NotStarted))
 
 			return err
@@ -703,9 +745,15 @@ func (t *Thresher) Shutdown(ctx context.Context) error {
 	for _, r := range t.instances {
 		regs = append(regs, r)
 	}
-
-	cancel := t.engineCancel
 	t.m.Unlock()
+
+	// The engine pair is atomic, never guarded by m (FIX-036 §1.1): loading it
+	// here — outside the registry lock — is both correct and the only way to
+	// read what Run published without racing it.
+	var cancel context.CancelFunc
+	if ec := t.engine.Load(); ec != nil {
+		cancel = ec.cancel
+	}
 
 	// Cancel the engine context: every instance (launched under t.ctx) observes
 	// it and walks to Terminated; the hub Run unblocks.
@@ -1167,8 +1215,13 @@ func (t *Thresher) launchInstanceFromEvent(
 
 	// The instance owns this context for its whole lifetime; cancel is retained
 	// in instanceReg.stop for later teardown (see launchInstance for why it is
-	// not deferred).
-	ctx, cancel := context.WithCancel(t.ctx)
+	// not deferred). The engine pair is loaded atomically (FIX-036 §1.1).
+	engCtx, ok := t.engineContext()
+	if !ok {
+		return t.errEngineNotRunning("launchInstanceFromEvent")
+	}
+
+	ctx, cancel := context.WithCancel(engCtx)
 	if err := inst.Run(ctx); err != nil {
 		cancel()
 
@@ -1343,7 +1396,13 @@ func (t *Thresher) launchInstance(s *snapshot.Snapshot) (*InstanceHandle, error)
 	// in instanceReg.stop for later teardown (engine stop / instance cleanup).
 	// It must NOT be deferred here — inst.Run is non-blocking, so a deferred
 	// cancel would terminate the instance the moment launchInstance returns.
-	ctx, cancel := context.WithCancel(t.ctx)
+	// The engine pair is loaded atomically (FIX-036 §1.1).
+	engCtx, ok := t.engineContext()
+	if !ok {
+		return nil, t.errEngineNotRunning("launchInstance")
+	}
+
+	ctx, cancel := context.WithCancel(engCtx)
 	if err = inst.Run(ctx); err != nil {
 		cancel()
 

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -473,6 +473,28 @@ func (t *Thresher) engineContext() (context.Context, bool) {
 	return ec.ctx, true
 }
 
+// instanceContext derives the context an instance owns for its lifetime, from
+// the engine's own. Every launch path needs exactly this — the engine pair,
+// checked, then a cancel the caller retains in instanceReg.stop — so it lives
+// in one place rather than four copies of the same guard, three of which no
+// caller can reach (InvokeProcess and launchInstanceFromEvent are both gated on
+// a started engine long before they get here).
+//
+// The cancel MUST NOT be deferred by the caller: inst.Run is non-blocking, so a
+// deferred cancel would terminate the instance the moment the launch returns.
+func (t *Thresher) instanceContext(
+	op string,
+) (context.Context, context.CancelFunc, error) {
+	engCtx, running := t.engineContext()
+	if !running {
+		return nil, nil, t.errEngineNotRunning(op)
+	}
+
+	ctx, cancel := context.WithCancel(engCtx)
+
+	return ctx, cancel, nil
+}
+
 // errEngineNotRunning is the classified refusal for work that needs the engine
 // context before Run established one.
 func (t *Thresher) errEngineNotRunning(op string) error {
@@ -499,26 +521,31 @@ func (t *Thresher) UpdateState(ns State) error {
 			errs.E(err))
 	}
 
-	cur := t.State()
-	if !operatorTransitions[stateChange{from: cur, to: ns}] {
-		return errs.New(
-			errs.M("couldn't move the Thresher from %q to %q: UpdateState"+
-				" admits only the operator transitions (Started↔Paused);"+
-				" starting and stopping belong to Run and Shutdown",
-				cur.String(), ns.String()),
-			errs.C(errorClass, errs.InvalidState))
-	}
+	// Claim the transition with a CAS, for the same reason Run and Shutdown
+	// claim theirs: between reading the current state and writing the new one, a
+	// concurrent Shutdown may have moved the engine on, and a plain Store would
+	// resurrect the state it left behind.
+	//
+	// A lost CAS re-reads and re-judges rather than failing. The question this
+	// method answers is "may the engine go there from where it IS", so the
+	// answer must be computed from where it is now — if a concurrent Shutdown
+	// moved it to Stopping, the retry refuses with that state named, which is
+	// the useful error; if another operator merely resumed it, pausing it again
+	// is a legitimate request that has no reason to fail.
+	for {
+		cur := t.State()
+		if !operatorTransitions[stateChange{from: cur, to: ns}] {
+			return errs.New(
+				errs.M("couldn't move the Thresher from %q to %q: UpdateState"+
+					" admits only the operator transitions (Started↔Paused);"+
+					" starting and stopping belong to Run and Shutdown",
+					cur.String(), ns.String()),
+				errs.C(errorClass, errs.InvalidState))
+		}
 
-	// CAS, not Store, for the same reason Run and Shutdown claim their
-	// transitions with one: between the read above and the write, a concurrent
-	// Shutdown may have moved the engine on, and a plain Store would resurrect
-	// the state it left behind.
-	if !t.state.CompareAndSwap(uint32(cur), uint32(ns)) {
-		return errs.New(
-			errs.M("couldn't move the Thresher from %q to %q: its state"+
-				" changed concurrently (now %q)",
-				cur.String(), ns.String(), t.State().String()),
-			errs.C(errorClass, errs.InvalidState))
+		if t.state.CompareAndSwap(uint32(cur), uint32(ns)) {
+			break
+		}
 	}
 
 	t.reportEngineState(ns)
@@ -1343,12 +1370,11 @@ func (t *Thresher) launchInstanceFromEvent(
 	// The instance owns this context for its whole lifetime; cancel is retained
 	// in instanceReg.stop for later teardown (see launchInstance for why it is
 	// not deferred). The engine pair is loaded atomically (FIX-036 §1.1).
-	engCtx, ok := t.engineContext()
-	if !ok {
-		return t.errEngineNotRunning("launchInstanceFromEvent")
+	ctx, cancel, err := t.instanceContext("launchInstanceFromEvent")
+	if err != nil {
+		return err
 	}
 
-	ctx, cancel := context.WithCancel(engCtx)
 	if err := inst.Run(ctx); err != nil {
 		cancel()
 
@@ -1540,12 +1566,11 @@ func (t *Thresher) launchInstance(s *snapshot.Snapshot) (*InstanceHandle, error)
 	// It must NOT be deferred here — inst.Run is non-blocking, so a deferred
 	// cancel would terminate the instance the moment launchInstance returns.
 	// The engine pair is loaded atomically (FIX-036 §1.1).
-	engCtx, ok := t.engineContext()
-	if !ok {
-		return nil, t.errEngineNotRunning("launchInstance")
+	ctx, cancel, err := t.instanceContext("launchInstance")
+	if err != nil {
+		return nil, err
 	}
 
-	ctx, cancel := context.WithCancel(engCtx)
 	if err = inst.Run(ctx); err != nil {
 		cancel()
 

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -163,7 +163,12 @@ type Thresher struct {
 	registrations map[string][]*ProcessRegistration
 	nextVersion   map[string]int
 	instances     map[string]instanceReg
-	seenKeys      map[string]struct{}
+	// seenKeys maps a namespaced correlation key → the id of the instance that
+	// owns that conversation (keyInFlight while its launch is still running).
+	// Knowing the OWNER is what lets a repeat business key start a new
+	// conversation once the old one finished, instead of joining a ghost
+	// (FIX-036 §1.2). Guarded by m; reaped by Forget.
+	seenKeys map[string]string
 	// tasks maps a parked UserTask id → its engine-level record: where it lives,
 	// who may act on it, and who currently holds it (SRD-034, SRD-073 FR-2).
 	// Guarded by m. Populated/cleared by taskDist as tasks are announced and
@@ -296,7 +301,7 @@ func New(id string, opts ...Option) (*Thresher, error) {
 		registrations: map[string][]*ProcessRegistration{},
 		nextVersion:   map[string]int{},
 		instances:     map[string]instanceReg{},
-		seenKeys:      map[string]struct{}{},
+		seenKeys:      map[string]string{},
 		tasks:         map[string]*taskRecord{},
 		keyLocks:      newKeyLockManager(),
 		waking:        map[string]bool{},
@@ -1159,9 +1164,7 @@ func (t *Thresher) resolveAndLaunch(
 		return t.launchInstanceFromEvent(ctx, s, startNode, eDef, keyName, key)
 	}
 
-	// Namespace the key by process so two processes correlating on the same
-	// value remain distinct conversations.
-	nsKey := s.ProcessID + "\x1f" + key
+	nsKey := nsKeyFor(s.ProcessID, key)
 
 	if !t.reserveKeyLocked(nsKey) {
 		t.cfg.logger.Debug("instance-starter: joined existing instance (key seen)",
@@ -1237,7 +1240,23 @@ func (t *Thresher) launchInstanceFromEvent(
 	// returns a usable handle for it instead of a nil that panics on observation.
 	t.trackInstanceLocked(inst, cancel, settled)
 
+	// Bind the correlation reservation to the instance that now owns it
+	// (FIX-036 §1.2): until this point the entry only says "a start is in
+	// flight", which is what suppresses a concurrent duplicate; from here it
+	// names the conversation, so a later message can tell a live instance
+	// (join) from a finished one (start again).
+	if keyVal != "" {
+		t.bindKeyLocked(nsKeyFor(s.ProcessID, keyVal), inst.ID())
+	}
+
 	return nil
+}
+
+// nsKeyFor namespaces a correlation value by its process, so two processes
+// correlating on the same value remain distinct conversations. The one
+// definition both the reservation and its binding use.
+func nsKeyFor(processID, key string) string {
+	return processID + "\x1f" + key
 }
 
 // StartProcess launches a new instance of the exact registered version named by

--- a/pkg/thresher/thresher_state_test.go
+++ b/pkg/thresher/thresher_state_test.go
@@ -46,17 +46,21 @@ func TestThresher_StateManagement(t *testing.T) {
 		require.Equal(t, thresher.NotStarted, th.State())
 	})
 
-	t.Run("update state success", func(t *testing.T) {
+	// A never-run engine refuses BOTH: Started belongs to Run's CAS ladder, and
+	// Paused is only reachable from Started. This subtest used to assert the
+	// opposite — it drove the engine to Started by hand, which is exactly the
+	// defect FIX-036 §1.6 closes, since RegisterEvent's `State() != Started`
+	// guard would then admit registrations to a hub that was never started.
+	// The legitimate pause/resume pair is covered by "run and pause workflow".
+	t.Run("update state refuses a lifecycle jump", func(t *testing.T) {
 		th, err := thresher.New("test-thresher")
 		require.NoError(t, err)
 
-		err = th.UpdateState(thresher.Started)
-		require.NoError(t, err)
-		require.Equal(t, thresher.Started, th.State())
+		require.Error(t, th.UpdateState(thresher.Started))
+		require.Equal(t, thresher.NotStarted, th.State())
 
-		err = th.UpdateState(thresher.Paused)
-		require.NoError(t, err)
-		require.Equal(t, thresher.Paused, th.State())
+		require.Error(t, th.UpdateState(thresher.Paused))
+		require.Equal(t, thresher.NotStarted, th.State())
 	})
 
 	t.Run("update state with invalid state", func(t *testing.T) {

--- a/pkg/thresher/wake.go
+++ b/pkg/thresher/wake.go
@@ -174,6 +174,10 @@ func (t *Thresher) rebuildAndContinue(
 
 	t.trackInstanceLocked(inst, cancel, t.settledFor(instanceID))
 
+	// A hydrated conversation re-takes its correlation reservation, for the
+	// same reason a recovered one does (FIX-036 §1.2).
+	t.rebindKeysLocked(doc.ProcessID, instanceID, doc.ConvKeys)
+
 	inst.Report(observability.Fact{
 		Kind:  observability.KindInstanceState,
 		Phase: observability.PhaseHydrated,

--- a/pkg/thresher/wake.go
+++ b/pkg/thresher/wake.go
@@ -111,7 +111,12 @@ func (t *Thresher) rebuildAndContinue(
 	pending *instance.PendingTrigger,
 	extra ...instance.Option,
 ) error {
-	ctx := t.ctx
+	// One atomic load serves the whole wake: the claim, the rebuild and the
+	// run all belong to the same engine incarnation (FIX-036 §1.1).
+	ctx, running := t.engineContext()
+	if !running {
+		return t.errEngineNotRunning("rebuildAndContinue")
+	}
 
 	rec, err := t.claimForWake(ctx, instanceID)
 	if err != nil {
@@ -143,7 +148,7 @@ func (t *Thresher) rebuildAndContinue(
 		return wakeErr("the instance doesn't rebuild", err)
 	}
 
-	runCtx, cancel := context.WithCancel(t.ctx)
+	runCtx, cancel := context.WithCancel(ctx)
 	if err := inst.Run(runCtx); err != nil {
 		cancel()
 

--- a/pkg/thresher/wake_internal_test.go
+++ b/pkg/thresher/wake_internal_test.go
@@ -951,6 +951,7 @@ type armHookHub struct {
 	onRegister func()
 	withdrawn  map[string]int // eDefID → successful withdrawals
 	registered int            // total successful arms
+	armErr     error          // when set, every persistent arm fails with it
 }
 
 // hookOnce installs a one-shot callback run at the start of the next arm.
@@ -983,9 +984,26 @@ func (h *armHookHub) RegisterEvent(
 
 // RegisterPersistentEvent counts the arms of the instance-STARTER path, which
 // is the one T-8 watches: a starter subscription is persistent by nature.
+// failArms makes every later starter arm fail, so a test can break the hub
+// under a RUNNING engine without racing the eventHub field.
+func (h *armHookHub) failArms(err error) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.armErr = err
+}
+
 func (h *armHookHub) RegisterPersistentEvent(
 	ep eventproc.EventProcessor, eDef flow.EventDefinition,
 ) error {
+	h.mu.Lock()
+	armErr := h.armErr
+	h.mu.Unlock()
+
+	if armErr != nil {
+		return armErr
+	}
+
 	err := h.EventHub.RegisterPersistentEvent(ep, eDef)
 	if err == nil {
 		h.mu.Lock()
@@ -1148,4 +1166,33 @@ func TestFailedSweepReleasesItsClaims(t *testing.T) {
 	require.False(t, th.registrations["k"][0].wired,
 		"a sweep that wired nothing must claim nothing")
 	th.m.Unlock()
+}
+
+// TestPromoteFailureSurfaces covers promote-on-removal's error path: removing
+// the latest version tears its starters off the hub and promotes the previous
+// one, and if THAT arm fails the caller must hear about it rather than be told
+// the unregister succeeded. The claim bookkeeping must not have moved either —
+// the promoted version is not wired, so a later attempt can still wire it.
+func TestPromoteFailureSurfaces(t *testing.T) {
+	th, hub, cancel := hookedWakeEngine(t, "engine-promote-fail")
+	defer cancel()
+
+	proc := msgStartProcess(t, "p-promote", "order placed")
+
+	_, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	v2, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	hub.failArms(errors.New("arm boom"))
+
+	require.ErrorContains(t, th.UnregisterVersion(v2), "arm boom",
+		"a failed promotion is the caller's error, not a silent half-removal")
+
+	th.m.Lock()
+	defer th.m.Unlock()
+
+	require.False(t, th.registrations[proc.ID()][0].wired,
+		"the version that could not be armed is not marked wired")
 }

--- a/pkg/thresher/wake_internal_test.go
+++ b/pkg/thresher/wake_internal_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/dr-dobermann/gobpm/internal/instance"
 
+	"github.com/dr-dobermann/gobpm/internal/eventproc"
 	"github.com/dr-dobermann/gobpm/internal/instance/checkpoint"
 	"github.com/dr-dobermann/gobpm/pkg/clock/clocktest"
 	gerrs "github.com/dr-dobermann/gobpm/pkg/errs"
@@ -937,4 +938,135 @@ func TestTwoTimerHoldsCoexist(t *testing.T) {
 	th.timerSvc.mu.Unlock()
 
 	require.Zero(t, remaining, "a released track leaves no deadline behind")
+}
+
+// armHookHub wraps the engine's hub so a test can drive something INTO the
+// middle of an arm — the only way to pin an interleaving deterministically
+// rather than hoping a goroutine race reproduces.
+type armHookHub struct {
+	eventproc.EventHub
+
+	mu         sync.Mutex
+	onRegister func()
+	withdrawn  map[string]int // eDefID → successful withdrawals
+}
+
+// hookOnce installs a one-shot callback run at the start of the next arm.
+func (h *armHookHub) hookOnce(fn func()) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.onRegister = fn
+}
+
+func (h *armHookHub) takeHook() func() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	fn := h.onRegister
+	h.onRegister = nil
+
+	return fn
+}
+
+func (h *armHookHub) RegisterEvent(
+	ep eventproc.EventProcessor, eDef flow.EventDefinition,
+) error {
+	if fn := h.takeHook(); fn != nil {
+		fn()
+	}
+
+	return h.EventHub.RegisterEvent(ep, eDef)
+}
+
+func (h *armHookHub) UnregisterEvent(
+	ep eventproc.EventProcessor, eDefID string,
+) error {
+	err := h.EventHub.UnregisterEvent(ep, eDefID)
+	if err == nil {
+		h.mu.Lock()
+		h.withdrawn[eDefID]++
+		h.mu.Unlock()
+	}
+
+	return err
+}
+
+func (h *armHookHub) withdrawals(eDefID string) int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.withdrawn[eDefID]
+}
+
+// hookedWakeEngine is armedWakeEngine with the hub wrapped BEFORE the engine
+// starts — the field is read by the running engine, so it may not be swapped
+// under it.
+func hookedWakeEngine(
+	t *testing.T, name string,
+) (*Thresher, *armHookHub, context.CancelFunc) {
+	t.Helper()
+
+	th, err := New(name,
+		WithoutBanner(), WithoutStartupConfig(),
+		WithRepository(memrepo.New()),
+		WithClock(clocktest.New(wakeEpoch)))
+	require.NoError(t, err)
+
+	hub := &armHookHub{EventHub: th.eventHub, withdrawn: map[string]int{}}
+	th.eventHub = hub
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, th.Run(ctx))
+
+	return th, hub, cancel
+}
+
+// TestReleaseWaitsDuringArmWithdrawsTheHold is FIX-036 T-4: a ReleaseWaits
+// landing in the MIDDLE of HoldSubscription must still leave the hub clean.
+//
+// The arm is two steps — record in t.subs, register on the hub — and a release
+// can land between them from either side. Arm-then-record loses the release
+// (it scans an empty map, withdraws nothing, and the record appears after it).
+// Record-then-arm alone lets the release find the record but unregister a
+// holder the hub does not know yet. Both end with a live subscription no track
+// waits on. Only recording first AND confirming after the arm closes it.
+func TestReleaseWaitsDuringArmWithdrawsTheHold(t *testing.T) {
+	th, hub, cancel := hookedWakeEngine(t, "engine-arm-race")
+	defer cancel()
+
+	sig := wakeSignalDef(t, "sig-mid-arm")
+
+	// the release fires while the registration is in flight.
+	hub.hookOnce(func() { th.ReleaseWaits("i-1", "t-1") })
+
+	require.NoError(t, th.HoldSubscription("i-1", "t-1", sig, nil, exec.WaitNode),
+		"the release is authoritative — a withdrawn hold is not a failed one")
+
+	th.subMu.Lock()
+	require.Empty(t, th.subs, "the released track holds nothing")
+	th.subMu.Unlock()
+
+	require.Equal(t, 1, hub.withdrawals(sig.ID()),
+		"the holder must actually leave the hub, not just the map")
+}
+
+// TestHoldSubscriptionRollsBackOnArmFailure pins the rollback half: if the hub
+// refuses the registration, nothing stays recorded — the record exists only to
+// make an ARMED hold releasable.
+func TestHoldSubscriptionRollsBackOnArmFailure(t *testing.T) {
+	th, err := New("engine-hold-rollback", WithoutBanner(),
+		WithoutStartupConfig(), WithRepository(memrepo.New()))
+	require.NoError(t, err)
+
+	// The engine is never Run, so RegisterEvent refuses: the hub is not
+	// started and the arm cannot succeed.
+	err = th.HoldSubscription("i-1", "t-1", wakeSignalDef(t, "sig-x"), nil,
+		exec.WaitNode)
+	require.Error(t, err)
+
+	th.subMu.Lock()
+	defer th.subMu.Unlock()
+
+	require.Empty(t, th.subs, "a hold that never armed must not stay recorded")
 }

--- a/pkg/thresher/wake_internal_test.go
+++ b/pkg/thresher/wake_internal_test.go
@@ -2,6 +2,7 @@ package thresher
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -949,6 +950,7 @@ type armHookHub struct {
 	mu         sync.Mutex
 	onRegister func()
 	withdrawn  map[string]int // eDefID → successful withdrawals
+	registered int            // total successful arms
 }
 
 // hookOnce installs a one-shot callback run at the start of the next arm.
@@ -977,6 +979,28 @@ func (h *armHookHub) RegisterEvent(
 	}
 
 	return h.EventHub.RegisterEvent(ep, eDef)
+}
+
+// RegisterPersistentEvent counts the arms of the instance-STARTER path, which
+// is the one T-8 watches: a starter subscription is persistent by nature.
+func (h *armHookHub) RegisterPersistentEvent(
+	ep eventproc.EventProcessor, eDef flow.EventDefinition,
+) error {
+	err := h.EventHub.RegisterPersistentEvent(ep, eDef)
+	if err == nil {
+		h.mu.Lock()
+		h.registered++
+		h.mu.Unlock()
+	}
+
+	return err
+}
+
+func (h *armHookHub) arms() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.registered
 }
 
 func (h *armHookHub) UnregisterEvent(
@@ -1069,4 +1093,59 @@ func TestHoldSubscriptionRollsBackOnArmFailure(t *testing.T) {
 	defer th.subMu.Unlock()
 
 	require.Empty(t, th.subs, "a hold that never armed must not stay recorded")
+}
+
+// TestStartersWiredExactlyOnce is FIX-036 T-8: a process registered while the
+// engine is running must reach the hub ONCE, no matter which of the two wiring
+// paths gets to it.
+//
+// RegisterProcess wires under the per-key lock when it sees a started engine;
+// Run's sweep wires the latest version of every key without that lock. Run
+// publishes Started BEFORE it sweeps, so a registration landing between the two
+// is visible to both, and both used to wire it — leaving two live subscriptions
+// on one event definition, so a single message spawned two instances.
+//
+// The interleaving is driven directly rather than raced: calling the sweep
+// after a live RegisterProcess is exactly the state that race produces, and the
+// sweep is idempotent by construction now.
+func TestStartersWiredExactlyOnce(t *testing.T) {
+	th, hub, cancel := hookedWakeEngine(t, "engine-wire-once")
+	defer cancel()
+
+	before := hub.arms()
+
+	_, err := th.RegisterProcess(msgStartProcess(t, "p-wire", "order placed"))
+	require.NoError(t, err)
+
+	wired := hub.arms() - before
+	require.Equal(t, 1, wired, "a live registration wires its starter itself")
+
+	require.NoError(t, th.registerAllStarters(),
+		"the sweep must succeed, having nothing left to do")
+	require.Equal(t, before+wired, hub.arms(),
+		"the sweep must not wire what RegisterProcess already wired")
+}
+
+// TestFailedSweepReleasesItsClaims pins the other half of the claim: a sweep
+// that cannot wire must hand every claim back. Run rolls the whole start back
+// on that failure, so a claim kept across it would make the RETRY find every
+// version already marked wired — an engine that starts cleanly with no
+// auto-start at all, which is worse than the double-wiring being prevented.
+func TestFailedSweepReleasesItsClaims(t *testing.T) {
+	th, err := New("engine-sweep-rollback", WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	th.registrations["k"] = []*ProcessRegistration{
+		{key: "k", id: "r1", version: 1, starters: []*instanceStarter{
+			mkStarter(t, "x"),
+		}},
+	}
+	th.eventHub = regFailHub{regErr: errors.New("subscribe boom")}
+
+	require.Error(t, th.registerAllStarters())
+
+	th.m.Lock()
+	require.False(t, th.registrations["k"][0].wired,
+		"a sweep that wired nothing must claim nothing")
+	th.m.Unlock()
 }


### PR DESCRIPTION
Remediates an external audit of `pkg/thresher`. The audit reported seven flags
and five edge cases; each was re-checked against `36d9751` before any code was
written. **Eight are real defects**, three are documented design and are
recorded in FIX-036 §7 so a later reader does not re-open them, and one is a
deliberate performance trade-off.

They are not one bug, but they are one *shape*: the engine's own bookkeeping —
its context, its reservations, its state — was maintained by convention, and
every place the convention was not machinery is a place it had already slipped.

## What an embedder can observe

Two of the eight are silent data-loss bugs, not merely leaks:

- **A repeat business key could never start a process again.** An event-started
  instance reserved its correlation key and nothing released it when the
  instance finished, so a later message carrying that key was answered "joined
  existing instance" and **dropped** — there was no instance to join. Order
  `ORD-42` handled today meant `ORD-42` could never start a process again.
- **A recovered conversation duplicated itself.** The mirror image, found while
  fixing the above and not in the audit: the reservation map is in-memory, so a
  conversation rebuilt from its checkpoint — a cold restart or a wake — came
  back **unreserved**, and the next message carrying its key started a duplicate
  beside it. The two halves are one defect seen from both ends: the
  reservation's lifetime was not tied to the conversation's.

The rest:

- **The engine context was written without synchronization** — `Run` assigned it
  with no lock while `Shutdown` read it under one, which is a data race, not
  synchronization. A `Shutdown` could cancel nothing and still report `Stopped`.
- **A held subscription could outlive its own release**, leaving a hub
  subscription registered forever that could still wake an instance for a wait
  nobody was waiting on.
- **A panic in the host's observability policy killed a business process** —
  both `FilterObservation` and `RedactLog` run on an instance's execution loop
  with no recover.
- **`Shutdown` left instances running** that were born between its snapshot and
  its cancel.
- **`UpdateState` bypassed the lifecycle ladder** — a host could put a never-run
  engine into `Started`, after which registrations were admitted to a hub that
  was never started.
- **Starter wiring could happen twice**, so one message spawned two instances.

## Approach

Every fix replaces a convention with machinery. Fields deliberately outside
`t.m` are now atomics, so "unguarded" and "unsafe" stop being the same shape.
The two maps with a lifecycle are reaped by the path that already exists for
reaping, and the correlation reservation additionally self-heals — a leak now
requires both mechanisms to fail. Host code called from inside the engine is
contained at both call sites, and `ObservationFilter` / `LogRedactor` now state
the obligations the implementation always relied on.

Three things the design document did not foresee, each surfaced by writing the
regression test rather than by reading the code (FIX-036 §8.2):

- **§1.4's prescribed ordering closes one side of the window and opens its
  mirror.** Recording before arming makes the hold visible to a concurrent
  release — which then unregisters a holder the hub does not know yet, after
  which the arm succeeds and the subscription is live with no record. The arm
  must also *confirm* it still owns the record. The doc-as-written version fails
  T-4 on "the holder must actually leave the hub, not just the map".
- **The observability defect has two entry points.** `LogRedactor` is the same
  interface family, off the same authorizer, on the same goroutine, with the
  same missing recover. Containing only the one the audit named would have left
  the identical crash reachable through the other.
- **The wiring flag needs a release as much as a claim.** `registerStarters` is
  all-or-nothing and `Run` rolls the whole start back on failure, so a claim
  kept across that rollback makes the retry wire *nothing* — an engine that
  starts cleanly with no auto-start at all, strictly worse than the
  double-wiring the flag prevents. An existing test caught it.

Both contained hooks **fall closed**: a panicking filter denies its recipient, a
panicking redactor suppresses the record. Treating a failed hook as
pass-through would make a crash in the policy code the one condition under which
the engine emits exactly what that policy exists to withhold.

## Behavioural changes

- **`Thresher.UpdateState` now validates the transition, not just the value.**
  It admits only `Started ↔ Paused` and refuses anything else with a classified
  `InvalidState` error naming both states. **A caller that used `UpdateState` to
  start an engine must call `Run`**; the pause/resume use is unaffected. In the
  CHANGELOG under Changed.
- `Shutdown` may wait marginally longer — it awaits instances it previously
  abandoned — bounded by the caller's context exactly as before.

Four pre-existing tests changed, each re-pinned rather than relaxed, with the
reasoning in FIX-036 §6. Three encoded the `UpdateState` defect as expected
behaviour. The fourth, `TestCorrelationDedup`, asserted the join rule using a
process that completed the instant it started, so its "existing instance" was
already gone; it now uses the parking process, which is what makes an instance
joinable at all. Joining a finished instance could never deliver the message
anywhere, so the old reservation did not preserve the join rule — it discarded
the message the rule exists to route.

## Verification

Twelve regression tests, T-1…T-8a (FIX-036 §4.1). Each was confirmed to **fail
with its fix reverted**, and the concurrency ones drive their interleaving
deterministically rather than hoping a goroutine race reproduces:

- **T-4** wraps the hub and fires `ReleaseWaits` from *inside* `RegisterEvent`,
  counting withdrawals at the hub — so it fails against **both** defective
  orderings, the old one and the record-only one.
- **T-7** replaces the engine's own published context/cancel pair with one whose
  cancel launches an instance first, putting the birth precisely in the window
  `Shutdown` used to miss.
- **T-8** counts arms at the hub rather than inferring them.

Two latent flakes were fixed on the way, both load-dependent and neither
introduced here. `TestCorrelationDedup` failed about one run in six once the
reservation change landed — a real contract reached through a racing test.
`TestRestartRecoveryBoundaryDeadline` failed once in a full parallel sweep
because engine-1, abandoned by lease rather than stopped, could fire its own
boundary and complete the instance before engine-2 recovered it.

`make ci` green end to end, verified by its own completion markers rather than
an exit code:

- `diff-coverage: 100.0% of 298 changed coverable lines (min 95%) — PASS`
- `No vulnerabilities found.` on every module
- `consumer-smoke ✓`, `linkcheck: every relative link resolves`, mock-check
  regenerated clean, `tidy` across all example modules, every example run
- no `*** [<target>] Error N` anywhere in the log

The only uncovered lines the change adds are three `if err != nil` propagations
at gated call sites that no caller can reach; the guard itself is pinned.

## Landing audit

`/check-srd` against the final commit: **0 🔴, 0 🟡**. All nine §3.2 changes
wired, all twelve §4.1 tests present and green, every line number in the
"Grounded in" header exact at `36d9751`, no downward ADR→FIX reference. The
audit's findings were all doc-side and are closed in this branch: §8 written,
the CHANGELOG entry added, `ADR-022` re-pinned v.1 → v.2 (the claim survives the
bump — v.2 §2.4 still reserves `Error` for engine-state failures and still
forbids a per-event record above `Debug`), three bare references pinned, and
§6's "only pre-existing test" sentence narrowed to "only asserted contract".

## Documents

- `docs/fix/FIX-036-thresher-lifecycle-races-and-reservations.md` — Accepted.
- No ADR or SAD changed: every fix realizes an existing contract rather than
  altering one.
