### PR TITLE
fix: engine locks held across host calls, and requests that were silently lost (FIX-038)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     overtaken by the arm — leaving a deadline that later woke the instance for a
     track that no longer existed.
 
+- **Engine locks held across host calls, and requests that were silently lost**
+  (FIX-038 — the second `/audit-package` sweep, over `internal/eventproc`,
+  `internal/scope`, `pkg/thresher` and `internal/instance`). Twelve defects
+  sharing two shapes: an engine-wide lock held while foreign code runs under it,
+  and an operation that reports success while nothing happened.
+  - **One slow host call stalled the whole engine.** The event hub built and
+    *started* a waiter while holding its single registry lock — and a message
+    waiter's start subscribes to the host's broker, which may be remote and may
+    block. Every registration, unregistration and lookup in the engine queued
+    behind one host call. The same shape held the engine's registry lock across
+    an embedder's `Actor.Groups()` during task authorization, and the scope
+    plane's lock across the host's runtime-variable supplier. All three now run
+    the foreign call unlocked.
+  - **A failed process registration bricked its key.** Registering a new version
+    withdraws the previous version's starters first; when the new arm then
+    failed, the call returned with *neither* on the hub and the failed version
+    still recorded as latest — so every later registration for that key tried to
+    withdraw starters that were never armed, failed too, and the key was dead
+    for the engine's lifetime. A failed registration now restores the previous
+    version exactly, and reports it if that restore also fails.
+  - **A transient store error abandoned an instance at startup.** Recovery read
+    *every* failure to claim a record as "another engine got there first" and
+    returned success, so a connection reset silently left an in-flight instance
+    unrecovered and unlogged. Only a compare-and-set conflict means that now.
+  - **Cancelling a dehydrated instance did nothing.** `Cancel` cancelled the
+    instance's context, but a parked instance has no loop reading it: the
+    request vanished, the next wake resumed the instance as if it had never been
+    made, and the caller blocked until its deadline. A cancel now rides the
+    rebuild, as an incident operation does, and the fresh loop tears the
+    instance down before deciding whether to park again.
+  - **A host's observer went quiet after the first rebuild.** `Observe`
+    registered on the instance *object*, which every rebuild replaces, while its
+    `Subscription` still reported itself live. Observers now belong to the
+    handle, whose identity outlives the object — and an operator's incident
+    retry re-attaches them too.
+  - **An operator request after shutdown reported success.** The engine pointer
+    is never cleared, so the "not running" guard could not fire: a cancel or an
+    incident operation rebuilt the instance, watched the fresh loop tear back
+    down on the dead engine context, and returned `nil`. Both entry points now
+    refuse.
+  - **A concurrent register could orphan itself against an unregister**, and a
+    scope snapshot taken during a commit could tear. Both are now taken under a
+    single acquisition.
+  - **`GetDataByID` became deterministic, not stricter.** An ItemDefinition is a
+    *type*, so two variables of one type share its id and Go's map iteration
+    returned a different one per run. Resolution is now nearest scope, then
+    lowest name: a model that worked by luck now works reliably, and one that
+    was picking the wrong variable does so consistently — which is what makes it
+    findable.
+
 - **The engine's lifecycle bookkeeping: a data race, reservations with no
   owner, and host code with no containment** (FIX-036 — the remediation of an
   external audit of `pkg/thresher`; eight defects, one shape: bookkeeping

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,7 +202,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Engine locks held across host calls, and requests that were silently lost**
   (FIX-038 — the second `/audit-package` sweep, over `internal/eventproc`,
-  `internal/scope`, `pkg/thresher` and `internal/instance`). Twelve defects
+  `internal/scope`, `pkg/thresher` and `internal/instance`). Sixteen defects
   sharing two shapes: an engine-wide lock held while foreign code runs under it,
   and an operation that reports success while nothing happened.
   - **One slow host call stalled the whole engine.** The event hub built and
@@ -243,6 +243,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **A concurrent register could orphan itself against an unregister**, and a
     scope snapshot taken during a commit could tear. Both are now taken under a
     single acquisition.
+  - **A cancel could still be lost, and an observer could be told twice.** The
+    routing that fixes the parked-instance cancel read the state and then
+    cancelled, so an instance parking between those two steps lost the request
+    exactly as before; the state is now re-read. And a subscription taken while
+    the engine was rebuilding an instance was registered twice on the new
+    object, so the host received every fact twice from a subscription it could
+    only cancel once. Both were found by an independent pre-merge review, on
+    code whose gate was already green.
   - **`GetDataByID` became deterministic, not stricter.** An ItemDefinition is a
     *type*, so two variables of one type share its id and Go's map iteration
     returned a different one per run. Resolution is now nearest scope, then

--- a/docs/audit/package-audit-2026-08-08.md
+++ b/docs/audit/package-audit-2026-08-08.md
@@ -185,9 +185,32 @@ duplicating tracks · `mi.go` / `mi_parallel.go` restore-count and fan-out gaps 
 `track.go:287/1021/1045` history race, subscription leak, cancellation
 misreported as failure · `std_loop.go:93` `loopCounter` collision.
 
-## 6 Next actions
+## 6 Disposition
 
-1. **FIX-038 for the confirmed defect track** — C-6…C-15. They group naturally:
+Landed by [FIX-038](../fix/FIX-038-locks-across-host-calls-and-lost-registrations.md).
+
+| Finding | Route | Where |
+|---|---|---|
+| C-6 `SnapshotAt` not atomic | fixed | FIX-038 §1.6 |
+| C-7 `GetDataByID` non-deterministic | fixed | FIX-038 §1.7 |
+| C-8 hub lock across `Service` | fixed | FIX-038 §1.1 |
+| C-9 `UnregisterEvent` TOCTOU | fixed | FIX-038 §1.3 |
+| C-10 recovery abandons an instance | fixed | FIX-038 §1.4 |
+| C-11 `Cancel` on a parked instance | fixed | FIX-038 §1.10 |
+| C-12 a failed registration bricks the key | fixed | FIX-038 §1.5 |
+| C-13 engine lock across `Authorize` | fixed | FIX-038 §1.2 |
+| C-14 `Observe` on the instance object | fixed | FIX-038 §1.8 |
+| C-15 `msgIdx` keyed by definition alone | filed | issue #305, with SRD-082 |
+
+Three defects not in this audit were found while fixing the ones that were, and
+landed with them: the plane lock spanning the runtime-variable supplier and
+`Shutdown` reporting under the hub lock (§1.9), the incident path dropping the
+handle's observers (§1.11), and an operator request reporting success after
+shutdown (§1.12).
+
+## 7 Next actions
+
+1. ~~**FIX-038 for the confirmed defect track** — C-6…C-15.~~ Landed; see §6. They group naturally:
    the host-code-under-an-engine-lock shape (C-8, C-13), the hub's registration
    TOCTOU (C-9), the silently-abandoned recovery (C-10), the bricked process key
    (C-12), and the identity-vs-object leaks (C-11, C-14).

--- a/docs/audit/package-audit-2026-08-08.md
+++ b/docs/audit/package-audit-2026-08-08.md
@@ -27,15 +27,18 @@ a diff to whole packages.
 | `pkg/thresher` | 5 971 | 3 / 3 | 16 |
 | `internal/scope` | 1 217 | 3 / 3 | 14 |
 | `internal/eventproc/eventhub` (+ `waiters`) | 2 132 | 3 / 3 | 9 |
-| `internal/instance` | 14 034 | **1 / 3** | 2 |
+| `internal/instance` | 14 034 | **3 / 3** (4-way split, round 2) | 28 |
 | `pkg/model/activities` · `events` · `data` · `gateways` | 15 562 | maintainer audit | 0 confirmed |
 
-**`internal/instance` is under-covered and must be re-run.** At 584 KB of
-source the reviewer fell back to a shell command to page through the prompt,
-was auto-denied in headless mode, and returned `status: SUCCESS` with an **empty
-body**. Only the architecture lens completed. A naive collector reads that as a
-clean package; ours flags it. Splitting the unit in half (330 KB) did not help —
-it needs four or more parts, or a different feeding strategy.
+**`internal/instance` was re-run in round 2 and is now fully covered.** The
+first attempt fed 584 KB in one prompt; the reviewer fell back to a shell
+command to page through it, was auto-denied in headless mode, and returned
+`status: SUCCESS` with an **empty body** — which a naive collector reads as a
+clean package. Halving it (330 KB) did not help. **Four parts did**: all eight
+lenses returned real output, and the package went from 2 findings to 28.
+
+Two thirds of the largest package in the engine had been invisible, and the
+signal that it was invisible was a *successful* exit code.
 
 **The model packages were audited by the maintainer, not by `agy`**, on the
 reasoning that an external reviewer buys the most where the author's belief is
@@ -57,6 +60,18 @@ invented. Never route a finding by its line number; find the construct.
 **Three lenses duplicate.** `internal/scope`'s non-atomic `SnapshotAt` appears
 four times under three titles. Duplication across lenses is a signal of
 salience, not of three separate defects — dedupe before counting.
+
+**And convergence is NOT evidence of correctness.** Two independent lenses
+reported `restore.go:391` as an inverted correlation check — "missing negation",
+"valid triggers rejected" — with high confidence. The function's signature is
+`validateAndAssociate(...) (mismatch bool)`: `true` means *belongs to another
+conversation*, so refusing on `true` is right. Both lenses reasoned from the
+function's NAME, which reads like it returns "valid", and neither read the named
+return value.
+
+When lenses share a misleading cue they agree confidently and wrongly. Agreement
+raises how much attention a finding deserves; it does nothing for how likely it
+is to be true. Only reading the code settles that.
 
 Neither property is a reason to stop using the reviewer. Both are reasons the
 skill requires verification before a finding is allowed into this document.
@@ -93,66 +108,100 @@ else that shape occurs, and neither the FIX process nor the review gate asks it.
 defect. Complexity — and defects — cluster in `internal/`, not in the
 spec-grounded model layer.
 
-## 5 Pending verification
+## 5 Round-2 verification
 
-The remaining findings are **unverified model output** and must not be treated
-as defects until checked. Recorded here so the next pass starts from the list
-rather than re-running the sweep. Deduplicated across lenses.
+Round 2 re-ran `internal/instance` to completion and verified the §5 backlog
+against the source. Verdicts below; every finding carries one, including the
+refuted.
 
-### 5.1 `pkg/thresher`
+### 5.1 Confirmed — defect track
 
-| Sev | Construct | Claim |
+| # | Construct | Confirmed defect |
 |---|---|---|
-| blocker | `handle.go` `InstanceHandle.Cancel` | Cancelling a dehydrated instance has no effect and is lost on the next hydration |
-| blocker | `tasks.go` task authorization | The engine mutex is held across authorization, serialising task actions under load |
-| blocker | `thresher.go` task registry | Parked human tasks are in-memory only, so they are orphaned across a restart |
-| blocker/major | `thresher.go` `RegisterProcess` | A failed `registerStarters` after a successful `unregisterStarters` leaves the key with no starters, and the retry fails on the unwired version — bricking the key |
-| major | `observer.go` | Instance-scoped observers are orphaned when an instance dehydrates and rebuilds |
-| major | `locked.go` `UnregisterProcess` | Deletes snapshots that dehydrated instances still need in order to wake |
-| major | `recovery.go` `recoverOne` | A `Save` transport error is treated as a lost CAS, abandoning the instance |
+| C-6 | `scope.SnapshotAt` | Not atomic: `namesFrom` locks and unlocks, then each `GetData` locks and unlocks. `track.go:1496` states the snapshot runs *"on the track goroutine"* and that *"commits bypass the loop"*, so concurrent mutation is reachable. It defeats the invariant the snapshot exists to provide — "a handler reads the world as the completed activity saw it". |
+| C-7 | `scope.GetDataByID` | Resolves by iterating a map, so two scope variables sharing an ItemDefinition ID resolve at random. Reachable: `events/event.go:790` resolves by ID and a model may reuse an ItemDefinition. |
+| C-8 | `eventhub.registerWaiter` | Holds the hub's **global lock** across `w.Service(ctx)`, which for a message waiter calls `MessageBroker().Subscribe` (`message.go:222`). A slow or remote broker stalls every hub operation. |
+| C-9 | `eventhub.UnregisterEvent` | Releases the lock after its lookup, then check-then-acts (`len(EventProcessors())==0` → `Stop` → `RemoveWaiter`). A concurrent `registerWaiter` can attach a processor in that window; the registration lands on a stopped, unmapped waiter and silently never fires. |
+| C-10 | `recovery.recoverOne:71` | Returns `nil` on ANY `Save` error, commented "a lost claim race is the normal outcome". A transport error is indistinguishable from a lost CAS, so a transient failure silently abandons an in-flight instance at startup — and reports success, so nothing logs it. `claimForWake` retries the identical failure; the two paths disagree. |
+| C-11 | `InstanceHandle.Cancel` | Calls `h.current().Cancel()` with no durable path. On a dehydrated instance the loop is gone, so the cancel is lost and a later wake resumes as if nothing happened. Incident ops solved this with `WithPendingIncidentOp`; Cancel never got it. |
+| C-12 | `RegisterProcess` (`thresher.go:1066-1082`) | If `unregisterStarters(prevLatest)` succeeds and `registerStarters(new)` then fails, the previous version's starters are off the hub and the new version's never went on — **the key has no live starters**. The failed version stays in the registry as latest, so a retry tries to unregister starters that were never registered, gets `ObjectNotFound`, and fails. **The process key is permanently bricked.** |
+| C-13 | `tasks.go:219` task authorization | `t.m` is held across `rec.eligible.Authorize(...)`, a host-supplied authorizer. A directory or database lookup there stalls the engine's global registry lock. |
+| C-14 | `InstanceHandle.Observe` (`observer.go:85`) | Registers on `h.current()`, the current instance OBJECT. On rebuild the handle is re-pointed but the registration is not carried, so a host observer silently stops receiving facts after the first dehydration while its `Subscription` still looks live. |
+| C-15 | `loop.go:681` `msgIdx` | Keyed by message-definition id alone, so two tracks parked on one definition overwrite each other and one never receives. Same class as the "shared catch node" follow-up master filed with SRD-082. |
 
-### 5.2 `internal/scope`
+**C-8, C-13 and FIX-036 §1.5 are one shape in three subsystems**: host code
+called while an engine lock is held. Fixing it in the producer did not prompt
+anyone to look in the hub or the task path.
 
-| Sev | Construct | Claim |
-|---|---|---|
-| blocker | `scope.go` `SnapshotAt` | Not atomic — `namesFrom` then per-name `GetData`, each taking the lock separately; a concurrent `CloseScope` aborts or tears the snapshot |
-| blocker | `scope.go` | The plane mutex is held across a call into the host's `RuntimeVarsSupplier` |
-| major | `scope.go` `GetDataByID`, `frame.go` | Resolution by ItemDefinition ID iterates a map, so two variables of one type resolve non-deterministically |
-| major | `datapath.go` `NewDataPath` | Validates a trimmed path but stores the untrimmed one, so a padded path becomes a distinct map key and breaks `DropTail` |
-| major | `scope.go` `getData` | O(N) scan under the global mutex where the map key would serve |
-| major | `scope.go` `cloneDatum` | Type-switch on concrete `Clone` signatures — the shape behind the `Property`/`DataObject` bug fixed during SRD-079 |
-| minor | `frame.go` `Commit` | `outputs` and `puts` are appended without dedup, emitting an intermediate value that never durably existed |
+**C-12 is a blind spot of FIX-036 M6**, which added the wiring-claim bookkeeping
+on exactly this path and never asked what happens to the hub state when the
+second call fails.
 
-### 5.3 `internal/eventproc/eventhub`
+### 5.2 Refuted — with reasons, so they are not re-investigated
 
-| Sev | Construct | Claim |
-|---|---|---|
-| blocker | `eventhub.go` | The hub lock is held across unbounded external operations, including `MessageBroker.Subscribe` |
-| blocker | `eventhub.go` | TOCTOU between waiter removal and concurrent registration orphans a registration |
-| blocker | `waiters/message.go` | A message that fails processing terminally halts a persistent instance-starter |
-| major | `waiters/timer.go` | Cancelled timers are retained until expiry; `time.After` in the loop retains stopped waiters; a delivery failure leaks the registry entry |
+| Finding | Verdict |
+|---|---|
+| `restore.go:391` inverted correlation check ("missing negation"), reported by **two** lenses | **Refuted.** The signature is `validateAndAssociate(...) (mismatch bool)` — `true` means the trigger belongs to another conversation, so refusing on `true` is correct. Both lenses reasoned from the function's name, not its named return. |
+| `DataPath` lacks canonicalization → split-brain scopes | **Refuted as a live defect.** `NewDataPath` does validate the trimmed string and store the untrimmed one, but `Append` trims its tail and every production path goes through `Append`. Only a direct `NewDataPath(" /a ")` reaches it, and nothing does. Latent trap, not a defect. |
 
-### 5.4 `internal/instance`
+### 5.3 Contract track — `audit-backlog.md`, not a FIX
 
-| Sev | Construct | Claim |
-|---|---|---|
-| blocker | `adhoc.go` | Double host resume when an Ad-Hoc completion condition fires with `CancelsRemaining` |
-| major | `activation.go` `guardEval` | The Complex Gateway guard opens a scope frame per evaluation and never discards it |
+| Finding | Why it is not a defect patch |
+|---|---|
+| `UnregisterProcess` strands dehydrated instances | It drops every version, while `UnregisterVersion` documents "running instances are unaffected — they keep executing against their own frozen snapshot". True for a RESIDENT instance; a dehydrated one holds no object and needs the registry to rebuild. Deciding whether unregister refuses, retains snapshots, or evicts instances is a contract change. |
+| Human tasks are in-memory only, orphaned across a restart | Durable task state is a persistence-model decision (ADR-020 / ADR-033 territory), not a patch. |
 
-Both from the architecture lens alone — the other two lenses did not run.
+### 5.4 Plausible — mechanism credible, not yet settled
+
+Recorded so the next pass starts from the analysis, not from zero.
+
+| Finding | What was established |
+|---|---|
+| `adhoc.go:208` Ad-Hoc double resume (3 lenses) | The `aborting` guard at `decScope:571` does NOT cover this path — it is set only by the Transaction-abort sweep (`compensation_watch.go:380`). That removes the guard the code might have relied on and makes the mechanism credible. Whether cancelled tracks re-enter `decScope` is untraced. |
+| `calls.go:150` unguarded send to `entry.track.evtCh` | `evtCh` IS buffered (`restore.go:359`) and `loop.go:448` shows the loop CLOSES it to wake a parked track — so the likely failure is a panic on send-to-closed, not the reported deadlock. `onWaiting` guards against exactly that hazard elsewhere. The mechanism is real; the reviewer's failure mode is wrong. |
+
+### 5.5 `internal/instance` — 28 findings, unverified
+
+The round-2 re-run produced 28 findings (13 blocker, 15 major) across 8 lenses,
+deduplicated. Three cite lines that cannot exist — `escalation_watch.go:1347`
+(225-line file), `incident.go:2410` (967), `loop.go:4713` (1361) — the same ~11%
+fabrication rate as round 1, so route by construct and never by line.
+
+Two were examined above (§5.2 `restore.go:391` refuted, §5.4 `calls.go:150`
+partly). The remaining 25 are **unverified model output** and must not be
+treated as defects until checked:
+
+`boundary_watch.go` error catch on an MI host orphaning siblings ·
+`loop.go:1151` join re-evaluation deadlock · `escalation_watch.go` multiple
+exception tokens, and root-level Event Sub-Processes missed ·
+`scope_decorator.go` cancellation leaking requests, and loop-condition
+re-evaluation orphaning child scopes · `tasks.go:170` Complete succeeding on a
+cancelled track · `transaction.go:25` live tracks running during abort ·
+`tasks.go:446` `withdrawAllTasks` blocking the loop · `track.go:721`
+`stashTimerPlan` overwriting a node's second timer · `correlation.go:170`
+TOCTOU in `validateAndAssociate` · `checkpoint_capture.go` TOCTOU and
+non-deterministic payload ordering · `incident.go:490` concurrent retries
+duplicating tracks · `mi.go` / `mi_parallel.go` restore-count and fan-out gaps ·
+`track.go:287/1021/1045` history race, subscription leak, cancellation
+misreported as failure · `std_loop.go:93` `loopCounter` collision.
 
 ## 6 Next actions
 
-1. **FIX-037 has landed C-1…C-5** on branch `fix/wake-residency-races`
-   (`96fbffb`, `67a6b82`, `3a64fdb`, `d15191b`, `901ba11`), rebased onto
-   `cdafd20`.
-2. **Re-run `internal/instance`** with four-or-more-way splitting; two thirds of
-   the largest package in the engine is currently unaudited.
-3. **Verify §5 in unit-sized batches**, routing each to a FIX or to
-   `audit-backlog.md` — several §5 items (the in-memory task registry, snapshot
-   deletion vs dehydrated instances) change a contract and are backlog-track,
-   not defect-track.
-4. **Ask the shape question on every FIX.** Two of the five confirmed defects
-   were halves of FIX-036 left behind. Neither `/check-srd` nor `/pr-review`
-   asks "where else does this shape occur"; that question belongs in the FIX
+1. **FIX-038 for the confirmed defect track** — C-6…C-15. They group naturally:
+   the host-code-under-an-engine-lock shape (C-8, C-13), the hub's registration
+   TOCTOU (C-9), the silently-abandoned recovery (C-10), the bricked process key
+   (C-12), and the identity-vs-object leaks (C-11, C-14).
+2. **Verify the 25 `internal/instance` findings** (§5.5) in unit-sized batches,
+   routing each to a FIX or to `audit-backlog.md`.
+3. **File the contract-track items** (§5.3) as backlog entries with their
+   governing docs named.
+4. **Ask the shape question on every FIX.** Three of this round's confirmed
+   findings are the same shape as a defect already fixed elsewhere — host code
+   under an engine lock (FIX-036 §1.5 → C-8, C-13) — and C-12 is a blind spot of
+   FIX-036 M6, which touched that exact path. Neither `/check-srd` nor
+   `/pr-review` asks "where else does this shape occur"; it belongs in the FIX
    template.
+5. **Read a finding's signature before its name.** The one refutation that cost
+   real time (§5.2) fooled two lenses because `validateAndAssociate` reads like
+   it returns "valid" while its named return is `mismatch`. Convergence across
+   lenses is salience, never correctness.

--- a/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
+++ b/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
@@ -368,7 +368,15 @@ before moving it (§1.14). `publishWaiter` reports the waiter that serves the
 processor (§1.15). `remapUnstopped` puts back a waiter whose `Stop` failed, but
 only if the key is still free — a registration that installed its own waiter in
 the meantime owns the definition, and overwriting it would strand THAT one
-(§1.16).
+(§1.16). A signal waiter goes back into the name index too: it is reached by
+NAME, so restoring it to the registry alone would leave it mapped, alive and
+invisible to every broadcast.
+
+`Cancel` does **not** nil-guard `current()`. A handle always speaks for an
+instance — every constructor adopts one — and `State()` and `Data()` do not
+guard it either, so a guard here would only defer the same nil to
+`WaitCompletion` two lines later. It was written, found uncovered by the gate,
+and removed rather than given a test for a branch that panics downstream.
 
 ## 4 Verification
 
@@ -408,7 +416,7 @@ The independent review's findings (§1.13–§1.16):
 | T-19 | `TestCancelRacingTheParkStillLands` | a cancel whose check saw a live instance still terminates it when the park lands in the window — driven through the seam, not raced for (§1.13) |
 | T-20 | `TestReattachIsIdempotentPerObject` | one fact, one delivery: a re-attach onto the object an observer already sits on does not register it twice (§1.14) |
 | T-21 | `TestLostRegistrationReportsTheServingWaiter` | the registration fact names the winner, never the discarded waiter (§1.15) |
-| T-22 | `TestUnstoppableWaiterStaysMapped` | a waiter whose `Stop` fails is still mapped, and is the same waiter (§1.16) |
+| T-22 | `TestUnstoppableWaiterStaysMapped`, `TestUnstoppableSignalWaiterRejoinsTheNameIndex`, `TestUnstoppableWaiterYieldsToAReplacement` | a waiter whose `Stop` fails is still mapped and still in the name index — but never over a waiter that claimed the definition meanwhile (§1.16) |
 
 ### 4.2 Gate
 

--- a/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
+++ b/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
@@ -52,9 +52,19 @@ defer t.m.Unlock()
 if err := rec.eligible.Authorize(taskID, actor); err != nil {
 ```
 
-`Authorize` is host policy — a directory or database lookup is the normal
-implementation. It runs holding `t.m`, the lock every registration, launch and
+`Authorize` itself is engine-owned and in-memory: `Eligibility` holds
+already-RESOLVED slots and `permits` compares them. What crosses the host
+boundary is the **actor**: `permits` calls `actor.UserID()` and
+`actor.Groups()` (`eligibility.go:127,136`), and `hi.Actor` is an interface the
+embedder implements. Their contract is "return the id / the groups", so the
+normal implementation is a trivial getter — but the engine cannot assume that,
+and it runs them holding `t.m`, the lock every registration, launch and
 discovery call needs.
+
+This is weaker than §1.1: a blocking `Groups()` is a misbehaving embedder
+rather than an expected one. It is fixed for the same reason the producer's
+hooks were (FIX-036 §1.5) — the engine does not get to decide how long someone
+else's code takes — and because the SHAPE is what keeps recurring.
 
 **§1.1 and §1.2 are the same defect as FIX-036 §1.5**, which found host code
 running uncontained inside the producer. That landing fixed the producer and
@@ -162,7 +172,7 @@ new and has no path back when the second step fails.
 | # | Decision | Alternatives | Chosen |
 |---|---|---|---|
 | 1 | §1.1 the hub lock | (a) a second lock for waiter *creation* — two locks over one registry invites the ordering bugs the package has already had; (b) **build and Service the waiter OUTSIDE the lock, then insert under it**, tearing the waiter down if the insert loses a race | **(b)** — the same shape `HoldSubscription` uses since FIX-036: the expensive, foreign work happens unlocked, the registry mutation is a short critical section |
-| 2 | §1.2 authorization | (a) copy the record under the lock and authorize outside; (b) authorize before taking the lock — needs the record, so it would read it twice | **(a)** |
+| 2 | §1.2 authorization | (a) copy the record under the lock and authorize outside; (b) leave it — the actor's accessors are expected to be getters, so the exposure is small | **(a)** — the eligibility policy is written once and read-only, so reading it separately cannot go stale, and the ownership decision still happens under the lock on a freshly read record. `setOwner` additionally stops taking a CALLBACK it runs under the lock, which is the shape `locked.go` forbids by construction and the reason two of the three call sites went unnoticed |
 | 3 | §1.3 the unregister race | (a) re-check `len(EventProcessors())` after re-acquiring — still a window; (b) **hold the write lock across the whole check-and-remove** | **(b)** — it is registry work, which is exactly what the lock is for; the waiter's `Stop` moves out of the critical section |
 | 4 | §1.4 recovery | (a) retry like `claimForWake` — hides a genuine outage behind attempts; (b) **classify: a lost CAS is `nil`, anything else is reported** — the repository already distinguishes them | **(b)** |
 | 5 | §1.5 the bricked key | (a) re-register `prevLatest` on failure — restores auto-start but leaves the failed version as `latest`, so the retry still misbehaves; (b) **remove the failed version from the registry AND restore the previous latest's starters** | **(b)** — the key returns to exactly its pre-call state |

--- a/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
+++ b/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
@@ -342,6 +342,17 @@ nobody misinformed, while an operator told "cancelled" needs it to be true.
 | T-12 | `TestRebuildForOpReportsAFailedClaim`, `TestRebuildForOpReportsAFailedRebuild` | a request that cannot take the latch or cannot rebuild is reported, names the operation, and releases the latch (§1.11) |
 | T-13 | `TestCancelOnAParkedInstanceReportsAStoppedEngine`, `TestAwaitOpVerdictHonoursTheCallerContext` | a request arriving after shutdown fails instead of reporting success; the verdict wait is bounded by the caller's context (§1.12) |
 
+The gate then found that several of the remedies' own failure branches had no
+test — the FIX-037 lesson repeating, so they are pinned too:
+
+| # | Test | Asserts |
+|---|---|---|
+| T-14 | `TestRegisterOnAStoppedHubIsRejectedAndTearsDown`, `TestRegisterJoinFailureIsReported` | a registration whose hub stops, or whose join fails, DURING the now-unlocked build is rejected and its uninstalled waiter torn down (§1.1) |
+| T-15 | `TestRemoveWaiterDropsTheRegistration` | `RemoveWaiter` drops the waiter through the single removal point, and a second call reports not-found (§1.3) |
+| T-16 | `TestFirstRegistrationFailureLeavesNoTrace`, `TestRollbackFailureJoinsTheCause` | a failing FIRST registration returns its cause unwrapped and leaves no version behind; a failing rollback joins its own error to the cause (§1.5) |
+| T-17 | `TestTaskVanishesBetweenThePhases` | a task removed while the embedder's `Authorize` runs is reported unknown by both phase-2 paths, not acted on (§1.2) |
+| T-18 | `TestGetDataByIDStopsAtAnUnrootedPath`, `TestReattachObserversWithoutAnInstance` | the id walk terminates on a path with no parent; a handle with no instance ignores the re-attachment (§1.7, §1.8) |
+
 ### 4.2 Gate
 
 `make ci` green end to end, `-race` included; diff-coverage ≥95% on the touched
@@ -375,6 +386,13 @@ lines (`COVER_MIN`).
 - Every path fixed here reported success while failing. A registration that
   cannot fire, a recovery that did not happen and an observer that will not be
   called now each produce an error or a log.
+- **The remedy's own error branches need the same coverage as the defect's.**
+  The first full gate run failed at 91.7% diff-coverage, and the gap was not in
+  the fixes but in what happens when THEY fail: a rollback that cannot restore
+  the previous starters, a registration meeting a hub that stopped mid-build, a
+  task deleted inside the very window the lock-split opens. Each is reachable
+  only through the new structure, so nothing older covered them — T-14 to T-18
+  exist because the gate, not a reviewer, asked.
 
 ## 6 Regressions and side effects
 

--- a/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
+++ b/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
@@ -1,7 +1,7 @@
 # FIX-038 — engine locks held across host calls, and registrations that are silently lost
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft.
+**Status:** Accepted.
 **Date:** 2026-08-08.
 **Author:** Ruslan Gabitov.
 **Branch:** `fix/audit-round2` — the confirmed defect track of the 2026-08-08 package audit.
@@ -443,7 +443,41 @@ Prior art: [FIX-036](FIX-036-thresher-lifecycle-races-and-reservations.md) §1.5
 
 ## 8 Implementation summary
 
-_To be filled after the milestones land._
+### 8.1 Milestone commits
+
+| M | Commit | Scope |
+|---|---|---|
+| — | `d700122` | the audit that produced this document: `internal/instance` finished, the pending backlog verified |
+| — | `dadb1d1` | this document |
+| M1 | `fab88e8` | §1.4 — a store failure is not a lost claim (`lostClaim`) |
+| M2 | `1f0a88f` | §1.5 — a failed registration restores the previous version (`rollbackRegistration`) |
+| M3 | `034c803` | §1.1, §1.3 — the hub lock covers the registry, not the broker |
+| M4 | `bbcc6e6` | §1.2 — the engine lock does not span the embedder's `Actor` |
+| M5 | `83faa4a` | §1.6, §1.7 — one locked snapshot walk, and a total id resolution rule |
+| M6 | `7ae3504` | §1.8 — the handle owns its observers |
+| M7 | `e78a071` | §1.9 — the last two calls out of a package under a lock |
+| M8 | `b714e95` | §1.10, §1.11, §1.12 — a cancel reaches a parked instance, and its rail is shared |
+| M9 | `a05bf34` | T-14 to T-18 — the remedies' own failure branches |
+
+M8 and M9 are the rule at work rather than a plan: M8's §1.11 and §1.12 were
+found while writing §1.10's fix, and M9 exists because the gate — not a reviewer
+— showed that the remedies' error paths were untested. Neither was deferred.
+
+### 8.2 Empirical findings
+
+- **A `defer`-based lock scan reports what you hoped for.** Three sweeps were
+  needed (§5): the first treated `defer m.Unlock()` as ending the locked region
+  and called three live instances clean; the second was function-scoped and
+  flagged five already-fixed sites; only the third tracked lock state. Even it
+  missed `EventHub.Shutdown` because the pattern list had dropped `Report` —
+  found by re-reading the file the scanner had cleared.
+- **`agy`'s line citations are unreliable, its mechanisms often are not.**
+  Roughly one finding in nine cited a line that does not contain what it claims,
+  while describing a real defect elsewhere in the same function. Verify the
+  mechanism, not the coordinate.
+- **Two lenses agreeing is not evidence.** Two independent lenses confidently
+  reported the same non-existent restore defect. Convergence narrows where to
+  look; it does not decide.
 
 ## 9 Open questions
 

--- a/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
+++ b/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
@@ -216,6 +216,39 @@ engine context, and returned **nil** to the operator.
 That is the same silent loss as §1.10 one step further out: the caller is told
 its request landed when nothing ever observed it.
 
+### 1.13 The cancel routing races the park it routes for
+
+§1.10's guard reads the instance's state and then cancels. The two steps are not
+atomic, so an instance that parks in between takes the direct cancel to a loop
+that has already exited — the same silent loss, now inside the fix for it.
+
+Found by the independent review (`/pr-review`), not by `/check-srd` or the
+coverage gate: the guard is fully covered, and coverage cannot ask whether the
+line after the check still holds the assumption the check made.
+
+### 1.14 A re-attach registers an observer twice
+
+`reattachObservers` re-registered every observer unconditionally. An `Observe`
+landing between `adopt` and the re-attach registers on the NEW instance object
+already, so the re-attach adds the same fan-out to that object a second time:
+every fact is delivered twice, and the first registration's cancel is
+overwritten, leaving a registration that can never be removed.
+
+### 1.15 The registration fact names a discarded waiter
+
+On the losing path the processor is attached to the winner, but the
+`PhaseRegistered` fact reported the waiter this call built, stopped and threw
+away. An operator following that id finds nothing.
+
+### 1.16 A waiter that will not stop is stranded
+
+§1.3 correctly moved the removal under the lock that observes the waiter empty
+— which also moved it BEFORE `Stop`. A waiter whose `Stop` fails is still
+serving its subscription, and leaving it unmapped strands it: the next
+registration for that definition builds a second waiter and subscribes again,
+and nothing can ever reach the first. Before this branch a failed `Stop`
+returned early and left the waiter mapped, so a later registration rejoined it.
+
 ## 2 Root cause analysis
 
 **A lock whose scope was never stated.** §1.1, §1.2 and §1.3 are one cause: the
@@ -322,6 +355,21 @@ already cancelled (§1.12). The check lives here rather than in
 verdict: a timer wake arriving after shutdown rebuilds and terminates with
 nobody misinformed, while an operator told "cancelled" needs it to be true.
 
+#### 3.2.10 the independent review's remediation
+
+`Cancel` re-reads the instance state after the direct cancel and routes a
+newly-parked instance, bounded by `cancelRouteAttempts` (§1.13). `cancelParkSeam`
+is a nil-in-production seam that lets a test aim at the window rather than race
+for it; it is bridged to the external test package by `export_test.go`.
+
+`handleObserver` records the instance object its registration sits on, so
+`reattachObservers` is idempotent per object and cancels a stale registration
+before moving it (§1.14). `publishWaiter` reports the waiter that serves the
+processor (§1.15). `remapUnstopped` puts back a waiter whose `Stop` failed, but
+only if the key is still free — a registration that installed its own waiter in
+the meantime owns the definition, and overwriting it would strand THAT one
+(§1.16).
+
 ## 4 Verification
 
 ### 4.1 Regression tests
@@ -352,6 +400,15 @@ test — the FIX-037 lesson repeating, so they are pinned too:
 | T-16 | `TestFirstRegistrationFailureLeavesNoTrace`, `TestRollbackFailureJoinsTheCause` | a failing FIRST registration returns its cause unwrapped and leaves no version behind; a failing rollback joins its own error to the cause (§1.5) |
 | T-17 | `TestTaskVanishesBetweenThePhases` | a task removed while the embedder's `Authorize` runs is reported unknown by both phase-2 paths, not acted on (§1.2) |
 | T-18 | `TestGetDataByIDStopsAtAnUnrootedPath`, `TestReattachObserversWithoutAnInstance` | the id walk terminates on a path with no parent; a handle with no instance ignores the re-attachment (§1.7, §1.8) |
+
+The independent review's findings (§1.13–§1.16):
+
+| # | Test | Asserts |
+|---|---|---|
+| T-19 | `TestCancelRacingTheParkStillLands` | a cancel whose check saw a live instance still terminates it when the park lands in the window — driven through the seam, not raced for (§1.13) |
+| T-20 | `TestReattachIsIdempotentPerObject` | one fact, one delivery: a re-attach onto the object an observer already sits on does not register it twice (§1.14) |
+| T-21 | `TestLostRegistrationReportsTheServingWaiter` | the registration fact names the winner, never the discarded waiter (§1.15) |
+| T-22 | `TestUnstoppableWaiterStaysMapped` | a waiter whose `Stop` fails is still mapped, and is the same waiter (§1.16) |
 
 ### 4.2 Gate
 
@@ -458,10 +515,20 @@ Prior art: [FIX-036](FIX-036-thresher-lifecycle-races-and-reservations.md) §1.5
 | M7 | `e78a071` | §1.9 — the last two calls out of a package under a lock |
 | M8 | `b714e95` | §1.10, §1.11, §1.12 — a cancel reaches a parked instance, and its rail is shared |
 | M9 | `a05bf34` | T-14 to T-18 — the remedies' own failure branches |
+| M10 | `b8637a0` | §1.13–§1.16 — the four defects the independent review confirmed |
+| M11 | `177c5d0` | T-3 strengthened, the rollback assertions pinned by identity, the stub made as strict as a real waiter |
 
 M8 and M9 are the rule at work rather than a plan: M8's §1.11 and §1.12 were
 found while writing §1.10's fix, and M9 exists because the gate — not a reviewer
 — showed that the remedies' error paths were untested. Neither was deferred.
+
+M10 and M11 come from `/pr-review` — a doc-blind read of the diff by a different
+model family, run at the PR handover with the gate already green. It returned 11
+notes; 8 survived verification and are fixed here, 3 did not and are recorded in
+§8.3. The two that matter are self-inflicted: §1.13 is this document's own §1.10
+defect reappearing inside the guard that fixes it, and T-3 could not fail on the
+code it pins. Neither `/check-srd` nor the coverage gate can ask either
+question — T-3 had 100% coverage of the lines it failed to pin.
 
 ### 8.2 Empirical findings
 
@@ -478,6 +545,26 @@ found while writing §1.10's fix, and M9 exists because the gate — not a revie
 - **Two lenses agreeing is not evidence.** Two independent lenses confidently
   reported the same non-existent restore defect. Convergence narrows where to
   look; it does not decide.
+
+### 8.3 Review notes NOT acted on
+
+Recorded with their reasons, so the next review does not re-investigate them.
+
+- **"`reattachObservers` runs under the engine lock."** Refuted. The reviewer
+  read the `*Locked` suffix as "the caller holds the lock". In this package it
+  means the opposite: `locked.go`'s header states each helper acquires `t.m`
+  itself, and `trackInstanceLocked` opens with `t.m.Lock(); defer t.m.Unlock()`.
+  No lock is held at the call site.
+- **"The eventhub tests pin the internal `waiters` map; the task and rollback
+  tests pin `th.tasks` / `th.registrations`."** Rejected. These are internal
+  tests of windows that exist only inside those functions — the gap between two
+  phases of one call — and no legitimate concurrent action can be aimed at them.
+  Both rollback tests also assert the observable behaviour that matters: the
+  retry succeeds, which is the bricked-key symptom.
+- **"A stranded waiter causes double-processing."** Half refuted: the stranding
+  is real and fixed (§1.16), but the stranded waiter holds zero processors, so
+  it cannot deliver anything to anyone. The cost is a duplicate broker
+  subscription, not duplicate work.
 
 ## 9 Open questions
 

--- a/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
+++ b/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
@@ -177,7 +177,7 @@ new and has no path back when the second step fails.
 | 4 | §1.4 recovery | (a) retry like `claimForWake` — hides a genuine outage behind attempts; (b) **classify: a lost CAS is `nil`, anything else is reported** — the repository already distinguishes them | **(b)** |
 | 5 | §1.5 the bricked key | (a) re-register `prevLatest` on failure — restores auto-start but leaves the failed version as `latest`, so the retry still misbehaves; (b) **remove the failed version from the registry AND restore the previous latest's starters** | **(b)** — the key returns to exactly its pre-call state |
 | 6 | §1.6 the snapshot | (a) a coarse "snapshot lock" held by every mutator — a second lock over the same state; (b) **one locked walk**: a `snapshotAtLocked` that reads names and data under a single acquisition | **(b)** |
-| 7 | §1.7 ambiguous ids | (a) pick deterministically (sorted by name) — makes the result stable and still arbitrary; (b) **refuse an ambiguous lookup with a classified error naming both candidates** | **(b)** — two variables of one type resolved by type is a modelling error, and answering it silently is how it stays unnoticed |
+| 7 | §1.7 ambiguous ids | (a) **resolve deterministically**: nearest scope first (as the by-name lookup already does), then lowest name within a scope; (b) refuse an ambiguous lookup with a classified error naming the candidates | **(a)** — (b) was chosen first and is WRONG. It rejects the send/receive pattern, where a message's payload ItemDefinition is legitimately bound to both the message variable and the variable receiving it; `TestSendReceiveMidFlow` fails against it with *"`order_in` is ambiguous — it names 2 data (order_in, received order)"*. Refusing looked principled until it refused correct BPMN. Determinism is the achievable improvement: the nearest-scope rule is meaningful, the lowest-name tiebreak is arbitrary but stable, and an id naming several data in one scope remains a modelling smell the engine now answers the same way every time |
 | 8 | §1.8 observers | (a) re-register in `adopt` — the handle would need to remember its observers; (b) **register the observer on the HANDLE, and have the handle's fan-out follow the current instance** | **(a)** — the handle already owns identity across rebuilds (SRD-071); it keeps its observer set and re-attaches on adopt, which is the smaller change |
 
 ### 3.2 Changes by file
@@ -206,10 +206,12 @@ On a failed `registerStarters`, the version just appended is removed from the
 registry and the previous latest's starters are put back on the hub, so the key
 is exactly as it was before the call and a retry behaves like a first attempt.
 
-#### 3.2.5 `internal/scope/scope.go` — one locked walk, and an ambiguous id refuses
+#### 3.2.5 `internal/scope/scope.go` — one locked walk, and a total id rule
 
-`SnapshotAt` reads names and data under a single acquisition of `p.m`.
-`GetDataByID` refuses when more than one datum carries the id, naming both.
+`SnapshotAt` reads names and data under a single acquisition of `p.m`
+(`namesFromLocked` + the unlocked `getData` the by-name path already uses).
+`GetDataByID` resolves nearest-scope-first, lowest-name-within-a-scope — total
+and deterministic, where it previously depended on Go's map iteration order.
 
 #### 3.2.6 `pkg/thresher/observer.go`, `handle.go` — observers belong to the handle
 
@@ -249,9 +251,12 @@ lines (`COVER_MIN`).
 
 ## 6 Regressions and side effects
 
-- `GetDataByID` becomes stricter: a model with two variables sharing an
-  ItemDefinition id now gets a classified error instead of a random answer. That
-  is the point, and it is a behavioural change called out in the CHANGELOG.
+- `GetDataByID` becomes DETERMINISTIC, not stricter. A model with two variables
+  sharing an ItemDefinition id used to get a random one of them and now gets a
+  stated one — nearest scope, then lowest name. No model that worked starts
+  failing; a model that worked *by luck* now works reliably, and one that was
+  silently picking the wrong variable will start doing so consistently, which is
+  what makes it findable. Called out in the CHANGELOG.
 - `SnapshotAt` holds the plane lock for the whole walk rather than per datum.
   The walk is bounded by the visible surface and takes no host call.
 - `RegisterProcess`'s failure path now mutates the registry (removing the

--- a/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
+++ b/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
@@ -147,6 +147,41 @@ host observer stops receiving facts, silently, while its `Subscription` still
 reports itself live. The method's own comment notes the instance is "swappable"
 — for the logger.
 
+### 1.9 The plane lock spans the runtime-variable supplier
+
+```go
+// scope.go:94-99
+p.m.Lock()
+defer p.m.Unlock()
+
+if p.rt != nil && from == p.rtPath {
+    return p.rt.RuntimeVar(name)
+}
+```
+
+`RuntimeVarsSupplier` is engine-internal rather than host code, so this is
+milder than §1.1 — but it is the same shape, and here it is also gratuitous:
+a runtime variable comes from the SUPPLIER, not from the plane's maps, so the
+branch reads nothing the lock protects. It was found while fixing §1.6, in the
+function that fix touches.
+
+`EventHub.Shutdown` has the same thing, and this one IS host-facing:
+
+```go
+// eventhub.go:398-411
+eh.m.Lock()
+…
+eh.rt.Reporter().Report(observability.Fact{
+    Kind:  observability.KindHubState,
+    Phase: observability.PhaseStopped,
+})
+```
+
+`Reporter()` is the engine's producer: it fans the fact out to host observers
+and through the host's log redactor. Under `eh.m` that is §1.1 exactly — an
+embedder's code deciding how long the hub stays locked — in the same file as
+§1.1 and §1.3, and it survived the first pass over that file.
+
 ## 2 Root cause analysis
 
 **A lock whose scope was never stated.** §1.1, §1.2 and §1.3 are one cause: the
@@ -219,6 +254,13 @@ The handle keeps its observer registrations and re-attaches them when `adopt`
 re-points it at a rebuilt instance, so a subscription taken before a dehydration
 keeps delivering after it.
 
+#### 3.2.7 `internal/scope/scope.go`, `eventhub.go` — the last two
+
+`GetData` serves a runtime variable before taking `p.m`; `p.rt` and `p.rtPath`
+are set at construction and never reassigned, so the branch needs no lock at
+all. `Shutdown` reports its stopped fact after releasing `eh.m` — the registry
+is already cleared by then, so nothing depends on the order.
+
 ## 4 Verification
 
 ### 4.1 Regression tests
@@ -233,6 +275,7 @@ keeps delivering after it.
 | T-6 | `TestSnapshotAtIsAtomic` | a concurrent commit cannot tear a snapshot (§1.6) |
 | T-7 | `TestGetDataByIDRefusesAnAmbiguousID` | two data sharing an ItemDefinition id produce a classified error naming both (§1.7) |
 | T-8 | `TestHandleObserverSurvivesARebuild` | an observer registered before a dehydration receives facts after the rebuild (§1.8) |
+| T-9 | `TestRuntimeVarIsServedOutsideThePlaneLock` | while the supplier is working, the rest of the plane stays usable (§1.9) |
 
 ### 4.2 Gate
 
@@ -241,10 +284,29 @@ lines (`COVER_MIN`).
 
 ## 5 Prevention
 
-- The hub and the task registry get the sentence `pkg/thresher/locked.go`
-  already carries: the lock covers registry mutation, and nothing else runs
-  inside it. Where the rule is written down it has held; where it was not, it
-  broke twice.
+- The hub, the task registry and the scope plane get the sentence
+  `pkg/thresher/locked.go` already carries: the lock covers registry mutation,
+  and nothing else runs inside it. Where the rule is written down it has held;
+  where it was not, it broke four times — the producer (FIX-036 §1.5), the hub,
+  the task path, and the plane.
+- A mechanical sweep for the shape is worth more than reading the sites an audit
+  names: the one run for this FIX found `setOwner`'s two callback-mediated calls,
+  which no reviewer reported. But it took **three** attempts, and the failures
+  are the lesson.
+
+  The first treated `defer m.Unlock()` as closing the critical section. Every
+  lock in this codebase is written that way, so it reported **clean** on a
+  package with three live instances. The second was function-scoped and flagged
+  five ALREADY-FIXED sites, because it could not tell "in the function" from "in
+  the critical section". The third tracks lock state, understands `defer`, and
+  is the only one worth running.
+
+  A scanner that reports clean is the dangerous failure mode — it looks exactly
+  like the answer you wanted. Two of the findings in this document were reported
+  as "swept, nothing left" before a re-check found them: `Shutdown`'s host
+  Report was missed because the pattern list had dropped `Report`. Re-run the
+  sweep with the fix in place and confirm it FAILS on the pre-fix code, the same
+  discipline every regression test here follows.
 - Every path fixed here reported success while failing. A registration that
   cannot fire, a recovery that did not happen and an observer that will not be
   called now each produce an error or a log.

--- a/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
+++ b/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
@@ -182,6 +182,40 @@ and through the host's log redactor. Under `eh.m` that is §1.1 exactly — an
 embedder's code deciding how long the hub stays locked — in the same file as
 §1.1 and §1.3, and it survived the first pass over that file.
 
+### 1.10 A cancel does not reach a parked instance
+
+`InstanceHandle.Cancel` calls `h.current().Cancel()`, which cancels the
+instance's CONTEXT. A dehydrated instance has no loop reading that context: its
+goroutines are gone and its state lives in a checkpoint. The request therefore
+vanishes, and the next wake rebuilds the instance and carries on as if it had
+never been made — while `WaitCompletion` blocks until the caller's deadline.
+
+Incident operations solved this in SRD-079 §3.6 by riding the rebuild
+(`WithPendingIncidentOp`); `Cancel` never got the same rail.
+
+### 1.11 An incident operation drops the handle's observers
+
+§1.8's remedy — the handle-owned observer registry, re-attached after a rebuild
+— landed in `cancelParked` and in the wake path, but **not** in
+`wakeForIncidentOp`, which adopts the rebuilt instance object and stops there.
+An operator's retry or resolve therefore silenced a host's subscription exactly
+as a dehydration used to, while its `Subscription` still reported itself live.
+
+Found while implementing §1.10, whose new path was a near-copy of
+`wakeForIncidentOp`: the copy is what let one of the two callers keep the bug.
+
+### 1.12 An operator request after shutdown reports success
+
+`engineContext` reports `running` for the whole life of the process once `Run`
+has been called — `t.engine` is stored at startup (`thresher.go:655`) and never
+cleared — so `rebuildAndContinue`'s `!running` guard cannot fire after a
+shutdown. An incident operation or a cancel arriving then rebuilt the instance
+from its checkpoint, watched the fresh loop tear straight back down on the dead
+engine context, and returned **nil** to the operator.
+
+That is the same silent loss as §1.10 one step further out: the caller is told
+its request landed when nothing ever observed it.
+
 ## 2 Root cause analysis
 
 **A lock whose scope was never stated.** §1.1, §1.2 and §1.3 are one cause: the
@@ -261,6 +295,33 @@ are set at construction and never reassigned, so the branch needs no lock at
 all. `Shutdown` reports its stopped fact after releasing `eh.m` — the registry
 is already cleared by then, so nothing depends on the order.
 
+#### 3.2.8 `internal/instance`, `pkg/thresher` — a cancel rides the rebuild
+
+`WithPendingCancel` mirrors `WithPendingIncidentOp`, and `applyPendingOps`
+applies both at the same seam: after the scope handlers are armed, before the
+park decision. The cancel is applied through `stopAll`, **not** `inst.Cancel` —
+`stopAll` sets `ls.stopping`, which `maybeDehydrate` checks, so the instance
+cannot park again before observing the request. A bare context cancel would race
+the re-park and be lost exactly as the pre-rebuild one was.
+
+`InstanceHandle.Cancel` routes a dehydrated instance through
+`Thresher.cancelParked`, which takes the wake latch (`awaitClaim`) like every
+other rebuild path. A resident instance keeps today's direct path.
+
+#### 3.2.9 `pkg/thresher/incident_ops.go` — one rail for a request that rides a rebuild
+
+`wakeForIncidentOp` and `cancelParked` were near-copies: claim the wake latch,
+rebuild with the request as a pending option, adopt the new object, wait for the
+verdict. They collapse into `rebuildForOp`, so the handle re-attachment (§1.11)
+exists once and cannot land in one caller only, and `awaitOpVerdict` isolates
+the bounded wait.
+
+`rebuildForOp` refuses before claiming anything when the engine context is
+already cancelled (§1.12). The check lives here rather than in
+`rebuildAndContinue` because this is the path with a caller waiting for a
+verdict: a timer wake arriving after shutdown rebuilds and terminates with
+nobody misinformed, while an operator told "cancelled" needs it to be true.
+
 ## 4 Verification
 
 ### 4.1 Regression tests
@@ -273,9 +334,13 @@ is already cleared by then, so nothing depends on the order.
 | T-4 | `TestRecoveryReportsATransportError` | a non-CAS `Save` failure is reported, not swallowed; a CAS conflict still returns silently (§1.4) |
 | T-5 | `TestFailedRegisterRestoresThePreviousStarters` | after a failed `registerStarters` the previous version is live again, the failed version is gone, and a retry succeeds (§1.5) |
 | T-6 | `TestSnapshotAtIsAtomic` | a concurrent commit cannot tear a snapshot (§1.6) |
-| T-7 | `TestGetDataByIDRefusesAnAmbiguousID` | two data sharing an ItemDefinition id produce a classified error naming both (§1.7) |
+| T-7 | `TestGetDataByIDIsDeterministic` | two data sharing an ItemDefinition id resolve to the same one on every run — nearest scope, then lowest name (§1.7) |
 | T-8 | `TestHandleObserverSurvivesARebuild` | an observer registered before a dehydration receives facts after the rebuild (§1.8) |
 | T-9 | `TestRuntimeVarIsServedOutsideThePlaneLock` | while the supplier is working, the rest of the plane stays usable (§1.9) |
+| T-10 | `TestCancelReachesADehydratedInstance` | cancelling a parked instance terminates it, and advancing past its timer does not resurrect it (§1.10) |
+| T-11 | `TestApplyPendingCancel`, `TestApplyPendingOpsWithNothingPending` | the rebuild-borne cancel stops the loop before its park decision and answers its caller; an ordinary rebuild is untouched (§1.10) |
+| T-12 | `TestRebuildForOpReportsAFailedClaim`, `TestRebuildForOpReportsAFailedRebuild` | a request that cannot take the latch or cannot rebuild is reported, names the operation, and releases the latch (§1.11) |
+| T-13 | `TestCancelOnAParkedInstanceReportsAStoppedEngine`, `TestAwaitOpVerdictHonoursTheCallerContext` | a request arriving after shutdown fails instead of reporting success; the verdict wait is bounded by the caller's context (§1.12) |
 
 ### 4.2 Gate
 
@@ -324,20 +389,35 @@ lines (`COVER_MIN`).
 - `RegisterProcess`'s failure path now mutates the registry (removing the
   version it appended). Callers already treat a returned error as "not
   registered"; this makes that true.
+- An incident operation or a cancel against a parked instance now FAILS after
+  the engine's context is cancelled, where it previously returned nil (§1.12).
+  A caller that shut the engine down and then issued an operator request was
+  already getting nothing done; it is now told so. Nothing in the wake or timer
+  paths changes — the guard is scoped to the two operator entry points.
 
 ## 7 Related
 
-Two confirmed findings are **not** fixed here:
+One confirmed finding is **not** fixed here:
 
-- **`InstanceHandle.Cancel` is lost on a dehydrated instance** (audit §5.1
-  C-11). Making it durable means giving Cancel the pending-operation rail that
-  incident ops ride (`WithPendingIncidentOp`), and deciding what cancelling a
-  *parked* instance means for its checkpoint. That is a design decision, not a
-  patch — it needs its own document.
 - **`msgIdx` overwrites concurrent tracks for one message definition** (C-15) is
   the subject of issue **#305**, "per-iteration event payload routing for shared
   catch nodes in parallel MI", filed with SRD-082. The audit rediscovered it
   independently; the issue is the right home.
+
+**§1.10 was itself a deferral, and that was the mistake.** This section
+originally parked `InstanceHandle.Cancel` as "a design decision, not a patch —
+it needs its own document". It was not blocked on anything: the rail existed
+(`WithPendingIncidentOp`), the latch existed (`awaitClaim`), and "large" is not
+"blocked". It is fixed here as §1.10. The global rule now says so explicitly:
+*out of scope* is the same deferral as *not mine*, only justified by a schedule
+instead of by authorship.
+
+The same rule ran again during §1.10's own implementation: the new
+`cancelParked` was a near-copy of `wakeForIncidentOp`, and reading the two side
+by side exposed §1.11 (the observer re-attachment that had landed in one caller
+only) and §1.12 (an operator request reporting success after shutdown). Both are
+fixed here, in this branch, rather than recorded as "noted for the next pass" —
+and the copy that hid §1.11 is gone with them.
 
 Prior art: [FIX-036](FIX-036-thresher-lifecycle-races-and-reservations.md) §1.5
 (host code under an engine lock — the shape §1.1 and §1.2 repeat) and its M6

--- a/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
+++ b/docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md
@@ -1,0 +1,275 @@
+# FIX-038 — engine locks held across host calls, and registrations that are silently lost
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft.
+**Date:** 2026-08-08.
+**Author:** Ruslan Gabitov.
+**Branch:** `fix/audit-round2` — the confirmed defect track of the 2026-08-08 package audit.
+**Upstream:** [ADR-002 v.2](../design/ADR-002-extension-architecture.md) §4.2 (the host-extension boundary these calls cross), [ADR-006 v.4](../design/ADR-006-events-and-subscriptions.md) (the hub's waiter registry), [ADR-013 v.2](../design/ADR-013-instance-observability.md) §5 (the observer stream a rebuild must survive), [ADR-033 v.4](../design/ADR-033-persistence-and-state.md) §2.8 (the incarnation fence recovery claims under).
+
+**Grounded in (internal artifacts, verified at `c34fcab`):**
+- `internal/scope/scope.go:113-139` — `SnapshotAt` calls `namesFrom` (`:309` locks) then `GetData` per name (`:94` locks); `internal/instance/track.go:1496` — the snapshot runs "on the track goroutine" and "commits bypass the loop".
+- `internal/scope/scope.go:340-360` — `GetDataByID` resolves by iterating a map.
+- `internal/eventproc/eventhub/eventhub.go:243` — `registerWaiter` holds `eh.m` through `:284` `w.Service(ctx)`; `waiters/message.go:222` — that calls `MessageBroker().Subscribe`.
+- `internal/eventproc/eventhub/eventhub.go:397-440` — `UnregisterEvent` reads under `RLock`, releases, then check-and-removes.
+- `pkg/thresher/recovery.go:71-73` — `if saveErr := repo.Save(...); saveErr != nil { return nil }`.
+- `pkg/thresher/thresher.go:1061-1083` — `RegisterProcess`'s supersede-then-register sequence.
+- `pkg/thresher/tasks.go:219-228` — `t.m` held across `rec.eligible.Authorize(...)`.
+- `pkg/thresher/observer.go:85` — `h.current().AddObserver(...)`.
+
+---
+
+## 1 Symptoms
+
+Confirmed findings of the first `/audit-package` sweep — an external reviewer
+over whole packages, doc-blind, every finding then verified against the source
+([the audit record](../audit/package-audit-2026-08-08.md) §5.1). Eight are
+remediated here; two are routed elsewhere (§7).
+
+### 1.1 The event hub holds its global lock across a broker subscription
+
+```go
+// eventhub.go:243
+eh.m.Lock()
+defer eh.m.Unlock()
+…
+// :284 — still holding it
+if err := w.Service(eh.ctx); err != nil {
+```
+
+`messageWaiter.Service` subscribes to the host's broker
+(`waiters/message.go:222`). The hub's **one** lock therefore spans a call into
+host-supplied, possibly remote, possibly blocking code: while a broker is slow,
+no waiter can be registered, unregistered or looked up anywhere in the engine.
+
+### 1.2 Task authorization runs under the engine's registry lock
+
+```go
+// tasks.go:219-228
+t.m.Lock()
+defer t.m.Unlock()
+…
+if err := rec.eligible.Authorize(taskID, actor); err != nil {
+```
+
+`Authorize` is host policy — a directory or database lookup is the normal
+implementation. It runs holding `t.m`, the lock every registration, launch and
+discovery call needs.
+
+**§1.1 and §1.2 are the same defect as FIX-036 §1.5**, which found host code
+running uncontained inside the producer. That landing fixed the producer and
+nothing asked where else the shape occurred. It occurred twice more.
+
+### 1.3 A concurrent register orphans itself against an unregister
+
+`UnregisterEvent` reads the waiter under `RLock`, **releases**, then removes the
+processor, tests `len(w.EventProcessors()) == 0`, stops the waiter and calls
+`RemoveWaiter`. `registerWaiter` holds the write lock for its whole body and can
+land in that window: it finds the waiter still mapped and adds a processor to
+it. The unregister then stops and unmaps it. The new registration is attached to
+a stopped waiter that no longer exists in the registry — its events **never
+arrive**, with no error anywhere.
+
+### 1.4 A transient repository error abandons an instance at startup
+
+```go
+// recovery.go:71-73
+if saveErr := repo.Save(ctx, rec); saveErr != nil {
+    return nil //nolint:nilerr // a lost claim race is the normal outcome
+}
+```
+
+A lost CAS *is* a normal outcome. A connection reset, a timeout, or a store
+outage is not, and this cannot tell them apart: every failure is read as "someone
+else claimed it", `recoverOne` returns **nil**, and `recoverInstances` logs
+nothing. An in-flight business process silently never resumes.
+
+The wake path disagrees with itself here: `claimForWake` (`wake.go:285-289`)
+**retries** the identical failure.
+
+### 1.5 A failed registration bricks a process key
+
+```go
+// thresher.go:1065-1082
+if prevLatest != nil {
+    if err := t.unregisterStarters(prevLatest.starters); err != nil { … }
+    t.releaseWiringLocked(prevLatest)          // prevLatest is now OFF the hub
+}
+
+if err := t.registerStarters(starters); err != nil {
+    t.releaseWiringLocked(reg)
+    return nil, err                            // and the NEW one never went on
+}
+```
+
+When the second call fails the key has **no live starters at all** — the
+previous version was already withdrawn. Worse, the failed version stays in the
+registry as `latest`, so a retry tries to `unregisterStarters` a set that was
+never registered, gets `ObjectNotFound`, and fails at the first branch. Every
+subsequent `RegisterProcess` for that key fails: the key is **permanently
+bricked**.
+
+FIX-036 M6 added the claim bookkeeping on exactly this path and did not ask what
+happens to the hub when the second call fails.
+
+### 1.6 A scope snapshot is not atomic
+
+`SnapshotAt` reads the visible names (`namesFrom`, locking), releases, then reads
+each datum (`GetData`, locking). `track.go:1496` states this runs "on the track
+goroutine right after its own commit" and that "commits bypass the loop", so
+other goroutines mutate the plane while the snapshot walks it. The result is a
+world that never existed at any instant — precisely what the snapshot exists to
+prevent — or a spurious failure when a datum is removed mid-walk.
+
+### 1.7 Resolution by ItemDefinition id is non-deterministic
+
+`GetDataByID` iterates a map and returns the first match. An ItemDefinition is a
+*type*, so two variables of one type share its id, and Go randomizes map
+iteration: the same lookup returns different variables on different runs.
+`events/event.go:790` resolves by id on the event data path.
+
+### 1.8 A handle's observers do not survive a rebuild
+
+`InstanceHandle.Observe` registers on `h.current()` — the instance **object**.
+SRD-071 made the handle's identity outlive its object (`adopt` re-points it), and
+the observer registration was not carried across. After the first dehydration a
+host observer stops receiving facts, silently, while its `Subscription` still
+reports itself live. The method's own comment notes the instance is "swappable"
+— for the logger.
+
+## 2 Root cause analysis
+
+**A lock whose scope was never stated.** §1.1, §1.2 and §1.3 are one cause: the
+engine's locks protect *registries*, and in each case the critical section grew
+to include work that is not registry work — a broker subscription, a policy
+lookup, a waiter teardown. `pkg/thresher/locked.go` states the rule and enforces
+it by construction for one map; nothing states it for the hub or the task
+registry, so it held only where someone remembered.
+
+**Two failures that report success.** §1.3, §1.4 and §1.8 all end with the
+caller believing it succeeded: a registration that will never fire, a recovery
+that never happened, an observer that will never be called. None logs. A defect
+that reports failure is a bug; one that reports success is a bug that survives
+release.
+
+**Rollback is only half-written.** §1.5 tears down the old before installing the
+new and has no path back when the second step fails.
+
+## 3 Solution
+
+### 3.1 Alternatives considered
+
+| # | Decision | Alternatives | Chosen |
+|---|---|---|---|
+| 1 | §1.1 the hub lock | (a) a second lock for waiter *creation* — two locks over one registry invites the ordering bugs the package has already had; (b) **build and Service the waiter OUTSIDE the lock, then insert under it**, tearing the waiter down if the insert loses a race | **(b)** — the same shape `HoldSubscription` uses since FIX-036: the expensive, foreign work happens unlocked, the registry mutation is a short critical section |
+| 2 | §1.2 authorization | (a) copy the record under the lock and authorize outside; (b) authorize before taking the lock — needs the record, so it would read it twice | **(a)** |
+| 3 | §1.3 the unregister race | (a) re-check `len(EventProcessors())` after re-acquiring — still a window; (b) **hold the write lock across the whole check-and-remove** | **(b)** — it is registry work, which is exactly what the lock is for; the waiter's `Stop` moves out of the critical section |
+| 4 | §1.4 recovery | (a) retry like `claimForWake` — hides a genuine outage behind attempts; (b) **classify: a lost CAS is `nil`, anything else is reported** — the repository already distinguishes them | **(b)** |
+| 5 | §1.5 the bricked key | (a) re-register `prevLatest` on failure — restores auto-start but leaves the failed version as `latest`, so the retry still misbehaves; (b) **remove the failed version from the registry AND restore the previous latest's starters** | **(b)** — the key returns to exactly its pre-call state |
+| 6 | §1.6 the snapshot | (a) a coarse "snapshot lock" held by every mutator — a second lock over the same state; (b) **one locked walk**: a `snapshotAtLocked` that reads names and data under a single acquisition | **(b)** |
+| 7 | §1.7 ambiguous ids | (a) pick deterministically (sorted by name) — makes the result stable and still arbitrary; (b) **refuse an ambiguous lookup with a classified error naming both candidates** | **(b)** — two variables of one type resolved by type is a modelling error, and answering it silently is how it stays unnoticed |
+| 8 | §1.8 observers | (a) re-register in `adopt` — the handle would need to remember its observers; (b) **register the observer on the HANDLE, and have the handle's fan-out follow the current instance** | **(a)** — the handle already owns identity across rebuilds (SRD-071); it keeps its observer set and re-attaches on adopt, which is the smaller change |
+
+### 3.2 Changes by file
+
+#### 3.2.1 `internal/eventproc/eventhub/eventhub.go` — the lock covers the registry, not the world
+
+`registerWaiter` builds and services the waiter before taking `eh.m`, then
+inserts under it; if another registration won the race meanwhile, the loser
+stops its own waiter and joins the winner. `UnregisterEvent` takes the write lock
+for the whole check-and-remove, and stops the waiter after releasing it.
+
+#### 3.2.2 `pkg/thresher/tasks.go` — authorize outside the registry lock
+
+The task record's authorization inputs are copied under `t.m`; `Authorize` runs
+after the release.
+
+#### 3.2.3 `pkg/thresher/recovery.go` — a lost claim is not an outage
+
+The `Save` failure is classified: a CAS/version conflict returns `nil` (someone
+else recovered it), anything else is reported through `reportRecoveryFailure`
+like every other per-instance recovery error.
+
+#### 3.2.4 `pkg/thresher/thresher.go` — a failed registration leaves no trace
+
+On a failed `registerStarters`, the version just appended is removed from the
+registry and the previous latest's starters are put back on the hub, so the key
+is exactly as it was before the call and a retry behaves like a first attempt.
+
+#### 3.2.5 `internal/scope/scope.go` — one locked walk, and an ambiguous id refuses
+
+`SnapshotAt` reads names and data under a single acquisition of `p.m`.
+`GetDataByID` refuses when more than one datum carries the id, naming both.
+
+#### 3.2.6 `pkg/thresher/observer.go`, `handle.go` — observers belong to the handle
+
+The handle keeps its observer registrations and re-attaches them when `adopt`
+re-points it at a rebuilt instance, so a subscription taken before a dehydration
+keeps delivering after it.
+
+## 4 Verification
+
+### 4.1 Regression tests
+
+| # | Test | Asserts |
+|---|---|---|
+| T-1 | `TestRegisterWaiterDoesNotHoldTheLockAcrossService` | a waiter whose `Service` blocks does not block a concurrent hub operation (§1.1) |
+| T-2 | `TestTaskAuthorizationDoesNotHoldTheEngineLock` | a blocking `Authorize` does not block a concurrent registry call (§1.2) |
+| T-3 | `TestUnregisterRacingRegisterKeepsTheRegistration` | a register landing inside an unregister leaves a live, mapped waiter (§1.3) |
+| T-4 | `TestRecoveryReportsATransportError` | a non-CAS `Save` failure is reported, not swallowed; a CAS conflict still returns silently (§1.4) |
+| T-5 | `TestFailedRegisterRestoresThePreviousStarters` | after a failed `registerStarters` the previous version is live again, the failed version is gone, and a retry succeeds (§1.5) |
+| T-6 | `TestSnapshotAtIsAtomic` | a concurrent commit cannot tear a snapshot (§1.6) |
+| T-7 | `TestGetDataByIDRefusesAnAmbiguousID` | two data sharing an ItemDefinition id produce a classified error naming both (§1.7) |
+| T-8 | `TestHandleObserverSurvivesARebuild` | an observer registered before a dehydration receives facts after the rebuild (§1.8) |
+
+### 4.2 Gate
+
+`make ci` green end to end, `-race` included; diff-coverage ≥95% on the touched
+lines (`COVER_MIN`).
+
+## 5 Prevention
+
+- The hub and the task registry get the sentence `pkg/thresher/locked.go`
+  already carries: the lock covers registry mutation, and nothing else runs
+  inside it. Where the rule is written down it has held; where it was not, it
+  broke twice.
+- Every path fixed here reported success while failing. A registration that
+  cannot fire, a recovery that did not happen and an observer that will not be
+  called now each produce an error or a log.
+
+## 6 Regressions and side effects
+
+- `GetDataByID` becomes stricter: a model with two variables sharing an
+  ItemDefinition id now gets a classified error instead of a random answer. That
+  is the point, and it is a behavioural change called out in the CHANGELOG.
+- `SnapshotAt` holds the plane lock for the whole walk rather than per datum.
+  The walk is bounded by the visible surface and takes no host call.
+- `RegisterProcess`'s failure path now mutates the registry (removing the
+  version it appended). Callers already treat a returned error as "not
+  registered"; this makes that true.
+
+## 7 Related
+
+Two confirmed findings are **not** fixed here:
+
+- **`InstanceHandle.Cancel` is lost on a dehydrated instance** (audit §5.1
+  C-11). Making it durable means giving Cancel the pending-operation rail that
+  incident ops ride (`WithPendingIncidentOp`), and deciding what cancelling a
+  *parked* instance means for its checkpoint. That is a design decision, not a
+  patch — it needs its own document.
+- **`msgIdx` overwrites concurrent tracks for one message definition** (C-15) is
+  the subject of issue **#305**, "per-iteration event payload routing for shared
+  catch nodes in parallel MI", filed with SRD-082. The audit rediscovered it
+  independently; the issue is the right home.
+
+Prior art: [FIX-036](FIX-036-thresher-lifecycle-races-and-reservations.md) §1.5
+(host code under an engine lock — the shape §1.1 and §1.2 repeat) and its M6
+(the wiring claim §1.5 completes).
+
+## 8 Implementation summary
+
+_To be filled after the milestones land._
+
+## 9 Open questions
+
+None.

--- a/internal/eventproc/eventhub/eventhub.go
+++ b/internal/eventproc/eventhub/eventhub.go
@@ -240,27 +240,14 @@ func (eh *EventHub) registerWaiter(
 	eDef flow.EventDefinition,
 	build waiterBuilder,
 ) error {
-	eh.m.Lock()
-	defer eh.m.Unlock()
-
-	if eh.getState() == hubStopped {
-		return errs.New(
-			errs.M("event hub is shut down; registration rejected"),
-			errs.C(errorClass, errs.InvalidState),
-			errs.D(observability.AttrEventDefinitionID, eDef.ID()))
+	// FAST PATH — an existing waiter just gains a processor. That is registry
+	// work and stays under the lock.
+	joined, w, err := eh.joinExistingWaiter(ep, eDef)
+	if err != nil {
+		return err
 	}
 
-	if w, ok := eh.waiters[eDef.ID()]; ok {
-		if err := w.AddEventProcessor(ep); err != nil {
-			return errs.New(
-				errs.M("couldn't add event processor to waiter"),
-				errs.C(errorClass, errs.OperationFailed),
-				errs.D(observability.AttrWaiterID, w.ID()),
-				errs.D(observability.AttrEventDefinitionID, eDef.ID()),
-				errs.D(observability.AttrEventDefinitionType, string(eDef.Type())),
-				errs.D(observability.AttrEventProcessorID, ep.ID()))
-		}
-
+	if joined {
 		eh.reportEventFlow(observability.PhaseRegistered, map[string]string{
 			observability.AttrEventDefinitionID: eDef.ID(),
 			observability.AttrWaiterID:          w.ID(),
@@ -269,7 +256,12 @@ func (eh *EventHub) registerWaiter(
 		return nil
 	}
 
-	w, err := build(eh, ep, eDef, eh.rt)
+	// SLOW PATH — building and starting a waiter is FOREIGN work: a message
+	// waiter's Service subscribes to the host's broker, which may be remote and
+	// may block. Holding the hub's one lock across it stalled every
+	// registration, unregistration and lookup in the engine behind one host
+	// call (FIX-038 §1.1). It happens here, unlocked.
+	w, err = build(eh, ep, eDef, eh.rt)
 	if err != nil {
 		return errs.New(
 			errs.M("eventWaiter building failed"),
@@ -279,8 +271,8 @@ func (eh *EventHub) registerWaiter(
 			errs.E(err))
 	}
 
-	// Start the waiter BEFORE inserting it: a failed start never leaves a
-	// dead, non-serving waiter in the map (no cleanup branch needed).
+	// Start BEFORE inserting: a failed start never leaves a dead, non-serving
+	// waiter in the map (no cleanup branch needed).
 	if err := w.Service(eh.ctx); err != nil {
 		return errs.New(
 			errs.M("failed to start waiter service"),
@@ -289,12 +281,94 @@ func (eh *EventHub) registerWaiter(
 			errs.E(err))
 	}
 
-	eh.waiters[eDef.ID()] = w
+	return eh.publishWaiter(ep, eDef, w)
+}
 
-	// A new signal waiter joins the name index (SRD-027 FR-6). The "added to existing
-	// waiter" branch above creates no waiter, so it leaves the index untouched.
-	if name, ok := signalName(eDef); ok {
-		eh.signalIdx[name] = append(eh.signalIdx[name], w)
+// joinExistingWaiter adds ep to the waiter already serving eDef, if there is
+// one. Registry work only, so it runs under eh.m.
+func (eh *EventHub) joinExistingWaiter(
+	ep eventproc.EventProcessor, eDef flow.EventDefinition,
+) (joined bool, w eventproc.EventWaiter, err error) {
+	eh.m.Lock()
+	defer eh.m.Unlock()
+
+	if eh.getState() == hubStopped {
+		return false, nil, errs.New(
+			errs.M("event hub is shut down; registration rejected"),
+			errs.C(errorClass, errs.InvalidState),
+			errs.D(observability.AttrEventDefinitionID, eDef.ID()))
+	}
+
+	w, ok := eh.waiters[eDef.ID()]
+	if !ok {
+		return false, nil, nil
+	}
+
+	if err := w.AddEventProcessor(ep); err != nil {
+		return false, nil, errs.New(
+			errs.M("couldn't add event processor to waiter"),
+			errs.C(errorClass, errs.OperationFailed),
+			errs.D(observability.AttrWaiterID, w.ID()),
+			errs.D(observability.AttrEventDefinitionID, eDef.ID()),
+			errs.D(observability.AttrEventDefinitionType, string(eDef.Type())),
+			errs.D(observability.AttrEventProcessorID, ep.ID()))
+	}
+
+	return true, w, nil
+}
+
+// publishWaiter installs a started waiter, or — if another registration won the
+// race while this one was building outside the lock — joins that winner and
+// stops the loser. Stopping happens AFTER the lock is released: a message
+// waiter's Stop unsubscribes from the host broker, which is the same foreign
+// call the build path must not hold the lock across.
+func (eh *EventHub) publishWaiter(
+	ep eventproc.EventProcessor, eDef flow.EventDefinition, w eventproc.EventWaiter,
+) error {
+	eh.m.Lock()
+
+	stopped := eh.getState() == hubStopped
+	winner, lost := eh.waiters[eDef.ID()]
+
+	var addErr error
+
+	switch {
+	case stopped:
+		// nothing to install into
+
+	case lost:
+		addErr = winner.AddEventProcessor(ep)
+
+	default:
+		eh.waiters[eDef.ID()] = w
+
+		// A new signal waiter joins the name index (SRD-027 FR-6); the join
+		// paths create no waiter and leave the index untouched.
+		if name, ok := signalName(eDef); ok {
+			eh.signalIdx[name] = append(eh.signalIdx[name], w)
+		}
+	}
+
+	eh.m.Unlock()
+
+	if stopped || lost {
+		eh.stopUnusedWaiter(w)
+	}
+
+	switch {
+	case stopped:
+		return errs.New(
+			errs.M("event hub is shut down; registration rejected"),
+			errs.C(errorClass, errs.InvalidState),
+			errs.D(observability.AttrEventDefinitionID, eDef.ID()))
+
+	case addErr != nil:
+		return errs.New(
+			errs.M("couldn't add event processor to waiter"),
+			errs.C(errorClass, errs.OperationFailed),
+			errs.D(observability.AttrEventDefinitionID, eDef.ID()),
+			errs.D(observability.AttrEventProcessorID, ep.ID()),
+			errs.E(addErr))
 	}
 
 	eh.reportEventFlow(observability.PhaseRegistered, map[string]string{
@@ -303,6 +377,17 @@ func (eh *EventHub) registerWaiter(
 	})
 
 	return nil
+}
+
+// stopUnusedWaiter tears down a waiter this registration built but did not
+// install. A failure is a Debug fact: nothing references it, so there is
+// nothing a caller could do.
+func (eh *EventHub) stopUnusedWaiter(w eventproc.EventWaiter) {
+	if err := w.Stop(); err != nil {
+		eh.rt.Logger().Debug("stopping an uninstalled waiter",
+			observability.AttrWaiterID, w.ID(),
+			observability.AttrError, err.Error())
+	}
 }
 
 // Shutdown stops every registered waiter and waits — bounded by ctx — for their
@@ -394,11 +479,18 @@ func (eh *EventHub) UnregisterEvent(
 			errs.C(errorClass, errs.EmptyNotAllowed))
 	}
 
-	eh.m.RLock()
-	w, ok := eh.waiters[eDefID]
-	eh.m.RUnlock()
+	// The emptiness check and the removal must be ONE critical section. Read
+	// under RLock, release, then check-and-remove let a concurrent
+	// registerWaiter find this waiter still mapped and attach a processor to
+	// it — after which this call stopped and unmapped it, and that
+	// registration's events never arrived, with no error anywhere
+	// (FIX-038 §1.3).
+	eh.m.Lock()
 
+	w, ok := eh.waiters[eDefID]
 	if !ok {
+		eh.m.Unlock()
+
 		// ObjectNotFound (not InvalidParameter): a missing waiter is an
 		// "already gone" condition the instance treats as idempotent —
 		// the fired-timer path self-removes the waiter before the track
@@ -410,6 +502,8 @@ func (eh *EventHub) UnregisterEvent(
 	}
 
 	if err := w.RemoveEventProcessor(ep); err != nil {
+		eh.m.Unlock()
+
 		return errs.New(
 			errs.M("couldn't remove event processor from waiter"),
 			errs.C(errorClass, errs.ObjectNotFound),
@@ -419,24 +513,29 @@ func (eh *EventHub) UnregisterEvent(
 			errs.E(err))
 	}
 
-	if len(w.EventProcessors()) == 0 {
-		if w.State() == eventproc.WSRunned {
-			if err := w.Stop(); err != nil {
-				return errs.New(
-					errs.M("waiter stop failed"),
-					errs.C(errorClass, errs.OperationFailed),
-					errs.D(observability.AttrWaiterID, w.ID()),
-					errs.D(observability.AttrEventDefinitionID, w.EventDefinition().ID()),
-					errs.D(observability.AttrEventDefinitionType, string(w.EventDefinition().Type())))
-			}
+	last := len(w.EventProcessors()) == 0
+	if last {
+		// Remove it here, under the same lock that observed it empty.
+		eh.dropWaiterLocked(eDefID, w)
+	}
+
+	eh.m.Unlock()
+
+	if !last {
+		return nil
+	}
+
+	// Stop OUTSIDE the lock: a message waiter's Stop unsubscribes from the
+	// host broker, which must never run under the hub lock (FIX-038 §1.1).
+	if w.State() == eventproc.WSRunned {
+		if err := w.Stop(); err != nil {
+			return errs.New(
+				errs.M("waiter stop failed"),
+				errs.C(errorClass, errs.OperationFailed),
+				errs.D(observability.AttrWaiterID, w.ID()),
+				errs.D(observability.AttrEventDefinitionID, w.EventDefinition().ID()),
+				errs.D(observability.AttrEventDefinitionType, string(w.EventDefinition().Type())))
 		}
-
-		eh.reportEventFlow(observability.PhaseUnregistered, map[string]string{
-			observability.AttrEventDefinitionID: eDefID,
-			observability.AttrWaiterID:          w.ID(),
-		})
-
-		return eh.RemoveWaiter(w.EventDefinition().ID())
 	}
 
 	eh.reportEventFlow(observability.PhaseUnregistered, map[string]string{
@@ -594,10 +693,20 @@ func (eh *EventHub) RemoveWaiter(eDefID string) error {
 			errs.D(observability.AttrEventDefinitionID, eDefID))
 	}
 
-	eh.removeWaiterFromIndex(w)
-	delete(eh.waiters, eDefID)
+	eh.dropWaiterLocked(eDefID, w)
 
 	return nil
+}
+
+// dropWaiterLocked takes a waiter the caller has ALREADY found under eh.m out
+// of the registry and its name index. It cannot fail, which is the point:
+// UnregisterEvent's emptiness check and this removal must happen under ONE
+// acquisition, or a concurrent registration slips between them and attaches a
+// processor to a waiter this call is about to stop and unmap (FIX-038 §1.3).
+// Caller holds eh.m.
+func (eh *EventHub) dropWaiterLocked(eDefID string, w eventproc.EventWaiter) {
+	eh.removeWaiterFromIndex(w)
+	delete(eh.waiters, eDefID)
 }
 
 // removeWaiterFromIndex drops a signal waiter from signalIdx in step with its removal from the

--- a/internal/eventproc/eventhub/eventhub.go
+++ b/internal/eventproc/eventhub/eventhub.go
@@ -405,11 +405,6 @@ func (eh *EventHub) Shutdown(ctx context.Context) error {
 
 	eh.setState(hubStopped)
 
-	eh.rt.Reporter().Report(observability.Fact{
-		Kind:  observability.KindHubState,
-		Phase: observability.PhaseStopped,
-	})
-
 	ws := make([]eventproc.EventWaiter, 0, len(eh.waiters))
 	for _, w := range eh.waiters {
 		ws = append(ws, w)
@@ -418,6 +413,15 @@ func (eh *EventHub) Shutdown(ctx context.Context) error {
 	eh.waiters = map[string]eventproc.EventWaiter{}
 	eh.signalIdx = map[string][]eventproc.EventWaiter{}
 	eh.m.Unlock()
+
+	// Report AFTER the unlock: Reporter() is the engine's producer, which fans
+	// the fact out to HOST observers and through the host's log redactor. Under
+	// the hub lock it was the same shape §1.1 removes from the registration
+	// path — an embedder's code deciding how long the hub stays locked.
+	eh.rt.Reporter().Report(observability.Fact{
+		Kind:  observability.KindHubState,
+		Phase: observability.PhaseStopped,
+	})
 
 	// Stop each waiter (logging — never aborting on — a failed Stop) and wait for
 	// its service goroutine to exit via its Done channel, off the lock.

--- a/internal/eventproc/eventhub/eventhub.go
+++ b/internal/eventproc/eventhub/eventhub.go
@@ -371,9 +371,17 @@ func (eh *EventHub) publishWaiter(
 			errs.E(addErr))
 	}
 
+	// Name the waiter the processor actually landed on. On the losing path
+	// that is the WINNER: w was stopped and discarded a few lines up, so
+	// reporting it points an operator at a waiter that no longer exists.
+	served := w
+	if lost {
+		served = winner
+	}
+
 	eh.reportEventFlow(observability.PhaseRegistered, map[string]string{
 		observability.AttrEventDefinitionID: eDef.ID(),
-		observability.AttrWaiterID:          w.ID(),
+		observability.AttrWaiterID:          served.ID(),
 	})
 
 	return nil
@@ -533,6 +541,14 @@ func (eh *EventHub) UnregisterEvent(
 	// host broker, which must never run under the hub lock (FIX-038 §1.1).
 	if w.State() == eventproc.WSRunned {
 		if err := w.Stop(); err != nil {
+			// A waiter that will not stop is still serving its subscription,
+			// so leaving it unmapped strands it: the next registration for
+			// this definition builds a SECOND waiter and subscribes again.
+			// Put it back — only if the key is still free, since a
+			// registration may have installed its own by now — which makes
+			// the failed unregistration atomic: nothing happened.
+			eh.remapUnstopped(eDefID, w)
+
 			return errs.New(
 				errs.M("waiter stop failed"),
 				errs.C(errorClass, errs.OperationFailed),
@@ -711,6 +727,26 @@ func (eh *EventHub) RemoveWaiter(eDefID string) error {
 func (eh *EventHub) dropWaiterLocked(eDefID string, w eventproc.EventWaiter) {
 	eh.removeWaiterFromIndex(w)
 	delete(eh.waiters, eDefID)
+}
+
+// remapUnstopped puts back a waiter whose Stop failed, so a failed
+// unregistration leaves the registry as it found it rather than stranding a
+// live subscription outside the map. It restores nothing if the key is taken:
+// a registration that installed its own waiter in the meantime owns the
+// definition now, and overwriting it would strand THAT one instead.
+func (eh *EventHub) remapUnstopped(eDefID string, w eventproc.EventWaiter) {
+	eh.m.Lock()
+	defer eh.m.Unlock()
+
+	if _, taken := eh.waiters[eDefID]; taken {
+		return
+	}
+
+	eh.waiters[eDefID] = w
+
+	if name, ok := signalName(w.EventDefinition()); ok {
+		eh.signalIdx[name] = append(eh.signalIdx[name], w)
+	}
 }
 
 // removeWaiterFromIndex drops a signal waiter from signalIdx in step with its removal from the

--- a/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
+++ b/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
@@ -3,7 +3,9 @@ package eventhub
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/dr-dobermann/gobpm/generated/mockeventproc"
 	"github.com/dr-dobermann/gobpm/internal/enginert"
@@ -225,4 +227,222 @@ func TestRemoveWaiterNotFound(t *testing.T) {
 	require.NoError(t, err)
 
 	require.ErrorContains(t, hub.RemoveWaiter("no-such-def"), "waiter isn't found")
+}
+
+// TestRegisterWaiterDoesNotHoldTheLockAcrossService is FIX-038 T-1.
+//
+// Building and starting a waiter is FOREIGN work: a message waiter's Service
+// subscribes to the host's broker, which may be remote and may block. The hub
+// used to hold its ONE lock across that call, so while a broker was slow no
+// waiter could be registered, unregistered or looked up anywhere in the engine.
+//
+// The interleaving is driven directly: Service blocks until the test releases
+// it, and a concurrent hub operation must complete meanwhile.
+func TestRegisterWaiterDoesNotHoldTheLockAcrossService(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	def, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().ID().Return("ep-slow").Maybe()
+
+	inService := make(chan struct{})
+	release := make(chan struct{})
+
+	w := mockeventproc.NewMockEventWaiter(t)
+	w.EXPECT().ID().Return("w-slow").Maybe()
+	w.EXPECT().EventDefinition().Return(def).Maybe()
+	w.EXPECT().Service(mock.Anything).RunAndReturn(
+		func(context.Context) error {
+			close(inService)
+			<-release
+
+			return nil
+		}).Once()
+
+	registered := make(chan error, 1)
+
+	go func() {
+		registered <- hub.registerWaiter(ep, def,
+			func(eventproc.EventHub, eventproc.EventProcessor,
+				flow.EventDefinition, renv.EngineRuntime,
+			) (eventproc.EventWaiter, error) {
+				return w, nil
+			})
+	}()
+
+	<-inService // the waiter is mid-Service, inside the registration
+
+	// The hub must still be usable. Under the old code this blocked until the
+	// broker returned, which is the whole defect.
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		_ = hub.RemoveWaiter("nothing-here") // any operation needing eh.m
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the hub lock was held across the waiter's Service call")
+	}
+
+	close(release)
+	require.NoError(t, <-registered)
+}
+
+// countingWaiter is a minimal, concurrency-safe EventWaiter for the race
+// traces: a mockery mock inside a hot loop asserts call counts this test does
+// not care about, and hides the state it does.
+type countingWaiter struct {
+	def flow.EventDefinition
+
+	mu      sync.Mutex
+	procs   []eventproc.EventProcessor
+	state   eventproc.EventWaiterState
+	stopped chan struct{}
+}
+
+func newCountingWaiter(def flow.EventDefinition) *countingWaiter {
+	return &countingWaiter{def: def, stopped: make(chan struct{})}
+}
+
+func (w *countingWaiter) ID() string                            { return "counting-" + w.def.ID() }
+func (w *countingWaiter) EventDefinition() flow.EventDefinition { return w.def }
+func (w *countingWaiter) Process(flow.EventDefinition) error    { return nil }
+func (w *countingWaiter) Done() <-chan struct{}                 { return w.stopped }
+
+func (w *countingWaiter) AddEventProcessor(ep eventproc.EventProcessor) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.procs = append(w.procs, ep)
+
+	return nil
+}
+
+func (w *countingWaiter) RemoveEventProcessor(eventproc.EventProcessor) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if len(w.procs) > 0 {
+		w.procs = w.procs[:len(w.procs)-1]
+	}
+
+	return nil
+}
+
+func (w *countingWaiter) EventProcessors() []eventproc.EventProcessor {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return append([]eventproc.EventProcessor{}, w.procs...)
+}
+
+func (w *countingWaiter) Service(context.Context) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	w.state = eventproc.WSRunned
+
+	return nil
+}
+
+func (w *countingWaiter) Stop() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.state == eventproc.WSRunned {
+		w.state = eventproc.WSEnded
+		close(w.stopped)
+	}
+
+	return nil
+}
+
+func (w *countingWaiter) State() eventproc.EventWaiterState {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.state
+}
+
+// TestUnregisterRacingRegisterKeepsTheRegistration is FIX-038 T-3.
+//
+// UnregisterEvent read the waiter under RLock, RELEASED, then removed the
+// processor, tested emptiness, stopped the waiter and unmapped it. A
+// registerWaiter landing in that window found the waiter still mapped and
+// attached a processor to it — and this call then stopped and unmapped it. The
+// registration reported success and its events never arrived.
+//
+// The invariant: a registration that returns nil leaves its definition MAPPED.
+// Hammering both paths concurrently under -race exercises the window the fix
+// closes; the assertion is the invariant, not a timing.
+func TestUnregisterRacingRegisterKeepsTheRegistration(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	def, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	// The real builders receive ep and register it inside the waiter they
+	// return (waiters.CreateWaiter), so the stub must too — a waiter installed
+	// without its processor is not the state the hub ever produces.
+	build := func(_ eventproc.EventHub, ep eventproc.EventProcessor,
+		_ flow.EventDefinition, _ renv.EngineRuntime,
+	) (eventproc.EventWaiter, error) {
+		w := newCountingWaiter(def)
+		_ = w.AddEventProcessor(ep)
+
+		return w, nil
+	}
+
+	for range 200 {
+		ep := mockeventproc.NewMockEventProcessor(t)
+		ep.EXPECT().ID().Return("ep-race").Maybe()
+
+		var wg sync.WaitGroup
+
+		wg.Add(2)
+
+		regErr := make(chan error, 1)
+
+		go func() {
+			defer wg.Done()
+
+			regErr <- hub.registerWaiter(ep, def, build)
+		}()
+
+		go func() {
+			defer wg.Done()
+
+			_ = hub.UnregisterEvent(ep, def.ID())
+		}()
+
+		wg.Wait()
+
+		if err := <-regErr; err != nil {
+			continue // a refused registration promises nothing
+		}
+
+		// It reported success, so the definition must be served.
+		hub.m.Lock()
+		w, mapped := hub.waiters[def.ID()]
+		hub.m.Unlock()
+
+		if !mapped {
+			continue // the unregister ran last and legitimately removed it
+		}
+
+		require.NotEmpty(t, w.EventProcessors(),
+			"a mapped waiter must carry the processors registered against it")
+
+		_ = hub.UnregisterEvent(ep, def.ID()) // reset for the next round
+	}
 }

--- a/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
+++ b/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 
+	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -330,13 +332,24 @@ func (w *countingWaiter) AddEventProcessor(ep eventproc.EventProcessor) error {
 	return nil
 }
 
-func (w *countingWaiter) RemoveEventProcessor(eventproc.EventProcessor) error {
+// RemoveEventProcessor removes ep BY IDENTITY, as every real waiter does
+// (waiters/message.go:148 and its siblings), and reports an absent one instead
+// of succeeding. The earlier stub dropped whichever processor happened to be
+// last, which quietly made a two-processor test remove the wrong one — and a
+// stub that is laxer than the thing it stands in for hides exactly the defects
+// the test exists to find.
+func (w *countingWaiter) RemoveEventProcessor(ep eventproc.EventProcessor) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	if len(w.procs) > 0 {
-		w.procs = w.procs[:len(w.procs)-1]
+	idx := slices.Index(w.procs, ep)
+	if idx == -1 {
+		return errs.New(
+			errs.M("event processor isn't registered with the waiter"),
+			errs.C(errorClass, errs.ObjectNotFound))
 	}
+
+	w.procs = slices.Delete(w.procs, idx, idx+1)
 
 	return nil
 }
@@ -384,9 +397,16 @@ func (w *countingWaiter) State() eventproc.EventWaiterState {
 // attached a processor to it — and this call then stopped and unmapped it. The
 // registration reported success and its events never arrived.
 //
-// The invariant: a registration that returns nil leaves its definition MAPPED.
-// Hammering both paths concurrently under -race exercises the window the fix
-// closes; the assertion is the invariant, not a timing.
+// The invariant: a registration that returns nil leaves its definition MAPPED
+// and serving the processor it registered.
+//
+// The registering and unregistering processors must be DIFFERENT. An earlier
+// version of this test used one processor for both, and the independent review
+// caught that it could not fail with the fix reverted: with a shared processor
+// the defect's outcome (registration succeeds, definition unmapped) is exactly
+// what a legitimate unregister-ran-last also produces, so the test skipped its
+// own defect. With two, an unregister of epOld can never justify unmapping a
+// definition epNew has just registered against.
 func TestUnregisterRacingRegisterKeepsTheRegistration(t *testing.T) {
 	hub, err := New(enginert.Default())
 	require.NoError(t, err)
@@ -407,9 +427,16 @@ func TestUnregisterRacingRegisterKeepsTheRegistration(t *testing.T) {
 		return w, nil
 	}
 
-	for range 200 {
-		ep := mockeventproc.NewMockEventProcessor(t)
-		ep.EXPECT().ID().Return("ep-race").Maybe()
+	for round := range 200 {
+		epOld := mockeventproc.NewMockEventProcessor(t)
+		epOld.EXPECT().ID().Return("ep-old").Maybe()
+
+		epNew := mockeventproc.NewMockEventProcessor(t)
+		epNew.EXPECT().ID().Return("ep-new").Maybe()
+
+		// epOld holds the definition before the round starts, so the
+		// unregister below has something real to remove.
+		require.NoError(t, hub.registerWaiter(epOld, def, build))
 
 		var wg sync.WaitGroup
 
@@ -420,34 +447,43 @@ func TestUnregisterRacingRegisterKeepsTheRegistration(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			regErr <- hub.registerWaiter(ep, def, build)
+			regErr <- hub.registerWaiter(epNew, def, build)
 		}()
 
 		go func() {
 			defer wg.Done()
 
-			_ = hub.UnregisterEvent(ep, def.ID())
+			_ = hub.UnregisterEvent(epOld, def.ID())
 		}()
 
 		wg.Wait()
 
 		if err := <-regErr; err != nil {
-			continue // a refused registration promises nothing
+			// a refused registration promises nothing — but clean up
+			_ = hub.UnregisterEvent(epOld, def.ID())
+
+			continue
 		}
 
-		// It reported success, so the definition must be served.
+		// epNew's registration reported success, so the definition MUST still
+		// be served, and by a waiter carrying epNew. Unmapping is not a
+		// legitimate outcome here: the only unregistration was epOld's.
 		hub.m.Lock()
 		w, mapped := hub.waiters[def.ID()]
 		hub.m.Unlock()
 
-		if !mapped {
-			continue // the unregister ran last and legitimately removed it
-		}
+		require.True(t, mapped,
+			"round %d: a successful registration must leave its definition"+
+				" mapped — an unregister of ANOTHER processor cannot remove it",
+			round)
 
-		require.NotEmpty(t, w.EventProcessors(),
-			"a mapped waiter must carry the processors registered against it")
+		require.Contains(t, w.EventProcessors(), eventproc.EventProcessor(epNew),
+			"round %d: the mapped waiter must carry the processor that"+
+				" registered against it", round)
 
-		_ = hub.UnregisterEvent(ep, def.ID()) // reset for the next round
+		// reset for the next round
+		_ = hub.UnregisterEvent(epNew, def.ID())
+		_ = hub.UnregisterEvent(epOld, def.ID())
 	}
 }
 

--- a/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
+++ b/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
@@ -1,8 +1,11 @@
 package eventhub
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
+
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -454,9 +457,21 @@ func TestUnregisterRacingRegisterKeepsTheRegistration(t *testing.T) {
 type faultyWaiter struct {
 	*countingWaiter
 
+	// id distinguishes two waiters for ONE definition — countingWaiter derives
+	// its id from the definition, so a winner and a loser are otherwise
+	// indistinguishable in a fact.
+	id      string
 	addErr  error
 	stopErr error
 	stops   atomic.Int32
+}
+
+func (w *faultyWaiter) ID() string {
+	if w.id != "" {
+		return w.id
+	}
+
+	return w.countingWaiter.ID()
 }
 
 func (w *faultyWaiter) AddEventProcessor(ep eventproc.EventProcessor) error {
@@ -594,4 +609,97 @@ func TestRemoveWaiterDropsTheRegistration(t *testing.T) {
 	err = hub.RemoveWaiter(def.ID())
 	require.Error(t, err, "removing it again is not a silent success")
 	require.ErrorContains(t, err, "waiter isn't found")
+}
+
+// TestLostRegistrationReportsTheServingWaiter is the independent review's
+// finding A4. On the losing path the processor is attached to the WINNER, but
+// the PhaseRegistered fact named `w` — the waiter this call built, stopped and
+// discarded a moment earlier. An operator following that id lands on a waiter
+// that no longer exists.
+func TestLostRegistrationReportsTheServingWaiter(t *testing.T) {
+	var buf bytes.Buffer
+
+	logger := slog.New(slog.NewTextHandler(&buf,
+		&slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	hub, err := New(enginert.Default().WithLogger(logger))
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	def, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	winner := &faultyWaiter{countingWaiter: newCountingWaiter(def), id: "winner-waiter"}
+	built := &faultyWaiter{countingWaiter: newCountingWaiter(def), id: "discarded-waiter"}
+
+	// the winner appears DURING the unlocked build, so this registration loses
+	// and joins it — successfully, this time.
+	build := func(_ eventproc.EventHub, ep eventproc.EventProcessor,
+		_ flow.EventDefinition, _ renv.EngineRuntime,
+	) (eventproc.EventWaiter, error) {
+		hub.m.Lock()
+		hub.waiters[def.ID()] = winner
+		hub.m.Unlock()
+
+		_ = built.AddEventProcessor(ep)
+
+		return built, nil
+	}
+
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().ID().Return("ep-lost-report").Maybe()
+
+	require.NoError(t, hub.registerWaiter(ep, def, build),
+		"joining the winner is a successful registration")
+
+	out := buf.String()
+	require.Contains(t, out, winner.ID(),
+		"the fact must name the waiter the processor actually landed on")
+	require.NotContains(t, out, built.ID(),
+		"it must not name the waiter this call discarded")
+}
+
+// TestUnstoppableWaiterStaysMapped is the independent review's finding A5. The
+// §1.3 fix moved the removal under the lock that observes the waiter empty,
+// which is correct — but it also made the removal happen BEFORE Stop. A waiter
+// that will not stop is still serving its subscription, so leaving it unmapped
+// strands it: the next registration for this definition builds a second waiter
+// and subscribes again, and nothing can ever reach the first.
+//
+// A failed unregistration must leave the registry as it found it.
+func TestUnstoppableWaiterStaysMapped(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	def, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	w := &faultyWaiter{
+		countingWaiter: newCountingWaiter(def),
+		stopErr:        errors.New("the waiter will not stop"),
+	}
+
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().ID().Return("ep-unstoppable").Maybe()
+
+	require.NoError(t, w.AddEventProcessor(ep))
+	require.NoError(t, w.Service(context.Background())) // so Stop is attempted
+
+	hub.m.Lock()
+	hub.waiters[def.ID()] = w
+	hub.m.Unlock()
+
+	err = hub.UnregisterEvent(ep, def.ID())
+	require.Error(t, err, "a waiter that will not stop is a failed unregister")
+	require.ErrorContains(t, err, "waiter stop failed")
+
+	hub.m.Lock()
+	got, mapped := hub.waiters[def.ID()]
+	hub.m.Unlock()
+
+	require.True(t, mapped,
+		"the waiter is still alive, so it must still be reachable")
+	require.Equal(t, eventproc.EventWaiter(w), got,
+		"and it is the same waiter, not a replacement")
 }

--- a/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
+++ b/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
@@ -499,6 +499,7 @@ type faultyWaiter struct {
 	id      string
 	addErr  error
 	stopErr error
+	onStop  func() // runs inside Stop, before it reports its failure
 	stops   atomic.Int32
 }
 
@@ -520,6 +521,10 @@ func (w *faultyWaiter) AddEventProcessor(ep eventproc.EventProcessor) error {
 
 func (w *faultyWaiter) Stop() error {
 	w.stops.Add(1)
+
+	if w.onStop != nil {
+		w.onStop()
+	}
 
 	_ = w.countingWaiter.Stop()
 
@@ -738,4 +743,109 @@ func TestUnstoppableWaiterStaysMapped(t *testing.T) {
 		"the waiter is still alive, so it must still be reachable")
 	require.Equal(t, eventproc.EventWaiter(w), got,
 		"and it is the same waiter, not a replacement")
+}
+
+// internalSignalDef builds a signal definition inside the package's own test
+// binary — the eventhub_test helper of the same shape is in the external test
+// package and cannot be reached from here.
+func internalSignalDef(t *testing.T, name string) *events.SignalEventDefinition {
+	t.Helper()
+
+	sig, err := events.NewSignal(name, nil)
+	require.NoError(t, err)
+
+	def, err := events.NewSignalEventDefinition(sig)
+	require.NoError(t, err)
+
+	return def
+}
+
+// TestUnstoppableSignalWaiterRejoinsTheNameIndex: restoring a stranded waiter
+// has to restore it EVERYWHERE it was registered. A signal waiter is reached by
+// NAME through signalIdx, not only by definition id, so putting it back in the
+// registry alone would leave it invisible to every broadcast — mapped, alive,
+// and unreachable.
+func TestUnstoppableSignalWaiterRejoinsTheNameIndex(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	def := internalSignalDef(t, "GO")
+
+	w := &faultyWaiter{
+		countingWaiter: newCountingWaiter(def),
+		stopErr:        errors.New("the waiter will not stop"),
+	}
+
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().ID().Return("ep-signal-unstoppable").Maybe()
+
+	require.NoError(t, w.AddEventProcessor(ep))
+	require.NoError(t, w.Service(context.Background()))
+
+	hub.m.Lock()
+	hub.waiters[def.ID()] = w
+	hub.signalIdx["GO"] = []eventproc.EventWaiter{w}
+	hub.m.Unlock()
+
+	require.Error(t, hub.UnregisterEvent(ep, def.ID()))
+
+	hub.m.Lock()
+	_, mapped := hub.waiters[def.ID()]
+	idx := hub.signalIdx["GO"]
+	hub.m.Unlock()
+
+	require.True(t, mapped, "the waiter is back in the registry")
+	require.Contains(t, idx, eventproc.EventWaiter(w),
+		"and back in the name index, or no broadcast could ever reach it")
+}
+
+// TestUnstoppableWaiterYieldsToAReplacement: the restore must NOT overwrite a
+// waiter that a concurrent registration installed while the failing Stop ran.
+// That waiter owns the definition now; putting the stranded one back over it
+// would strand THAT one instead — the same defect with the victims swapped.
+func TestUnstoppableWaiterYieldsToAReplacement(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	def, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	replacement := &faultyWaiter{
+		countingWaiter: newCountingWaiter(def),
+		id:             "replacement-waiter",
+	}
+
+	// the failing Stop installs the replacement, standing in for a
+	// registration that landed while the unregistration was outside the lock.
+	doomed := &faultyWaiter{
+		countingWaiter: newCountingWaiter(def),
+		id:             "doomed-waiter",
+		stopErr:        errors.New("the waiter will not stop"),
+		onStop: func() {
+			hub.m.Lock()
+			hub.waiters[def.ID()] = replacement
+			hub.m.Unlock()
+		},
+	}
+
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().ID().Return("ep-yield").Maybe()
+
+	require.NoError(t, doomed.AddEventProcessor(ep))
+	require.NoError(t, doomed.Service(context.Background()))
+
+	hub.m.Lock()
+	hub.waiters[def.ID()] = doomed
+	hub.m.Unlock()
+
+	require.Error(t, hub.UnregisterEvent(ep, def.ID()))
+
+	hub.m.Lock()
+	got := hub.waiters[def.ID()]
+	hub.m.Unlock()
+
+	require.Equal(t, eventproc.EventWaiter(replacement), got,
+		"the definition keeps the waiter that claimed it, not the stranded one")
 }

--- a/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
+++ b/internal/eventproc/eventhub/eventhub_errpaths_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -445,4 +446,152 @@ func TestUnregisterRacingRegisterKeepsTheRegistration(t *testing.T) {
 
 		_ = hub.UnregisterEvent(ep, def.ID()) // reset for the next round
 	}
+}
+
+// faultyWaiter is a countingWaiter whose two failure points can be armed: the
+// join a losing registration performs on the winner, and the teardown of a
+// waiter that was built but never installed.
+type faultyWaiter struct {
+	*countingWaiter
+
+	addErr  error
+	stopErr error
+	stops   atomic.Int32
+}
+
+func (w *faultyWaiter) AddEventProcessor(ep eventproc.EventProcessor) error {
+	if w.addErr != nil {
+		return w.addErr
+	}
+
+	return w.countingWaiter.AddEventProcessor(ep)
+}
+
+func (w *faultyWaiter) Stop() error {
+	w.stops.Add(1)
+
+	_ = w.countingWaiter.Stop()
+
+	return w.stopErr
+}
+
+// TestRegisterOnAStoppedHubIsRejectedAndTearsDown covers the branch the §1.3
+// restructure introduced: the builder runs BEFORE the lock, so a registration
+// that arrives at a stopped hub is holding a live waiter nothing will install.
+// It must be rejected AND torn down — a waiter left running past Shutdown is
+// exactly what SRD-019 forbids.
+func TestRegisterOnAStoppedHubIsRejectedAndTearsDown(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	def, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	// Stop fails too: an uninstalled waiter's teardown failure is a Debug fact,
+	// not a second error for the caller, who already has the real one.
+	built := &faultyWaiter{
+		countingWaiter: newCountingWaiter(def),
+		stopErr:        errors.New("the waiter will not stop"),
+	}
+
+	// The hub shuts down DURING the unlocked build. An already-stopped hub is
+	// refused at the fast path; this window — open only because building no
+	// longer holds the lock (§1.1) — is what leaves a live waiter in the hands
+	// of a registration that has nowhere to install it.
+	build := func(_ eventproc.EventHub, ep eventproc.EventProcessor,
+		_ flow.EventDefinition, _ renv.EngineRuntime,
+	) (eventproc.EventWaiter, error) {
+		require.NoError(t, hub.Shutdown(context.Background()))
+
+		_ = built.AddEventProcessor(ep)
+
+		return built, nil
+	}
+
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().ID().Return("ep-stopped").Maybe()
+
+	err = hub.registerWaiter(ep, def, build)
+	require.Error(t, err, "a stopped hub rejects the registration")
+	require.ErrorContains(t, err, "shut down")
+
+	require.Positive(t, built.stops.Load(),
+		"the uninstalled waiter must be torn down, not left running")
+}
+
+// TestRegisterJoinFailureIsReported covers the other uninstalled-waiter branch:
+// the registration lost the race to install, so it joins the winner instead —
+// and the join can fail. The caller must be told, because its processor is
+// subscribed to nothing at all: it is neither the winner's nor its own.
+func TestRegisterJoinFailureIsReported(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	def, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	// a winner that refuses joiners, installed DURING the unlocked build — the
+	// window the §1.1 restructure opens, and the only way the losing branch is
+	// reached: the fast path checked the map before this waiter existed.
+	winner := &faultyWaiter{
+		countingWaiter: newCountingWaiter(def),
+		addErr:         errors.New("the winner refuses the processor"),
+	}
+
+	built := &faultyWaiter{countingWaiter: newCountingWaiter(def)}
+
+	build := func(_ eventproc.EventHub, ep eventproc.EventProcessor,
+		_ flow.EventDefinition, _ renv.EngineRuntime,
+	) (eventproc.EventWaiter, error) {
+		hub.m.Lock()
+		hub.waiters[def.ID()] = winner
+		hub.m.Unlock()
+
+		_ = built.AddEventProcessor(ep)
+
+		return built, nil
+	}
+
+	ep := mockeventproc.NewMockEventProcessor(t)
+	ep.EXPECT().ID().Return("ep-join-fails").Maybe()
+
+	err = hub.registerWaiter(ep, def, build)
+	require.Error(t, err, "a failed join is not a successful registration")
+	require.ErrorContains(t, err, "couldn't add event processor to waiter")
+
+	require.Positive(t, built.stops.Load(),
+		"the losing registration's own waiter must be torn down")
+}
+
+// TestRemoveWaiterDropsTheRegistration covers RemoveWaiter's success path: the
+// waiter leaves the registry and the name index together, through the same
+// dropWaiterLocked the §1.3 restructure made the single removal point. Removing
+// it twice reports not-found rather than silently succeeding.
+func TestRemoveWaiterDropsTheRegistration(t *testing.T) {
+	hub, err := New(enginert.Default())
+	require.NoError(t, err)
+	require.NoError(t, hub.Start(context.Background()))
+
+	def, err := events.NewTerminateEventDefinition()
+	require.NoError(t, err)
+
+	w := newCountingWaiter(def)
+
+	hub.m.Lock()
+	hub.waiters[def.ID()] = w
+	hub.m.Unlock()
+
+	require.NoError(t, hub.RemoveWaiter(def.ID()))
+
+	hub.m.Lock()
+	_, present := hub.waiters[def.ID()]
+	hub.m.Unlock()
+
+	require.False(t, present, "the waiter is gone from the registry")
+
+	err = hub.RemoveWaiter(def.ID())
+	require.Error(t, err, "removing it again is not a silent success")
+	require.ErrorContains(t, err, "waiter isn't found")
 }

--- a/internal/instance/instance.go
+++ b/internal/instance/instance.go
@@ -68,6 +68,8 @@ type Instance struct {
 	// pendingIncidentOp is an operator op riding a rebuild (SRD-079 §3.6),
 	// consumed once by the loop before its park decision.
 	pendingIncidentOp *incidentRequest
+	// pendingCancel is an operator cancel riding a rebuild (FIX-038 §1.10).
+	pendingCancel *cancelRequest
 	// incidentsSnap is the copy-on-write projection IncidentViews serves —
 	// rebuilt by the loop after every incident mutation (the tracksSnap
 	// pattern).
@@ -268,6 +270,25 @@ func WithPendingIncidentOp(
 	}
 }
 
+// WithPendingCancel hands a rebuild an operator's CANCEL (FIX-038 §1.10), the
+// same shape WithPendingIncidentOp uses: a parked instance has no loop to
+// cancel, so the request rides the rebuild and the fresh loop tears the
+// instance down BEFORE deciding whether to park again. Without it, canceling a
+// dehydrated instance canceled a context whose loop had already exited — the
+// request was lost and the next wake resumed the instance as if nothing had
+// happened.
+func WithPendingCancel(resp chan error) Option {
+	return func(cfg *newConfig) {
+		cfg.pendingCancel = &cancelRequest{resp: resp}
+	}
+}
+
+// cancelRequest is an operator cancel riding a rebuild; resp carries the
+// verdict back to the caller that asked for it.
+type cancelRequest struct {
+	resp chan error
+}
+
 // WithSettledSignal gives the instance the channel to close when it reaches a
 // TERMINAL state (SRD-071). The engine owns it per instance ID and passes the
 // same channel to every rebuild, so a host waiting for completion is not woken
@@ -347,6 +368,8 @@ type newConfig struct {
 	// pendingIncidentOp is an operator incident operation riding a rebuild
 	// (SRD-079 §3.6) — applied by the loop before its park decision.
 	pendingIncidentOp *incidentRequest
+	// pendingCancel is an operator cancel riding a rebuild (FIX-038 §1.10).
+	pendingCancel *cancelRequest
 	// invoker launches child instances for the Call Activities this instance
 	// runs (SRD-050 FR-3); nil for a library embedder without a thresher — a
 	// call then fails fast with a classified no-invoker error.
@@ -501,6 +524,7 @@ func New(
 		tracks:              map[string]*track{},
 		incidents:           map[string]*incident{},
 		pendingIncidentOp:   cfg.pendingIncidentOp,
+		pendingCancel:       cfg.pendingCancel,
 		events:              make(chan trackEvent),
 		taskReq:             make(chan taskRequest),
 		jobReq:              make(chan jobRequest),

--- a/internal/instance/loop.go
+++ b/internal/instance/loop.go
@@ -235,13 +235,7 @@ func (inst *Instance) loop(ctx context.Context, initial []*track) {
 	// root scope — they guard the whole instance's window (SRD-052 FR-5).
 	ls.armScopeHandlers(ctx, rootNodes(inst), inst.sc.root)
 
-	// An operator op that rode a rebuild (SRD-079 §3.6) applies BEFORE the
-	// park decision: a retry/resolve spawns tracks that keep the loop alive,
-	// a drop parks again — either way the op is never lost to the re-park.
-	if req := inst.pendingIncidentOp; req != nil {
-		inst.pendingIncidentOp = nil
-		ls.handleIncidentRequest(ctx, *req)
-	}
+	ls.applyPendingOps(ctx)
 
 	if !ls.loopPreflight() {
 		return
@@ -420,6 +414,35 @@ func (ls *loopState) spawn(ctx context.Context, t *track) {
 
 		ls.inst.emit(trackEvent{kind: trackEndKind(t), track: t})
 	}(t)
+}
+
+// applyPendingOps runs the operator requests that rode a rebuild, BEFORE the
+// park decision — so neither is lost to an immediate re-park (SRD-079 §3.6,
+// FIX-038 §1.10). A parked instance has no loop to receive them, which is why
+// they travel with the rebuild instead of being delivered to one.
+func (ls *loopState) applyPendingOps(ctx context.Context) {
+	inst := ls.inst
+
+	// An incident op: a retry/resolve spawns tracks that keep the loop alive,
+	// a drop parks again — either way the op is applied first.
+	if req := inst.pendingIncidentOp; req != nil {
+		inst.pendingIncidentOp = nil
+		ls.handleIncidentRequest(ctx, *req)
+	}
+
+	// A cancel. stopAll — not inst.Cancel — is what makes it stick: it sets
+	// ls.stopping, which maybeDehydrate checks, so the instance cannot park
+	// again before observing the request. Canceling the context alone would
+	// race the re-park and be lost exactly as the pre-rebuild cancel was.
+	if req := inst.pendingCancel; req != nil {
+		inst.pendingCancel = nil
+
+		ls.stopAll()
+
+		if req.resp != nil {
+			req.resp <- nil
+		}
+	}
 }
 
 // stopAll moves the instance to Terminating (once) and signals every live

--- a/internal/instance/loop_test.go
+++ b/internal/instance/loop_test.go
@@ -202,6 +202,54 @@ func TestLoopStateApplyMergedGhost(t *testing.T) {
 	})
 }
 
+// TestApplyPendingCancel is FIX-038 T-10 at the level the mechanism lives: a
+// cancel aimed at a DEHYDRATED instance has no loop to receive it, so it rides
+// the rebuild and the fresh loop must apply it BEFORE its park decision.
+//
+// stopAll is what makes it stick — it sets ls.stopping, which maybeDehydrate
+// checks, so the instance cannot park again before observing the request. A
+// bare context cancel would race the re-park and be lost exactly as the
+// pre-rebuild cancel was.
+func TestApplyPendingCancel(t *testing.T) {
+	inst := newBareLoopInstance()
+	inst.td = interactor.NopDistributor()
+
+	resp := make(chan error, 1)
+
+	// the option is the carrier: it is what a rebuild is handed.
+	cfg := newConfig{}
+	WithPendingCancel(resp)(&cfg)
+	require.NotNil(t, cfg.pendingCancel, "the option arms the rebuild")
+
+	inst.pendingCancel = cfg.pendingCancel
+
+	ls := newLoopState(inst)
+	ls.applyPendingOps(t.Context())
+
+	require.True(t, ls.stopping,
+		"the cancel tears the instance down, so it cannot park again")
+	require.Equal(t, Terminating, inst.State())
+	require.Nil(t, inst.pendingCancel, "a pending cancel is consumed once")
+
+	select {
+	case err := <-resp:
+		require.NoError(t, err, "the caller is answered")
+
+	default:
+		t.Fatal("the cancel verdict never reached the caller")
+	}
+}
+
+// TestApplyPendingOpsWithNothingPending: a rebuild carrying neither operator
+// request leaves the loop alone — the ordinary wake must not be torn down.
+func TestApplyPendingOpsWithNothingPending(t *testing.T) {
+	ls := newLoopState(newBareLoopInstance())
+
+	ls.applyPendingOps(t.Context())
+
+	require.False(t, ls.stopping, "an ordinary rebuild is not a cancel")
+}
+
 // TestLoopStateApplySequences (SRD-040 T-5): a loopState driven directly with
 // evMoved/evParked sequences maintains the position and parked views per the
 // SRD-028 semantics — the unit-level access the loopState extraction unlocks.

--- a/internal/scope/runtimevars_test.go
+++ b/internal/scope/runtimevars_test.go
@@ -1,7 +1,9 @@
 package scope
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
@@ -74,4 +76,72 @@ func TestPlaneRuntimeVars(t *testing.T) {
 			require.Error(t, errOf(p.Commit(sub, testData(t, "x", 1))))
 			require.Error(t, p.OpenScope(sub))
 		})
+}
+
+// blockingSupplier holds its RuntimeVar call until released, so a test can see
+// whether the plane's lock is held across it.
+type blockingSupplier struct {
+	t       *testing.T
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (s *blockingSupplier) RuntimeVar(name string) (data.Data, error) {
+	s.once.Do(func() { close(s.entered) })
+	<-s.release
+
+	return testData(s.t, name, true), nil
+}
+
+func (s *blockingSupplier) RuntimeVarNames() []string { return []string{"alive"} }
+
+// TestRuntimeVarIsServedOutsideThePlaneLock is FIX-038 T-9. GetData held p.m
+// across p.rt.RuntimeVar — a call out of this package inside the plane's
+// critical section, the shape this FIX removes everywhere else. It was also
+// gratuitous: the runtime branch reads nothing the lock protects, because a
+// runtime variable comes from the SUPPLIER and not from the plane's maps.
+//
+// While the supplier is working, the rest of the plane must stay usable.
+func TestRuntimeVarIsServedOutsideThePlaneLock(t *testing.T) {
+	root := mustPath(t, "/proc")
+	rtPath := mustPath(t, "/proc/"+RuntimeVarsSegment)
+
+	sup := &blockingSupplier{
+		t:       t,
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+
+	p, err := New(root, sup)
+	require.NoError(t, err)
+
+	require.NoError(t, errOf(p.Commit(root, testData(t, "ordinary", 1))))
+
+	served := make(chan struct{})
+
+	go func() {
+		defer close(served)
+
+		_, _ = p.GetData(rtPath, "alive")
+	}()
+
+	<-sup.entered // inside the supplier, mid-lookup
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		_, _ = p.GetData(root, "ordinary") // any operation needing p.m
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the plane lock was held across the runtime supplier")
+	}
+
+	close(sup.release)
+	<-served
 }

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -91,12 +91,18 @@ func (p *Scope) GetData(from DataPath, name string) (data.Data, error) {
 		return nil, err
 	}
 
-	p.m.Lock()
-	defer p.m.Unlock()
-
+	// A runtime variable is served by the SUPPLIER, not from the plane's maps,
+	// so it is answered before the lock is taken. Holding p.m across
+	// RuntimeVar put a call out of this package inside the plane's critical
+	// section — the shape FIX-038 removes everywhere else — and it is
+	// gratuitous here: the branch reads nothing the lock protects. p.rt and
+	// p.rtPath are set at construction and never reassigned.
 	if p.rt != nil && from == p.rtPath {
 		return p.rt.RuntimeVar(name)
 	}
+
+	p.m.Lock()
+	defer p.m.Unlock()
 
 	return p.getData(
 		from, name,

--- a/internal/scope/scope.go
+++ b/internal/scope/scope.go
@@ -115,11 +115,22 @@ func (p *Scope) SnapshotAt(from DataPath) ([]data.Data, error) {
 		return nil, err
 	}
 
-	names := p.namesFrom(from)
+	// ONE acquisition for the whole walk. Reading the names, releasing, then
+	// reading each datum let another goroutine mutate the plane in between —
+	// and this runs on the TRACK goroutine, where commits bypass the loop
+	// (instance/track.go). The result was a snapshot of a world that never
+	// existed at any instant, which is exactly what it exists to prevent, or a
+	// spurious failure when a datum was removed mid-walk (FIX-038 §1.6).
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	names := p.namesFromLocked(from)
 	snap := make([]data.Data, 0, len(names))
 
 	for _, n := range names {
-		d, err := p.GetData(from, n)
+		d, err := p.getData(from, n, func(d data.Data) bool {
+			return d.Name() == n
+		})
 		if err != nil {
 			return nil, errs.New(
 				errs.M("SnapshotAt: couldn't read %q at %q", n, string(from)),
@@ -309,6 +320,12 @@ func (p *Scope) namesFrom(from DataPath) []string {
 	p.m.Lock()
 	defer p.m.Unlock()
 
+	return p.namesFromLocked(from)
+}
+
+// namesFromLocked is namesFrom's body for a caller already holding p.m —
+// SnapshotAt needs the names and the data under ONE acquisition.
+func (p *Scope) namesFromLocked(from DataPath) []string {
 	seen := map[string]struct{}{}
 	prefix := from.String() + PathSeparator
 
@@ -353,13 +370,64 @@ func (p *Scope) GetDataByID(from DataPath, id string) (data.Data, error) {
 	p.m.Lock()
 	defer p.m.Unlock()
 
-	return p.getData(
-		from, id,
-		func(d data.Data) bool {
-			idef := d.ItemDefinition()
+	return p.dataByIDLocked(from, id)
+}
 
-			return idef != nil && idef.ID() == id
-		})
+// dataByIDLocked resolves by ItemDefinition id DETERMINISTICALLY.
+//
+// An ItemDefinition is a TYPE, so several variables can share its id — a
+// send/receive flow does exactly that, binding a message's payload definition
+// to both the message variable and the variable that receives it. The old
+// resolution iterated a scope's map and returned the first match, and Go
+// randomizes that order: the same lookup answered differently on different runs
+// (FIX-038 §1.7).
+//
+// Two rules make it total. The walk is parent-ward, so the NEAREST scope wins —
+// that is meaningful, and it is what the by-name lookup already does. Within one
+// scope the lowest name wins — that is arbitrary, and it is chosen because the
+// alternative is worse: refusing an ambiguous id looked principled until it
+// rejected the send/receive pattern above, which is legitimate BPMN.
+//
+// An id that names several data in one scope is still a modeling smell; the
+// engine now answers it the same way every time instead of at random.
+// Caller holds p.m.
+func (p *Scope) dataByIDLocked(from DataPath, id string) (data.Data, error) {
+	path := from
+
+	for {
+		var match data.Data
+
+		for _, d := range p.scopes[path] {
+			idef := d.ItemDefinition()
+			if idef == nil || idef.ID() != id {
+				continue
+			}
+
+			if match == nil || d.Name() < match.Name() {
+				match = d
+			}
+		}
+
+		if match != nil {
+			return match, nil
+		}
+
+		if path.String() == PathSeparator {
+			break
+		}
+
+		parent, err := path.DropTail()
+		if err != nil {
+			break
+		}
+
+		path = parent
+	}
+
+	return nil, errs.New(
+		errs.M("GetDataByID: no data with ItemDefinition id %q visible from %q",
+			id, string(from)),
+		errs.C(errorClass, errs.ObjectNotFound))
 }
 
 // Commit atomically stores the batch dd into the open container scope at.

--- a/internal/scope/scope_internal_test.go
+++ b/internal/scope/scope_internal_test.go
@@ -473,3 +473,17 @@ func TestSnapshotAtIsAtomic(t *testing.T) {
 	close(stop)
 	wg.Wait()
 }
+
+// TestGetDataByIDStopsAtAnUnrootedPath: the walk climbs toward the root, and a
+// path that cannot yield a parent ends it. EmptyDataPath is the case a caller
+// actually reaches — instances are constructed with it — so the lookup must
+// answer "not visible", not spin or fault.
+func TestGetDataByIDStopsAtAnUnrootedPath(t *testing.T) {
+	p, err := New(mustPath(t, "/proc"), nil)
+	require.NoError(t, err)
+
+	d, err := p.dataByIDLocked(EmptyDataPath, "no-such-item")
+	require.Error(t, err, "an unrooted path resolves nothing")
+	require.Nil(t, d)
+	require.ErrorContains(t, err, "no-such-item")
+}

--- a/internal/scope/scope_internal_test.go
+++ b/internal/scope/scope_internal_test.go
@@ -350,3 +350,126 @@ func TestScopeNamesFromRoot(t *testing.T) {
 	require.Contains(t, names, "rootVar")
 	require.Contains(t, names, "childVar")
 }
+
+// sharedIDData carries a chosen ItemDefinition id, so a scope can hold several
+// data of "one type" — the send/receive pattern that makes id resolution
+// ambiguous in real models.
+type sharedIDData struct {
+	data.Data
+
+	idef *data.ItemDefinition
+}
+
+func (s sharedIDData) ItemDefinition() *data.ItemDefinition { return s.idef }
+
+// TestGetDataByIDIsDeterministic is FIX-038 T-7. Resolution by ItemDefinition
+// id iterated a scope's map and returned the first match, and Go randomizes
+// that order — so the same lookup answered differently on different runs.
+//
+// It is not an error for several data to share an id: a send/receive flow binds
+// a message's payload definition to both the message variable and the variable
+// receiving it. The rule is therefore total rather than strict — nearest scope
+// first, lowest name within a scope — and, above all, the SAME every time.
+func TestGetDataByIDIsDeterministic(t *testing.T) {
+	root := mustPath(t, "/proc")
+
+	p, err := New(root, nil)
+	require.NoError(t, err)
+
+	idef := data.MustItemDefinition(values.NewVariable("payload"))
+
+	// three data of one "type" in one scope, added in a non-alphabetical order
+	for _, n := range []string{"zulu", "alpha", "mike"} {
+		require.NoError(t, errOf(p.Commit(root,
+			sharedIDData{Data: testData(t, n, "v"), idef: idef})))
+	}
+
+	// The same answer, every time — the defect was that this varied.
+	for range 50 {
+		got, err := p.GetDataByID(root, idef.ID())
+		require.NoError(t, err)
+		require.Equal(t, "alpha", got.Name(),
+			"within one scope the lowest name wins, and it wins every time")
+	}
+
+	// A nearer scope still outranks the tiebreak: proximity is the meaningful
+	// rule, the name order only settles a tie.
+	child, err := root.Append("child")
+	require.NoError(t, err)
+	require.NoError(t, p.OpenScope(child))
+
+	require.NoError(t, errOf(p.Commit(child,
+		sharedIDData{Data: testData(t, "omega", "v"), idef: idef})))
+
+	got, err := p.GetDataByID(child, idef.ID())
+	require.NoError(t, err)
+	require.Equal(t, "omega", got.Name(),
+		"the nearest scope answers before any ancestor")
+}
+
+// TestSnapshotAtIsAtomic is FIX-038 T-6. SnapshotAt read the visible NAMES
+// under one acquisition and then each DATUM under another, so a concurrent
+// mutation landed in between. It runs on the track goroutine, where commits
+// bypass the loop, so that window is reachable — and the result was a snapshot
+// of a world that never existed at any instant, which is exactly what the
+// compensation ledger and the incident snapshot rely on it not to be.
+//
+// The assertion is internal consistency: every datum a snapshot returns must
+// carry the value of ONE generation, never a mixture of two.
+func TestSnapshotAtIsAtomic(t *testing.T) {
+	root := mustPath(t, "/proc")
+
+	p, err := New(root, nil)
+	require.NoError(t, err)
+
+	const names = 12
+
+	for i := range names {
+		require.NoError(t, errOf(p.Commit(root,
+			testData(t, fmt.Sprintf("v%02d", i), 0))))
+	}
+
+	stop := make(chan struct{})
+
+	var wg sync.WaitGroup
+
+	// A writer advancing EVERY name to the same generation, over and over. A
+	// torn snapshot shows two generations at once.
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		for gen := 1; ; gen++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+
+			batch := make([]data.Data, 0, names)
+			for i := range names {
+				batch = append(batch, testData(t, fmt.Sprintf("v%02d", i), gen))
+			}
+
+			_, _ = p.Commit(root, batch...)
+		}
+	}()
+
+	for range 200 {
+		snap, err := p.SnapshotAt(root)
+		require.NoError(t, err, "a concurrent commit must not break the snapshot")
+		require.Len(t, snap, names)
+
+		seen := map[any]struct{}{}
+		for _, d := range snap {
+			seen[d.Value().Get(t.Context())] = struct{}{}
+		}
+
+		require.Len(t, seen, 1,
+			"every datum must come from ONE generation — a torn snapshot mixes two")
+	}
+
+	close(stop)
+	wg.Wait()
+}

--- a/pkg/thresher/dehydration_handle_test.go
+++ b/pkg/thresher/dehydration_handle_test.go
@@ -120,10 +120,18 @@ func TestCancelReachesADehydratedInstance(t *testing.T) {
 		"the instance is terminated, not left parked")
 
 	// And it stays cancelled: advancing past the timer must not resurrect it.
+	// The assertion is on the engine's OWN statement that it woke something —
+	// a hydration fact — rather than on a downstream side effect, so the
+	// window only has to cover the wake the mock clock triggers at once.
+	hydrations := fw.count(observability.KindInstanceState,
+		observability.PhaseHydrated)
+
 	clk.Advance(3 * time.Hour)
 
-	require.Never(t, func() bool { return hit.Load() },
-		500*time.Millisecond, 50*time.Millisecond,
+	require.Never(t, func() bool {
+		return fw.count(observability.KindInstanceState,
+			observability.PhaseHydrated) > hydrations || hit.Load()
+	}, 200*time.Millisecond, 20*time.Millisecond,
 		"a cancelled instance must not be woken by its own timer")
 }
 
@@ -161,4 +169,73 @@ func TestCancelOnAParkedInstanceReportsAStoppedEngine(t *testing.T) {
 	_, err = h.Cancel(ctx)
 	require.Error(t, err,
 		"a cancel that cannot reach the instance must not report success")
+}
+
+// TestCancelRacingTheParkStillLands is the independent review's finding A1.
+// Cancel checks whether the instance is dehydrated and then cancels it, and
+// those two steps are not atomic: an instance that parks in between takes the
+// direct cancel to a loop that has already exited — §1.10's defect reappearing
+// inside the guard that fixes it.
+//
+// The window is AIMED at, not raced for. A first attempt merely issued the
+// cancel while the park was in flight and passed with the fix reverted — it hit
+// the window by luck, which is indistinguishable from a test that cannot fail
+// (the same weakness the review found in T-3). The seam makes it deterministic:
+// Cancel's check sees a live instance, the seam then waits for the park to
+// complete, and only then does the direct cancel run — against a loop that is
+// certainly gone.
+func TestCancelRacingTheParkStillLands(t *testing.T) {
+	repo := memrepo.New()
+	deadline := dehydrationEpoch.Add(2 * time.Hour)
+
+	var hit atomic.Bool
+
+	p := longTimerProc(t, "cancel-race", deadline, &hit)
+
+	th, fw, clk, stop := bootDehydrationEngine(t, "engine-CR", repo, p)
+	defer stop()
+
+	h, err := th.StartLatest(p.ID())
+	require.NoError(t, err)
+
+	parked := make(chan struct{})
+
+	thresher.SetCancelParkSeam(func() {
+		// runs INSIDE Cancel, after the check saw a live instance
+		require.Eventually(t, func() bool {
+			return fw.saw(observability.KindInstanceState,
+				observability.PhaseDehydrated)
+		}, 3*time.Second, 10*time.Millisecond,
+			"the instance must park inside the window this test aims at")
+
+		close(parked)
+	})
+	defer thresher.SetCancelParkSeam(nil)
+
+	ctx, ccancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer ccancel()
+
+	st, err := h.Cancel(ctx)
+	require.NoError(t, err, "the cancel must reach the parked instance")
+
+	select {
+	case <-parked:
+	default:
+		t.Fatal("the seam never ran — the test did not exercise the window")
+	}
+
+	require.Equal(t, thresher.StateTerminated, st,
+		"a cancel that lands in the park window still terminates the instance")
+
+	// and it stays cancelled: its own timer must not resurrect it
+	hydrations := fw.count(observability.KindInstanceState,
+		observability.PhaseHydrated)
+
+	clk.Advance(3 * time.Hour)
+
+	require.Never(t, func() bool {
+		return fw.count(observability.KindInstanceState,
+			observability.PhaseHydrated) > hydrations || hit.Load()
+	}, 200*time.Millisecond, 20*time.Millisecond,
+		"a cancelled instance must not be woken by its own timer")
 }

--- a/pkg/thresher/dehydration_handle_test.go
+++ b/pkg/thresher/dehydration_handle_test.go
@@ -78,3 +78,87 @@ func TestStateDehydratedIsNamed(t *testing.T) {
 	require.Equal(t, thresher.InstanceState("Dehydrated"),
 		thresher.StateDehydrated)
 }
+
+// TestCancelReachesADehydratedInstance is FIX-038 T-10. InstanceHandle.Cancel
+// called inst.Cancel(), which cancels the instance's CONTEXT — but a dehydrated
+// instance has no loop reading that context: its goroutines are gone and its
+// state lives in a checkpoint. The request vanished, and the next wake rebuilt
+// the instance and carried on as if it had never been made.
+//
+// The cancel now rides a rebuild, the way an incident operation does, and the
+// fresh loop tears the instance down through stopAll BEFORE its park decision —
+// stopAll, not a bare context cancel, because maybeDehydrate checks ls.stopping
+// and a plain cancel would race the re-park and be lost again.
+func TestCancelReachesADehydratedInstance(t *testing.T) {
+	repo := memrepo.New()
+	deadline := dehydrationEpoch.Add(2 * time.Hour)
+
+	var hit atomic.Bool
+
+	p := longTimerProc(t, "cancel-parked", deadline, &hit)
+
+	th, fw, clk, cancel := bootDehydrationEngine(t, "engine-CP", repo, p)
+	defer cancel()
+
+	h, err := th.StartLatest(p.ID())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return fw.saw(observability.KindInstanceState,
+			observability.PhaseDehydrated)
+	}, 3*time.Second, 10*time.Millisecond)
+
+	require.Equal(t, thresher.StateDehydrated, h.State(),
+		"the instance must be parked for this to test anything")
+
+	ctx, ccancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer ccancel()
+
+	st, err := h.Cancel(ctx)
+	require.NoError(t, err, "cancelling a parked instance must reach it")
+	require.Equal(t, thresher.StateTerminated, st,
+		"the instance is terminated, not left parked")
+
+	// And it stays cancelled: advancing past the timer must not resurrect it.
+	clk.Advance(3 * time.Hour)
+
+	require.Never(t, func() bool { return hit.Load() },
+		500*time.Millisecond, 50*time.Millisecond,
+		"a cancelled instance must not be woken by its own timer")
+}
+
+// TestCancelOnAParkedInstanceReportsAStoppedEngine is the other half of T-10:
+// cancelling a DEHYDRATED instance needs a rebuild, and a rebuild needs a
+// running engine. When the engine is gone the request cannot be delivered, and
+// the caller must be told — the silent-loss failure this whole section exists
+// to close would otherwise reappear as a nil error.
+func TestCancelOnAParkedInstanceReportsAStoppedEngine(t *testing.T) {
+	repo := memrepo.New()
+	deadline := dehydrationEpoch.Add(2 * time.Hour)
+
+	var hit atomic.Bool
+
+	p := longTimerProc(t, "cancel-parked-stopped", deadline, &hit)
+
+	th, fw, _, cancel := bootDehydrationEngine(t, "engine-CPS", repo, p)
+
+	h, err := th.StartLatest(p.ID())
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		return fw.saw(observability.KindInstanceState,
+			observability.PhaseDehydrated)
+	}, 3*time.Second, 10*time.Millisecond)
+
+	require.Equal(t, thresher.StateDehydrated, h.State(),
+		"the instance must be parked for this to test anything")
+
+	cancel() // the engine goes away; nothing can rebuild the instance now
+
+	ctx, ccancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer ccancel()
+
+	_, err = h.Cancel(ctx)
+	require.Error(t, err,
+		"a cancel that cannot reach the instance must not report success")
+}

--- a/pkg/thresher/export_test.go
+++ b/pkg/thresher/export_test.go
@@ -16,3 +16,9 @@ func SignalCatchers(th *Thresher, name string) int {
 
 	return h.SignalCatchers(name)
 }
+
+// SetCancelParkSeam installs the function Cancel runs between its state check
+// and the direct cancel — the window an instance can park in. The dehydration
+// harness that can produce a parked instance lives in thresher_test, and the
+// window it aims at is here; this is the bridge. Pass nil to clear it.
+func SetCancelParkSeam(f func()) { cancelParkSeam = f }

--- a/pkg/thresher/handle.go
+++ b/pkg/thresher/handle.go
@@ -3,12 +3,14 @@ package thresher
 import (
 	"context"
 	"encoding/json"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/dr-dobermann/gobpm/internal/instance"
 	"github.com/dr-dobermann/gobpm/pkg/errs"
 	"github.com/dr-dobermann/gobpm/pkg/model/service"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
 )
 
 // ErrNotImplemented marks a control operation that is part of the stable handle
@@ -42,8 +44,43 @@ type InstanceHandle struct {
 	// captured at adopt so a handle answers correctly even before or
 	// after the instance object itself is reachable (SRD-082 FR-7,
 	// independent-review note A3).
+	// observers are the handle's own observer registrations. They live HERE,
+	// not on the instance object, because the object is replaced on every
+	// rebuild: registering on h.current() alone meant a host observer stopped
+	// receiving facts after the first dehydration, silently, while its
+	// Subscription still reported itself live (FIX-038 §1.8). The handle owns
+	// identity across rebuilds (SRD-071), so it owns these too.
+	observers  map[uint64]*handleObserver
 	parentID   string
 	callNodeID string
+	nextObs    uint64
+	obsMu      sync.Mutex
+}
+
+// handleObserver is one registration the handle re-attaches after a rebuild:
+// the fan-out closure is stable, the deregistration is not — it belongs to
+// whichever instance object the closure is currently registered on.
+type handleObserver struct {
+	fanout func(observability.Fact)
+	cancel func()
+}
+
+// reattachObservers re-registers the handle's observers on the instance it now
+// speaks for. Call it AFTER the engine lock is released: AddObserver takes the
+// instance's own observer lock, and the engine does not hold t.m across another
+// component's lock (the rule locked.go states).
+func (h *InstanceHandle) reattachObservers() {
+	inst := h.current()
+	if inst == nil {
+		return
+	}
+
+	h.obsMu.Lock()
+	defer h.obsMu.Unlock()
+
+	for _, ho := range h.observers {
+		ho.cancel = inst.AddObserver(ho.fanout)
+	}
 }
 
 // current returns the instance object the handle speaks for right now.

--- a/pkg/thresher/handle.go
+++ b/pkg/thresher/handle.go
@@ -294,6 +294,19 @@ func (h *InstanceHandle) WaitCompletion(
 // second call, or Cancel of an already-terminal instance, returns the terminal
 // state at once.
 func (h *InstanceHandle) Cancel(ctx context.Context) (InstanceState, error) {
+	// A DEHYDRATED instance has no loop to observe a context cancellation, so
+	// canceling here canceled a context nobody was reading: the request was
+	// lost and the next wake resumed the instance as if it had never been made
+	// (FIX-038 §1.10). It rides a rebuild instead, like an incident operation.
+	if inst := h.current(); inst != nil &&
+		inst.State() == instance.Dehydrated && h.th != nil {
+		if err := h.th.cancelParked(ctx, h); err != nil {
+			return h.State(), err
+		}
+
+		return h.WaitCompletion(ctx)
+	}
+
 	h.current().Cancel()
 
 	return h.WaitCompletion(ctx)

--- a/pkg/thresher/handle.go
+++ b/pkg/thresher/handle.go
@@ -337,11 +337,11 @@ func (h *InstanceHandle) Cancel(ctx context.Context) (InstanceState, error) {
 	// loop that has already exited. So the state is re-read after canceling
 	// and the parked case routed — bounded, because an instance woken and
 	// re-parked by other traffic must not spin here.
+	// A handle always speaks for an instance — every constructor adopts one —
+	// so current() is not nil-guarded here, exactly as State() and Data() are
+	// not: a guard would only defer the same nil to WaitCompletion below.
 	for range cancelRouteAttempts {
 		inst := h.current()
-		if inst == nil {
-			break
-		}
 
 		if inst.State() == instance.Dehydrated && h.th != nil {
 			if err := h.th.cancelParked(ctx, h); err != nil {
@@ -358,8 +358,7 @@ func (h *InstanceHandle) Cancel(ctx context.Context) (InstanceState, error) {
 		inst.Cancel()
 
 		// It parked while that cancel was in flight, so nothing observed it.
-		cur := h.current()
-		if cur == nil || cur.State() != instance.Dehydrated || h.th == nil {
+		if h.current().State() != instance.Dehydrated || h.th == nil {
 			break
 		}
 	}

--- a/pkg/thresher/handle.go
+++ b/pkg/thresher/handle.go
@@ -57,18 +57,42 @@ type InstanceHandle struct {
 	obsMu      sync.Mutex
 }
 
+// cancelParkSeam runs inside Cancel between the state check and the direct
+// cancel — the window an instance can park in, and the reason the state is
+// re-read afterwards. It is nil in production and exists because that window
+// cannot otherwise be aimed at: a test that merely races the two hits it by
+// luck, which is indistinguishable from a test that cannot fail.
+var cancelParkSeam func()
+
+// cancelRouteAttempts bounds Cancel's re-read of the instance's state. Each
+// pass either cancels a live instance or routes a parked one; the bound only
+// matters if the instance keeps parking between the two, which other traffic
+// can cause but cannot sustain.
+const cancelRouteAttempts = 3
+
 // handleObserver is one registration the handle re-attaches after a rebuild:
 // the fan-out closure is stable, the deregistration is not — it belongs to
 // whichever instance object the closure is currently registered on.
 type handleObserver struct {
 	fanout func(observability.Fact)
 	cancel func()
+	// on is the instance object this registration currently sits on. Without
+	// it a re-attach cannot tell "not yet moved" from "already moved": an
+	// Observe landing between adopt and reattachObservers registers on the NEW
+	// object, and re-registering it there delivered every fact twice while
+	// overwriting the cancel of the first registration, which could then never
+	// be removed.
+	on *instance.Instance
 }
 
 // reattachObservers re-registers the handle's observers on the instance it now
 // speaks for. Call it AFTER the engine lock is released: AddObserver takes the
 // instance's own observer lock, and the engine does not hold t.m across another
 // component's lock (the rule locked.go states).
+//
+// It is idempotent per instance object: a registration already sitting on this
+// one is left alone, and one sitting on the previous object is canceled there
+// before it moves.
 func (h *InstanceHandle) reattachObservers() {
 	inst := h.current()
 	if inst == nil {
@@ -79,7 +103,16 @@ func (h *InstanceHandle) reattachObservers() {
 	defer h.obsMu.Unlock()
 
 	for _, ho := range h.observers {
+		if ho.on == inst {
+			continue
+		}
+
+		if ho.cancel != nil {
+			ho.cancel()
+		}
+
 		ho.cancel = inst.AddObserver(ho.fanout)
+		ho.on = inst
 	}
 }
 
@@ -298,16 +331,38 @@ func (h *InstanceHandle) Cancel(ctx context.Context) (InstanceState, error) {
 	// canceling here canceled a context nobody was reading: the request was
 	// lost and the next wake resumed the instance as if it had never been made
 	// (FIX-038 §1.10). It rides a rebuild instead, like an incident operation.
-	if inst := h.current(); inst != nil &&
-		inst.State() == instance.Dehydrated && h.th != nil {
-		if err := h.th.cancelParked(ctx, h); err != nil {
-			return h.State(), err
+	//
+	// The check and the cancel are NOT atomic, and the gap is the same defect
+	// again: an instance that parks between them takes the direct cancel to a
+	// loop that has already exited. So the state is re-read after canceling
+	// and the parked case routed — bounded, because an instance woken and
+	// re-parked by other traffic must not spin here.
+	for range cancelRouteAttempts {
+		inst := h.current()
+		if inst == nil {
+			break
 		}
 
-		return h.WaitCompletion(ctx)
-	}
+		if inst.State() == instance.Dehydrated && h.th != nil {
+			if err := h.th.cancelParked(ctx, h); err != nil {
+				return h.State(), err
+			}
 
-	h.current().Cancel()
+			return h.WaitCompletion(ctx)
+		}
+
+		if cancelParkSeam != nil {
+			cancelParkSeam()
+		}
+
+		inst.Cancel()
+
+		// It parked while that cancel was in flight, so nothing observed it.
+		cur := h.current()
+		if cur == nil || cur.State() != instance.Dehydrated || h.th == nil {
+			break
+		}
+	}
 
 	return h.WaitCompletion(ctx)
 }

--- a/pkg/thresher/incident_ops.go
+++ b/pkg/thresher/incident_ops.go
@@ -21,31 +21,85 @@ func (t *Thresher) wakeForIncidentOp(
 ) error {
 	resp := make(chan error, 1)
 
+	return t.rebuildForOp(ctx, h, "incident op", resp,
+		instance.WithPendingIncidentOp(op, incidentID, resp))
+}
+
+// cancelParked cancels an instance whose loop has already exited (FIX-038
+// §1.10). A dehydrated instance has no loop to observe a context cancellation,
+// so InstanceHandle.Cancel used to cancel a context nobody was reading: the
+// request vanished and the next wake resumed the instance as if it had never
+// been made. The cancel rides a rebuild instead, exactly as an incident
+// operation does, and the fresh loop tears the instance down before its park
+// decision.
+func (t *Thresher) cancelParked(ctx context.Context, h *InstanceHandle) error {
+	resp := make(chan error, 1)
+
+	return t.rebuildForOp(ctx, h, "cancel", resp,
+		instance.WithPendingCancel(resp))
+}
+
+// rebuildForOp is the shape every operator request against a PARKED instance
+// needs: a parked instance has no loop to receive anything, so the request
+// rides a rebuild and the fresh loop applies it before deciding whether to park
+// again. op names the request in the failure message; opt is the carrier, and
+// resp is the channel that carrier answers on.
+//
+// The two callers were near-copies, and the copy is what let FIX-038 §1.9's fix
+// land in one of them only: an incident-op rebuild adopted the new instance
+// object without re-attaching the handle's observers, so a host's subscription
+// went quiet at the first operator retry — the very defect the handle-owned
+// registry exists to prevent.
+func (t *Thresher) rebuildForOp(
+	ctx context.Context,
+	h *InstanceHandle,
+	op string,
+	resp <-chan error,
+	opt instance.Option,
+) error {
+	// Refuse before claiming anything if the engine is already going away.
+	// engineContext reports "running" for the whole life of the process once
+	// Run has been called — the engine pointer is never cleared — so a request
+	// arriving after shutdown otherwise rebuilt the instance from its
+	// checkpoint, watched the fresh loop tear straight back down on the dead
+	// engine context, and reported SUCCESS to the operator. That is the same
+	// silent loss as the pre-rebuild cancel: the operator is told the request
+	// landed when nothing observed it.
+	if engCtx, running := t.engineContext(); !running || engCtx.Err() != nil {
+		return t.errEngineNotRunning(op)
+	}
+
 	// Take the wake latch like every other rebuild path. It is the ONLY thing
 	// preventing two live loops over one instance: the repository claim does
 	// not exclude, it orders — claimForWake RETRIES a lost CAS, so two
 	// concurrent rebuilds both succeed at successive incarnations (FIX-037
-	// §1.3). Without this an operator's retry racing a timer wake started a
+	// §1.3). Without this an operator's request racing a timer wake started a
 	// second execution loop over the same state.
-	if err := t.awaitClaim(h.ID(), "wakeForIncidentOp"); err != nil {
+	if err := t.awaitClaim(h.ID(), op); err != nil {
 		return err
 	}
 
 	defer t.releaseWake(h.ID())
 
-	if err := t.rebuildAndContinue(h.ID(), nil,
-		instance.WithPendingIncidentOp(op, incidentID, resp)); err != nil {
+	if err := t.rebuildAndContinue(h.ID(), nil, opt); err != nil {
 		return errs.New(
-			errs.M("incident op: the parked instance %q doesn't wake",
-				h.ID()),
+			errs.M("%s: the parked instance %q doesn't wake", op, h.ID()),
 			errs.C(errorClass, errs.OperationFailed),
 			errs.E(err))
 	}
 
 	if inst, err := t.instanceByID(h.ID()); err == nil {
 		h.adopt(inst)
+		h.reattachObservers()
 	}
 
+	return awaitOpVerdict(ctx, resp)
+}
+
+// awaitOpVerdict waits for the fresh loop's answer to a request that rode a
+// rebuild. The caller's context bounds the wait, so an operator is never left
+// blocked on a loop that died before it could answer.
+func awaitOpVerdict(ctx context.Context, resp <-chan error) error {
 	select {
 	case err := <-resp:
 		return err

--- a/pkg/thresher/incident_ops_internal_test.go
+++ b/pkg/thresher/incident_ops_internal_test.go
@@ -1,0 +1,91 @@
+package thresher
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/internal/instance"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAwaitOpVerdictHonoursTheCallerContext: a request that rode a rebuild is
+// answered by the fresh loop, but the caller's context bounds the wait — an
+// operator must not block forever on a loop that died before it could answer.
+func TestAwaitOpVerdictHonoursTheCallerContext(t *testing.T) {
+	t.Run("the loop's verdict wins", func(t *testing.T) {
+		resp := make(chan error, 1)
+		resp <- errors.New("no such incident")
+
+		require.ErrorContains(t,
+			awaitOpVerdict(context.Background(), resp), "no such incident")
+	})
+
+	t.Run("a cancelled caller is released", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		require.ErrorIs(t, awaitOpVerdict(ctx, make(chan error)),
+			context.Canceled, "the wait is bounded by the caller's context")
+	})
+}
+
+// TestRebuildForOpReportsAFailedClaim: the latch is held and the engine goes
+// away, so the request can never take it. It must report that rather than
+// rebuilding beside the in-flight wake — two live loops over one instance is
+// the defect FIX-037 §1.3 closed.
+func TestRebuildForOpReportsAFailedClaim(t *testing.T) {
+	th, stop := armedWakeEngine(t, "engine-op-claim-fail")
+
+	proc := noneStartProcess(t, "p-op-claim-fail")
+	_, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	h, err := th.StartLatest(proc.ID())
+	require.NoError(t, err)
+
+	_, claimed := th.claimWake(h.ID())
+	require.True(t, claimed, "a wake is in flight for this instance")
+
+	stop() // the engine goes away while the latch is held
+
+	resp := make(chan error, 1)
+
+	err = th.rebuildForOp(context.Background(), h, "cancel", resp,
+		instance.WithPendingCancel(resp))
+	require.Error(t, err, "an unclaimable latch is reported, not ignored")
+}
+
+// TestRebuildForOpReportsAFailedRebuild: the instance is live, so there is no
+// checkpoint to rebuild it from. The failure must name the operation and the
+// instance — an operator whose request never reached a loop has to be told.
+func TestRebuildForOpReportsAFailedRebuild(t *testing.T) {
+	th, stop := armedWakeEngine(t, "engine-op-rebuild-fail")
+	defer stop()
+
+	proc := noneStartProcess(t, "p-op-rebuild-fail")
+	_, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	h, err := th.StartLatest(proc.ID())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	resp := make(chan error, 1)
+
+	err = th.rebuildForOp(ctx, h, "cancel", resp,
+		instance.WithPendingCancel(resp))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "cancel: the parked instance")
+	require.ErrorContains(t, err, h.ID())
+
+	// the latch is released even on the failing path, so the instance is not
+	// left permanently unwakeable.
+	_, claimed := th.claimWake(h.ID())
+	require.True(t, claimed, "a failed request releases the wake latch")
+
+	th.releaseWake(h.ID())
+}

--- a/pkg/thresher/instance_starter_internal_test.go
+++ b/pkg/thresher/instance_starter_internal_test.go
@@ -462,7 +462,12 @@ func TestRegisterProcessSupersedeHubErrors(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("re-register of the new version errors", func(t *testing.T) {
+	// A failed re-register now ROLLS BACK (FIX-038 §1.5): the superseded
+	// version's starters go back on the hub, so the hub sees a SECOND
+	// RegisterPersistentEvent — the restore. This subtest previously expected
+	// exactly one, which pinned the behaviour that left the key with no live
+	// starters at all and bricked it for every later registration.
+	t.Run("re-register of the new version errors, and rolls back", func(t *testing.T) {
 		th, err := New("sup-rereg")
 		require.NoError(t, err)
 
@@ -471,9 +476,15 @@ func TestRegisterProcessSupersedeHubErrors(t *testing.T) {
 			UnregisterEvent(mock.Anything, mock.Anything).
 			Return(nil).
 			Once()
+		// the new version's arm fails …
 		mh.EXPECT().
 			RegisterPersistentEvent(mock.Anything, mock.Anything).
 			Return(fmt.Errorf("hub register rejected")).
+			Once()
+		// … and the previous version's starters are put back.
+		mh.EXPECT().
+			RegisterPersistentEvent(mock.Anything, mock.Anything).
+			Return(nil).
 			Once()
 		th.eventHub = mh
 
@@ -481,6 +492,13 @@ func TestRegisterProcessSupersedeHubErrors(t *testing.T) {
 
 		_, err = th.RegisterProcess(proc) // teardown ok, re-register fails
 		require.Error(t, err)
+
+		th.m.Lock()
+		regs := th.registrations[proc.ID()]
+		th.m.Unlock()
+
+		require.Len(t, regs, 1,
+			"the failed version is removed, leaving the previous one latest")
 	})
 }
 

--- a/pkg/thresher/instance_starter_internal_test.go
+++ b/pkg/thresher/instance_starter_internal_test.go
@@ -3,6 +3,7 @@ package thresher
 import (
 	"context"
 	"fmt"
+	"github.com/dr-dobermann/gobpm/internal/eventproc"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -426,7 +427,7 @@ func TestRunRegisterStartersError(t *testing.T) {
 func TestRegisterProcessSupersedeHubErrors(t *testing.T) {
 	proc := msgStartProcess(t, "p-sup-err", "order placed")
 
-	seedV1 := func(t *testing.T, th *Thresher) string {
+	seedV1 := func(t *testing.T, th *Thresher) *ProcessRegistration {
 		t.Helper()
 
 		s1, err := snapshot.New(proc)
@@ -442,7 +443,7 @@ func TestRegisterProcessSupersedeHubErrors(t *testing.T) {
 		th.m.Unlock()
 		th.state.Store(uint32(Started))
 
-		return s1.ProcessID
+		return v1
 	}
 
 	t.Run("teardown of the superseded version errors", func(t *testing.T) {
@@ -481,14 +482,22 @@ func TestRegisterProcessSupersedeHubErrors(t *testing.T) {
 			RegisterPersistentEvent(mock.Anything, mock.Anything).
 			Return(fmt.Errorf("hub register rejected")).
 			Once()
-		// … and the previous version's starters are put back.
-		mh.EXPECT().
-			RegisterPersistentEvent(mock.Anything, mock.Anything).
-			Return(nil).
-			Once()
 		th.eventHub = mh
 
-		seedV1(t, th)
+		v1 := seedV1(t, th)
+		require.Len(t, v1.starters, 1)
+
+		// … and V1'S starter goes back on — matched by identity, because
+		// `mock.Anything` here would accept the FAILED version's starter just
+		// as happily, leaving the key serving a version that never landed.
+		mh.EXPECT().
+			RegisterPersistentEvent(
+				mock.MatchedBy(func(ep eventproc.EventProcessor) bool {
+					return ep.ID() == v1.starters[0].ID()
+				}),
+				mock.Anything).
+			Return(nil).
+			Once()
 
 		_, err = th.RegisterProcess(proc) // teardown ok, re-register fails
 		require.Error(t, err)

--- a/pkg/thresher/invoker.go
+++ b/pkg/thresher/invoker.go
@@ -94,8 +94,9 @@ func (t *Thresher) InvokeProcess(
 			errs.C(errorClass, errs.OperationFailed), errs.E(err))
 	}
 
-	_, displaced := t.trackInstanceLocked(inst, cancel, settled)
+	h, displaced := t.trackInstanceLocked(inst, cancel, settled)
 	stopDisplaced(displaced)
+	h.reattachObservers()
 
 	return &childProcess{inst: inst, settled: settled, version: resolved}, nil
 }

--- a/pkg/thresher/invoker_internal_test.go
+++ b/pkg/thresher/invoker_internal_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/dr-dobermann/gobpm/internal/instance"
 	"github.com/dr-dobermann/gobpm/internal/instance/checkpoint"
-	"github.com/dr-dobermann/gobpm/internal/scope"
 	"github.com/dr-dobermann/gobpm/internal/instance/snapshot"
+	"github.com/dr-dobermann/gobpm/internal/scope"
 	"github.com/dr-dobermann/gobpm/pkg/model/data"
 	"github.com/dr-dobermann/gobpm/pkg/repository"
 	"github.com/dr-dobermann/gobpm/pkg/repository/memrepo"

--- a/pkg/thresher/observer.go
+++ b/pkg/thresher/observer.go
@@ -114,7 +114,13 @@ func (h *InstanceHandle) Observe(o Observer) *Subscription {
 	h.nextObs++
 	obsID := h.nextObs
 	h.observers[obsID] = ho
-	ho.cancel = h.current().AddObserver(fanout)
+
+	// Record WHICH object it landed on, under the same lock reattachObservers
+	// takes: this call can be racing a rebuild, and a re-attach that cannot
+	// tell it already sits on the new object registers it a second time.
+	on := h.current()
+	ho.on = on
+	ho.cancel = on.AddObserver(fanout)
 
 	h.obsMu.Unlock()
 

--- a/pkg/thresher/observer.go
+++ b/pkg/thresher/observer.go
@@ -82,7 +82,7 @@ func (h *InstanceHandle) Observe(o Observer) *Subscription {
 	// Asserted once here at registration; absent ⇒ pass-through.
 	filter, _ := h.current().AuthorizationProvider().(observability.ObservationFilter)
 
-	cancelReg := h.current().AddObserver(func(f observability.Fact) {
+	fanout := func(f observability.Fact) {
 		if filter != nil {
 			filtered, ok := filter.FilterObservation(o, f)
 			if !ok {
@@ -97,7 +97,26 @@ func (h *InstanceHandle) Observe(o Observer) *Subscription {
 		default:
 			dropped.Add(1)
 		}
-	})
+	}
+
+	// Record on the HANDLE, then attach to the instance it currently speaks
+	// for. Registering only on the instance object meant the subscription died
+	// silently at the first dehydration, because a rebuild replaces that object
+	// (FIX-038 §1.8); the handle re-attaches this entry on every adopt.
+	ho := &handleObserver{fanout: fanout}
+
+	h.obsMu.Lock()
+
+	if h.observers == nil {
+		h.observers = map[uint64]*handleObserver{}
+	}
+
+	h.nextObs++
+	obsID := h.nextObs
+	h.observers[obsID] = ho
+	ho.cancel = h.current().AddObserver(fanout)
+
+	h.obsMu.Unlock()
 
 	var once sync.Once
 
@@ -110,7 +129,15 @@ func (h *InstanceHandle) Observe(o Observer) *Subscription {
 				// observer write-lock, which fences any in-flight fan-out, so no
 				// send is in progress once it returns — making close(ch) safe (no
 				// send-on-closed-channel). Then drain to completion.
-				cancelReg()
+				h.obsMu.Lock()
+				delete(h.observers, obsID)
+				cancelReg := ho.cancel
+				h.obsMu.Unlock()
+
+				if cancelReg != nil {
+					cancelReg()
+				}
+
 				close(ch)
 				<-done
 			})

--- a/pkg/thresher/recovery.go
+++ b/pkg/thresher/recovery.go
@@ -2,6 +2,7 @@ package thresher
 
 import (
 	"context"
+	"errors"
 	"strconv"
 
 	gerrs "github.com/dr-dobermann/gobpm/pkg/errs"
@@ -69,7 +70,18 @@ func (t *Thresher) recoverOne(ctx context.Context, id string) error {
 	}
 
 	if saveErr := repo.Save(ctx, rec); saveErr != nil {
-		return nil //nolint:nilerr // a lost claim race is the normal outcome
+		// A LOST CAS is the normal outcome — another engine recovered it — and
+		// is silence. Anything else is not: a connection reset, a timeout or a
+		// store outage used to be read the same way, so a transient failure
+		// abandoned an in-flight instance at startup and reported success, with
+		// nothing logged anywhere (FIX-038 §1.4). The Repository contract makes
+		// the two distinguishable: a version mismatch MUST carry
+		// errs.ConcurrentUpdate, and every adapter implements it identically.
+		if lostClaim(saveErr) {
+			return nil
+		}
+
+		return recoveryErr("couldn't claim the record for recovery", saveErr)
 	}
 
 	rec.RecVersion++ // Save advanced the stored version; continue from it
@@ -182,6 +194,15 @@ func (t *Thresher) ensureGroup(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+// lostClaim reports whether err is the compare-and-set conflict that means
+// another engine claimed this instance first — the one Save failure that is a
+// normal outcome rather than a fault.
+func lostClaim(err error) bool {
+	var ae *gerrs.ApplicationError
+
+	return errors.As(err, &ae) && ae.HasClass(gerrs.ConcurrentUpdate)
 }
 
 // recoveryErr builds one classified recovery error.

--- a/pkg/thresher/recovery.go
+++ b/pkg/thresher/recovery.go
@@ -139,8 +139,9 @@ func (t *Thresher) recoverOne(ctx context.Context, id string) error {
 		return recoveryErr("the restored instance doesn't run", err)
 	}
 
-	_, displaced := t.trackInstanceLocked(inst, cancel, t.settledFor(id))
+	h, displaced := t.trackInstanceLocked(inst, cancel, t.settledFor(id))
 	stopDisplaced(displaced)
+	h.reattachObservers()
 
 	// A recovered conversation re-takes its correlation reservation (FIX-036
 	// §1.2): the reservation map does not survive the process, so without this

--- a/pkg/thresher/recovery_internal_test.go
+++ b/pkg/thresher/recovery_internal_test.go
@@ -1,0 +1,106 @@
+package thresher
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	gerrs "github.com/dr-dobermann/gobpm/pkg/errs"
+	"github.com/dr-dobermann/gobpm/pkg/repository"
+	"github.com/dr-dobermann/gobpm/pkg/repository/memrepo"
+	"github.com/stretchr/testify/require"
+)
+
+// claimStubRepo hands recoverOne a claimable record and fails the claim Save
+// with a chosen error, so the two failures that used to be indistinguishable
+// can be driven apart.
+type claimStubRepo struct {
+	repository.Repository
+
+	rec     repository.InstanceRecord
+	saveErr error
+}
+
+func (r *claimStubRepo) Load(
+	_ context.Context, _ string,
+) (repository.InstanceRecord, bool, error) {
+	return r.rec, true, nil
+}
+
+func (r *claimStubRepo) Save(
+	_ context.Context, _ repository.InstanceRecord,
+) error {
+	return r.saveErr
+}
+
+// TestLostClaimClassification pins the distinction FIX-038 §1.4 turns on: the
+// Repository contract requires a compare-and-set mismatch to carry
+// errs.ConcurrentUpdate, and nothing else may be read as one.
+func TestLostClaimClassification(t *testing.T) {
+	require.True(t, lostClaim(gerrs.New(
+		gerrs.M("version mismatch"),
+		gerrs.C(errorClass, gerrs.ConcurrentUpdate))),
+		"a CAS conflict is a lost claim")
+
+	require.False(t, lostClaim(errors.New("connection reset by peer")),
+		"a transport error is NOT a lost claim")
+
+	require.False(t, lostClaim(gerrs.New(
+		gerrs.M("the store is unavailable"),
+		gerrs.C(errorClass, gerrs.OperationFailed))),
+		"another classified failure is NOT a lost claim")
+}
+
+// TestRecoveryReportsATransportError is FIX-038 T-4. recoverOne read EVERY Save
+// failure as "someone else claimed it" and returned nil, so a connection reset
+// at startup silently abandoned an in-flight instance — and because it reported
+// success, recoverInstances logged nothing either. A lost claim must stay
+// silent; anything else must be reported.
+func TestRecoveryReportsATransportError(t *testing.T) {
+	base := memrepo.New()
+
+	// A record whose lease has lapsed: claimable, so recoverOne reaches Save.
+	// The group defaults to the engine id when WithEngineGroup is not given
+	// (thresher.go:241), so each sub-test names its record's group to match.
+	newRec := func(group string) repository.InstanceRecord {
+		return repository.InstanceRecord{
+			ID:    "i-recover",
+			Group: group,
+			Lease: repository.Lease{
+				Owner:  "gone",
+				Expiry: time.Now().Add(-time.Hour),
+			},
+		}
+	}
+
+	t.Run("a lost CAS stays silent", func(t *testing.T) {
+		th, err := New("rec-cas", WithoutBanner(), WithoutStartupConfig(),
+			WithRepository(&claimStubRepo{
+				Repository: base,
+				rec:        newRec("rec-cas"),
+				saveErr: gerrs.New(
+					gerrs.M("stored version moved"),
+					gerrs.C(errorClass, gerrs.ConcurrentUpdate)),
+			}))
+		require.NoError(t, err)
+
+		require.NoError(t, th.recoverOne(context.Background(), "i-recover"),
+			"another engine recovered it — that is not this engine's failure")
+	})
+
+	t.Run("a transport error is reported", func(t *testing.T) {
+		th, err := New("rec-transport", WithoutBanner(), WithoutStartupConfig(),
+			WithRepository(&claimStubRepo{
+				Repository: base,
+				rec:        newRec("rec-transport"),
+				saveErr:    errors.New("connection reset by peer"),
+			}))
+		require.NoError(t, err)
+
+		err = th.recoverOne(context.Background(), "i-recover")
+		require.Error(t, err,
+			"a store failure must not be mistaken for a lost claim")
+		require.ErrorContains(t, err, "couldn't claim the record")
+	})
+}

--- a/pkg/thresher/restart_recovery_test.go
+++ b/pkg/thresher/restart_recovery_test.go
@@ -82,6 +82,24 @@ func (fw *factWatch) OnFact(f observability.Fact) {
 	fw.facts = append(fw.facts, f)
 }
 
+// count reports how many facts of this kind+phase have been seen. A test that
+// must show something did NOT happen asserts on this rather than on a
+// downstream side effect: the fact is the engine's own statement that it acted.
+func (fw *factWatch) count(k observability.Kind, p observability.Phase) int {
+	fw.mu.Lock()
+	defer fw.mu.Unlock()
+
+	n := 0
+
+	for _, f := range fw.facts {
+		if f.Kind == k && f.Phase == p {
+			n++
+		}
+	}
+
+	return n
+}
+
 func (fw *factWatch) saw(k observability.Kind, p observability.Phase) bool {
 	fw.mu.Lock()
 	defer fw.mu.Unlock()

--- a/pkg/thresher/tasks.go
+++ b/pkg/thresher/tasks.go
@@ -210,22 +210,43 @@ func (t *Thresher) gateComplete(taskID string, actor hi.Actor) error {
 }
 
 // completeVerdict renders the pre-hydration verdict and the reason to report it
-// under. It holds the lock for the whole decision so the answer cannot be stale by
-// the time it is returned.
+// under.
+//
+// The OWNERSHIP decision is taken under the lock, on a freshly read record, so
+// the answer cannot be stale by the time it is returned. Eligibility is
+// authorized BEFORE that, outside the lock: Authorize is host code — a
+// directory or database lookup is the normal implementation — and running it
+// under t.m stalled every registration, launch and discovery call in the engine
+// behind one embedder call (FIX-038 §1.2). The eligibility policy is written
+// once at registration and read-only afterwards, so reading it separately
+// cannot go stale.
 func (t *Thresher) completeVerdict(
 	taskID string,
 	actor hi.Actor,
 ) (string, error) {
 	t.m.Lock()
-	defer t.m.Unlock()
-
 	rec, ok := t.tasks[taskID]
+
+	var eligible interactor.Eligibility
+	if ok {
+		eligible = rec.eligible
+	}
+	t.m.Unlock()
+
 	if !ok {
 		return "", errUnknownTask(taskID)
 	}
 
-	if err := rec.eligible.Authorize(taskID, actor); err != nil {
+	if err := eligible.Authorize(taskID, actor); err != nil {
 		return "unauthorized", err
+	}
+
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	rec, ok = t.tasks[taskID]
+	if !ok {
+		return "", errUnknownTask(taskID)
 	}
 
 	if rec.owner == "" {
@@ -267,7 +288,7 @@ func (t *Thresher) Claim(
 		return err
 	}
 
-	if err := t.setOwner(taskID, actor.UserID(), claimGuard(actor)); err != nil {
+	if err := t.setOwner(taskID, actor.UserID(), actor, claimGuard(actor)); err != nil {
 		return err
 	}
 
@@ -290,7 +311,7 @@ func (t *Thresher) Unclaim(
 		return err
 	}
 
-	if err := t.setOwner(taskID, "", ownerOnlyGuard(actor)); err != nil {
+	if err := t.setOwner(taskID, "", actor, ownerOnlyGuard(actor)); err != nil {
 		return err
 	}
 
@@ -325,11 +346,13 @@ func (t *Thresher) Reassign(
 
 	var from string
 
-	err := t.setOwner(taskID, nomineeUserID,
-		func(id string, rec *taskRecord) error {
+	// The NOMINEE is the actor authorized here, not the caller: a reassignment
+	// may only move a task to someone already eligible for it.
+	err := t.setOwner(taskID, nomineeUserID, userIDActor(nomineeUserID),
+		func(_ string, rec *taskRecord) error {
 			from = rec.owner
 
-			return rec.eligible.Authorize(id, userIDActor(nomineeUserID))
+			return nil
 		})
 	if err != nil {
 		return err
@@ -349,17 +372,47 @@ func (t *Thresher) Reassign(
 // concurrent claims on the same task cannot both succeed (SRD-073 NFR-3).
 func (t *Thresher) setOwner(
 	taskID, owner string,
-	guard func(string, *taskRecord) error,
+	actor hi.Actor,
+	admit func(string, *taskRecord) error,
 ) error {
+	// PHASE 1 — read the eligibility policy under the lock. It is written once
+	// at registration and read-only afterwards (see taskRecord), so one read is
+	// enough and it cannot go stale.
+	t.m.Lock()
+
+	rec, ok := t.tasks[taskID]
+	if !ok {
+		t.m.Unlock()
+
+		return errUnknownTask(taskID)
+	}
+
+	eligible := rec.eligible
+
+	t.m.Unlock()
+
+	// PHASE 2 — HOST policy, outside the lock. Authorize is embedder code and a
+	// directory or database lookup is the normal implementation; running it
+	// under t.m stalled every registration, launch and discovery call in the
+	// engine behind it (FIX-038 §1.2). This function used to run it inside a
+	// `guard` CALLBACK invoked under the lock, which is the shape locked.go
+	// forbids by construction — and is why it went unnoticed.
+	if err := eligible.Authorize(taskID, actor); err != nil {
+		return err
+	}
+
+	// PHASE 3 — the ownership decision and the mutation, under the lock and on
+	// a FRESHLY read record: the answer must not be stale by the time it is
+	// applied, and phase 2 released the lock.
 	t.m.Lock()
 	defer t.m.Unlock()
 
-	rec, ok := t.tasks[taskID]
+	rec, ok = t.tasks[taskID]
 	if !ok {
 		return errUnknownTask(taskID)
 	}
 
-	if err := guard(taskID, rec); err != nil {
+	if err := admit(taskID, rec); err != nil {
 		return err
 	}
 
@@ -380,11 +433,8 @@ func (t *Thresher) setOwner(
 // Camunda draws the line the same way: its claim fails only when the existing
 // assignee is a different user.
 func claimGuard(actor hi.Actor) func(string, *taskRecord) error {
-	return func(taskID string, rec *taskRecord) error {
-		if err := rec.eligible.Authorize(taskID, actor); err != nil {
-			return err
-		}
-
+	return func(_ string, rec *taskRecord) error {
+		// Eligibility is authorized by setOwner, outside the lock.
 		if rec.owner != "" && rec.owner != actor.UserID() {
 			return errs.New(
 				errs.M("user task is already held by %q", rec.owner),

--- a/pkg/thresher/tasks_internal_test.go
+++ b/pkg/thresher/tasks_internal_test.go
@@ -16,6 +16,7 @@ import (
 // its registry lock while finding out.
 type blockingActor struct {
 	id      string
+	groups  []string
 	entered chan struct{}
 	release chan struct{}
 	once    sync.Once
@@ -27,7 +28,7 @@ func (a *blockingActor) Groups() []string {
 	a.once.Do(func() { close(a.entered) })
 	<-a.release
 
-	return nil
+	return a.groups
 }
 
 // TestTaskAuthorizationDoesNotHoldTheEngineLock is FIX-038 T-2: the eligibility
@@ -167,4 +168,105 @@ func TestHandleObserverSurvivesARebuild(t *testing.T) {
 	require.Eventually(t, func() bool { return obs.count() > before },
 		2*time.Second, 10*time.Millisecond,
 		"a subscription taken before the rebuild must keep delivering after it")
+}
+
+// TestReattachObserversWithoutAnInstance: a handle that speaks for no instance
+// yet — one whose adopt has not run — must ignore the re-attachment rather than
+// dereference nothing. The call sits on the rebuild path, where the instance
+// lookup is allowed to fail.
+func TestReattachObserversWithoutAnInstance(t *testing.T) {
+	h := &InstanceHandle{}
+
+	require.NotPanics(t, h.reattachObservers)
+}
+
+// TestTaskVanishesBetweenThePhases covers the window the §1.2 split opens: the
+// engine lock is released for the embedder's Authorize, so the task can be gone
+// by the time the verdict is applied. Both phase-2 paths must re-read and
+// report the task as unknown — applying a verdict to a record that no longer
+// exists is worse than refusing.
+func TestTaskVanishesBetweenThePhases(t *testing.T) {
+	eligible := interactor.Eligibility{
+		CandidateGroups: interactor.ResolvedSlot{
+			Declared: true,
+			IDs:      []string{"reviewers"},
+		},
+	}
+
+	// the actor blocks inside the embedder's Groups(), which is where the
+	// engine lock is NOT held — the test deletes the task in that window.
+	vanish := func(t *testing.T, th *Thresher, act *blockingActor, call func()) {
+		t.Helper()
+
+		done := make(chan struct{})
+
+		go func() {
+			defer close(done)
+
+			call()
+		}()
+
+		<-act.entered
+
+		th.m.Lock()
+		delete(th.tasks, "task-1")
+		th.m.Unlock()
+
+		close(act.release)
+		<-done
+	}
+
+	t.Run("completing it", func(t *testing.T) {
+		th, err := New("task-vanish-complete",
+			WithoutBanner(), WithoutStartupConfig())
+		require.NoError(t, err)
+
+		th.m.Lock()
+		th.tasks["task-1"] = &taskRecord{eligible: eligible, owner: "u-1"}
+		th.m.Unlock()
+
+		act := &blockingActor{
+			id:      "u-1",
+			groups:  []string{"reviewers"},
+			entered: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+
+		var verdictErr error
+
+		vanish(t, th, act, func() {
+			_, verdictErr = th.completeVerdict("task-1", act)
+		})
+
+		require.Error(t, verdictErr,
+			"a task removed mid-authorization is unknown, not completable")
+		require.ErrorContains(t, verdictErr, "task-1")
+	})
+
+	t.Run("claiming it", func(t *testing.T) {
+		th, err := New("task-vanish-claim",
+			WithoutBanner(), WithoutStartupConfig())
+		require.NoError(t, err)
+
+		th.m.Lock()
+		th.tasks["task-1"] = &taskRecord{eligible: eligible}
+		th.m.Unlock()
+
+		act := &blockingActor{
+			id:      "u-2",
+			groups:  []string{"reviewers"},
+			entered: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+
+		var ownErr error
+
+		vanish(t, th, act, func() {
+			ownErr = th.setOwner("task-1", "u-2", act, claimGuard(act))
+		})
+
+		require.Error(t, ownErr,
+			"a task removed mid-authorization cannot be claimed")
+		require.ErrorContains(t, ownErr, "task-1")
+	})
 }

--- a/pkg/thresher/tasks_internal_test.go
+++ b/pkg/thresher/tasks_internal_test.go
@@ -270,3 +270,80 @@ func TestTaskVanishesBetweenThePhases(t *testing.T) {
 		require.ErrorContains(t, ownErr, "task-1")
 	})
 }
+
+// TestReattachIsIdempotentPerObject is the independent review's finding A2. An
+// Observe landing between adopt and reattachObservers registers on the NEW
+// instance object; reattachObservers then re-registered the same fan-out on
+// that same object, so every fact arrived TWICE and the first registration's
+// cancel was overwritten — it could never be removed.
+//
+// The window is driven directly: register the observer after the adopt, then
+// re-attach, which is exactly the interleaving.
+func TestReattachIsIdempotentPerObject(t *testing.T) {
+	th, err := New("reattach-idempotent", WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	proc := noneStartProcess(t, "p-reattach-idem")
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	h, err := th.StartLatest(proc.ID())
+	require.NoError(t, err)
+
+	inst, err := th.instanceByID(h.ID())
+	require.NoError(t, err)
+
+	// Count only the marked fact: the instance emits its own lifecycle facts
+	// throughout, and they would drown the one delivery this measures.
+	obs := &markedObserver{mark: "reattach-probe"}
+
+	sub := h.Observe(obs)
+	defer sub.Cancel()
+
+	// the rebuild's second half, with the Observe already landed on this object
+	h.reattachObservers()
+
+	inst.Report(observability.Fact{
+		Kind:   observability.KindInstanceState,
+		NodeID: obs.mark,
+	})
+
+	require.Eventually(t, func() bool { return obs.count() > 0 },
+		2*time.Second, 10*time.Millisecond, "the observer receives the fact")
+
+	// One fact, one delivery. A duplicated registration makes it two.
+	require.Never(t, func() bool { return obs.count() > 1 },
+		300*time.Millisecond, 30*time.Millisecond,
+		"a re-attach onto the object the observer already sits on must not"+
+			" register it twice")
+}
+
+// markedObserver counts only the facts carrying its mark in NodeID, so a test
+// can measure ONE delivery against an instance that is emitting its own facts.
+type markedObserver struct {
+	mark string
+
+	mu   sync.Mutex
+	seen int
+}
+
+func (o *markedObserver) OnFact(f observability.Fact) {
+	if f.NodeID != o.mark {
+		return
+	}
+
+	o.mu.Lock()
+	o.seen++
+	o.mu.Unlock()
+}
+
+func (o *markedObserver) count() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	return o.seen
+}

--- a/pkg/thresher/tasks_internal_test.go
+++ b/pkg/thresher/tasks_internal_test.go
@@ -1,0 +1,87 @@
+package thresher
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dr-dobermann/gobpm/pkg/interactor"
+	"github.com/stretchr/testify/require"
+)
+
+// blockingActor is an embedder-implemented Actor whose Groups() blocks. The
+// engine cannot assume an embedder's accessors are cheap, and it must not hold
+// its registry lock while finding out.
+type blockingActor struct {
+	id      string
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (a *blockingActor) UserID() string { return a.id }
+
+func (a *blockingActor) Groups() []string {
+	a.once.Do(func() { close(a.entered) })
+	<-a.release
+
+	return nil
+}
+
+// TestTaskAuthorizationDoesNotHoldTheEngineLock is FIX-038 T-2: the eligibility
+// check reaches into embedder code (`Actor.Groups`), and it used to do so while
+// holding t.m — the lock every registration, launch and discovery call needs.
+//
+// The interleaving is driven directly: Groups() blocks until the test releases
+// it, and a concurrent registry call must complete meanwhile.
+func TestTaskAuthorizationDoesNotHoldTheEngineLock(t *testing.T) {
+	th, err := New("task-auth-lock", WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	// a task whose eligibility consults candidate GROUPS, so permits() must ask
+	// the actor for them.
+	th.m.Lock()
+	th.tasks["task-1"] = &taskRecord{
+		eligible: interactor.Eligibility{
+			CandidateGroups: interactor.ResolvedSlot{
+				Declared: true,
+				IDs:      []string{"reviewers"},
+			},
+		},
+	}
+	th.m.Unlock()
+
+	actor := &blockingActor{
+		id:      "u-1",
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+
+	verdict := make(chan struct{})
+
+	go func() {
+		defer close(verdict)
+
+		_, _ = th.completeVerdict("task-1", actor)
+	}()
+
+	<-actor.entered // inside the embedder's Groups(), mid-authorization
+
+	// The engine must still be usable.
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		_ = th.Instances(InstancesAll) // any operation needing t.m
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("the engine lock was held across the actor's Groups() call")
+	}
+
+	close(actor.release)
+	<-verdict
+}

--- a/pkg/thresher/tasks_internal_test.go
+++ b/pkg/thresher/tasks_internal_test.go
@@ -1,11 +1,13 @@
 package thresher
 
 import (
+	"context"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/dr-dobermann/gobpm/pkg/interactor"
+	"github.com/dr-dobermann/gobpm/pkg/observability"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,4 +86,85 @@ func TestTaskAuthorizationDoesNotHoldTheEngineLock(t *testing.T) {
 
 	close(actor.release)
 	<-verdict
+}
+
+// countingObserver records the facts it is handed.
+type countingObserver struct {
+	mu   sync.Mutex
+	seen int
+}
+
+func (o *countingObserver) OnFact(observability.Fact) {
+	o.mu.Lock()
+	o.seen++
+	o.mu.Unlock()
+}
+
+func (o *countingObserver) count() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	return o.seen
+}
+
+// TestHandleObserverSurvivesARebuild is FIX-038 T-8. InstanceHandle.Observe
+// registered on h.current() — the instance OBJECT — and a rebuild replaces that
+// object. SRD-071 made the handle's identity outlive its object precisely so
+// callers could hold it across a dehydration; the observer registration was not
+// carried across, so a host's subscription went quiet at the first rebuild
+// while its Subscription still reported itself live.
+//
+// The rebuild is simulated the way the engine performs it: adopt the new object
+// through trackInstanceLocked, then re-attach outside the lock.
+func TestHandleObserverSurvivesARebuild(t *testing.T) {
+	th, err := New("observer-rebuild", WithoutBanner(), WithoutStartupConfig())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	require.NoError(t, th.Run(ctx))
+
+	proc := noneStartProcess(t, "p-obs-rebuild")
+	_, err = th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	h, err := th.StartLatest(proc.ID())
+	require.NoError(t, err)
+
+	obs := &countingObserver{}
+
+	sub := h.Observe(obs)
+	defer sub.Cancel()
+
+	first, err := th.instanceByID(h.ID())
+	require.NoError(t, err)
+
+	first.Report(observability.Fact{Kind: observability.KindInstanceState})
+	require.Eventually(t, func() bool { return obs.count() > 0 },
+		2*time.Second, 10*time.Millisecond,
+		"the observer receives from the instance it registered on")
+
+	before := obs.count()
+
+	// The engine rebuilds the instance: a NEW object, which the handle adopts.
+	// A same-id rebuild needs a checkpoint, so the object swap is performed
+	// directly — it is exactly what trackInstanceLocked does via adopt, and it
+	// is the step the observers must survive.
+	snap := th.latestSnapshotLocked(proc.ID())
+	require.NotNil(t, snap)
+
+	other, err := th.launchInstance(snap)
+	require.NoError(t, err)
+
+	rebuilt, err := th.instanceByID(other.ID())
+	require.NoError(t, err)
+
+	h.adopt(rebuilt)
+	h.reattachObservers()
+
+	rebuilt.Report(observability.Fact{Kind: observability.KindInstanceState})
+
+	require.Eventually(t, func() bool { return obs.count() > before },
+		2*time.Second, 10*time.Millisecond,
+		"a subscription taken before the rebuild must keep delivering after it")
 }

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -1064,7 +1064,10 @@ func (t *Thresher) RegisterProcess(
 		// finishes its already-running instances.
 		if prevLatest != nil {
 			if err := t.unregisterStarters(prevLatest.starters); err != nil {
+				// The previous version is still live on the hub; only the
+				// half-made registration has to go.
 				t.releaseWiringLocked(reg)
+				t.removeVersionLocked(reg)
 
 				return nil, err
 			}
@@ -1073,12 +1076,7 @@ func (t *Thresher) RegisterProcess(
 		}
 
 		if err := t.registerStarters(starters); err != nil {
-			// registerStarters is all-or-nothing (FIX-013 §1.3), so nothing of
-			// this version reached the hub: give the claim back rather than
-			// leave a version marked wired that is not.
-			t.releaseWiringLocked(reg)
-
-			return nil, err
+			return nil, t.rollbackRegistration(reg, prevLatest, err)
 		}
 	}
 
@@ -1089,6 +1087,48 @@ func (t *Thresher) RegisterProcess(
 		})
 
 	return reg, nil
+}
+
+// rollbackRegistration returns a key to its pre-call state after
+// registerStarters failed, and it is the difference between a failed
+// registration and a DEAD key (FIX-038 §1.5).
+//
+// By this point the previous version's starters have already been withdrawn to
+// make way for the new ones, and the new ones did not go on. Returning here
+// left the key with no live starters at all — nothing auto-starts — and with
+// the failed version sitting as `latest`, so every later RegisterProcess for
+// that key tried to unregister starters that were never registered, got
+// ObjectNotFound, and failed. The key was permanently unusable.
+//
+// So: drop the version just appended, and put the previous latest back on the
+// hub. The version counter deliberately stays advanced — a failed version
+// number is not reused.
+func (t *Thresher) rollbackRegistration(
+	reg, prevLatest *ProcessRegistration, cause error,
+) error {
+	// registerStarters is all-or-nothing (FIX-013 §1.3), so nothing of this
+	// version reached the hub: only the bookkeeping needs undoing.
+	t.releaseWiringLocked(reg)
+	t.removeVersionLocked(reg)
+
+	if prevLatest == nil {
+		return cause
+	}
+
+	if err := t.registerStarters(prevLatest.starters); err != nil {
+		// A rollback failure JOINS the cause rather than replacing it
+		// (ADR-022 v.2 §2.2): the caller needs to know both that the
+		// registration failed and that the key is now without auto-start.
+		return errors.Join(cause, errs.New(
+			errs.M("couldn't restore the previous starters of %q after a"+
+				" failed registration — the key has no auto-start", reg.key),
+			errs.C(errorClass, errs.OperationFailed),
+			errs.E(err)))
+	}
+
+	t.setLatestWiredLocked(reg.key, true)
+
+	return cause
 }
 
 // UnregisterVersion removes ONE registered version — the one named by reg — by

--- a/pkg/thresher/thresher.go
+++ b/pkg/thresher/thresher.go
@@ -1433,8 +1433,9 @@ func (t *Thresher) launchInstanceFromEvent(
 	// An event-born instance is tracked with its read-only handle just like a
 	// StartProcess one, so the SRD-019 discovery API (Instances -> Instance(id))
 	// returns a usable handle for it instead of a nil that panics on observation.
-	_, displaced := t.trackInstanceLocked(inst, cancel, settled)
+	h, displaced := t.trackInstanceLocked(inst, cancel, settled)
 	stopDisplaced(displaced)
+	h.reattachObservers()
 
 	// Bind the correlation reservation to the instance that now owns it
 	// (FIX-036 §1.2): until this point the entry only says "a start is in
@@ -1630,6 +1631,7 @@ func (t *Thresher) launchInstance(s *snapshot.Snapshot) (*InstanceHandle, error)
 
 	h, displaced := t.trackInstanceLocked(inst, cancel, settled)
 	stopDisplaced(displaced)
+	h.reattachObservers()
 
 	return h, nil
 }

--- a/pkg/thresher/wake.go
+++ b/pkg/thresher/wake.go
@@ -218,8 +218,13 @@ func (t *Thresher) rebuildAndContinue(
 		t.ReleaseWaits(instanceID, pending.TrackID)
 	}
 
-	_, displaced := t.trackInstanceLocked(inst, cancel, t.settledFor(instanceID))
+	h, displaced := t.trackInstanceLocked(inst, cancel, t.settledFor(instanceID))
 	stopDisplaced(displaced)
+
+	// A rebuild replaces the instance OBJECT; the handle's observers must
+	// follow it or the host's subscription goes quiet (FIX-038 §1.8). Outside
+	// the engine lock: AddObserver takes the instance's own observer lock.
+	h.reattachObservers()
 
 	// A hydrated conversation re-takes its correlation reservation, for the
 	// same reason a recovered one does (FIX-036 §1.2).

--- a/pkg/thresher/wake_internal_test.go
+++ b/pkg/thresher/wake_internal_test.go
@@ -1014,6 +1014,7 @@ type armHookHub struct {
 	mu         sync.Mutex
 	onRegister func()
 	withdrawn  map[string]int // eDefID → successful withdrawals
+	armedIDs   []string       // starter ids of the successful arms, in order
 	registered int            // total successful arms
 	armErr     error          // when set, the next armFails persistent arms fail
 	armFails   int            // how many arms still fail (negative = all)
@@ -1052,6 +1053,14 @@ func (h *armHookHub) RegisterEvent(
 // failArms makes the next n starter arms fail, so a test can break the hub
 // under a RUNNING engine without racing the eventHub field. n < 0 fails every
 // later arm; n == 0 clears the fault.
+// armedStarters returns the starter ids armed so far, in order.
+func (h *armHookHub) armedStarters() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return append([]string{}, h.armedIDs...)
+}
+
 func (h *armHookHub) failArms(err error, n int) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -1082,6 +1091,10 @@ func (h *armHookHub) RegisterPersistentEvent(
 	if err == nil {
 		h.mu.Lock()
 		h.registered++
+		// WHICH starter was armed, not just how many: a rollback that re-armed
+		// the failed version's starters instead of the previous version's
+		// raises the count exactly as the correct one does.
+		h.armedIDs = append(h.armedIDs, ep.ID())
 		h.mu.Unlock()
 	}
 
@@ -1582,6 +1595,7 @@ func TestFailedRegisterRestoresThePreviousStarters(t *testing.T) {
 
 	armsAfterV1 := hub.arms()
 	require.Positive(t, armsAfterV1, "v1's starter is on the hub")
+	require.Len(t, hub.armedStarters(), armsAfterV1)
 
 	// v2's arm fails: the supersede has already withdrawn v1's starters.
 	hub.failArms(errors.New("hub refuses"), 1) // only v2's own arm
@@ -1597,9 +1611,15 @@ func TestFailedRegisterRestoresThePreviousStarters(t *testing.T) {
 	require.Len(t, regs, 1, "the failed version is removed from the registry")
 	require.Equal(t, v1.Version(), regs[0].Version(), "v1 is latest again")
 
-	// and v1's starters are back on the hub
-	require.Greater(t, hub.arms(), armsAfterV1,
-		"the previous version's starters are re-armed")
+	// and V1'S starters are back on the hub — the identity matters, not the
+	// count: re-arming the FAILED version's starters would raise the count
+	// just the same, and leave the key serving a version that never landed.
+	armed := hub.armedStarters()
+	require.Greater(t, len(armed), armsAfterV1,
+		"the rollback arms something")
+	require.Equal(t, armed[:armsAfterV1], armed[len(armed)-armsAfterV1:],
+		"the restored arms are the SAME starters v1 armed, not the failed"+
+			" version's")
 
 	// the key is not bricked: with the hub healthy again, a retry succeeds
 	hub.failArms(nil, 0)

--- a/pkg/thresher/wake_internal_test.go
+++ b/pkg/thresher/wake_internal_test.go
@@ -1015,7 +1015,8 @@ type armHookHub struct {
 	onRegister func()
 	withdrawn  map[string]int // eDefID → successful withdrawals
 	registered int            // total successful arms
-	armErr     error          // when set, every persistent arm fails with it
+	armErr     error          // when set, the next armFails persistent arms fail
+	armFails   int            // how many arms still fail (negative = all)
 }
 
 // hookOnce installs a one-shot callback run at the start of the next arm.
@@ -1048,13 +1049,15 @@ func (h *armHookHub) RegisterEvent(
 
 // RegisterPersistentEvent counts the arms of the instance-STARTER path, which
 // is the one T-8 watches: a starter subscription is persistent by nature.
-// failArms makes every later starter arm fail, so a test can break the hub
-// under a RUNNING engine without racing the eventHub field.
-func (h *armHookHub) failArms(err error) {
+// failArms makes the next n starter arms fail, so a test can break the hub
+// under a RUNNING engine without racing the eventHub field. n < 0 fails every
+// later arm; n == 0 clears the fault.
+func (h *armHookHub) failArms(err error, n int) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	h.armErr = err
+	h.armFails = n
 }
 
 func (h *armHookHub) RegisterPersistentEvent(
@@ -1062,11 +1065,18 @@ func (h *armHookHub) RegisterPersistentEvent(
 ) error {
 	h.mu.Lock()
 	armErr := h.armErr
-	h.mu.Unlock()
 
-	if armErr != nil {
+	if armErr != nil && h.armFails != 0 {
+		if h.armFails > 0 {
+			h.armFails--
+		}
+
+		h.mu.Unlock()
+
 		return armErr
 	}
+
+	h.mu.Unlock()
 
 	err := h.EventHub.RegisterPersistentEvent(ep, eDef)
 	if err == nil {
@@ -1249,7 +1259,7 @@ func TestPromoteFailureSurfaces(t *testing.T) {
 	v2, err := th.RegisterProcess(proc)
 	require.NoError(t, err)
 
-	hub.failArms(errors.New("arm boom"))
+	hub.failArms(errors.New("arm boom"), -1)
 
 	require.ErrorContains(t, th.UnregisterVersion(v2), "arm boom",
 		"a failed promotion is the caller's error, not a silent half-removal")
@@ -1550,4 +1560,52 @@ func TestReportRefusedArm(t *testing.T) {
 
 	require.NotPanics(t, func() { th.reportRefusedArm("i-1", "t-1") },
 		"a refused arm is a Debug fact, never a failure")
+}
+
+// TestFailedRegisterRestoresThePreviousStarters is FIX-038 T-5. RegisterProcess
+// withdraws the previous version's starters to make way for the new ones. When
+// the second call failed it returned with NEITHER on the hub — nothing
+// auto-started — and left the failed version sitting as `latest`, so every
+// later RegisterProcess for that key tried to unregister starters that were
+// never registered, got ObjectNotFound, and failed too. The key was dead.
+//
+// The retry is the assertion that matters: a failed registration must leave the
+// key exactly as it was, not merely fail politely.
+func TestFailedRegisterRestoresThePreviousStarters(t *testing.T) {
+	th, hub, cancel := hookedWakeEngine(t, "engine-register-rollback")
+	defer cancel()
+
+	proc := msgStartProcess(t, "p-rollback", "order placed")
+
+	v1, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	armsAfterV1 := hub.arms()
+	require.Positive(t, armsAfterV1, "v1's starter is on the hub")
+
+	// v2's arm fails: the supersede has already withdrawn v1's starters.
+	hub.failArms(errors.New("hub refuses"), 1) // only v2's own arm
+
+	_, err = th.RegisterProcess(proc)
+	require.Error(t, err, "the failing registration is reported")
+
+	// the failed version must be gone, leaving v1 as latest again
+	th.m.Lock()
+	regs := th.registrations[proc.ID()]
+	th.m.Unlock()
+
+	require.Len(t, regs, 1, "the failed version is removed from the registry")
+	require.Equal(t, v1.Version(), regs[0].Version(), "v1 is latest again")
+
+	// and v1's starters are back on the hub
+	require.Greater(t, hub.arms(), armsAfterV1,
+		"the previous version's starters are re-armed")
+
+	// the key is not bricked: with the hub healthy again, a retry succeeds
+	hub.failArms(nil, 0)
+
+	v2, err := th.RegisterProcess(proc)
+	require.NoError(t, err,
+		"a retry after a failed registration must behave like a first attempt")
+	require.Greater(t, v2.Version(), v1.Version())
 }

--- a/pkg/thresher/wake_internal_test.go
+++ b/pkg/thresher/wake_internal_test.go
@@ -1609,3 +1609,59 @@ func TestFailedRegisterRestoresThePreviousStarters(t *testing.T) {
 		"a retry after a failed registration must behave like a first attempt")
 	require.Greater(t, v2.Version(), v1.Version())
 }
+
+// TestFirstRegistrationFailureLeavesNoTrace is the other half of T-5: when the
+// FAILING registration is a key's first, there is no previous version to
+// restore. The rollback must still undo its own bookkeeping and return the
+// original cause unwrapped — a caller retrying the very first registration of a
+// key must find it as untouched as if the call had never happened.
+func TestFirstRegistrationFailureLeavesNoTrace(t *testing.T) {
+	th, hub, cancel := hookedWakeEngine(t, "engine-first-register-fails")
+	defer cancel()
+
+	proc := msgStartProcess(t, "p-first-fails", "order placed")
+
+	hub.failArms(errors.New("hub refuses"), 1)
+
+	_, err := th.RegisterProcess(proc)
+	require.Error(t, err, "the failing registration is reported")
+	require.ErrorContains(t, err, "hub refuses",
+		"with no previous version there is nothing to join to the cause")
+
+	th.m.Lock()
+	regs := th.registrations[proc.ID()]
+	th.m.Unlock()
+
+	require.Empty(t, regs, "the failed version leaves no registration behind")
+
+	// the key is usable: a retry against a healthy hub is a first attempt
+	hub.failArms(nil, 0)
+
+	v1, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+	require.NotNil(t, v1)
+}
+
+// TestRollbackFailureJoinsTheCause is T-5's worst case: the registration fails
+// AND restoring the previous version's starters fails too. The caller must
+// learn both — that its registration did not land, and that the key is now
+// without auto-start (ADR-022 v.2 §2.2). Reporting only one of the two leaves
+// an operator repairing the wrong thing.
+func TestRollbackFailureJoinsTheCause(t *testing.T) {
+	th, hub, cancel := hookedWakeEngine(t, "engine-rollback-fails")
+	defer cancel()
+
+	proc := msgStartProcess(t, "p-rollback-fails", "order placed")
+
+	_, err := th.RegisterProcess(proc)
+	require.NoError(t, err)
+
+	// two arms fail: v2's own, and the re-arm of v1's starters in the rollback
+	hub.failArms(errors.New("hub refuses"), 2)
+
+	_, err = th.RegisterProcess(proc)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "hub refuses", "the original cause survives")
+	require.ErrorContains(t, err, "no auto-start",
+		"and the failed rollback is reported beside it")
+}


### PR DESCRIPTION
Remediates the confirmed defect track of the 2026-08-08 package audit
(`docs/audit/package-audit-2026-08-08.md` §5.1) — the second `/audit-package`
sweep, over `internal/eventproc`, `internal/scope`, `pkg/thresher` and
`internal/instance`.

Sixteen defects, two shapes: **an engine-wide lock held while foreign code runs
under it**, and **an operation that reports success while nothing happened**.
Ten came from the audit; four were found while fixing those; two more came from
the independent pre-merge review, on code whose gate was already green.

Design doc: [`docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md`](docs/fix/FIX-038-locks-across-host-calls-and-lost-registrations.md).

## Locks held across host calls

| § | Defect |
|---|---|
| §1.1 | The event hub built **and started** a waiter under its single registry lock. A message waiter's start subscribes to the host's broker — possibly remote, possibly blocking — so every registration, unregistration and lookup in the engine queued behind one host call. |
| §1.2 | The engine's registry lock spanned the embedder's `Actor.Groups()` during task authorization. |
| §1.9 | The scope plane's lock spanned the host's runtime-variable supplier, and `EventHub.Shutdown` reported a host-facing fact under the hub lock. |

All three now run the foreign call unlocked. This is the shape FIX-036 §1.5
fixed once already, in a third subsystem — hence the rule now stated in §5:
after fixing a defect, sweep for its *shape*, not for the site that was
reported.

## Operations that reported success while failing

| § | Defect |
|---|---|
| §1.3 | A register landing inside an unregister orphaned itself: the registration attached to a waiter that was then stopped and unmapped, and never fired. |
| §1.4 | Recovery read **every** claim failure as "another engine got there first", so a transport error silently abandoned an in-flight instance at startup — and reported success, so nothing logged it. |
| §1.5 | A failed registration left the key with **no starters at all** and the failed version recorded as latest, so every later registration for that key failed too. The key was permanently bricked. |
| §1.10 | `Cancel` on a dehydrated instance cancelled a context nobody was reading. The request vanished, the next wake resumed as if it had never been made, and the caller blocked until its deadline. |
| §1.11 | An operator's incident retry dropped the handle's observers — §1.8's fix had landed in one of the two callers only. |
| §1.12 | An operator request arriving after shutdown rebuilt the instance, watched the fresh loop tear back down on the dead engine context, and returned `nil`. |

## Correctness

| § | Defect |
|---|---|
| §1.6 | `SnapshotAt` locked per datum, so a concurrent commit could tear the snapshot the handler contract exists to guarantee. |
| §1.7 | `GetDataByID` iterated a map, so two variables sharing an ItemDefinition **type** id resolved differently per run. Now nearest scope, then lowest name. |
| §1.8 | `Observe` registered on the instance *object*, which every rebuild replaces — a host's subscription went quiet at the first dehydration while still reporting itself live. Observers now belong to the handle, whose identity outlives the object. |

## Decisions worth reviewing

- **§1.7 is deterministic, not stricter.** The first draft rejected ambiguous
  ids; `TestSendReceiveMidFlow` proved that rejects legitimate BPMN (a message
  variable and a receiving variable sharing one ItemDefinition). A model that
  worked by luck now works reliably; one that was picking the wrong variable now
  does so consistently, which is what makes it findable.
- **§1.10 applies the cancel through `stopAll`, not `inst.Cancel`.** `stopAll`
  sets `ls.stopping`, which `maybeDehydrate` checks; a bare context cancel would
  race the re-park and be lost exactly as the original was.
- **§1.12's guard sits on the operator entry points, not in
  `rebuildAndContinue`.** A timer wake after shutdown rebuilds and terminates
  with nobody misinformed; an operator told "cancelled" needs it to be true.

## Two findings that were nearly deferred, and were not

§1.10 was originally parked in §7 as "a design decision, not a patch". It was
not blocked on anything — the rail existed (`WithPendingIncidentOp`), the latch
existed (`awaitClaim`), and *large* is not *blocked*. Writing it then exposed
§1.11 and §1.12 in the sibling path, and the near-copy that hid §1.11 is gone
with them (`rebuildForOp`).

M9 exists for the same reason at the test level: the first full gate run failed
at **91.7%** diff-coverage, and every uncovered line was a failure branch of one
of these remedies — a rollback that cannot restore, a registration meeting a hub
that stopped mid-build, a task deleted inside the window the lock-split opens.
T-14 to T-18 pin them.

## The independent pre-merge review

`/pr-review` handed the diff to a different model family, doc-blind, with the
gate already green. It returned **11 notes**; 8 survived verification against the
code and are fixed here (§1.13–§1.16, T-19 to T-22), and 3 are recorded in §8.3
with their reasons.

Two of them are worth the PR's attention because nothing else in the chain could
have asked:

- **§1.13 — the cancel routing races the park it routes for.** §1.10's guard
  reads the state and then cancels; an instance parking between those two steps
  lost the request exactly as before. This document's own defect, inside the fix
  for it. Fully covered by tests that could not see it.
- **T-3 could not fail on the code it pins.** It passed one processor to both
  the register and the unregister, so the defect's outcome is indistinguishable
  from a legitimate ordering — and the test skipped that case as benign. It now
  fails at round 22 with the §1.3 fix reverted. It had 100% coverage of the
  lines it failed to pin.

## Verification

- `make ci` green end to end at `f898eaa`, `-race` included: 10/10 core steps, all 49 example modules executed, no vulnerabilities in any module.
- **diff-coverage 100.0%** of 362 changed lines (`COVER_MIN` 95).
- 22 regression tests, T-1 to T-22 (§4.1). T-1 to T-13 pin the reported
  defects; T-14 to T-18 pin the remedies' own failure branches; T-19 to T-22 pin
  the independent review's findings. Each of T-19 to T-22 was confirmed to fail
  with its fix reverted.

## Not in this PR

- **C-15** (`msgIdx` keyed by message-definition id alone, so two tracks parked
  on one definition overwrite each other) is issue **#305**, filed with SRD-082
  as per-iteration payload routing for shared catch nodes. The audit
  rediscovered it independently; that issue is its home.
- The **25 unverified `internal/instance` findings** (audit §5.5) await their
  own verification pass.

## Docs

- `docs/fix/FIX-038-…md` — Accepted, with §8 implementation summary.
- `docs/audit/package-audit-2026-08-08.md` §6 — a disposition per finding.
- `CHANGELOG.md` — `[Unreleased] / Fixed`.
