### PR TITLE
fix(thresher): the wake latch and two retained handles — FIX-037

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Iteration-counter race**: the loop decorators wrote the pass
   ordinal bare while the checkpoint capture read it under the track
   mutex.
+- **The wake latch discarded what it refused, and two retained handles were
+  never released** (FIX-037 — the first findings of the `/audit-package` sweep).
+  - **A message arriving during a timer wake was permanently lost.** The
+    single-flight latch told a second trigger that another wake was already in
+    flight, and that trigger returned `nil` — which the event hub and the timer
+    service both read as *delivered*. The in-flight wake carries its own
+    trigger and cannot deliver another's. An Event-Based Gateway arming a timer
+    and a message on one dehydrated instance is the ordinary shape that reached
+    it. A refused caller now waits for the in-flight wake and retries its own
+    delivery, and a trigger that cannot be delivered is reported rather than
+    dropped.
+  - **An operator's incident retry could start a second execution loop.**
+    `RetryIncident` on a parked instance rebuilt it without taking the latch —
+    the only rebuild path that did not. The durable claim does not compensate:
+    it retries a lost compare-and-swap rather than failing, so two concurrent
+    rebuilds both succeed and two goroutine loops run over one instance's state.
+  - **A task action racing a wake unbalanced the residency counter** and could
+    act on a still-dehydrated instance, surfacing a spurious failure.
+  - **Every dehydrate/rehydrate cycle leaked a context.** A rebuild replaced the
+    instance's registration and dropped the previous cancel without calling it,
+    so each cycle left a child attached to the engine context for the engine's
+    lifetime.
+  - **A cancelled timer wait could re-arm itself.** `HoldTimer` registered its
+    deadline blind, so a release landing mid-arm withdrew nothing and was
+    overtaken by the arm — leaving a deadline that later woke the instance for a
+    track that no longer existed.
 
 - **The engine's lifecycle bookkeeping: a data race, reservations with no
   owner, and host code with no containment** (FIX-036 — the remediation of an

--- a/docs/audit/package-audit-2026-08-08.md
+++ b/docs/audit/package-audit-2026-08-08.md
@@ -141,7 +141,8 @@ Both from the architecture lens alone — the other two lenses did not run.
 
 ## 6 Next actions
 
-1. **FIX-037** lands C-1…C-5 (in progress, branch `fix/wake-residency-races`).
+1. **FIX-037 has landed C-1…C-5** on branch `fix/wake-residency-races`
+   (`2afb305`, `a4af0de`, `55399d4`).
 2. **Re-run `internal/instance`** with four-or-more-way splitting; two thirds of
    the largest package in the engine is currently unaudited.
 3. **Verify §5 in unit-sized batches**, routing each to a FIX or to

--- a/docs/audit/package-audit-2026-08-08.md
+++ b/docs/audit/package-audit-2026-08-08.md
@@ -7,7 +7,9 @@ unit — architecture & contracts, correctness & concurrency, failure modes &
 testability. Findings are raw model output until verified against the source;
 this document records what verification found, including what it **refuted**.
 
-**Baseline:** `11a0321` (master, after FIX-036).
+**Baseline:** `11a0321` (master, after FIX-036). The remediation branch was
+later rebased onto `cdafd20` (SRD-082); none of the five confirmed findings had
+been fixed there, and none of §5's pending items were invalidated by it.
 
 **Why an external reviewer.** `/check-srd` asks whether the code matches its
 document and `/check-style` whether it matches the house rules. Both are the
@@ -142,7 +144,8 @@ Both from the architecture lens alone — the other two lenses did not run.
 ## 6 Next actions
 
 1. **FIX-037 has landed C-1…C-5** on branch `fix/wake-residency-races`
-   (`2afb305`, `a4af0de`, `55399d4`).
+   (`96fbffb`, `67a6b82`, `3a64fdb`, `d15191b`, `901ba11`), rebased onto
+   `cdafd20`.
 2. **Re-run `internal/instance`** with four-or-more-way splitting; two thirds of
    the largest package in the engine is currently unaudited.
 3. **Verify §5 in unit-sized batches**, routing each to a FIX or to

--- a/docs/audit/package-audit-2026-08-08.md
+++ b/docs/audit/package-audit-2026-08-08.md
@@ -1,0 +1,154 @@
+# Package audit — 2026-08-08
+
+**Method:** `/audit-package` — an external reviewer (Antigravity / `agy`,
+`gemini-3.1-pro-high`, `--effort high`) over whole packages, **doc-blind**: it
+was given non-test source and nothing else, no ADR, SRD or FIX. Three lenses per
+unit — architecture & contracts, correctness & concurrency, failure modes &
+testability. Findings are raw model output until verified against the source;
+this document records what verification found, including what it **refuted**.
+
+**Baseline:** `11a0321` (master, after FIX-036).
+
+**Why an external reviewer.** `/check-srd` asks whether the code matches its
+document and `/check-style` whether it matches the house rules. Both are the
+author checking the author. FIX-036 passed both at 0 red / 0 yellow with a green
+gate, and an external read still found a context leak in `Forget` the whole
+chain was structurally unable to look for. This sweep is that read, widened from
+a diff to whole packages.
+
+---
+
+## 1 Coverage — and one real gap
+
+| Unit | Non-test LOC | Lenses run | Raw findings |
+|---|---:|---|---:|
+| `pkg/thresher` | 5 971 | 3 / 3 | 16 |
+| `internal/scope` | 1 217 | 3 / 3 | 14 |
+| `internal/eventproc/eventhub` (+ `waiters`) | 2 132 | 3 / 3 | 9 |
+| `internal/instance` | 14 034 | **1 / 3** | 2 |
+| `pkg/model/activities` · `events` · `data` · `gateways` | 15 562 | maintainer audit | 0 confirmed |
+
+**`internal/instance` is under-covered and must be re-run.** At 584 KB of
+source the reviewer fell back to a shell command to page through the prompt,
+was auto-denied in headless mode, and returned `status: SUCCESS` with an **empty
+body**. Only the architecture lens completed. A naive collector reads that as a
+clean package; ours flags it. Splitting the unit in half (330 KB) did not help —
+it needs four or more parts, or a different feeding strategy.
+
+**The model packages were audited by the maintainer, not by `agy`**, on the
+reasoning that an external reviewer buys the most where the author's belief is
+strongest, and these are the packages the recent work barely touched. Four
+candidate defects were investigated and **all four were refuted** (§4).
+
+## 2 What the sweep is worth — read this before trusting a finding
+
+Two properties of the raw output matter more than any individual finding.
+
+**Line citations are unreliable; mechanisms often are not.** Five findings cite
+lines that cannot exist — `incident_ops.go:716` in a 44-line file,
+`recovery.go:2782` in a 198-line one, `observer.go:1791` in a 193-line one,
+`timer.go:1905` in a 537-line one, `handle.go:562` in a 357-line one. In at
+least one case the *same* defect was reported by another lens at the correct
+location (`incident_ops.go:24`), so the finding was real and the citation
+invented. Never route a finding by its line number; find the construct.
+
+**Three lenses duplicate.** `internal/scope`'s non-atomic `SnapshotAt` appears
+four times under three titles. Duplication across lenses is a signal of
+salience, not of three separate defects — dedupe before counting.
+
+Neither property is a reason to stop using the reviewer. Both are reasons the
+skill requires verification before a finding is allowed into this document.
+
+## 3 Confirmed — remediated by FIX-037
+
+Five findings verified against the source at `11a0321`. They reduce to two root
+causes and are addressed together in
+[FIX-037](../fix/FIX-037-wake-latch-and-retained-handles.md).
+
+| # | Sev | Construct | Confirmed defect |
+|---|---|---|---|
+| C-1 | blocker | `wake.go` `wakeInstance` | A lost `claimWake` returns `nil` and discards the `PendingTrigger`. The comment claims the in-flight wake will deliver it; that wake carries its own trigger and cannot. Callers read `nil` as success, so a message arriving during a timer wake is permanently lost. |
+| C-2 | blocker | `tasks.go` `hydrateForTask` | A lost `claimWake` returns `nil` having neither rebuilt nor pinned, while `residentForTask` documents that the instance "was built already pinned". `onTaskInstance` then unpins a pin it never took. |
+| C-3 | blocker | `incident_ops.go` `wakeForIncidentOp` | Rebuilds without taking the latch — the only rebuild path that does not. The repository CAS does not compensate: `claimForWake` **retries** a lost CAS, so two concurrent rebuilds both succeed and two live loops run over one instance. |
+| C-4 | major | `locked.go` `trackInstanceLocked` | Overwrites `instanceReg` and drops the previous `stop` without calling it, leaking one child context per dehydration cycle. The rebuild half of the defect FIX-036 §8.2 fixed in `Forget`. |
+| C-5 | blocker | `wake.go` `HoldTimer` | Arms `timerSvc.hold` with no confirm-after-arm, so a `ReleaseWaits` landing mid-arm leaves a zombie deadline. The timer half of the defect FIX-036 §1.4 fixed for subscriptions. |
+
+Two of the five are halves that FIX-036 left behind. That is the most useful
+thing this sweep produced: a landing that fixes a *shape* should be asked where
+else that shape occurs, and neither the FIX process nor the review gate asks it.
+
+## 4 Refuted — with reasons, so they are not re-investigated
+
+| Finding | Verdict |
+|---|---|
+| `Association.calculate` picks `SourcesIDs()[0]` from a map → nondeterministic source | **Refuted.** `asscConfig.Validate` (`data_options.go:184`) rejects `trans == nil && len(src) != 1`, so the no-transformation path has exactly one source and iteration order is irrelevant. |
+| `newAssociation` keys sources by ItemDefinition ID → two same-typed sources silently collapse | **Refuted.** `WithSource` (`data_options.go:158-165`) rejects a duplicate ItemDefinition ID at construction. |
+| `NewProperty` does not validate `item` / `state` | **Refuted.** Both are validated one level down in `NewItemAwareElement` (`item.go:187,194`); `state == nil` is a documented default, not an omission. |
+| `NewSignal` stores `str *ItemDefinition` unchecked | **Refuted.** A nil structure is legal for a BPMN Signal and is nil-checked at both consumers (`signal.go:122,138`). |
+| `pkg/model/data` bypasses `errs` classification in 42 places | **Refuted as a runtime defect.** The sites are model-construction paths, and the one runtime path (`Association.calculate`) is wrapped by `Value()` in a classified `errs.New` with `errs.E(err)`, so the class reaches the caller. Remains a stylistic inconsistency, not a defect. |
+
+`pkg/model/{activities,events,data,gateways}` came through with no confirmed
+defect. Complexity — and defects — cluster in `internal/`, not in the
+spec-grounded model layer.
+
+## 5 Pending verification
+
+The remaining findings are **unverified model output** and must not be treated
+as defects until checked. Recorded here so the next pass starts from the list
+rather than re-running the sweep. Deduplicated across lenses.
+
+### 5.1 `pkg/thresher`
+
+| Sev | Construct | Claim |
+|---|---|---|
+| blocker | `handle.go` `InstanceHandle.Cancel` | Cancelling a dehydrated instance has no effect and is lost on the next hydration |
+| blocker | `tasks.go` task authorization | The engine mutex is held across authorization, serialising task actions under load |
+| blocker | `thresher.go` task registry | Parked human tasks are in-memory only, so they are orphaned across a restart |
+| blocker/major | `thresher.go` `RegisterProcess` | A failed `registerStarters` after a successful `unregisterStarters` leaves the key with no starters, and the retry fails on the unwired version — bricking the key |
+| major | `observer.go` | Instance-scoped observers are orphaned when an instance dehydrates and rebuilds |
+| major | `locked.go` `UnregisterProcess` | Deletes snapshots that dehydrated instances still need in order to wake |
+| major | `recovery.go` `recoverOne` | A `Save` transport error is treated as a lost CAS, abandoning the instance |
+
+### 5.2 `internal/scope`
+
+| Sev | Construct | Claim |
+|---|---|---|
+| blocker | `scope.go` `SnapshotAt` | Not atomic — `namesFrom` then per-name `GetData`, each taking the lock separately; a concurrent `CloseScope` aborts or tears the snapshot |
+| blocker | `scope.go` | The plane mutex is held across a call into the host's `RuntimeVarsSupplier` |
+| major | `scope.go` `GetDataByID`, `frame.go` | Resolution by ItemDefinition ID iterates a map, so two variables of one type resolve non-deterministically |
+| major | `datapath.go` `NewDataPath` | Validates a trimmed path but stores the untrimmed one, so a padded path becomes a distinct map key and breaks `DropTail` |
+| major | `scope.go` `getData` | O(N) scan under the global mutex where the map key would serve |
+| major | `scope.go` `cloneDatum` | Type-switch on concrete `Clone` signatures — the shape behind the `Property`/`DataObject` bug fixed during SRD-079 |
+| minor | `frame.go` `Commit` | `outputs` and `puts` are appended without dedup, emitting an intermediate value that never durably existed |
+
+### 5.3 `internal/eventproc/eventhub`
+
+| Sev | Construct | Claim |
+|---|---|---|
+| blocker | `eventhub.go` | The hub lock is held across unbounded external operations, including `MessageBroker.Subscribe` |
+| blocker | `eventhub.go` | TOCTOU between waiter removal and concurrent registration orphans a registration |
+| blocker | `waiters/message.go` | A message that fails processing terminally halts a persistent instance-starter |
+| major | `waiters/timer.go` | Cancelled timers are retained until expiry; `time.After` in the loop retains stopped waiters; a delivery failure leaks the registry entry |
+
+### 5.4 `internal/instance`
+
+| Sev | Construct | Claim |
+|---|---|---|
+| blocker | `adhoc.go` | Double host resume when an Ad-Hoc completion condition fires with `CancelsRemaining` |
+| major | `activation.go` `guardEval` | The Complex Gateway guard opens a scope frame per evaluation and never discards it |
+
+Both from the architecture lens alone — the other two lenses did not run.
+
+## 6 Next actions
+
+1. **FIX-037** lands C-1…C-5 (in progress, branch `fix/wake-residency-races`).
+2. **Re-run `internal/instance`** with four-or-more-way splitting; two thirds of
+   the largest package in the engine is currently unaudited.
+3. **Verify §5 in unit-sized batches**, routing each to a FIX or to
+   `audit-backlog.md` — several §5 items (the in-memory task registry, snapshot
+   deletion vs dehydrated instances) change a contract and are backlog-track,
+   not defect-track.
+4. **Ask the shape question on every FIX.** Two of the five confirmed defects
+   were halves of FIX-036 left behind. Neither `/check-srd` nor `/pr-review`
+   asks "where else does this shape occur"; that question belongs in the FIX
+   template.

--- a/docs/fix/FIX-037-wake-latch-and-retained-handles.md
+++ b/docs/fix/FIX-037-wake-latch-and-retained-handles.md
@@ -1,0 +1,233 @@
+# FIX-037 — the wake latch loses what it refuses, and two retained handles are never released
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft.
+**Date:** 2026-08-08.
+**Author:** Ruslan Gabitov.
+**Branch:** `fix/wake-residency-races` — remediation of the first `/audit-package` sweep of `pkg/thresher` (2026-08-08).
+**Upstream:** [ADR-007 v.2.1](../design/ADR-007-in-memory-long-waits.md) §2.3 (dehydration & wake-on-trigger — the model whose latch this repairs), [ADR-033 v.3](../design/ADR-033-persistence-and-state.md) §2.8 (the incarnation fence, which does NOT fence an in-process duplicate), [ADR-020 v.3](../design/ADR-020-human-interaction-execution-model.md) §2.1.1 (the residency a task action requires).
+
+**Grounded in (internal artifacts, verified at `11a0321`):**
+- `pkg/thresher/wake.go:93-97` — `wakeInstance` returns `nil` on a lost `claimWake`, discarding `pending`.
+- `pkg/thresher/tasks.go:602-609` — `hydrateForTask` returns `nil` on a lost `claimWake`, having neither rebuilt nor pinned.
+- `pkg/thresher/tasks.go:564-598` — `residentForTask` documents "it was built already pinned"; `:513-520` — `onTaskInstance` unconditionally `UnpinResident()`s.
+- `pkg/thresher/incident_ops.go:23-25` — `wakeForIncidentOp` calls `rebuildAndContinue` with **no** `claimWake`; the only two callers of `claimWake` are `wake.go:93` and `tasks.go:603`.
+- `pkg/thresher/wake.go:263-289` — `claimForWake` **retries** on a lost CAS (`continue // the record moved under us`), so a repository claim does not serialise two rebuilds; it only orders them.
+- `pkg/thresher/locked.go:492-496` — `trackInstanceLocked` overwrites `instanceReg`, dropping the previous `stop` without calling it.
+- `pkg/thresher/wake.go:25-47` — `HoldTimer` arms `timerSvc.hold` with no confirm, unlike `HoldSubscription` (`subscription_holder.go`, FIX-036 §3.2.4).
+
+---
+
+## 1 Symptoms
+
+Found by the first `/audit-package` run — an external reviewer (Antigravity /
+`agy`, `gemini-3.1-pro-high`) over the whole package, doc-blind. Five findings
+survived verification against the source. They are not five bugs; they are two.
+
+### 1.1 A refused wake silently discards its trigger
+
+```go
+// wake.go:93-97
+if !t.claimWake(instanceID) {
+    // another wake is already hydrating this instance — it will deliver
+    // the trigger into the soon-resident loop; nothing to do here (§4.6).
+    return nil
+}
+```
+
+The comment is false. The concurrent wake carries **its own** `PendingTrigger`
+— the one it was called with. It has no access to this goroutine's trigger and
+cannot deliver it. `wakeInstance` returns `nil`, which its callers read as
+success: `wakeFromSubscription` reports nothing, and the timer service treats a
+`nil` as delivered and drops the deadline. The event is **permanently lost**.
+
+An Event-Based Gateway arming a timer and a message on one dehydrated instance
+is the ordinary shape that reaches this: the timer fires and claims; the message
+arrives, is refused, and is dropped.
+
+### 1.2 A refused task hydration returns an unpinned instance
+
+```go
+// tasks.go:602-606
+func (t *Thresher) hydrateForTask(instanceID string) error {
+    if !t.claimWake(instanceID) {
+        return nil // another wake is already rebuilding it
+    }
+```
+
+`residentForTask` treats that `nil` as "the rebuild happened", and says so:
+
+```go
+// tasks.go:580-582
+// the rebuild re-registered the instance — resolve it afresh. It was built
+// already pinned, so it cannot have released in between.
+```
+
+On this path no rebuild happened and **no pin was taken**. `onTaskInstance`
+(`:520`) then unconditionally calls `inst.UnpinResident()`, decrementing a
+counter this call never incremented. The instance may also still be
+`Dehydrated`, so the action fast-fails and burns its retries.
+
+### 1.3 An incident operation rebuilds without claiming
+
+`wakeForIncidentOp` (`incident_ops.go:23`) calls `rebuildAndContinue` directly.
+It is the only rebuild path that does not take the latch — `grep` shows exactly
+two `claimWake` callers, and this is not one.
+
+The repository claim does not save it. `claimForWake` **retries** a lost CAS
+(`wake.go:285-289`) rather than failing, so two concurrent rebuilds both
+succeed, at incarnation+1 and incarnation+2. `claimWake` is the *only* thing
+preventing two live `Instance` objects for one id, and this path skips it: an
+operator's `RetryIncident` racing a timer wake starts a second execution loop
+over the same state.
+
+### 1.4 `trackInstanceLocked` drops the previous context-cancel
+
+```go
+// locked.go:492-496
+t.instances[inst.ID()] = instanceReg{
+    stop:   cancel,
+    inst:   inst,
+    handle: h,
+}
+```
+
+Every rebuild derives a fresh child context from the engine's and stores its
+cancel here, overwriting the previous one **without calling it**. The old child
+stays attached to the engine context's children for the engine's lifetime.
+
+This is the same defect FIX-036 §8.2 fixed in `Forget`, reached by the other
+path: that landing made `Forget` call the retained cancel and did not notice
+that the *rebuild* path discards one on every dehydration cycle. A long-lived
+instance that parks and wakes repeatedly leaks one context per cycle, which is
+the worse of the two.
+
+### 1.5 `HoldTimer` arms without confirming, as `HoldSubscription` used to
+
+```go
+// wake.go:36-45
+if t.timerSvc == nil { … }
+
+t.timerSvc.hold(timerHold{…})
+
+return nil
+```
+
+`ReleaseWaits` releases the timer first (`subscription_holder.go`), then the
+subscriptions. A `ReleaseWaits` that runs between this method's entry and its
+`hold` finds no deadline to remove, and the `hold` that follows registers one
+for a wait that has been cancelled — a zombie deadline that later wakes the
+instance for a track that is gone.
+
+FIX-036 §1.4 identified precisely this shape for subscriptions and gave
+`HoldSubscription` a record→arm→**confirm**. The timer half was not examined.
+
+## 2 Root cause analysis
+
+**A try-lock used where a barrier is needed.** §1.1, §1.2 and §1.3 are one
+cause. `claimWake` answers "is a wake in flight?" and every caller treats
+`false` as "then my work is already being done by someone else" — which is true
+of *rebuilding the instance* and false of *everything the caller was carrying*:
+a trigger, a residency pin, an operator's operation. The latch protects the
+shared resource correctly and silently discards the caller's payload. A refused
+claim needs to mean **wait, then do your own part**, not **give up and report
+success**.
+
+**A retained handle nobody is required to release.** §1.4 and §1.5 are the
+other. `instanceReg.stop` and a `timerSvc` deadline are both handles taken on
+behalf of something with a lifetime, and in both cases the code that ends that
+lifetime is not the code that took the handle. FIX-036 §8.2 fixed one instance
+of this and the pattern remained.
+
+## 3 Solution
+
+### 3.1 Alternatives considered
+
+| # | Decision | Alternatives | Chosen |
+|---|---|---|---|
+| 1 | §1.1–1.3 the latch | (a) hand the trigger to the in-flight wake (a queue per instance) — the winner must then own delivery for waits it knows nothing about, and the queue needs its own lifecycle; (b) make the latch **waitable**: a loser blocks until the winner finishes, then retries its own path against the now-resident instance | **(b)** — the retry is already written (the resident path at `wake.go:81-91`), each caller keeps ownership of its own payload, and no new lifetime is introduced |
+| 2 | §1.3 the incident path | (a) leave it and rely on the repository CAS — refuted in §1.3: `claimForWake` retries, so the CAS orders but does not exclude; (b) take the same waitable latch | **(b)** |
+| 3 | §1.4 the cancel | (a) cancel the old context inside `trackInstanceLocked` — runs a cancel under `t.m`, the forbidden shape; (b) return the displaced cancel to the caller and let it run outside the lock, exactly as `Forget` does since FIX-036 §8.2 | **(b)** |
+| 4 | §1.5 the timer | (a) mirror `HoldSubscription`'s confirm — needs a record of the hold outside `timerSvc` to confirm against, duplicating the service's own bookkeeping; (b) an **epoch per (instance, track)** in `timerSvc`: `ReleaseWaits` bumps it, and a `hold` carrying a stale epoch is refused | **(b)** — the service already owns this state, and the epoch makes the refusal total-ordered rather than a re-check |
+
+### 3.2 Changes by file
+
+#### 3.2.1 `pkg/thresher/wake.go` — the latch becomes waitable
+
+`claimWake` gains a companion that blocks until an in-flight wake completes.
+A refused claimant waits, then retries its own path rather than returning.
+`wakeInstance` re-enters its resident delivery (`WakeParkedTrack`) with the
+trigger it still holds; if the instance parked again in between, it re-claims.
+The retry is bounded so a pathological wake storm cannot spin.
+
+#### 3.2.2 `pkg/thresher/tasks.go` — a refused hydration waits, then pins
+
+`hydrateForTask` waits for the in-flight rebuild and then takes its own
+residency pin, so `residentForTask`'s documented invariant ("it was built
+already pinned") becomes true on every path rather than one. `onTaskInstance`'s
+unconditional `UnpinResident` is then correct as written.
+
+#### 3.2.3 `pkg/thresher/incident_ops.go` — the incident path claims like the rest
+
+`wakeForIncidentOp` takes the latch before `rebuildAndContinue`, so the operator
+path cannot start a second loop beside a timer wake.
+
+#### 3.2.4 `pkg/thresher/locked.go` — the displaced cancel is returned, not dropped
+
+`trackInstanceLocked` returns the `stop` it displaced along with the handle; the
+caller runs it after the lock is released. A first registration returns nil and
+the caller does nothing.
+
+#### 3.2.5 `pkg/thresher/timer_service.go` — a hold carries an epoch
+
+`release` bumps the (instance, track) epoch; `hold` records the epoch it was
+issued under and is refused if the epoch has moved. A refused hold is not an
+error — the wait it belonged to is gone.
+
+## 4 Verification
+
+### 4.1 Regression tests
+
+| # | Test | Asserts |
+|---|---|---|
+| T-1 | `TestRefusedWakeStillDeliversItsTrigger` | a second trigger arriving while a wake is in flight is delivered, not dropped — the instance observes both (§1.1) |
+| T-2 | `TestRefusedTaskHydrationPinsBeforeReturning` | a task action racing a wake gets a pinned, resident instance; the residency counter is balanced after `UnpinResident` (§1.2) |
+| T-3 | `TestIncidentOpDoesNotDuplicateTheLoop` | an incident op racing a timer wake produces exactly one live instance for the id (§1.3) |
+| T-4 | `TestRebuildReleasesThePreviousContext` | a dehydrate→rehydrate cycle cancels the displaced context; N cycles leave no accumulation (§1.4) |
+| T-5 | `TestReleaseWaitsDuringHoldTimerRefusesTheArm` | a `ReleaseWaits` driven into the middle of `HoldTimer` leaves no deadline registered (§1.5) |
+
+### 4.2 Gate
+
+`make ci` green end to end, `-race` included; diff-coverage ≥95% on the touched
+lines (`COVER_MIN`).
+
+## 5 Prevention
+
+- The wake latch's contract is stated where it is defined: refusing a claim
+  transfers responsibility for **the instance**, never for the caller's payload.
+- Every handle the engine retains on behalf of a lifetime (`instanceReg.stop`, a
+  `timerSvc` deadline) is released by the code that ends that lifetime, and the
+  two paths that end an instance's — `Forget` and the rebuild — now both do.
+
+## 6 Regressions and side effects
+
+- A refused wake now **blocks** briefly instead of returning immediately. It is
+  bounded by the in-flight rebuild it waits on, and that rebuild is already on
+  the caller's critical path in the common (uncontended) case.
+- `trackInstanceLocked`'s signature changes; it is package-private.
+
+## 7 Related
+
+[FIX-036](FIX-036-thresher-lifecycle-races-and-reservations.md) — §1.4 fixed the
+subscription half of §1.5 here and left the timer half; §8.2 fixed the `Forget`
+half of §1.4 here and left the rebuild half. This document is the other half of
+both, which is why it exists as its own FIX rather than an amendment: FIX-036 is
+merged.
+
+## 8 Implementation summary
+
+_To be filled after the milestones land._
+
+## 9 Open questions
+
+None.

--- a/docs/fix/FIX-037-wake-latch-and-retained-handles.md
+++ b/docs/fix/FIX-037-wake-latch-and-retained-handles.md
@@ -1,7 +1,7 @@
 # FIX-037 — the wake latch loses what it refuses, and two retained handles are never released
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft.
+**Status:** Accepted.
 **Date:** 2026-08-08.
 **Author:** Ruslan Gabitov.
 **Branch:** `fix/wake-residency-races` — remediation of the first `/audit-package` sweep of `pkg/thresher` (2026-08-08).

--- a/docs/fix/FIX-037-wake-latch-and-retained-handles.md
+++ b/docs/fix/FIX-037-wake-latch-and-retained-handles.md
@@ -250,10 +250,15 @@ merged.
 
 | # | Commit | Scope |
 |---|---|---|
-| — | `982ef34` | this document and the 2026-08-08 package audit |
-| M1 | `2afb305` | §1.4 — `trackInstanceLocked` returns the cancel it displaces (§3.2.4) |
-| M2 | `a4af0de` | §1.5 — an arm is announced before it is built (§3.2.5) |
-| M3 | `55399d4` | §1.1–1.3 — the waitable latch and its three callers (§3.2.1–3.2.3) |
+| — | `b7fad7b` | this document and the 2026-08-08 package audit |
+| M1 | `96fbffb` | §1.4 — `trackInstanceLocked` returns the cancel it displaces (§3.2.4) |
+| M2 | `67a6b82` | §1.5 — an arm is announced before it is built (§3.2.5) |
+| M3 | `3a64fdb` | §1.1–1.3 — the waitable latch and its three callers (§3.2.1–3.2.3) |
+| M4 | `d15191b` | one `awaitClaim` for every rebuild path; the branches the fix adds, covered |
+| M5 | `901ba11` | the gate re-earned on master's new base after the rebase |
+
+The branch was rebased onto `cdafd20` (SRD-082 — composite checkpoint fidelity)
+partway through, so these are the post-rebase hashes.
 
 M3 and M4 of the planned four landed together: they are one root cause reached
 through three callers, and the latch's signature change touches all three at
@@ -296,7 +301,21 @@ a rebuild path takes the latch.
 observable: the invariant §1.2 breaks could not be asserted from `pkg/thresher`
 at all, which is why the original test could only check that it unblocked.
 
-Final: `diff-coverage: 96.5% of 113 changed coverable lines (min 95%) — PASS`.
+Then the rebase onto `cdafd20` changed the diff's shape and the gate had to be
+re-earned: `internal/instance/instance.go` read 0/2, because `ResidentPins` is
+called only from `pkg/thresher`'s tests and Go instruments the package under
+test. It gets a test in its own package.
+
+Final, on the rebased base: `diff-coverage: 95.8% of 118 changed coverable
+lines (min 95%) — PASS`, no vulnerabilities, no error markers, exit 0.
+
+**Two branches are not covered end to end, and this is not a waiver.**
+`HoldTimer`'s refused-arm branch and `awaitClaim`'s exhaustion return each need
+an interleaving that cannot be scheduled deterministically — a release landing
+inside `HoldTimer`'s own arm, and three consecutive lost claims. Both are pinned
+where they can be: the refusal report directly, the service-level interleaving
+by T-5, and the delivery bound by driving the attempt counter. A flaky race test
+would assert less than it appears to, which is the defect §1.2 came from.
 
 ## 9 Open questions
 

--- a/docs/fix/FIX-037-wake-latch-and-retained-handles.md
+++ b/docs/fix/FIX-037-wake-latch-and-retained-handles.md
@@ -172,6 +172,11 @@ unconditional `UnpinResident` is then correct as written.
 `wakeForIncidentOp` takes the latch before `rebuildAndContinue`, so the operator
 path cannot start a second loop beside a timer wake.
 
+Both go through **one** helper, `awaitClaim` (`wake.go`): claim, and on a loss
+wait for the in-flight wake and retry, bounded, refusing when the engine stops.
+Writing it twice was how §1.3 happened in the first place — the third rebuild
+path simply never grew the code the other two had.
+
 #### 3.2.4 `pkg/thresher/locked.go` — the displaced cancel is returned, not dropped
 
 `trackInstanceLocked` returns the `stop` it displaced along with the handle; the
@@ -205,9 +210,9 @@ which the defect could return.
 
 | # | Test | Asserts |
 |---|---|---|
-| T-1 | `TestRefusedWakeStillDeliversItsTrigger` | a second trigger arriving while a wake is in flight is delivered, not dropped — the instance observes both (§1.1) |
-| T-2 | `TestRefusedTaskHydrationPinsBeforeReturning` | a task action racing a wake gets a pinned, resident instance; the residency counter is balanced after `UnpinResident` (§1.2) |
-| T-3 | `TestIncidentOpDoesNotDuplicateTheLoop` | an incident op racing a timer wake produces exactly one live instance for the id (§1.3) |
+| T-1 | `TestWakeSingleFlightWaitsThenRetries` | a second trigger arriving while a wake is in flight is delivered, not dropped — the instance observes both (§1.1) |
+| T-2 | `TestHydrateForTaskWaitsForAnInFlightWake` | a task action racing a wake gets a pinned, resident instance; the residency counter is balanced after `UnpinResident` (§1.2) |
+| T-3 | `TestIncidentOpTakesTheWakeLatch` | an incident op racing a timer wake produces exactly one live instance for the id (§1.3) |
 | T-4 | `TestRebuildReleasesThePreviousContext` | a dehydrate→rehydrate cycle cancels the displaced context; N cycles leave no accumulation (§1.4) |
 | T-5 | `TestReleaseWaitsDuringHoldTimerRefusesTheArm` | a `ReleaseWaits` driven into the middle of `HoldTimer` leaves no deadline registered (§1.5) |
 
@@ -241,7 +246,57 @@ merged.
 
 ## 8 Implementation summary
 
-_To be filled after the milestones land._
+### 8.1 Milestones
+
+| # | Commit | Scope |
+|---|---|---|
+| — | `982ef34` | this document and the 2026-08-08 package audit |
+| M1 | `2afb305` | §1.4 — `trackInstanceLocked` returns the cancel it displaces (§3.2.4) |
+| M2 | `a4af0de` | §1.5 — an arm is announced before it is built (§3.2.5) |
+| M3 | `55399d4` | §1.1–1.3 — the waitable latch and its three callers (§3.2.1–3.2.3) |
+
+M3 and M4 of the planned four landed together: they are one root cause reached
+through three callers, and the latch's signature change touches all three at
+once — splitting them would have left the tree uncompilable between commits.
+
+### 8.2 What the implementation added to the design
+
+- **§3.2.5's epoch became an in-flight token.** An epoch keyed by
+  (instance, track) is never emptied, so it grows for every track the engine has
+  ever run — the §1.4 leak class, reintroduced by the §1.5 remedy. A token keyed
+  by the arming *call* lives only for the duration of one `HoldTimer`. The
+  window closed is identical; §3.1 #4 and §3.2.5 are amended.
+- **Three existing tests asserted the defective contract.**
+  `TestWakeSingleFlightRefusesSecond` documented §1.1 as intended behaviour ("a
+  no-op (it will ride the resident loop)"), and its task counterpart did the
+  same for the pin. Both are re-pinned to the corrected contract rather than
+  relaxed. A defect that a test asserts is a defect the test will defend.
+- **A refused arm and an exhausted retry differ.** A `HoldTimer` refused by a
+  concurrent release is a success — the wait is gone, nothing to hold. A trigger
+  that exhausts `wakeDeliverAttempts` is an error, reported loudly. Both used to
+  be `nil`, which is what made §1.1 invisible.
+
+### 8.3 Gate
+
+The first full run at `55399d4` **failed**: diff-coverage 78.2% against a 95%
+floor. The uncovered lines were the branches this fix exists to create — most
+importantly `hydrateForTask`'s pin path, the actual remedy for §1.2, which the
+first T-2 never asserted (it checked only that the call unblocked). A test that
+asserts less than it appears to is the failure mode §1.2 itself came from.
+
+Closing it produced a better shape than more tests would have. `hydrateForTask`
+and `wakeForIncidentOp` had each hand-rolled the same wait-then-claim loop;
+both now call one `awaitClaim` helper, which is the reusable form of "I need to
+rebuild this instance and someone else may be rebuilding it right now". The
+duplication and the coverage gap went together — `incident_ops.go` and
+`tasks.go` are at 100% of changed lines, and there is now a single place where
+a rebuild path takes the latch.
+
+`Instance.ResidentPins` was added (internal package) so the pin BALANCE is
+observable: the invariant §1.2 breaks could not be asserted from `pkg/thresher`
+at all, which is why the original test could only check that it unblocked.
+
+Final: `diff-coverage: 96.5% of 113 changed coverable lines (min 95%) — PASS`.
 
 ## 9 Open questions
 

--- a/docs/fix/FIX-037-wake-latch-and-retained-handles.md
+++ b/docs/fix/FIX-037-wake-latch-and-retained-handles.md
@@ -148,7 +148,7 @@ of this and the pattern remained.
 | 1 | §1.1–1.3 the latch | (a) hand the trigger to the in-flight wake (a queue per instance) — the winner must then own delivery for waits it knows nothing about, and the queue needs its own lifecycle; (b) make the latch **waitable**: a loser blocks until the winner finishes, then retries its own path against the now-resident instance | **(b)** — the retry is already written (the resident path at `wake.go:81-91`), each caller keeps ownership of its own payload, and no new lifetime is introduced |
 | 2 | §1.3 the incident path | (a) leave it and rely on the repository CAS — refuted in §1.3: `claimForWake` retries, so the CAS orders but does not exclude; (b) take the same waitable latch | **(b)** |
 | 3 | §1.4 the cancel | (a) cancel the old context inside `trackInstanceLocked` — runs a cancel under `t.m`, the forbidden shape; (b) return the displaced cancel to the caller and let it run outside the lock, exactly as `Forget` does since FIX-036 §8.2 | **(b)** |
-| 4 | §1.5 the timer | (a) mirror `HoldSubscription`'s confirm — needs a record of the hold outside `timerSvc` to confirm against, duplicating the service's own bookkeeping; (b) an **epoch per (instance, track)** in `timerSvc`: `ReleaseWaits` bumps it, and a `hold` carrying a stale epoch is refused | **(b)** — the service already owns this state, and the epoch makes the refusal total-ordered rather than a re-check |
+| 4 | §1.5 the timer | (a) mirror `HoldSubscription`'s confirm — needs a record of the hold outside `timerSvc` to confirm against, duplicating the service's own bookkeeping; (b) an **epoch per (instance, track)** in `timerSvc` — correct, but the map is keyed by track and never emptied, so it grows for the engine's lifetime: the §1.4 leak class reintroduced by the §1.5 remedy; (c) an **in-flight arming token**: `beginArm` announces, `hold` refuses a token a `release` has dropped | **(c)** — the same window as (b), with a map bounded by concurrent arms instead of by every track ever run |
 
 ### 3.2 Changes by file
 
@@ -178,11 +178,26 @@ path cannot start a second loop beside a timer wake.
 caller runs it after the lock is released. A first registration returns nil and
 the caller does nothing.
 
-#### 3.2.5 `pkg/thresher/timer_service.go` — a hold carries an epoch
+#### 3.2.5 `pkg/thresher/timer_service.go` — an arm is announced before it is built
 
-`release` bumps the (instance, track) epoch; `hold` records the epoch it was
-issued under and is refused if the epoch has moved. A refused hold is not an
-error — the wait it belonged to is gone.
+`beginArm` registers an in-flight token for the track and returns it; `hold`
+refuses a token that is no longer live; `release` drops the tokens of every arm
+in flight for that track. A refused hold is not an error — the wait it belonged
+to is gone — so `HoldTimer` logs it at `Debug` and returns nil, exactly as a
+withdrawn subscription hold reports success.
+
+**This replaces the epoch-per-(instance, track) design this section first
+specified.** An epoch map is keyed by track and never emptied, so it grows for
+every track the engine has ever run — the precise leak class §1.4 is about,
+reintroduced by the remedy for §1.5. A token keyed by the *arming call* lives
+only for the duration of one `HoldTimer`, so the map is bounded by concurrent
+arms rather than by history. The window closed is identical: §1.5 is about a
+release landing "between this method's entry and its `hold`", which is exactly
+the span a token covers.
+
+The four existing test call sites move to the token form rather than gaining a
+blind convenience wrapper — one protocol, and no second entry point through
+which the defect could return.
 
 ## 4 Verification
 

--- a/internal/instance/dehydration_test.go
+++ b/internal/instance/dehydration_test.go
@@ -1331,3 +1331,25 @@ func TestHoldTaskDeclinedStaysResident(t *testing.T) {
 		"no holder registry — the wait stays resident")
 	require.False(t, tr.holdTask(tr.currentStep().node))
 }
+
+// TestResidentPinsCounts pins the accessor the engine's tests use to assert the
+// pin BALANCE (FIX-037 §1.2): a caller that takes a pin must hand back exactly
+// one, and a path that returns without pinning while its caller unpins
+// unconditionally drives this below zero. Without an accessor that invariant
+// could not be asserted from pkg/thresher at all, so the test that should have
+// caught the defect could only check that the call returned.
+func TestResidentPinsCounts(t *testing.T) {
+	inst := &Instance{}
+
+	require.Zero(t, inst.ResidentPins(), "a fresh instance holds no pins")
+
+	inst.PinResident()
+	inst.PinResident()
+	require.EqualValues(t, 2, inst.ResidentPins(), "pins nest")
+
+	inst.UnpinResident()
+	require.EqualValues(t, 1, inst.ResidentPins())
+
+	inst.UnpinResident()
+	require.Zero(t, inst.ResidentPins(), "a balanced pair leaves nothing held")
+}

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -239,6 +239,15 @@ func (inst *Instance) UnpinResident() {
 	inst.dehydrationPins.Add(-1)
 }
 
+// ResidentPins reports how many interactions are currently holding the instance
+// in memory. It exists so the engine's own tests can assert the pin BALANCE:
+// every caller that takes a pin must hand back exactly one, and a path that
+// returns without pinning while its caller unpins unconditionally underflows
+// this counter (FIX-037 §1.2).
+func (inst *Instance) ResidentPins() int32 {
+	return inst.dehydrationPins.Load()
+}
+
 // pinnedResident reports whether an interaction is holding the instance in
 // memory.
 func (inst *Instance) pinnedResident() bool {

--- a/pkg/thresher/incident_ops.go
+++ b/pkg/thresher/incident_ops.go
@@ -27,22 +27,8 @@ func (t *Thresher) wakeForIncidentOp(
 	// concurrent rebuilds both succeed at successive incarnations (FIX-037
 	// §1.3). Without this an operator's retry racing a timer wake started a
 	// second execution loop over the same state.
-	done, claimed := t.claimWake(h.ID())
-	if !claimed {
-		if !t.awaitWake(done) {
-			return t.errEngineNotRunning("wakeForIncidentOp")
-		}
-
-		// the in-flight wake rebuilt it; claim the rebuild this op needs.
-		done, claimed = t.claimWake(h.ID())
-		if !claimed {
-			_ = t.awaitWake(done)
-
-			return errs.New(
-				errs.M("incident op: instance %q is being woken concurrently",
-					h.ID()),
-				errs.C(errorClass, errs.OperationFailed))
-		}
+	if err := t.awaitClaim(h.ID(), "wakeForIncidentOp"); err != nil {
+		return err
 	}
 
 	defer t.releaseWake(h.ID())

--- a/pkg/thresher/incident_ops.go
+++ b/pkg/thresher/incident_ops.go
@@ -21,6 +21,32 @@ func (t *Thresher) wakeForIncidentOp(
 ) error {
 	resp := make(chan error, 1)
 
+	// Take the wake latch like every other rebuild path. It is the ONLY thing
+	// preventing two live loops over one instance: the repository claim does
+	// not exclude, it orders — claimForWake RETRIES a lost CAS, so two
+	// concurrent rebuilds both succeed at successive incarnations (FIX-037
+	// §1.3). Without this an operator's retry racing a timer wake started a
+	// second execution loop over the same state.
+	done, claimed := t.claimWake(h.ID())
+	if !claimed {
+		if !t.awaitWake(done) {
+			return t.errEngineNotRunning("wakeForIncidentOp")
+		}
+
+		// the in-flight wake rebuilt it; claim the rebuild this op needs.
+		done, claimed = t.claimWake(h.ID())
+		if !claimed {
+			_ = t.awaitWake(done)
+
+			return errs.New(
+				errs.M("incident op: instance %q is being woken concurrently",
+					h.ID()),
+				errs.C(errorClass, errs.OperationFailed))
+		}
+	}
+
+	defer t.releaseWake(h.ID())
+
 	if err := t.rebuildAndContinue(h.ID(), nil,
 		instance.WithPendingIncidentOp(op, incidentID, resp)); err != nil {
 		return errs.New(

--- a/pkg/thresher/invoker.go
+++ b/pkg/thresher/invoker.go
@@ -94,7 +94,8 @@ func (t *Thresher) InvokeProcess(
 			errs.C(errorClass, errs.OperationFailed), errs.E(err))
 	}
 
-	t.trackInstanceLocked(inst, cancel, settled)
+	_, displaced := t.trackInstanceLocked(inst, cancel, settled)
+	stopDisplaced(displaced)
 
 	return &childProcess{inst: inst, settled: settled, version: resolved}, nil
 }

--- a/pkg/thresher/locked.go
+++ b/pkg/thresher/locked.go
@@ -474,11 +474,21 @@ func (t *Thresher) settledFor(instanceID string) chan struct{} {
 	return ch
 }
 
+// trackInstanceLocked records a launched instance with its cancel and its
+// read-only handle, returning the handle AND the cancel it displaced.
+//
+// The displaced cancel belongs to the PREVIOUS incarnation's context, and the
+// caller must run it once the lock is released (FIX-037 §1.4). Dropping it
+// leaves that child attached to the engine context's children for the engine's
+// whole lifetime, and a dehydrating instance replaces its registration on every
+// wake — so the leak is per cycle, not per instance. It is returned rather than
+// canceled here because canceling under t.m is the shape this file exists to
+// forbid. A first registration displaces nothing and returns nil.
 func (t *Thresher) trackInstanceLocked(
 	inst *instance.Instance,
 	cancel context.CancelFunc,
 	settled chan struct{},
-) *InstanceHandle {
+) (*InstanceHandle, context.CancelFunc) {
 	t.m.Lock()
 	defer t.m.Unlock()
 
@@ -489,11 +499,21 @@ func (t *Thresher) trackInstanceLocked(
 	h := t.handleForLocked(inst.ID(), settled)
 	h.adopt(inst)
 
+	displaced := t.instances[inst.ID()].stop
+
 	t.instances[inst.ID()] = instanceReg{
 		stop:   cancel,
 		inst:   inst,
 		handle: h,
 	}
 
-	return h
+	return h, displaced
+}
+
+// stopDisplaced runs the cancel trackInstanceLocked displaced, if any. Always
+// call it OUTSIDE t.m.
+func stopDisplaced(displaced context.CancelFunc) {
+	if displaced != nil {
+		displaced()
+	}
 }

--- a/pkg/thresher/locked.go
+++ b/pkg/thresher/locked.go
@@ -439,9 +439,6 @@ func (t *Thresher) snapshotForVersionLocked(
 	return nil
 }
 
-// trackInstanceLocked records a launched instance with its cancel func and a
-// fresh read-only handle in the instances map, returning the handle. Shared by
-// launchInstance and launchInstanceFromEvent.
 // handleForLocked returns the handle for an instance id, minting one (with its
 // per-ID terminal signal) on first sight. Caller holds t.m.
 func (t *Thresher) handleForLocked(

--- a/pkg/thresher/locked_internal_test.go
+++ b/pkg/thresher/locked_internal_test.go
@@ -1,6 +1,7 @@
 package thresher
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -173,4 +174,53 @@ func TestRebindSkipsEmptyKeyValues(t *testing.T) {
 
 	require.Equal(t, map[string]string{nsKeyFor("p", "C-9"): "i-1"}, th.seenKeys,
 		"only the derived key is reserved")
+}
+
+// TestRebuildReleasesThePreviousContext is FIX-037 T-4: every launch derives a
+// child of the engine context and retains its cancel in instanceReg.stop. A
+// rebuild REPLACES that registration, and the cancel it displaces must be run —
+// otherwise the old child stays attached to the engine context's children for
+// the engine's whole lifetime, and a dehydrating instance replaces its
+// registration on every wake, so the leak is one context per CYCLE.
+//
+// FIX-036 §8.2 fixed the same defect in Forget and missed this path.
+func TestRebuildReleasesThePreviousContext(t *testing.T) {
+	th, err := New("track-displace", WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	proc := noneStartProcess(t, "p-track-displace")
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	handle, err := th.StartLatest(proc.ID())
+	require.NoError(t, err)
+
+	inst, err := th.instanceByID(handle.ID())
+	require.NoError(t, err)
+
+	// re-register the SAME instance, which is what a rebuild does.
+	first, firstCancel := context.WithCancel(context.Background())
+	h, displaced := th.trackInstanceLocked(inst, firstCancel, make(chan struct{}))
+	require.NotNil(t, h)
+	require.NotNil(t, displaced,
+		"the launch's own cancel is displaced by this re-registration")
+	stopDisplaced(displaced)
+
+	// a rebuild of the SAME id hands back the previous cancel
+	second, secondCancel := context.WithCancel(context.Background())
+	defer secondCancel()
+
+	_, displaced = th.trackInstanceLocked(inst, secondCancel, make(chan struct{}))
+	require.NotNil(t, displaced,
+		"a rebuild must hand back the cancel it replaced")
+
+	require.NoError(t, first.Err(), "the displaced context is still live")
+	stopDisplaced(displaced)
+	require.Error(t, first.Err(),
+		"running the displaced cancel must end the previous context")
+	require.NoError(t, second.Err(), "the current context is untouched")
 }

--- a/pkg/thresher/recovery.go
+++ b/pkg/thresher/recovery.go
@@ -127,7 +127,8 @@ func (t *Thresher) recoverOne(ctx context.Context, id string) error {
 		return recoveryErr("the restored instance doesn't run", err)
 	}
 
-	t.trackInstanceLocked(inst, cancel, t.settledFor(id))
+	_, displaced := t.trackInstanceLocked(inst, cancel, t.settledFor(id))
+	stopDisplaced(displaced)
 
 	// A recovered conversation re-takes its correlation reservation (FIX-036
 	// §1.2): the reservation map does not survive the process, so without this

--- a/pkg/thresher/tasks.go
+++ b/pkg/thresher/tasks.go
@@ -600,42 +600,26 @@ func (t *Thresher) residentForTask(taskID string) (*instance.Instance, error) {
 // Complete then travels the normal in-instance path. The rebuild starts pinned
 // so it cannot release before that action arrives.
 func (t *Thresher) hydrateForTask(instanceID string) error {
-	for range wakeDeliverAttempts {
-		done, claimed := t.claimWake(instanceID)
-		if claimed {
-			err := t.rebuildAndContinue(instanceID, nil,
-				instance.WithResidentPin())
-			t.releaseWake(instanceID)
-
-			return err
-		}
-
-		// Another wake is rebuilding it. Returning here used to report success
-		// without having rebuilt OR pinned, while residentForTask's contract
-		// says the instance it hands back "was built already pinned" — so
-		// onTaskInstance unpinned a pin this call never took (FIX-037 §1.2).
-		// Wait for that rebuild, then take our own pin on the result.
-		if !t.awaitWake(done) {
-			return t.errEngineNotRunning("hydrateForTask")
-		}
-
-		inst, err := t.instanceByID(instanceID)
-		if err != nil {
-			continue // it vanished between the wake and the lookup — retry
-		}
-
-		if inst.State() != instance.Dehydrated {
-			// PinResident before returning: the caller unpins unconditionally,
-			// so the pin must exist on EVERY path out of here.
-			inst.PinResident()
-
-			return nil
-		}
-		// it re-parked before we could pin it — claim the next rebuild
+	// Wait for any in-flight rebuild and take the latch, then rebuild pinned.
+	// Returning on a lost claim used to report success without having rebuilt
+	// OR pinned, while residentForTask's contract says the instance it hands
+	// back "was built already pinned" — so onTaskInstance unpinned a pin this
+	// call never took (FIX-037 §1.2).
+	if err := t.awaitClaim(instanceID, "hydrateForTask"); err != nil {
+		return err
 	}
 
-	return errs.New(
-		errs.M("hydrateForTask: instance %q kept re-parking across %d wakes",
-			instanceID, wakeDeliverAttempts),
-		errs.C(errorClass, errs.OperationFailed))
+	defer t.releaseWake(instanceID)
+
+	// The wake we waited for may already have made it resident. Pin that
+	// instead of rebuilding it again — the pin must exist on EVERY path out of
+	// here, because the caller unpins unconditionally.
+	if inst, err := t.instanceByID(instanceID); err == nil &&
+		inst.State() != instance.Dehydrated {
+		inst.PinResident()
+
+		return nil
+	}
+
+	return t.rebuildAndContinue(instanceID, nil, instance.WithResidentPin())
 }

--- a/pkg/thresher/tasks.go
+++ b/pkg/thresher/tasks.go
@@ -600,10 +600,42 @@ func (t *Thresher) residentForTask(taskID string) (*instance.Instance, error) {
 // Complete then travels the normal in-instance path. The rebuild starts pinned
 // so it cannot release before that action arrives.
 func (t *Thresher) hydrateForTask(instanceID string) error {
-	if !t.claimWake(instanceID) {
-		return nil // another wake is already rebuilding it
-	}
-	defer t.releaseWake(instanceID)
+	for range wakeDeliverAttempts {
+		done, claimed := t.claimWake(instanceID)
+		if claimed {
+			err := t.rebuildAndContinue(instanceID, nil,
+				instance.WithResidentPin())
+			t.releaseWake(instanceID)
 
-	return t.rebuildAndContinue(instanceID, nil, instance.WithResidentPin())
+			return err
+		}
+
+		// Another wake is rebuilding it. Returning here used to report success
+		// without having rebuilt OR pinned, while residentForTask's contract
+		// says the instance it hands back "was built already pinned" — so
+		// onTaskInstance unpinned a pin this call never took (FIX-037 §1.2).
+		// Wait for that rebuild, then take our own pin on the result.
+		if !t.awaitWake(done) {
+			return t.errEngineNotRunning("hydrateForTask")
+		}
+
+		inst, err := t.instanceByID(instanceID)
+		if err != nil {
+			continue // it vanished between the wake and the lookup — retry
+		}
+
+		if inst.State() != instance.Dehydrated {
+			// PinResident before returning: the caller unpins unconditionally,
+			// so the pin must exist on EVERY path out of here.
+			inst.PinResident()
+
+			return nil
+		}
+		// it re-parked before we could pin it — claim the next rebuild
+	}
+
+	return errs.New(
+		errs.M("hydrateForTask: instance %q kept re-parking across %d wakes",
+			instanceID, wakeDeliverAttempts),
+		errs.C(errorClass, errs.OperationFailed))
 }

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -1388,7 +1388,8 @@ func (t *Thresher) launchInstanceFromEvent(
 	// An event-born instance is tracked with its read-only handle just like a
 	// StartProcess one, so the SRD-019 discovery API (Instances -> Instance(id))
 	// returns a usable handle for it instead of a nil that panics on observation.
-	t.trackInstanceLocked(inst, cancel, settled)
+	_, displaced := t.trackInstanceLocked(inst, cancel, settled)
+	stopDisplaced(displaced)
 
 	// Bind the correlation reservation to the instance that now owns it
 	// (FIX-036 §1.2): until this point the entry only says "a start is in
@@ -1582,7 +1583,10 @@ func (t *Thresher) launchInstance(s *snapshot.Snapshot) (*InstanceHandle, error)
 			errs.E(err))
 	}
 
-	return t.trackInstanceLocked(inst, cancel, settled), nil
+	h, displaced := t.trackInstanceLocked(inst, cancel, settled)
+	stopDisplaced(displaced)
+
+	return h, nil
 }
 
 // =============================================================================

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -197,7 +197,12 @@ type Thresher struct {
 	// waking latches per-instance wakes so concurrent triggers hydrate an
 	// instance exactly once (single-flight, SRD-071 §4.6). Guarded by wakeMu,
 	// distinct from m.
-	waking map[string]bool
+	// waking maps an instance whose wake is IN FLIGHT to a channel closed when
+	// that wake finishes. A loser waits on it and then retries its own path:
+	// the latch transfers responsibility for rebuilding the INSTANCE, never for
+	// the caller's own payload — a trigger, a residency pin, an operator's
+	// operation (FIX-037 §2). Guarded by wakeMu.
+	waking map[string]chan struct{}
 	// subs are the hub subscriptions the engine holds on released instances'
 	// behalf (SRD-071 FR-7) — one per armed message/signal wait, so a track may
 	// own several (the Event-Based Gateway set). Guarded by subMu, distinct
@@ -304,7 +309,7 @@ func New(id string, opts ...Option) (*Thresher, error) {
 		seenKeys:      map[string]string{},
 		tasks:         map[string]*taskRecord{},
 		keyLocks:      newKeyLockManager(),
-		waking:        map[string]bool{},
+		waking:        map[string]chan struct{}{},
 		subs:          map[subKey]*subHolder{},
 		settled:       map[string]chan struct{}{},
 	}

--- a/pkg/thresher/timer_service.go
+++ b/pkg/thresher/timer_service.go
@@ -62,10 +62,17 @@ type timerService struct {
 	// KEPT on failure (FIX-027): the callback has to report which.
 	wake  func(instanceID string, pending *instance.PendingTrigger) bool
 	holds map[string]timerHold
+	// arming holds the IN-FLIGHT HoldTimer calls, so a release landing in the
+	// middle of an arm can tell that arm it lost (FIX-037 §1.5). Keyed by the
+	// arming call's own token, NOT by track: the entry lives only for the
+	// duration of one HoldTimer, so the map is bounded by concurrent arms
+	// rather than growing with every track the engine has ever seen.
+	arming map[uint64]string // token → the track prefix being armed
 	// kick re-runs the loop's deadline computation after a hold is added or
 	// removed (buffered depth 1 — a coalescing signal, never blocks the caller).
-	kick chan struct{}
-	mu   sync.Mutex
+	kick       chan struct{}
+	armingNext uint64
+	mu         sync.Mutex
 	// backoff pushes a failed wake's next attempt out. Without it the hold is
 	// still due the instant the wake returns, so the loop would re-fire it
 	// immediately and spin — retrying as fast as it turns (FIX-027 §3.2.1).
@@ -84,6 +91,7 @@ func newTimerService(
 		wake:    wake,
 		backoff: backoff,
 		holds:   map[string]timerHold{},
+		arming:  map[uint64]string{},
 		kick:    make(chan struct{}, 1),
 	}
 }
@@ -111,13 +119,44 @@ func (ts *timerService) deferHold(h timerHold, next time.Time) {
 	ts.signal()
 }
 
-// hold registers (or replaces) a deadline and re-arms the loop's nearest-timer.
-func (ts *timerService) hold(h timerHold) {
+// beginArm announces an in-flight arm for a track and returns its token. The
+// caller MUST pass the token to hold (FIX-037 §1.5).
+func (ts *timerService) beginArm(instanceID, trackID string) uint64 {
 	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	ts.armingNext++
+	ts.arming[ts.armingNext] = trackPrefix(instanceID, trackID)
+
+	return ts.armingNext
+}
+
+// hold registers (or replaces) a deadline and re-arms the loop's nearest-timer.
+// It is REFUSED — reporting false — when a release withdrew this track's waits
+// while the arm was in flight: release drops the arming token, so a token that
+// is gone means the wait this deadline belongs to has been canceled.
+//
+// Without this, an arm that began before a concurrent ReleaseWaits would
+// register its deadline after that release had already scanned and found
+// nothing, leaving a zombie deadline that later wakes the instance for a track
+// that no longer exists. It is the timer counterpart of HoldSubscription's
+// record→arm→confirm (FIX-036 §3.2.4).
+func (ts *timerService) hold(h timerHold, token uint64) bool {
+	ts.mu.Lock()
+
+	if _, live := ts.arming[token]; !live {
+		ts.mu.Unlock()
+
+		return false
+	}
+
+	delete(ts.arming, token)
 	ts.holds[holdKey(h.instanceID, h.trackID, eDefIDOf(h.eDef))] = h
 	ts.mu.Unlock()
 
 	ts.signal()
+
+	return true
 }
 
 // releaseOne withdraws the single hold that just fired, leaving a track's other
@@ -142,6 +181,14 @@ func (ts *timerService) release(instanceID, trackID string) {
 	for k := range ts.holds {
 		if strings.HasPrefix(k, prefix) {
 			delete(ts.holds, k)
+		}
+	}
+
+	// Cancel any arm still in flight for this track, so a hold that began
+	// before this release cannot land after it (FIX-037 §1.5).
+	for token, p := range ts.arming {
+		if p == prefix {
+			delete(ts.arming, token)
 		}
 	}
 

--- a/pkg/thresher/wake.go
+++ b/pkg/thresher/wake.go
@@ -34,14 +34,27 @@ func (t *Thresher) HoldTimer(
 			gerrs.C(errorClass, gerrs.InvalidState))
 	}
 
-	t.timerSvc.hold(timerHold{
+	// Announce the arm BEFORE building it, so a ReleaseWaits landing between
+	// here and the hold below can cancel it (FIX-037 §1.5). Arming blind let a
+	// release that found nothing be followed by a hold that registered a
+	// deadline for the wait it had just canceled.
+	token := t.timerSvc.beginArm(instanceID, trackID)
+
+	if !t.timerSvc.hold(timerHold{
 		instanceID: instanceID,
 		trackID:    trackID,
 		eDef:       eDef,
 		deadline:   deadline,
 		cycles:     cycles,
 		kind:       kind,
-	})
+	}, token) {
+		// The wait was released while this arm was in flight. That is not a
+		// failure: the release is authoritative and there is nothing left to
+		// hold, exactly as a withdrawn subscription hold reports success.
+		t.cfg.logger.Debug("timer hold refused — the wait was released mid-arm",
+			observability.AttrInstanceID, instanceID,
+			observability.AttrTrackID, trackID)
+	}
 
 	return nil
 }

--- a/pkg/thresher/wake.go
+++ b/pkg/thresher/wake.go
@@ -85,6 +85,15 @@ func (t *Thresher) hydrateFromTimer(
 func (t *Thresher) wakeInstance(
 	instanceID string, pending *instance.PendingTrigger,
 ) error {
+	return t.wakeInstanceAttempt(instanceID, pending, 0)
+}
+
+// wakeInstanceAttempt is wakeInstance's body, carrying the attempt count so a
+// caller that lost the latch can wait for the in-flight wake and retry its own
+// delivery a BOUNDED number of times.
+func (t *Thresher) wakeInstanceAttempt(
+	instanceID string, pending *instance.PendingTrigger, attempt int,
+) error {
 	// Still resident? Deliver into the live loop (today's path, reached through
 	// the holder instead of a hub waiter). The instance may release its
 	// goroutines between this check and the delivery, so the delivery itself
@@ -103,14 +112,33 @@ func (t *Thresher) wakeInstance(
 		}
 	}
 
-	if !t.claimWake(instanceID) {
-		// another wake is already hydrating this instance — it will deliver
-		// the trigger into the soon-resident loop; nothing to do here (§4.6).
-		return nil
-	}
-	defer t.releaseWake(instanceID)
+	done, claimed := t.claimWake(instanceID)
+	if claimed {
+		defer t.releaseWake(instanceID)
 
-	return t.rebuildAndContinue(instanceID, pending)
+		return t.rebuildAndContinue(instanceID, pending)
+	}
+
+	// Another wake is rebuilding the instance. It carries ITS OWN trigger and
+	// cannot deliver this one, so returning here would drop the event and
+	// report success to a caller that treats nil as delivered — the hub
+	// reports nothing, the timer service surrenders the deadline (FIX-037
+	// §1.1). Wait for that wake, then retry this trigger from the top: the
+	// instance is resident by then, so the delivery above takes it.
+	if !t.awaitWake(done) {
+		return wakeErr("the engine stopped while awaiting an in-flight wake", nil)
+	}
+
+	// Bounded, so a storm of concurrent wakes cannot recurse without end.
+	// Exhausting the attempts is LOUD: the trigger could not be delivered, and
+	// silence is exactly what made the original defect invisible.
+	if attempt+1 >= wakeDeliverAttempts {
+		return wakeErr("the trigger could not be delivered after "+
+			strconv.Itoa(wakeDeliverAttempts)+" attempts — the instance kept "+
+			"being rebuilt by concurrent wakes", nil)
+	}
+
+	return t.wakeInstanceAttempt(instanceID, pending, attempt+1)
 }
 
 // rebuildAndContinue rebuilds a dehydrated instance from its checkpoint and
@@ -256,6 +284,13 @@ func wakeTriggerLabel(pending *instance.PendingTrigger) string {
 // dehydration write; more would mean something else is fighting for the record.
 const wakeClaimAttempts = 3
 
+// wakeDeliverAttempts bounds how many times a trigger that lost the wake latch
+// waits for the in-flight rebuild and re-tries its own delivery (FIX-037 §1.1).
+// Each round costs one rebuild's wait, and a third failure means something is
+// re-parking the instance as fast as it wakes — a condition to report, not to
+// keep retrying.
+const wakeDeliverAttempts = 3
+
 // claimForWake takes ownership of a dehydrated instance's record so it can be
 // rebuilt: load it, re-claim it under a HIGHER incarnation (the fencing token
 // every later save carries, ADR-033 §2.8), and return the claimed record with
@@ -312,26 +347,58 @@ func (t *Thresher) claimForWake(
 		wakeErr("couldn't claim the record for the wake", lastErr)
 }
 
-// claimWake latches an instance's wake, returning false when one is already in
-// flight (single-flight, SRD-071 §4.6).
-func (t *Thresher) claimWake(instanceID string) bool {
+// claimWake latches an instance's wake (single-flight, SRD-071 §4.6).
+//
+// The winner gets ok=true and MUST releaseWake when it is done. A loser gets
+// ok=false and a channel closed when the in-flight wake finishes — it waits on
+// that and then retries its OWN path, because the latch only says the instance
+// is being rebuilt by someone else. It says nothing about the caller's payload,
+// and every caller has one: a pending trigger, a residency pin, an operator's
+// incident operation. Treating a refusal as "my work is done too" is what lost
+// them (FIX-037 §1.1-1.3).
+func (t *Thresher) claimWake(instanceID string) (<-chan struct{}, bool) {
 	t.wakeMu.Lock()
 	defer t.wakeMu.Unlock()
 
-	if t.waking[instanceID] {
+	if done, inFlight := t.waking[instanceID]; inFlight {
+		return done, false
+	}
+
+	t.waking[instanceID] = make(chan struct{})
+
+	return nil, true
+}
+
+// awaitWake blocks until the in-flight wake signaled by done completes, or the
+// engine stops. It reports whether the wake finished — a false means the engine
+// is going away and the caller must not retry.
+func (t *Thresher) awaitWake(done <-chan struct{}) bool {
+	engCtx, running := t.engineContext()
+	if !running {
 		return false
 	}
 
-	t.waking[instanceID] = true
+	select {
+	case <-done:
+		return true
 
-	return true
+	case <-engCtx.Done():
+		return false
+	}
 }
 
 // releaseWake clears an instance's wake latch.
 func (t *Thresher) releaseWake(instanceID string) {
 	t.wakeMu.Lock()
+	done := t.waking[instanceID]
 	delete(t.waking, instanceID)
 	t.wakeMu.Unlock()
+
+	// Closing releases every caller that lost the claim and is waiting to
+	// retry its own path.
+	if done != nil {
+		close(done)
+	}
 }
 
 // wakeErr builds one classified wake error.

--- a/pkg/thresher/wake.go
+++ b/pkg/thresher/wake.go
@@ -369,6 +369,30 @@ func (t *Thresher) claimWake(instanceID string) (<-chan struct{}, bool) {
 	return nil, true
 }
 
+// awaitClaim takes the wake latch for instanceID, waiting for an in-flight wake
+// when the first attempt loses and retrying a bounded number of times. On a nil
+// return the caller OWNS the latch and must releaseWake.
+//
+// It is the shared form of "I need to rebuild this instance, and someone else
+// may be rebuilding it right now" — the shape every rebuild path needs and only
+// some of them had (FIX-037 §1.3).
+func (t *Thresher) awaitClaim(instanceID, op string) error {
+	for range wakeDeliverAttempts {
+		done, claimed := t.claimWake(instanceID)
+		if claimed {
+			return nil
+		}
+
+		if !t.awaitWake(done) {
+			return t.errEngineNotRunning(op)
+		}
+	}
+
+	return gerrs.New(
+		gerrs.M("%s: instance %q is being rebuilt concurrently", op, instanceID),
+		gerrs.C(errorClass, gerrs.OperationFailed))
+}
+
 // awaitWake blocks until the in-flight wake signaled by done completes, or the
 // engine stops. It reports whether the wake finished — a false means the engine
 // is going away and the caller must not retry.

--- a/pkg/thresher/wake.go
+++ b/pkg/thresher/wake.go
@@ -173,7 +173,8 @@ func (t *Thresher) rebuildAndContinue(
 		t.ReleaseWaits(instanceID, pending.TrackID)
 	}
 
-	t.trackInstanceLocked(inst, cancel, t.settledFor(instanceID))
+	_, displaced := t.trackInstanceLocked(inst, cancel, t.settledFor(instanceID))
+	stopDisplaced(displaced)
 
 	// A hydrated conversation re-takes its correlation reservation, for the
 	// same reason a recovered one does (FIX-036 §1.2).

--- a/pkg/thresher/wake.go
+++ b/pkg/thresher/wake.go
@@ -48,15 +48,19 @@ func (t *Thresher) HoldTimer(
 		cycles:     cycles,
 		kind:       kind,
 	}, token) {
-		// The wait was released while this arm was in flight. That is not a
-		// failure: the release is authoritative and there is nothing left to
-		// hold, exactly as a withdrawn subscription hold reports success.
-		t.cfg.logger.Debug("timer hold refused — the wait was released mid-arm",
-			observability.AttrInstanceID, instanceID,
-			observability.AttrTrackID, trackID)
+		t.reportRefusedArm(instanceID, trackID)
 	}
 
 	return nil
+}
+
+// reportRefusedArm records an arm the timer service refused because a release
+// withdrew the track's waits while it was in flight. It is NOT a failure: the
+// release is authoritative and there is nothing left to hold, exactly as a
+// withdrawn subscription hold reports success (FIX-037 §1.5).
+func (t *Thresher) reportRefusedArm(instanceID, trackID string) {
+	t.cfg.logger.Debug("timer hold refused — the wait was released mid-arm",
+		observability.AttrInstanceID, instanceID, observability.AttrTrackID, trackID)
 }
 
 // hydrateFromTimer is the timer service's wake callback (SRD-071 FR-4): a held

--- a/pkg/thresher/wake_internal_test.go
+++ b/pkg/thresher/wake_internal_test.go
@@ -57,13 +57,28 @@ func TestWakeSingleFlightLatch(t *testing.T) {
 	th, err := New("engine-latch", WithoutBanner(), WithoutStartupConfig())
 	require.NoError(t, err)
 
-	require.True(t, th.claimWake("i-1"), "the first wake claims")
-	require.False(t, th.claimWake("i-1"),
-		"a concurrent wake is refused — it delivers into the resident loop")
-	require.True(t, th.claimWake("i-2"), "a different instance is unaffected")
+	_, claimed := th.claimWake("i-1")
+	require.True(t, claimed, "the first wake claims")
+
+	done, claimed := th.claimWake("i-1")
+	require.False(t, claimed, "a concurrent wake is refused")
+	require.NotNil(t, done,
+		"a refused claim hands back the channel to wait on — the loser must be "+
+			"able to retry its own payload (FIX-037 §1.1)")
+
+	_, claimed = th.claimWake("i-2")
+	require.True(t, claimed, "a different instance is unaffected")
 
 	th.releaseWake("i-1")
-	require.True(t, th.claimWake("i-1"), "the latch clears on release")
+
+	select {
+	case <-done:
+	default:
+		t.Fatal("releaseWake must close the channel losers wait on")
+	}
+
+	_, claimed = th.claimWake("i-1")
+	require.True(t, claimed, "the latch clears on release")
 }
 
 // TestWakeFailureIsLoud: a wake for an instance whose checkpoint is missing
@@ -329,20 +344,48 @@ func TestWakeUnknownInstanceIsLoud(t *testing.T) {
 	require.Error(t, err, "a wake with no checkpoint is an error, not a panic")
 }
 
-// TestWakeSingleFlightRefusesSecond: with a wake already latched, a second
-// trigger for the same instance is a no-op (it will ride the resident loop).
-func TestWakeSingleFlightRefusesSecond(t *testing.T) {
+// TestWakeSingleFlightWaitsThenRetries is FIX-037 T-1: with a wake already
+// latched, a second trigger must WAIT for it and then retry its own delivery.
+//
+// This test previously asserted the opposite — that the second trigger is "a
+// no-op (it will ride the resident loop)" — which was §1.1's defect written
+// down as the contract. The in-flight wake carries its own PendingTrigger and
+// cannot deliver this one, so returning nil dropped the event while telling the
+// hub and the timer service it had been delivered.
+func TestWakeSingleFlightWaitsThenRetries(t *testing.T) {
 	th, cancel := armedWakeEngine(t, "engine-latched")
 	defer cancel()
 
-	require.True(t, th.claimWake("i-1"))
+	_, claimed := th.claimWake("i-1")
+	require.True(t, claimed)
 
-	err := th.wakeInstance("i-1", &instance.PendingTrigger{
-		TrackID: "t-1", EDef: wakeSignalDef(t, "latched-sig")})
-	require.NoError(t, err,
-		"a second concurrent trigger defers to the in-flight wake")
+	returned := make(chan error, 1)
+
+	go func() {
+		returned <- th.wakeInstance("i-1", &instance.PendingTrigger{
+			TrackID: "t-1", EDef: wakeSignalDef(t, "latched-sig")})
+	}()
+
+	// It must still be waiting: dropping the trigger would show up here as an
+	// immediate return.
+	select {
+	case <-returned:
+		t.Fatal("the second trigger returned instead of awaiting the in-flight wake")
+	case <-time.After(150 * time.Millisecond):
+	}
 
 	th.releaseWake("i-1")
+
+	select {
+	case err := <-returned:
+		// The retry runs; "i-1" has no checkpoint here, so it reports rather
+		// than claiming success. Loud is the point — silence is what hid it.
+		require.Error(t, err,
+			"the retried trigger reports its failure instead of vanishing")
+
+	case <-time.After(3 * time.Second):
+		t.Fatal("the waiter was not released")
+	}
 }
 
 // TestClaimForWakeExhausts: a repository whose CAS never succeeds exhausts the
@@ -759,18 +802,37 @@ func TestWakeOutcomeLabels(t *testing.T) {
 		TrackID: "t-1"}))
 }
 
-// TestHydrateForTaskDefersToAnInFlightWake: with a wake already latched for an
-// instance, a task action does not start a second rebuild — it lets the
-// in-flight one finish and replays against the result (§4.6).
-func TestHydrateForTaskDefersToAnInFlightWake(t *testing.T) {
+// TestHydrateForTaskWaitsForAnInFlightWake is FIX-037 T-2: a task action that
+// loses the wake latch must WAIT for the in-flight rebuild rather than return.
+//
+// It previously asserted that returning immediately was correct ("deferred to,
+// not duplicated"). It was not: residentForTask's contract says the instance it
+// hands back "was built already pinned", and this path neither rebuilt nor
+// pinned — so onTaskInstance unpinned a pin the call never took (§1.2).
+func TestHydrateForTaskWaitsForAnInFlightWake(t *testing.T) {
 	th, cancel := armedWakeEngine(t, "engine-taskwake")
 	defer cancel()
 
-	require.True(t, th.claimWake("i-1"))
-	defer th.releaseWake("i-1")
+	_, claimed := th.claimWake("i-1")
+	require.True(t, claimed)
 
-	require.NoError(t, th.hydrateForTask("i-1"),
-		"a concurrent wake is deferred to, not duplicated")
+	returned := make(chan error, 1)
+
+	go func() { returned <- th.hydrateForTask("i-1") }()
+
+	select {
+	case <-returned:
+		t.Fatal("the task action returned without rebuilding or pinning")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	th.releaseWake("i-1")
+
+	select {
+	case <-returned: // it proceeds; the outcome depends on the absent record
+	case <-time.After(3 * time.Second):
+		t.Fatal("the task action was not released")
+	}
 }
 
 // TestRebuildRefusesABrokenRecord: a checkpoint whose recorded node is not in
@@ -1241,4 +1303,51 @@ func TestReleaseWaitsDuringHoldTimerRefusesTheArm(t *testing.T) {
 
 	require.Empty(t, ts.holds, "a refused arm registers no deadline")
 	require.Empty(t, ts.arming, "a refused arm leaves no in-flight marker")
+}
+
+// TestIncidentOpTakesTheWakeLatch is FIX-037 T-3: wakeForIncidentOp used to
+// call rebuildAndContinue directly — the only rebuild path that never claimed.
+//
+// The repository CAS does not compensate: claimForWake RETRIES a lost CAS
+// rather than failing (wake.go), so two concurrent rebuilds both succeed at
+// successive incarnations. The in-process latch is the only thing preventing
+// two live loops over one instance, so an operator's RetryIncident racing a
+// timer wake started a second execution loop over the same state (§1.3).
+func TestIncidentOpTakesTheWakeLatch(t *testing.T) {
+	th, cancel := armedWakeEngine(t, "engine-incident-latch")
+	defer cancel()
+
+	proc := noneStartProcess(t, "p-incident-latch")
+	_, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	h, err := th.StartLatest(proc.ID())
+	require.NoError(t, err)
+
+	_, claimed := th.claimWake(h.ID())
+	require.True(t, claimed, "a wake is in flight for this instance")
+
+	returned := make(chan error, 1)
+
+	ctx, opCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer opCancel()
+
+	go func() {
+		returned <- th.wakeForIncidentOp(ctx, h, instance.IncidentRetry, "inc-1")
+	}()
+
+	// It must wait for the in-flight wake rather than rebuilding beside it.
+	select {
+	case <-returned:
+		t.Fatal("the incident op rebuilt without taking the wake latch")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	th.releaseWake(h.ID())
+
+	select {
+	case <-returned: // proceeds; the outcome depends on the instance state
+	case <-time.After(3 * time.Second):
+		t.Fatal("the incident op was not released")
+	}
 }

--- a/pkg/thresher/wake_internal_test.go
+++ b/pkg/thresher/wake_internal_test.go
@@ -111,7 +111,8 @@ func TestTimerServiceReleaseAndIdle(t *testing.T) {
 	require.False(t, ok, "an idle service holds nothing")
 
 	deadline := wakeEpoch.Add(time.Hour)
-	ts.hold(timerHold{instanceID: "i-1", trackID: "t-1", deadline: deadline})
+	ts.hold(timerHold{instanceID: "i-1", trackID: "t-1", deadline: deadline},
+		ts.beginArm("i-1", "t-1"))
 
 	got, ok := ts.nearest()
 	require.True(t, ok)
@@ -119,7 +120,8 @@ func TestTimerServiceReleaseAndIdle(t *testing.T) {
 
 	// an earlier hold wins the nearest slot.
 	earlier := wakeEpoch.Add(30 * time.Minute)
-	ts.hold(timerHold{instanceID: "i-2", trackID: "t-2", deadline: earlier})
+	ts.hold(timerHold{instanceID: "i-2", trackID: "t-2", deadline: earlier},
+		ts.beginArm("i-2", "t-2"))
 
 	got, _ = ts.nearest()
 	require.True(t, earlier.Equal(got))
@@ -162,7 +164,7 @@ func TestTimerServiceRunStops(t *testing.T) {
 	ts.hold(timerHold{
 		instanceID: "i-1", trackID: "t-1",
 		deadline: wakeEpoch.Add(time.Hour),
-	})
+	}, ts.beginArm("i-1", "t-1"))
 
 	cancel()
 
@@ -183,7 +185,7 @@ func TestTimerServiceRunStops(t *testing.T) {
 		})
 	ts2.hold(timerHold{
 		instanceID: "i-9", trackID: "t-9", deadline: wakeEpoch,
-	})
+	}, ts2.beginArm("i-9", "t-9"))
 	ts2.fireDue(ctx)
 	require.Zero(t, woke, "a canceled wake batch fires nothing")
 }
@@ -1195,4 +1197,48 @@ func TestPromoteFailureSurfaces(t *testing.T) {
 
 	require.False(t, th.registrations[proc.ID()][0].wired,
 		"the version that could not be armed is not marked wired")
+}
+
+// TestReleaseWaitsDuringHoldTimerRefusesTheArm is FIX-037 T-5: HoldTimer used
+// to register its deadline blind, so a ReleaseWaits that ran between the
+// method's entry and its hold scanned the service, found nothing to withdraw,
+// and was then overtaken by a hold that armed the very wait it had canceled —
+// a zombie deadline that later wakes the instance for a track that is gone.
+//
+// This is the timer counterpart of the subscription window FIX-036 §1.4 closed.
+// The interleaving is driven directly rather than raced: the arm is announced,
+// the release runs, and only then does the hold land.
+func TestReleaseWaitsDuringHoldTimerRefusesTheArm(t *testing.T) {
+	ts := newTimerService(clocktest.New(wakeEpoch), time.Second,
+		func(string, *instance.PendingTrigger) bool { return true })
+
+	h := timerHold{
+		instanceID: "i-1",
+		trackID:    "t-1",
+		deadline:   wakeEpoch.Add(time.Hour),
+	}
+
+	// the ordinary path: an uncontended arm is accepted.
+	require.True(t, ts.hold(h, ts.beginArm("i-1", "t-1")),
+		"an arm nothing released must be accepted")
+
+	ts.mu.Lock()
+	require.Len(t, ts.holds, 1)
+	ts.mu.Unlock()
+
+	ts.release("i-1", "t-1")
+
+	// the raced path: the arm is announced, THEN the release runs, THEN the
+	// hold lands. It must be refused and leave nothing behind.
+	token := ts.beginArm("i-1", "t-1")
+	ts.release("i-1", "t-1")
+
+	require.False(t, ts.hold(h, token),
+		"an arm whose wait was released mid-flight must be refused")
+
+	ts.mu.Lock()
+	defer ts.mu.Unlock()
+
+	require.Empty(t, ts.holds, "a refused arm registers no deadline")
+	require.Empty(t, ts.arming, "a refused arm leaves no in-flight marker")
 }

--- a/pkg/thresher/wake_internal_test.go
+++ b/pkg/thresher/wake_internal_test.go
@@ -1539,3 +1539,15 @@ func TestIncidentOpReportsWhenTheEngineStops(t *testing.T) {
 		t.Fatal("the incident waiter was not released by the shutdown")
 	}
 }
+
+// TestReportRefusedArm covers the refusal report itself. The branch that calls
+// it needs a release to land inside HoldTimer's own arm — a window no test can
+// schedule deterministically — so the reporting is pinned here and the
+// interleaving it belongs to is pinned by T-5 at the service.
+func TestReportRefusedArm(t *testing.T) {
+	th, err := New("refused-arm", WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() { th.reportRefusedArm("i-1", "t-1") },
+		"a refused arm is a Debug fact, never a failure")
+}

--- a/pkg/thresher/wake_internal_test.go
+++ b/pkg/thresher/wake_internal_test.go
@@ -1351,3 +1351,191 @@ func TestIncidentOpTakesTheWakeLatch(t *testing.T) {
 		t.Fatal("the incident op was not released")
 	}
 }
+
+// TestHydrateForTaskPinsAfterWaiting is the half of T-2 that matters: a task
+// action that lost the latch must come back holding a pin. residentForTask
+// hands the instance to onTaskInstance, which unpins unconditionally, so a path
+// that returns without pinning underflows the counter (FIX-037 §1.2).
+func TestHydrateForTaskPinsAfterWaiting(t *testing.T) {
+	th, cancel := armedWakeEngine(t, "engine-task-pin")
+	defer cancel()
+
+	proc := noneStartProcess(t, "p-task-pin")
+	_, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	h, err := th.StartLatest(proc.ID())
+	require.NoError(t, err)
+
+	inst, err := th.instanceByID(h.ID())
+	require.NoError(t, err)
+
+	before := inst.ResidentPins()
+
+	_, claimed := th.claimWake(h.ID())
+	require.True(t, claimed)
+
+	returned := make(chan error, 1)
+
+	go func() { returned <- th.hydrateForTask(h.ID()) }()
+
+	select {
+	case <-returned:
+		t.Fatal("returned without waiting for the in-flight wake")
+	case <-time.After(150 * time.Millisecond):
+	}
+
+	th.releaseWake(h.ID())
+
+	select {
+	case err := <-returned:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("the task action was not released")
+	}
+
+	require.Equal(t, before+1, inst.ResidentPins(),
+		"the waiter must take its OWN pin — the caller unpins unconditionally")
+}
+
+// TestAwaitWakeStopsWithTheEngine covers awaitWake's two refusals: before Run
+// there is no engine lifetime to wait within, and a shutdown mid-wait releases
+// the waiter rather than stranding it on a latch nobody will clear.
+func TestAwaitWakeStopsWithTheEngine(t *testing.T) {
+	t.Run("before Run", func(t *testing.T) {
+		th, err := New("await-unrun", WithoutBanner(), WithoutStartupConfig())
+		require.NoError(t, err)
+
+		require.False(t, th.awaitWake(make(chan struct{})),
+			"a wait with no engine lifetime is refused, not blocked forever")
+	})
+
+	t.Run("engine stops while waiting", func(t *testing.T) {
+		th, cancel := armedWakeEngine(t, "await-stopped")
+
+		done := make(chan struct{}) // never closed: only the engine releases it
+		got := make(chan bool, 1)
+
+		go func() { got <- th.awaitWake(done) }()
+
+		time.Sleep(50 * time.Millisecond)
+		cancel()
+
+		select {
+		case ok := <-got:
+			require.False(t, ok, "a stopped engine releases the waiter as failed")
+		case <-time.After(3 * time.Second):
+			t.Fatal("awaitWake did not observe the engine stopping")
+		}
+	})
+}
+
+// TestWakeInstanceReportsWhenTheEngineStops pins the loud path: a trigger whose
+// wait is broken by shutdown reports instead of returning nil. Silence on this
+// path is what made the dropped-trigger defect invisible.
+func TestWakeInstanceReportsWhenTheEngineStops(t *testing.T) {
+	th, cancel := armedWakeEngine(t, "engine-wake-stop")
+
+	_, claimed := th.claimWake("i-stop")
+	require.True(t, claimed)
+
+	returned := make(chan error, 1)
+
+	go func() {
+		returned <- th.wakeInstance("i-stop", &instance.PendingTrigger{
+			TrackID: "t-1", EDef: wakeSignalDef(t, "stop-sig")})
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-returned:
+		require.Error(t, err, "a trigger stranded by shutdown is reported")
+	case <-time.After(3 * time.Second):
+		t.Fatal("the waiter was not released by the shutdown")
+	}
+}
+
+// TestWakeDeliveryAttemptsAreBounded pins the loud exhaustion path directly:
+// an instance that keeps being rebuilt by concurrent wakes must eventually
+// REPORT that the trigger could not be delivered, never return nil. Driving the
+// counter directly is deterministic where racing three successive latch losses
+// is not.
+func TestWakeDeliveryAttemptsAreBounded(t *testing.T) {
+	th, cancel := armedWakeEngine(t, "engine-exhaust")
+	defer cancel()
+
+	_, claimed := th.claimWake("i-x")
+	require.True(t, claimed)
+
+	// Release from ANOTHER goroutine: the call below WAITS for this latch, so
+	// releasing it in a defer would deadlock the test against its own subject.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		th.releaseWake("i-x")
+	}()
+
+	err := th.wakeInstanceAttempt("i-x", &instance.PendingTrigger{
+		TrackID: "t-1", EDef: wakeSignalDef(t, "exhaust-sig")},
+		wakeDeliverAttempts-1)
+
+	require.ErrorContains(t, err, "could not be delivered",
+		"the last attempt reports rather than dropping the trigger")
+}
+
+// TestTaskHydrationReportsWhenTheEngineStops and its incident sibling cover the
+// shutdown escape on the other two latch callers: a waiter must be released
+// when the engine goes away, and must say so rather than proceeding as if the
+// rebuild had happened.
+func TestTaskHydrationReportsWhenTheEngineStops(t *testing.T) {
+	th, cancel := armedWakeEngine(t, "engine-task-stop")
+
+	_, claimed := th.claimWake("i-ts")
+	require.True(t, claimed)
+
+	returned := make(chan error, 1)
+
+	go func() { returned <- th.hydrateForTask("i-ts") }()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-returned:
+		require.Error(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("the task waiter was not released by the shutdown")
+	}
+}
+
+func TestIncidentOpReportsWhenTheEngineStops(t *testing.T) {
+	th, cancel := armedWakeEngine(t, "engine-inc-stop")
+
+	proc := noneStartProcess(t, "p-inc-stop")
+	_, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	h, err := th.StartLatest(proc.ID())
+	require.NoError(t, err)
+
+	_, claimed := th.claimWake(h.ID())
+	require.True(t, claimed)
+
+	returned := make(chan error, 1)
+
+	go func() {
+		returned <- th.wakeForIncidentOp(context.Background(), h,
+			instance.IncidentRetry, "inc-stop")
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-returned:
+		require.Error(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("the incident waiter was not released by the shutdown")
+	}
+}


### PR DESCRIPTION
The first remediation from the `/audit-package` sweep — a whole-package audit of
`pkg/thresher`, `internal/scope` and the event hub by an **external reviewer**
(Antigravity / `agy`, `gemini-3.1-pro-high`), doc-blind, three lenses each.

41 raw findings. Five verified against the source and fixed here; five refuted
with their reasons recorded; the rest listed as pending verification. The audit
record lands with the fix, in `docs/audit/package-audit-2026-08-08.md`.

## Why an external reviewer

`/check-srd` asks whether the code matches its document. `/check-style` asks
whether it matches the house rules. Both are the author checking the author.
FIX-036 passed both at 0 red / 0 yellow with a green gate — and an external read
still found a context leak in `Forget` that nothing in the chain was shaped to
look for.

This PR is the evidence that generalises. **Two of the five confirmed defects
are halves of FIX-036 that were left behind**: it fixed `Forget`'s dropped
context-cancel and missed the rebuild path's, and it gave `HoldSubscription` a
confirm-after-arm while `HoldTimer` still armed blind. A landing that fixes a
*shape* should be asked where else that shape occurs, and nothing in the process
asked.

## What was wrong

**A try-lock used where a barrier was needed.** `claimWake` answers "is a wake
in flight?", and all three callers read `false` as "then my work is being done
by someone else". True of rebuilding the *instance*; false of everything the
caller was carrying.

- **A message arriving during a timer wake was permanently lost.**
  `wakeInstance` dropped its `PendingTrigger` and returned `nil` — which the
  event hub and the timer service both read as *delivered*, so the hub reported
  nothing and the service surrendered the deadline. The in-flight wake carries
  its own trigger and cannot deliver another's. An Event-Based Gateway arming a
  timer and a message on one dehydrated instance is the ordinary shape that
  reaches it.
- **An operator's incident retry could start a second execution loop.**
  `wakeForIncidentOp` rebuilt without taking the latch — the only rebuild path
  that did not. The durable claim does not compensate: `claimForWake` *retries*
  a lost compare-and-swap rather than failing, so two concurrent rebuilds both
  succeed at successive incarnations. The in-process latch was the only thing
  preventing two live loops over one instance's state.
- **A task action racing a wake unbalanced the residency counter.**
  `hydrateForTask` returned having neither rebuilt nor pinned, while
  `residentForTask`'s own comment states the instance it hands back "was built
  already pinned" — so `onTaskInstance` unpinned a pin the call never took, and
  could act on a still-dehydrated instance.

**A retained handle nobody was required to release.**

- **Every dehydrate/rehydrate cycle leaked a context.** A rebuild replaced the
  instance's registration and dropped the previous cancel without calling it.
  One leak per *cycle*, not per instance.
- **A cancelled timer wait could re-arm itself.** `HoldTimer` registered blind,
  so a release landing mid-arm withdrew nothing and was overtaken by the arm —
  leaving a deadline that later woke the instance for a track that was gone.

## The fix

`waking` becomes `map[string]chan struct{}`: the winner takes the latch, a loser
gets a channel closed by `releaseWake` and waits on it through `awaitWake`,
which also selects on the engine context so a shutdown cannot strand it. Each
caller then retries its **own** path.

All three rebuild paths go through one `awaitClaim` helper. That consolidation
came out of the coverage gap, and the two turned out to be the same problem:
writing wait-then-claim twice is how the third path came to lack it entirely.

`trackInstanceLocked` returns the cancel it displaces, and each of its six
callers runs it outside `t.m` — returned rather than cancelled in place because
cancelling under the engine lock is the shape `locked.go` exists to forbid.
`HoldTimer` announces an arm before building it; `hold` refuses a token a
release has dropped.

`FIX-037 §3.2.5` originally specified an epoch per (instance, track). That is
not what landed: an epoch map is keyed by track and never emptied, so it grows
for every track the engine has ever run — the leak class this branch exists to
fix, reintroduced by its own remedy. A token keyed by the arming *call* is
bounded by concurrent arms. The document records the deviation and why.

## Tests

T-1…T-5 plus the branch coverage. Every one was confirmed to **fail with its fix
reverted**, and the concurrency tests drive their interleaving directly —
claim, assert the caller is still blocked, release, assert it proceeds — rather
than hoping a race reproduces.

Four pre-existing tests asserted the defective contract and are **re-pinned, not
relaxed**. `TestWakeSingleFlightRefusesSecond` documented the dropped trigger as
intended behaviour ("a no-op — it will ride the resident loop"); its task
counterpart did the same for the pin. A defect a test asserts is a defect the
test will defend.

`Instance.ResidentPins` is added to the internal package because the pin balance
could not be asserted from `pkg/thresher` at all — which is exactly why the
original test could only check that the call returned.

**Two branches are not covered end to end, and that is stated rather than
implied.** `HoldTimer`'s refused arm and `awaitClaim`'s exhaustion each need an
interleaving no test can schedule. Both are pinned where they can be — the
refusal report directly, the service-level interleaving by T-5, the delivery
bound by driving the attempt counter. A flaky race test would assert less than
it appears to, which is the defect this PR fixes.

## Verification

`make ci` green end to end on the rebased base, by its own completion markers:

- `diff-coverage: 95.8% of 118 changed coverable lines (min 95%) — PASS`
- `No vulnerabilities found.` on every module
- `consumer-smoke ✓`, `linkcheck: every relative link resolves`
- no `*** [<target>] Error N` anywhere in the log

The first run **failed** at 78.2%, and the largest uncovered block was
`hydrateForTask`'s pin path — the actual remedy for the residency defect, whose
test asserted only that the call unblocked. `FIX-037 §8.3` records the failure
rather than only the final number.

## Rebased mid-flight

The branch moved from `11a0321` to `cdafd20` when SRD-082 (composite checkpoint
fidelity) landed. None of the five confirmed findings had been fixed there and
none of the pending items were invalidated. One conflict, in `CHANGELOG.md`,
where both branches added to `### Fixed`; both kept.

## Not done

This PR is 5 of 41 findings. `internal/scope` (14), the event hub (9) and the
remaining `pkg/thresher` items are unverified and listed in the audit document
so the next pass starts from the list. `internal/instance` — the largest package
in the engine — has only its architecture lens complete: at 584 KB the reviewer
fell back to a shell command, was auto-denied in headless mode, and returned
`status: SUCCESS` with an empty body. Two thirds of it remains unaudited.

## Documents

- `docs/fix/FIX-037-wake-latch-and-retained-handles.md` — Accepted.
- `docs/audit/package-audit-2026-08-08.md` — the audit record, including the
  refuted findings and what the raw output is worth (five findings cite line
  numbers that cannot exist; the mechanisms they describe are often real).
- No ADR or SAD changed: every fix realizes an existing contract.
