### PR TITLE
fix(ci): the gate announces its steps and records its own verdict (FIX-039)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,8 @@ examples/incident-retry/incident-retry
 
 # Python bytecode (scripts/mkdocs_hooks.py)
 __pycache__/
+
+# The gate's own record of itself (FIX-039): the last run's verdict and a
+# machine-local timing baseline. Not source — and a baseline from a 24-core box
+# is false on a 2-core runner, so it is never shared.
+.ci/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,37 @@ gate that way. The check lives in the REQUIRED core gate rather than the
 non-blocking examples job on purpose — a regression here is a hole in *that* job,
 and a guard in the half that can go red unnoticed guards nothing.
 
+### Reading a gate run (FIX-039)
+
+`make ci` announces every step and records its own verdict, because an exit code
+alone did not survive the trip to whoever asked for it.
+
+```
+[ 8/14] test-core              started 23:31:35 (typically 1m05s)
+[ 8/14] test-core              … 30s elapsed
+[ 8/14] test-core              ok 1m05s
+[full] verdict: PASS — 14/14 steps in 2m22s (see .ci/last-run.json)
+```
+
+**Judge a run by `.ci/last-run.json`, never by the exit code of whatever wrapped
+it.** That file names the failing step, times every step, and carries the HEAD
+sha and start time so a stale one cannot pass for the current one.
+
+- **Absent means the run did not finish** — never a pass. It is deleted when a
+  run starts and written only when one ends, so a killed run leaves nothing.
+- A trailing `echo` masks the real status (`make ci; echo $?` reports *echo's*),
+  and an output-filtering wrapper can truncate the log and return its own
+  status. Both happened on 2026-08-08; one produced a false pass for a run that
+  had failed at 91.7% diff-coverage.
+- Do not detect liveness with `pgrep -f 'make ci'` — the pattern matches the
+  checking command itself, which once reported a dead run as alive for 18
+  minutes. Use the heartbeat lines, or the status file.
+
+The per-step baseline in `.ci/timings.tsv` is machine-local and gitignored: 146s
+on a 24-core box is not what a 2-core runner does, and a wrong estimate is worse
+than none. On GitHub each core step is its own workflow step, so CI already
+names and times them; the driver gives a local run the same information.
+
 ```bash
 # One-time per machine: install the Go dev tools at the versions CI pins
 # (mockery, golangci-lint, govulncheck, covercheck). Versions live in Makefile.

--- a/Makefile
+++ b/Makefile
@@ -351,12 +351,6 @@ TEST_CPUS ?= 4
 # 2-core runner, so a shared baseline would be wrong nearly everywhere.
 CI_DIR ?= .ci
 
-# MAKE_BIN carries the same value as $(MAKE), under a name make does not
-# recognise. GNU make executes any recipe line containing the literal $(MAKE)
-# even under -n, so `make -n ci` used to RUN the driver — which then invoked
-# each step with -n inherited, got 14 instant successes, and recorded a PASS
-# for a run that executed nothing (FIX-039 §1.5). A dry run must print, not do.
-MAKE_BIN := $(MAKE)
 
 test-all:
 	@set -e; for dir in $(MODULES); do \
@@ -492,7 +486,7 @@ CI_EXAMPLE_STEPS = examples-tidy examples-lint examples-build run-examples
 # Four announced steps rather than two opaque $(MAKE) calls — the run phase
 # alone executes 49 modules and used to report nothing but ::group:: lines.
 ci-examples:
-	@MAKE="$(MAKE_BIN)" CI_DIR="$(CI_DIR)" ./scripts/ci-run.sh examples \
+	@MAKE="$(MAKE)" CI_DIR="$(CI_DIR)" ./scripts/ci-run.sh examples \
 		$(CI_EXAMPLE_STEPS)
 .PHONY: ci-examples
 
@@ -528,8 +522,9 @@ examples-module-check:
 	fi; \
 	echo "example-module check: all $(words $(EXAMPLE_DIRS)) example directories are modules"
 
-# The ten core steps, in the order the REQUIRED CI job runs them. Named once
-# here so the list, the banners and the workflow cannot drift apart.
+# The ten core steps, in the order the REQUIRED CI job runs them. The workflow
+# runs each as its own job step, so the list exists in two places; workflow-check
+# below compares them rather than leaving the comment to assert it.
 CI_CORE_STEPS = mock-check link-check examples-module-check tidy-check-core \
                 lint-core build-core consumer-smoke test-core cover-check \
                 vuln-core
@@ -546,8 +541,30 @@ CI_CORE_STEPS = mock-check link-check examples-module-check tidy-check-core \
 # On GitHub each of these steps is its own workflow step (check.yml), so CI
 # already names and times them; this driver is what gives the same information
 # to a local run, where all ten happen inside one process.
+# workflow-check keeps CI_CORE_STEPS and .github/workflows/check.yml in step.
+# The workflow invokes each core step separately (`run: make <step>`), so the
+# list is duplicated by necessity — and a duplicated list that nothing compares
+# is a list that drifts. An independent review pointed out that the comment
+# above used to claim drift was impossible; this makes the claim true.
+workflow-check:
+	@tmp=$$(mktemp -d); \
+	grep -v '^[[:space:]]*#' .github/workflows/check.yml \
+		| grep -oE '\bmake [a-z-]+' | sed 's/make //' \
+		| grep -vxE 'ci|ci-core|ci-examples|tools' \
+		| sort -u > $$tmp/workflow; \
+	printf '%s\n' $(CI_CORE_STEPS) | sort -u > $$tmp/makefile; \
+	if ! diff -q $$tmp/workflow $$tmp/makefile >/dev/null 2>&1; then \
+		echo "ERROR: CI_CORE_STEPS and check.yml disagree"; \
+		echo "  < workflow-only   > Makefile-only"; \
+		diff $$tmp/workflow $$tmp/makefile; \
+		rm -rf $$tmp; exit 1; \
+	fi; \
+	rm -rf $$tmp; \
+	echo "workflow-check: check.yml runs exactly the $(words $(CI_CORE_STEPS)) core steps"
+.PHONY: workflow-check
+
 ci-core:
-	@MAKE="$(MAKE_BIN)" CI_DIR="$(CI_DIR)" ./scripts/ci-run.sh core $(CI_CORE_STEPS)
+	@MAKE="$(MAKE)" CI_DIR="$(CI_DIR)" ./scripts/ci-run.sh core $(CI_CORE_STEPS)
 .PHONY: ci-core
 
 # Umbrella target that runs the full local-equivalent of CI (BOTH CI jobs).
@@ -559,6 +576,6 @@ ci-core:
 # overwrite the first — leaving a file that describes half the run while
 # looking like it describes all of it.
 ci:
-	@MAKE="$(MAKE_BIN)" CI_DIR="$(CI_DIR)" ./scripts/ci-run.sh full \
+	@MAKE="$(MAKE)" CI_DIR="$(CI_DIR)" ./scripts/ci-run.sh full \
 		$(CI_CORE_STEPS) $(CI_EXAMPLE_STEPS)
 .PHONY: ci

--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,19 @@ build-all:
 # use the host default, or set another number to experiment.
 TEST_CPUS ?= 4
 
+# CI_DIR holds the gate's own record of itself (FIX-039): the verdict of the
+# last run and a local, machine-specific timing baseline. Both are gitignored —
+# a verdict is not source, and timings that are true on 24 cores are false on a
+# 2-core runner, so a shared baseline would be wrong nearly everywhere.
+CI_DIR ?= .ci
+
+# MAKE_BIN carries the same value as $(MAKE), under a name make does not
+# recognise. GNU make executes any recipe line containing the literal $(MAKE)
+# even under -n, so `make -n ci` used to RUN the driver — which then invoked
+# each step with -n inherited, got 14 instant successes, and recorded a PASS
+# for a run that executed nothing (FIX-039 §1.5). A dry run must print, not do.
+MAKE_BIN := $(MAKE)
+
 test-all:
 	@set -e; for dir in $(MODULES); do \
 		echo "::group::test $$dir (TEST_CPUS=$(TEST_CPUS))"; \
@@ -474,10 +487,26 @@ run-examples:
 # the core `vuln` scan already covers the shared dependency graph; scanning it
 # 35 more times added minutes of CI for no new signal). Runs as CI's parallel
 # non-blocking job AND inside the local `make ci`.
+CI_EXAMPLE_STEPS = examples-tidy examples-lint examples-build run-examples
+
+# Four announced steps rather than two opaque $(MAKE) calls — the run phase
+# alone executes 49 modules and used to report nothing but ::group:: lines.
 ci-examples:
-	@$(MAKE) tidy-check-all lint-all-modules build-all MODULES="$(EXAMPLE_MODULES)"
-	@$(MAKE) run-examples
+	@MAKE="$(MAKE_BIN)" CI_DIR="$(CI_DIR)" ./scripts/ci-run.sh examples \
+		$(CI_EXAMPLE_STEPS)
 .PHONY: ci-examples
+
+examples-tidy:
+	@$(MAKE) tidy-check-all MODULES="$(EXAMPLE_MODULES)"
+.PHONY: examples-tidy
+
+examples-lint:
+	@$(MAKE) lint-all-modules MODULES="$(EXAMPLE_MODULES)"
+.PHONY: examples-lint
+
+examples-build:
+	@$(MAKE) build-all MODULES="$(EXAMPLE_MODULES)"
+.PHONY: examples-build
 
 # examples-module-check guards the run sweep's completeness: an example
 # directory without a go.mod is invisible to EXAMPLE_MODULES, so it is built
@@ -499,12 +528,37 @@ examples-module-check:
 	fi; \
 	echo "example-module check: all $(words $(EXAMPLE_DIRS)) example directories are modules"
 
-# The core gate — everything the REQUIRED CI job runs, in the same order.
-ci-core: mock-check link-check examples-module-check tidy-check-core lint-core build-core consumer-smoke test-core cover-check vuln-core
+# The ten core steps, in the order the REQUIRED CI job runs them. Named once
+# here so the list, the banners and the workflow cannot drift apart.
+CI_CORE_STEPS = mock-check link-check examples-module-check tidy-check-core \
+                lint-core build-core consumer-smoke test-core cover-check \
+                vuln-core
+
+# The core gate. It runs through scripts/ci-run.sh, which announces each step
+# with its ordinal and elapsed time, heartbeats inside the long ones, and writes
+# the run's verdict to $(CI_DIR)/last-run.json.
+#
+# READ THE VERDICT FROM THAT FILE, never from the exit code of whatever wrapped
+# this: a trailing `echo` masks it, a filtering wrapper can fabricate it, and a
+# killed process group destroys it. An ABSENT file means the run did not finish
+# and is never a pass.
+#
+# On GitHub each of these steps is its own workflow step (check.yml), so CI
+# already names and times them; this driver is what gives the same information
+# to a local run, where all ten happen inside one process.
+ci-core:
+	@MAKE="$(MAKE_BIN)" CI_DIR="$(CI_DIR)" ./scripts/ci-run.sh core $(CI_CORE_STEPS)
 .PHONY: ci-core
 
 # Umbrella target that runs the full local-equivalent of CI (BOTH CI jobs).
 # Use this before pushing to catch regressions before GitHub runs them.
 # test-core writes coverage.txt; cover-check consumes it (single test run).
-ci: ci-core ci-examples
+# One run, one verdict: `ci` drives all fourteen steps through a SINGLE driver
+# invocation rather than calling ci-core and ci-examples in turn. Two
+# invocations would write $(CI_DIR)/last-run.json twice, and the second would
+# overwrite the first — leaving a file that describes half the run while
+# looking like it describes all of it.
+ci:
+	@MAKE="$(MAKE_BIN)" CI_DIR="$(CI_DIR)" ./scripts/ci-run.sh full \
+		$(CI_CORE_STEPS) $(CI_EXAMPLE_STEPS)
 .PHONY: ci

--- a/docs/fix/FIX-039-gate-progress-and-verdict.md
+++ b/docs/fix/FIX-039-gate-progress-and-verdict.md
@@ -1,7 +1,7 @@
 # FIX-039 — the gate's progress is invisible and its verdict is destructible
 
 **Type:** FIX (one-shot bug-fix; not rewritten after landing).
-**Status:** Draft.
+**Status:** Accepted.
 **Date:** 2026-08-08.
 **Author:** Руслан Габитов.
 **Branch:** `fix/ci-progress-and-verdict`.

--- a/docs/fix/FIX-039-gate-progress-and-verdict.md
+++ b/docs/fix/FIX-039-gate-progress-and-verdict.md
@@ -1,0 +1,329 @@
+# FIX-039 — the gate's progress is invisible and its verdict is destructible
+
+**Type:** FIX (one-shot bug-fix; not rewritten after landing).
+**Status:** Draft.
+**Date:** 2026-08-08.
+**Author:** Руслан Габитов.
+**Branch:** `fix/ci-progress-and-verdict`.
+**Upstream:** none — this is build tooling, not engine behaviour. The rules it
+serves are the parity rules in `CLAUDE.md` ("if `make ci` is green locally, CI
+is green") and the `/check-srd` rule "verify the gate by its own completion
+markers, not a wrapper exit code".
+
+**Grounded in (verified at `4d8d3be`):**
+- `Makefile:503` — `ci-core: mock-check link-check examples-module-check tidy-check-core lint-core build-core consumer-smoke test-core cover-check vuln-core` (ten steps).
+- `Makefile:509` — `ci: ci-core ci-examples`.
+- `Makefile:334,350,359,367,379,464` — the only progress output the gate emits is `::group::<verb> <dir>`, one per module per step.
+- `Makefile:348` — `test-all` loops modules serially; `go test` prints nothing until a package completes.
+- `.github/workflows/check.yml:114` — "the verdict is identical local and on CI".
+
+---
+
+## 1 Symptoms
+
+### 1.1 The verdict exists only in the caller, so killing the caller destroys it
+
+`make ci` communicates pass/fail solely through its exit code. Nothing durable
+is written. Every observer therefore invents its own capture, and each invention
+has failed in a different way:
+
+- **A trailing `echo` masks the status.** `make ci > log 2>&1; echo "X=$?"` is
+  the obvious idiom, and the shell reports *echo's* exit code to whatever is
+  watching the compound command. `/check-srd` already documents this trap, which
+  is evidence that it is easy to fall into rather than evidence that it is
+  avoided.
+- **Killing the wrapper kills the gate — or doesn't, and nobody can tell
+  which.** On 2026-08-08 a harness killed a backgrounded wrapper; the process
+  group died mid-`test-core`, at step 8 of 10, after roughly 90 seconds of work.
+  The log simply stopped. There was no record that a run had started, no record
+  that it had died, and no way to distinguish "died" from "still working" except
+  by inspecting processes.
+- **A filtering wrapper can fabricate a pass.** The same day, a run whose
+  `cover-check` step failed at 91.7% was reported as exit 0, because an
+  output-summarising layer between the gate and the observer truncated the log
+  (it wrote a literal `... (563 lines truncated)` line into the file) and
+  returned its own status.
+
+The common shape: **the gate knows the answer and the answer does not survive
+the trip to whoever asked.** A verdict that a spectator can destroy or forge is
+not a verdict.
+
+### 1.2 Progress is invisible, so silence is unreadable
+
+The gate's only progress output is `::group::<verb> <dir>` (`Makefile:334` and
+five siblings). Nothing states which of the ten steps is running, how many
+remain, how long this step has taken, or how long it usually takes.
+
+`test-core` is the pathological case: it echoes `::group::test .` and then says
+nothing at all until the module's whole race suite finishes, because `go test`
+buffers per package. An observer sees one line and then a silence of arbitrary
+length. That silence is identical whether the suite is working, deadlocked, or
+already dead — all three were observed on 2026-08-08, and the dead one was
+mistaken for the working one for eighteen minutes.
+
+The cost is not aesthetic. Silence with no expected duration attached makes
+every long step a decision: keep waiting, or investigate. Made wrong in one
+direction it wastes the session; made wrong in the other it kills a healthy run.
+
+### 1.3 Nothing records how long anything takes
+
+There is no history, so "is this normal?" is unanswerable — by a human or by an
+agent. The absence has a measurable cost: during the same session the full gate
+was estimated at "10–20 minutes for the race step alone" from watching a killed
+process, when the true figure for the entire gate on that machine is **146
+seconds** (`exit=0 seconds=146 head=f898eaa`). Two orders of magnitude, and
+nothing in the repository could have corrected it.
+
+### 1.4 Reconstructing progress from the outside is unreliable — and looks reliable
+
+Because the gate publishes no progress, every observer parses its log, and a
+parser is a second thing that can be wrong while sounding confident. Both
+failures below happened within one hour, and both produced plausible output:
+
+- A liveness check of `pgrep -f 'make ci'` matched **its own command line**,
+  which contains that string, and so reported "alive" for a process that had
+  been dead for eighteen minutes.
+- A step classifier keyed on `::group::lint .` also matched
+  `::group::lint ./examples/...`, so the examples sweep was reported as core
+  step 5 — after step 8 had already been reported. Progress ran backwards.
+
+Neither bug was in the gate. Both were in the act of guessing what the gate was
+doing, which is only necessary because the gate does not say.
+
+### 1.5 The runner itself can lose a verdict — three ways found while building this
+
+Implementing the fix surfaced three more instances of the same shape, each
+found by running the thing rather than by reasoning about it:
+
+- **Two driver invocations, two verdicts.** `ci` first called `ci-core` and
+  `ci-examples` in turn, so the status file was written twice and the second
+  overwrote the first — leaving a file that described half the run while looking
+  like it described all of it.
+- **Editing the script mid-run corrupted the running interpreter.** Bash reads a
+  script incrementally as it executes, so an edit shifts byte offsets underneath
+  it. A 14/14 green run died at its last line with `syntax error near unexpected
+  token 'done'` and wrote no verdict. The run was correct; the file describing it
+  was destroyed by a concurrent editor.
+- **A trap cannot fire during a long step.** Bash defers a trap until the
+  current FOREGROUND command completes, so a SIGTERM arriving during a
+  multi-minute `make test-core` sat pending for the rest of that step — the
+  handler would have run long after the sender concluded nothing had happened.
+  Measured: the first T-7 run left `go test -race` running and wrote nothing.
+- **A DRY RUN forged a pass.** `make -n ci` wrote
+  `verdict: PASS, 14 steps, 1s` for a run that executed nothing. GNU make runs
+  any recipe line containing the literal `$(MAKE)` even under `-n` — so the
+  driver started — and passes the dry-run flag down in `MAKEFLAGS`, so every
+  step returned instantly and successfully. This is the worst defect found in
+  this work: the machinery built to make a verdict unforgeable forged one, and
+  it did so in the most innocuous way imaginable, from a command whose entire
+  purpose is not to do anything.
+
+## 2 Root cause analysis
+
+One cause with two faces: **the gate reports to its caller and to nobody else.**
+Pass/fail goes out through an exit code, which only the immediate parent can
+read and which the parent must then relay; progress goes out as unstructured
+log text, which anyone downstream must re-derive.
+
+Both make the *observer* responsible for information only the *gate* possesses.
+Every failure in §1 is an observer getting that responsibility wrong — a masked
+exit code, a killed process group, a truncating filter, a self-matching pgrep, a
+too-loose glob. The gate was correct in every one of those runs.
+
+The fix is therefore not "watch it better". It is to have the gate state its own
+progress and record its own verdict, so that no downstream party has to
+reconstruct either.
+
+## 3 Solution
+
+### 3.1 Alternatives considered
+
+| # | Option | Verdict |
+|---|---|---|
+| 1 | Leave it; observers must be careful | Rejected — five distinct observer bugs in one session, each careful-looking. The failure rate is the argument. |
+| 2 | Parse the log better (a shared parser script) | Rejected — this is §1.4 with more code. A parser is a second source of truth, and the log format is not a contract. |
+| 3 | Emit numbered step banners + write a status file, in the gate | **Chosen.** The step that runs is the only party that knows which step it is; the process that ends is the only party that knows how it ended. |
+| 4 | Also parallelise the module sweeps to shorten the wait | Rejected — explicitly out of scope. The gate takes 146s; the complaint is unpredictability, not duration. Making a timing-sensitive race suite faster buys flakes, and a flake is the purest form of unpredictability. |
+| 5 | Branch the output on `$CI` | Rejected — no conditional is needed, and adding one would be the divergence the parity rule forbids. GitHub invokes each core step as its OWN workflow step (`check.yml:80-124`: `run: make mock-check`, `run: make test-core`, …), so it never runs the driver and already names and times every step in its UI. The driver announces what it drives; CI simply drives the steps itself. The `examples` job DOES call `make ci-examples` (`check.yml:155`) and so gets banners there. |
+| 6 | Commit the timing baseline | Rejected — timings are machine-specific (146s on 24 cores; a 2-core runner is far slower), so a shared baseline is wrong for nearly every machine, and a wrong estimate is worse than none. It also rewrites a tracked file on every run, leaving a dirty tree — which this repo can least afford, since `cover-check` is HEAD-based. Ignored, beside `coverage.*`. |
+
+### 3.2 Changes by file
+
+#### 3.2.1 `Makefile` — a step announces itself
+
+Each of the ten `ci-core` steps and the four `ci-examples` phases is wrapped so
+it prints its ordinal, its name, its start time and, when a local baseline
+exists, its typical duration; and on completion its elapsed time:
+
+```
+[ 7/10] consumer-smoke   started 22:51:44  (typically 6s)
+[ 7/10] consumer-smoke   ok 5s
+[ 8/10] test-core        started 22:51:49  (typically 1m38s)
+```
+
+The banner is emitted by the step, so it cannot disagree with reality — the
+class of bug §1.4 describes becomes unrepresentable rather than merely rarer.
+
+#### 3.2.2 `Makefile` — a heartbeat inside the long steps
+
+`test-core` and `run-examples` emit a liveness line every 30s while a module is
+in flight (`[ 8/10] test-core  … 2m30s elapsed, module ./`). Silence then has a
+name and a clock on it, and a stall is distinguishable from work without
+inspecting processes.
+
+#### 3.2.3 `Makefile` — the gate records its own verdict
+
+The gate writes `.ci/last-run.json` when it ends, **on both paths**, containing:
+the exit code, the failing step if any, per-step durations, the HEAD sha, and
+the start/finish timestamps. Three properties are required:
+
+- **Written by the gate**, so killing the caller cannot lose it (§1.1).
+- **Absent means "did not finish"** — never inferred as a pass.
+- **Carries the HEAD sha and start time**, so a stale file from an earlier run
+  cannot be mistaken for this one.
+
+#### 3.2.3b `scripts/ci-run.sh` — the runner protects its own run
+
+Three properties, each earned by a failure in §1.5: the script's body is wrapped
+in a braced group ending in `exit`, so bash parses it in ONE pass and an edit
+during a run cannot corrupt it; each step runs in the background under an
+interruptible `wait`, so a trap fires at once instead of after the step; and the
+handler signals its whole process group before recording the verdict, so
+stopping the gate stops `make` and `go test` too rather than leaving orphans
+holding the CPU and the coverage file.
+
+`make ci` drives all fourteen steps through a SINGLE invocation, so one run
+produces exactly one verdict.
+
+A dry run records nothing, guarded twice. The Makefile passes `$(MAKE_BIN)` — a
+variable holding the same value under a name make does not recognise — so `-n`
+prints these recipes instead of running them; and the driver refuses outright
+when `MAKEFLAGS` carries `n`, covering any other route. Two guards because the
+failure they prevent is a false PASS, and a false PASS is worse than no gate:
+it is a gate that lies in the direction you want to believe.
+
+#### 3.2.4 `.ci/timings.json`, `.gitignore` — a local baseline
+
+Per-step durations from the last N runs, used only to print "typically …".
+Machine-local and ignored (§3.1 #6). Absent baseline prints no estimate and says
+so, rather than borrowing someone else's number.
+
+#### 3.2.5 `CLAUDE.md` — how to read the gate
+
+The CI-parity section gains the rule the failures teach: **judge a run by
+`.ci/last-run.json`, never by the exit code of whatever wrapped it, and never by
+a log line count**. Plus the two observer traps by name, since both are easy to
+re-invent: a `pgrep` pattern that matches its own command line, and a
+`::group::lint .` glob that also matches `./examples/`.
+
+## 4 Verification
+
+### 4.1 Regression tests
+
+Shell-level, run from the repo (a Makefile change cannot be pinned by `go test`):
+
+| # | Test | Asserts |
+|---|---|---|
+| T-1 | `make ci` on a clean tree | every step prints a banner with ordinal, name and elapsed; the ordinals are strictly increasing (the §1.4 backwards-progress bug cannot recur) |
+| T-2 | kill the gate mid-`test-core` | `.ci/last-run.json` is ABSENT, and the documented reading of that is "did not finish" — never a pass |
+| T-3 | a deliberately failing step (`COVER_MIN=100`) | the status file records `exit != 0` AND names `cover-check` as the failing step |
+| T-4 | `make ci > log 2>&1; echo $?` from a wrapper | the status file's verdict matches the true outcome even when the wrapper's own exit code does not (§1.1's masking trap) |
+| T-5 | a second run after a first | banners carry "typically …" from `.ci/timings.json`; a fresh clone prints no estimate and says the baseline is missing |
+| T-6 | `git status --porcelain` after a run | clean — the timing baseline and status file are ignored, so the gate never dirties the tree |
+| T-7 | SIGTERM the driver mid-`test-core` | the verdict records `interrupted by a signal`, AND no `go test` survives the driver — an unstopped child is a gate that is still running after you stopped it |
+| T-8 | `make -n ci` | NO verdict is written and nothing executes — a dry run must never produce a pass. Also `MAKEFLAGS=n ./scripts/ci-run.sh …` directly, covering the guard independently of the Makefile |
+
+### 4.2 Gate
+
+`make ci` green end to end. The change touches no Go code, so diff-coverage has
+nothing to measure. The parity requirement is that the ten core steps and their
+order are unchanged — they are now named once in `CI_CORE_STEPS` and consumed by
+the driver, so the list, the banners and the workflow cannot drift apart.
+
+T-7 covers the signal path found while testing this script: a driver that traps
+INT/TERM must take its children down with it. Killed without one, the driver
+exits while `go test -race` runs on — an orphan holding CPU and the coverage
+file, invisible to whoever believes they stopped the gate.
+
+## 5 Prevention
+
+- **A process that knows something must publish it.** Progress and verdict are
+  facts only the gate holds; every attempt to re-derive them downstream failed.
+  When a consumer has to guess, that is a missing output, not a careless
+  consumer.
+- **A status that only one process can read is a status that will be lost.**
+  Exit codes are unforgeable but fragile: one wrapper, one filter, one kill and
+  they are gone. Durable, self-described state survives all three.
+- **Absent must never read as success.** Every mechanism here fails toward "did
+  not finish". The 2026-08-08 false pass came from a layer that answered when it
+  did not know.
+- **A monitor is code and can be wrong.** Two monitors were wrong in one hour,
+  both plausibly. Prefer a signal the producer emits over one an observer
+  reconstructs; when reconstruction is unavoidable, test the reconstruction
+  against a known-bad case.
+- **Test the interruption, not just the happy path.** Every failure in §1.5 was
+  invisible to a passing run and appeared the moment something was killed, edited
+  or raced. T-2 and T-7 exist because "it works when nothing goes wrong" is the
+  weakest thing a gate can demonstrate.
+- **Do not edit a script or Makefile while a run of it is in flight.** Bash
+  re-reads a script as it executes and each step spawns a fresh `make` that
+  re-reads the Makefile. The braced-group wrapper makes the first case safe;
+  nothing makes the second safe, so wait for the run.
+
+## 6 Regressions and side effects
+
+- The gate's stdout gains ~14 banner lines plus heartbeats. `::group::` folding
+  is unaffected; the workflow's job structure is unchanged.
+- `.ci/` appears in the working tree and is gitignored, so nothing is committed.
+- No Go code changes; no runtime behaviour changes.
+- **The "typically" estimate is warm-cache biased, and says nothing about a cold
+  run.** Measured on consecutive runs of the same commit: `examples-lint` took
+  1m30s cold and 19s warm, `lint-core` 21s then 3s. The median over recent runs
+  therefore converges on warm figures, and a fresh clone or a cleared build cache
+  will overshoot it substantially. The estimate orients; it does not bound. A
+  step exceeding it is a reason to look, never a reason to act — and the
+  heartbeat, not the estimate, is what proves the step is alive.
+
+## 7 Related
+
+Nothing in this document depends on unfinished work, and nothing is deferred.
+The parallelisation of the module sweeps (§3.1 #4) is not deferred work — it is
+rejected work: the wait is 146s and the goal is predictability, not speed.
+
+## 8 Implementation summary
+
+### 8.1 What landed
+
+| File | Change |
+|---|---|
+| `scripts/ci-run.sh` | the driver: numbered banners with elapsed time and a typical-duration hint, a 30s heartbeat inside long steps, a machine-local timing baseline, and the verdict |
+| `Makefile` | `CI_DIR`, `CI_CORE_STEPS`, `CI_EXAMPLE_STEPS` named once; `ci-core`, `ci-examples` and `ci` drive through the script; `ci` is a SINGLE invocation over all 14 steps |
+| `.gitignore` | `.ci/` |
+| `CLAUDE.md` | "Reading a gate run" — judge by the status file, absent means unfinished, and the two observer traps by name |
+
+### 8.2 Empirical findings
+
+- **The gate takes ~2 minutes, not the 10–20 estimated.** Measured
+  `PASS — 14/14 steps in 2m03s`, with `test-core` at 1m00s the largest single
+  step. The 10–20 minute figure came from watching a process that had been dead
+  for eighteen minutes — §1.3's cost, priced.
+- **Cache state swings step times by 5x.** `examples-lint` 1m30s cold, 19s warm;
+  `lint-core` 21s then 3s. The baseline is a median of recent runs precisely
+  because the last run is a poor predictor.
+- **Every mechanism here was wrong on its first attempt** (§1.5): the verdict was
+  written twice, the script corrupted itself under a concurrent edit, and the
+  signal handler could not fire during the step it most needed to interrupt.
+  None of the three was visible to a passing run.
+- **T-4 reproduced live during testing.** The pipeline reported `exit=0` while
+  the status file recorded `FAIL` at `cover-check` — the masking trap, caught by
+  the mechanism built to catch it.
+- **The forged pass came from `make -n`, discovered by accident.** A dry run
+  executed to check that the Makefile still parsed left a `PASS` verdict on
+  disk, which was then read back as though a real run had produced it. Nothing
+  in the design anticipated a command that is defined as doing nothing being
+  able to record having done everything. It is now guarded twice and pinned by
+  T-8.
+
+## 9 Open questions
+
+None.

--- a/docs/fix/FIX-039-gate-progress-and-verdict.md
+++ b/docs/fix/FIX-039-gate-progress-and-verdict.md
@@ -118,6 +118,25 @@ found by running the thing rather than by reasoning about it:
   it did so in the most innocuous way imaginable, from a command whose entire
   purpose is not to do anything.
 
+### 1.6 What the independent review found
+
+`/pr-review` read the diff doc-blind (two lenses, a different model family) and
+returned nine notes; six survived verification and are fixed here. Three are
+worth naming because each is the document's own thesis turned on the fix:
+
+- **The driver crashed when run directly.** `${MAKEFLAGS%% *}` under `set -u` is
+  fatal when the variable is unset — which is exactly how the script's own usage
+  line says to invoke it. Reproduced: `MAKEFLAGS: unbound variable`.
+- **Hiding `$(MAKE)` broke the jobserver.** The `MAKE_BIN` trick that stopped
+  `-n` from executing the driver also stopped make from passing its jobserver,
+  so `make -j4` warned `jobserver unavailable: using -j1` on every step.
+  Measured. The guard alone is sufficient and keeps both properties.
+- **The verdict was written non-atomically.** Multiple `printf`s into one
+  redirect, while the file's whole purpose is to be read by someone else — the
+  session's own monitor polled it. A reader could see half a JSON document.
+
+Two notes were refuted and recorded in §8.3 rather than dropped.
+
 ## 2 Root cause analysis
 
 One cause with two faces: **the gate reports to its caller and to nobody else.**
@@ -232,6 +251,9 @@ Shell-level, run from the repo (a Makefile change cannot be pinned by `go test`)
 | T-6 | `git status --porcelain` after a run | clean — the timing baseline and status file are ignored, so the gate never dirties the tree |
 | T-7 | SIGTERM the driver mid-`test-core` | the verdict records `interrupted by a signal`, AND no `go test` survives the driver — an unstopped child is a gate that is still running after you stopped it |
 | T-8 | `make -n ci` | NO verdict is written and nothing executes — a dry run must never produce a pass. Also `MAKEFLAGS=n ./scripts/ci-run.sh …` directly, covering the guard independently of the Makefile |
+| T-9 | `make -j4 <target>` | no `jobserver unavailable` warning — the recipes stay recursive so make passes its jobserver, and the dry-run guard, not a hidden `$(MAKE)`, is what makes `-n` harmless |
+| T-10 | `env -u MAKEFLAGS ./scripts/ci-run.sh …` | the driver runs when invoked directly, as its usage line says it may be |
+| T-11 | `make workflow-check` | `CI_CORE_STEPS` and the ten `make <step>` invocations in `check.yml` agree — the list is duplicated by necessity, so something must compare them |
 
 ### 4.2 Gate
 
@@ -300,6 +322,7 @@ rejected work: the wait is 146s and the goal is predictability, not speed.
 | `Makefile` | `CI_DIR`, `CI_CORE_STEPS`, `CI_EXAMPLE_STEPS` named once; `ci-core`, `ci-examples` and `ci` drive through the script; `ci` is a SINGLE invocation over all 14 steps |
 | `.gitignore` | `.ci/` |
 | `CLAUDE.md` | "Reading a gate run" — judge by the status file, absent means unfinished, and the two observer traps by name |
+| `Makefile` (`workflow-check`) | compares `CI_CORE_STEPS` against the steps `check.yml` runs, so the duplicated list cannot drift silently |
 
 ### 8.2 Empirical findings
 
@@ -323,6 +346,27 @@ rejected work: the wait is 146s and the goal is predictability, not speed.
   in the design anticipated a command that is defined as doing nothing being
   able to record having done everything. It is now guarded twice and pinned by
   T-8.
+
+### 8.3 Review notes NOT acted on
+
+- **"`--no-print-directory` triggers a false dry-run."** Refuted by measurement:
+  GNU make puts long options in their own words, so `MAKEFLAGS` reads
+  `s --no-print-directory` and the first-word check never sees them. Only `-n`
+  places an `n` there. The line does carry a real bug — the unbound variable
+  above — but not this one.
+- **"Running a step directly leaves a stale FAIL verdict."** Rejected: the file
+  describes a gate RUN, not the state of the tree, and it carries that run's
+  HEAD sha and finish time. `make test-core` on its own is not a gate run and
+  must not claim to be one.
+
+### 8.4 A defect the review did not find, and the tests did
+
+Fixes #4 and #5 were each correct alone and wrong together. Putting the
+heartbeat in its own process group (so killing it takes its `sleep` along) also
+put it outside the group the signal handler kills — so an interrupted run left a
+heartbeat printing into a log nobody was writing. Neither lens saw it, because
+it exists only in the interaction; it appeared the first time T-7 was re-run
+after both landed. Verify the combination, not the changes.
 
 ## 9 Open questions
 

--- a/scripts/ci-run.sh
+++ b/scripts/ci-run.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# ci-run.sh — run a gate phase as numbered, announced, timed steps, and record
+# the phase's own verdict (FIX-039).
+#
+# The gate used to report pass/fail through an exit code and progress through
+# unstructured log text, which made every downstream observer responsible for
+# information only the gate holds. That produced a masked exit code, a lost
+# verdict when a wrapper was killed, a fabricated pass from a truncating filter,
+# a liveness check that matched its own command line, and a step classifier that
+# ran backwards — five failures, none of them in the gate. So the gate says what
+# it is doing and records how it ended, and nobody downstream re-derives either.
+#
+# Usage: ci-run.sh <phase-label> <step>...
+# Env:   MAKE (defaults to make), CI_DIR (defaults to .ci), CI_HEARTBEAT (30)
+
+# The whole body is wrapped in a braced group that ends with `exit`, so bash
+# parses it in ONE pass. Without that, bash reads a script incrementally as it
+# runs, and editing this file mid-run shifts the byte offsets under the running
+# interpreter — which happened on 2026-08-08: a 14/14 green run died at the last
+# line with `syntax error near unexpected token done`, and its verdict was lost.
+# A run's integrity must not depend on nobody touching the file while it runs.
+{
+set -uo pipefail
+
+phase="${1:?phase label required}"
+shift
+steps=("$@")
+[ "${#steps[@]}" -gt 0 ] || { echo "ci-run: no steps given" >&2; exit 64; }
+
+MAKE="${MAKE:-make}"
+CI_DIR="${CI_DIR:-.ci}"
+CI_HEARTBEAT="${CI_HEARTBEAT:-30}"
+status="$CI_DIR/last-run.json"
+timings="$CI_DIR/timings.tsv"
+
+# Refuse to record anything during a DRY RUN. GNU make executes a recipe line
+# containing $(MAKE) even under -n — so `make -n ci` reached this script — and
+# passes the dry-run flag down in MAKEFLAGS, so every step returned instantly
+# and successfully. The result was a verdict reading "PASS, 14 steps, 1s" for a
+# run that executed nothing: a forged pass produced by the machinery built to
+# make passes unforgeable. The Makefile no longer spells $(MAKE) literally in
+# these recipes, and this guard covers every other way -n could arrive.
+case "${MAKEFLAGS%% *}" in
+	*n*)
+		echo "ci-run: dry run (-n) — executing nothing and recording no verdict"
+		exit 0
+		;;
+esac
+
+mkdir -p "$CI_DIR"
+
+# A stale verdict must never be mistaken for this run's, so it goes before the
+# first step rather than being overwritten at the end.
+rm -f "$status"
+
+total="${#steps[@]}"
+started_at="$(date -Is)"
+run_start="$(date +%s)"
+head_sha="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+durations=""
+
+# human renders seconds as 5s / 1m38s / 1h02m — a bare "98" is a number the
+# reader has to convert, and the point of this file is not making people work.
+human() {
+	local s="$1"
+	if   [ "$s" -lt 60 ];   then printf '%ds' "$s"
+	elif [ "$s" -lt 3600 ]; then printf '%dm%02ds' "$((s / 60))" "$((s % 60))"
+	else printf '%dh%02dm' "$((s / 3600))" "$(((s % 3600) / 60))"
+	fi
+}
+
+# typical_for reports the median of a step's recent runs, or nothing at all when
+# there is no history. Nothing is deliberate: a borrowed or invented estimate is
+# worse than none, because the reader stops trusting the number instead of the
+# clock.
+typical_for() {
+	local step="$1" n
+	[ -f "$timings" ] || return 0
+	local vals
+	vals="$(awk -F'\t' -v s="$step" '$1 == s { print $2 }' "$timings" | tail -5 | sort -n)"
+	[ -n "$vals" ] || return 0
+	n="$(printf '%s\n' "$vals" | wc -l)"
+	printf '%s\n' "$vals" | sed -n "$(((n + 1) / 2))p"
+}
+
+# write_status records the verdict. It is written by the gate, not by the
+# caller, so killing the caller cannot lose it; and it carries the HEAD sha and
+# start time so an older file cannot be read as this run's.
+write_status() {
+	local code="$1" failed="$2" note="$3"
+	local elapsed=$(($(date +%s) - run_start))
+	{
+		printf '{\n'
+		printf '  "phase": "%s",\n' "$phase"
+		printf '  "exit": %s,\n' "$code"
+		printf '  "verdict": "%s",\n' "$([ "$code" -eq 0 ] && echo PASS || echo FAIL)"
+		printf '  "failed_step": "%s",\n' "$failed"
+		printf '  "note": "%s",\n' "$note"
+		printf '  "head": "%s",\n' "$head_sha"
+		printf '  "started": "%s",\n' "$started_at"
+		printf '  "finished": "%s",\n' "$(date -Is)"
+		printf '  "seconds": %s,\n' "$elapsed"
+		printf '  "steps": {%s}\n' "$durations"
+		printf '}\n'
+	} > "$status"
+}
+
+# A signal that can be caught is recorded AND taken down with its children.
+# Without the group kill the driver dies while `go test -race` runs on — an
+# orphan holding the CPU and the coverage file, invisible to whoever thinks
+# they stopped the gate (observed while testing this script).
+#
+# SIGKILL cannot be caught: the status file then stays absent, which is the
+# correct reading of a run that did not finish, but the children DO survive. A
+# caller that must be certain should signal the process group
+# (`kill -TERM -<pgid>`), which this handler makes sufficient.
+on_signal() {
+	trap '' INT TERM                 # do not re-enter on our own group signal
+	kill -TERM 0 2>/dev/null         # make, its shell, go test — the whole group
+	write_status 130 "$current_step" "interrupted by a signal"
+	echo "[$phase] INTERRUPTED during $current_step — verdict recorded as FAIL"
+	exit 130
+}
+
+current_step="(none)"
+trap on_signal INT TERM
+
+i=0
+for step in "${steps[@]}"; do
+	i=$((i + 1))
+	current_step="$step"
+
+	typical="$(typical_for "$step")"
+	if [ -n "$typical" ]; then
+		hint=" (typically $(human "$typical"))"
+	else
+		hint=" (no local baseline yet)"
+	fi
+
+	printf '[%2d/%d] %-22s started %s%s\n' \
+		"$i" "$total" "$step" "$(date +%H:%M:%S)" "$hint"
+
+	step_start="$(date +%s)"
+
+	# The heartbeat is what makes a silence readable. test-core emits one
+	# ::group:: line and then nothing until a whole race suite finishes, so a
+	# working step, a deadlocked step and a dead step look identical.
+	(
+		while sleep "$CI_HEARTBEAT"; do
+			printf '[%2d/%d] %-22s … %s elapsed\n' \
+				"$i" "$total" "$step" "$(human "$(($(date +%s) - step_start))")"
+		done
+	) &
+	beat=$!
+
+	# The step runs in the BACKGROUND and is waited on, because bash defers a
+	# trap until the current FOREGROUND command finishes. A SIGTERM arriving
+	# during a multi-minute `make test-core` sat pending for the rest of that
+	# step, so the handler ran long after whoever sent the signal had concluded
+	# nothing happened — measured 2026-08-08, and the reason T-7 exists. `wait`
+	# is interruptible, so the trap fires at once.
+	"$MAKE" "$step" &
+	step_pid=$!
+	wait "$step_pid"
+	code=$?
+
+	kill "$beat" 2>/dev/null
+	wait "$beat" 2>/dev/null
+
+	elapsed=$(($(date +%s) - step_start))
+	durations="$durations$([ -n "$durations" ] && echo ,) \"$step\": $elapsed"
+
+	if [ "$code" -ne 0 ]; then
+		printf '[%2d/%d] %-22s FAILED after %s (exit %d)\n' \
+			"$i" "$total" "$step" "$(human "$elapsed")" "$code"
+		write_status "$code" "$step" "step failed"
+		echo "[$phase] verdict: FAIL at $step — see $status"
+		exit "$code"
+	fi
+
+	printf '[%2d/%d] %-22s ok %s\n' "$i" "$total" "$step" "$(human "$elapsed")"
+
+	# Only a PASSING step's duration becomes a baseline: a step that died after
+	# two seconds is not evidence that it takes two seconds.
+	printf '%s\t%s\n' "$step" "$elapsed" >> "$timings"
+done
+
+write_status 0 "" ""
+printf '[%s] verdict: PASS — %d/%d steps in %s (see %s)\n' \
+	"$phase" "$total" "$total" "$(human "$(($(date +%s) - run_start))")" "$status"
+
+exit 0
+}

--- a/scripts/ci-run.sh
+++ b/scripts/ci-run.sh
@@ -38,10 +38,19 @@ timings="$CI_DIR/timings.tsv"
 # passes the dry-run flag down in MAKEFLAGS, so every step returned instantly
 # and successfully. The result was a verdict reading "PASS, 14 steps, 1s" for a
 # run that executed nothing: a forged pass produced by the machinery built to
-# make passes unforgeable. The Makefile no longer spells $(MAKE) literally in
-# these recipes, and this guard covers every other way -n could arrive.
-case "${MAKEFLAGS%% *}" in
-	*n*)
+# make passes unforgeable. The Makefile deliberately KEEPS $(MAKE) in these
+# recipes — hiding it stops -n from recursing but also closes make's jobserver,
+# so `make -j4 ci` warns "jobserver unavailable" on every step (measured) — and
+# this guard is what makes the dry run harmless instead.
+# ${MAKEFLAGS:-} because `set -u` makes a bare expansion fatal when the script
+# is run directly rather than through make — which its own usage line invites,
+# and which an independent review caught crashing on line one.
+#
+# Only the FIRST word carries short flags; long options are separate words
+# (verified: `s --no-print-directory`), so matching the first word alone cannot
+# be fooled by a long option that happens to contain an n.
+case "${MAKEFLAGS:-}" in
+	n*|*[[:space:]]n*)
 		echo "ci-run: dry run (-n) — executing nothing and recording no verdict"
 		exit 0
 		;;
@@ -87,6 +96,10 @@ typical_for() {
 # caller, so killing the caller cannot lose it; and it carries the HEAD sha and
 # start time so an older file cannot be read as this run's.
 write_status() {
+	# Disarm first: a signal arriving mid-write would otherwise re-enter this
+	# function through the trap and interleave two writers on one file.
+	trap '' INT TERM
+
 	local code="$1" failed="$2" note="$3"
 	local elapsed=$(($(date +%s) - run_start))
 	{
@@ -102,7 +115,12 @@ write_status() {
 		printf '  "seconds": %s,\n' "$elapsed"
 		printf '  "steps": {%s}\n' "$durations"
 		printf '}\n'
-	} > "$status"
+	} > "$status.tmp"
+
+	# Atomic: a reader polling this file must see either the previous verdict or
+	# the complete new one, never a half-written JSON document. rename(2) is the
+	# only way to promise that.
+	mv -f "$status.tmp" "$status"
 }
 
 # A signal that can be caught is recorded AND taken down with its children.
@@ -116,6 +134,14 @@ write_status() {
 # (`kill -TERM -<pgid>`), which this handler makes sufficient.
 on_signal() {
 	trap '' INT TERM                 # do not re-enter on our own group signal
+
+	# The heartbeat lives in its OWN process group (setsid, so that killing it
+	# takes its sleep along), which means the group kill below does NOT reach
+	# it. Without this line an interrupted run leaves a heartbeat printing into
+	# a log nobody is producing any more — measured, after the two fixes were
+	# applied separately and their interaction was not.
+	[ -n "${beat:-}" ] && kill -TERM -"$beat" 2>/dev/null
+
 	kill -TERM 0 2>/dev/null         # make, its shell, go test — the whole group
 	write_status 130 "$current_step" "interrupted by a signal"
 	echo "[$phase] INTERRUPTED during $current_step — verdict recorded as FAIL"
@@ -145,12 +171,17 @@ for step in "${steps[@]}"; do
 	# The heartbeat is what makes a silence readable. test-core emits one
 	# ::group:: line and then nothing until a whole race suite finishes, so a
 	# working step, a deadlocked step and a dead step look identical.
-	(
-		while sleep "$CI_HEARTBEAT"; do
-			printf '[%2d/%d] %-22s … %s elapsed\n' \
-				"$i" "$total" "$step" "$(human "$(($(date +%s) - step_start))")"
+	# setsid puts the heartbeat in its own process group, so killing it below
+	# takes its `sleep` with it. Killing the subshell alone leaves the sleep
+	# orphaned until its timer expires — up to one stray process per step.
+	setsid bash -c '
+		while sleep "$1"; do
+			e=$(( $(date +%s) - $5 ))
+			if [ "$e" -lt 60 ]; then el="${e}s"; else
+				el="$((e / 60))m$(printf %02d $((e % 60)))s"; fi
+			printf "[%2d/%d] %-22s … %s elapsed\n" "$2" "$3" "$4" "$el"
 		done
-	) &
+	' _ "$CI_HEARTBEAT" "$i" "$total" "$step" "$step_start" &
 	beat=$!
 
 	# The step runs in the BACKGROUND and is waited on, because bash defers a
@@ -164,7 +195,7 @@ for step in "${steps[@]}"; do
 	wait "$step_pid"
 	code=$?
 
-	kill "$beat" 2>/dev/null
+	kill -TERM -"$beat" 2>/dev/null || kill "$beat" 2>/dev/null
 	wait "$beat" 2>/dev/null
 
 	elapsed=$(($(date +%s) - step_start))


### PR DESCRIPTION
`make ci` reported pass/fail through an exit code and progress through
unstructured log text. Both make the *observer* responsible for information only
the *gate* holds — and on 2026-08-08 that produced five wrong answers in one
session, none of them the gate's fault.

Design doc: [`docs/fix/FIX-039-gate-progress-and-verdict.md`](docs/fix/FIX-039-gate-progress-and-verdict.md).

## What went wrong, before any of this was written

| Symptom | What happened |
|---|---|
| A trailing `echo` masks the status | `make ci; echo $?` reports *echo's* exit code |
| A filtering wrapper fabricated a pass | a run that failed at 91.7% diff-coverage came back exit 0, its log truncated mid-write |
| A killed wrapper destroyed the verdict | the process group died at step 8 of 10; nothing recorded that a run had started, or died |
| A liveness check matched itself | `pgrep -f 'make ci'` matched the monitor's own command line, calling an 18-minute-dead run "alive" |
| A step classifier ran backwards | `::group::lint .` also matches `./examples/…`, so the examples sweep reported as core step 5 — after step 8 |

The cost, priced: the full gate was estimated at "10–20 minutes for the race step
alone", inferred from watching a corpse. It takes **119 seconds**.

## What the gate does now

```
[ 8/14] test-core              started 23:31:35 (typically 1m05s)
[ 8/14] test-core              … 30s elapsed
[ 8/14] test-core              ok 1m05s
[full] verdict: PASS — 14/14 steps in 1m59s (see .ci/last-run.json)
```

- **Every step announces itself** with its ordinal, name, elapsed time and — once
  a local baseline exists — how long it usually takes. Silence always has a name
  and a clock on it.
- **Long steps heartbeat** every 30s. `test-core` emits one `::group::` line and
  then nothing until a whole race suite finishes, so working, deadlocked and
  dead used to look identical.
- **The gate writes its own verdict** to `.ci/last-run.json`: exit code, failing
  step, per-step durations, HEAD sha, timestamps.

Four properties make that verdict trustworthy. It is written by the gate, so
killing the caller cannot lose it. **Absent means the run did not finish** and is
never a pass — the file is removed at the start, so a stale one cannot pass for
current. It carries the HEAD sha, so it cannot be attributed to the wrong
commit. And a dry run records nothing.

## Deliberately not in scope

**Speed.** The gate takes ~2 minutes; the complaint was unpredictability, not
duration. Parallelising the module sweeps or raising `TEST_CPUS` would make a
timing-sensitive race suite faster and flakier, and a flake is the purest form of
unpredictability. `§3.1 #4` records this as rejected, not deferred.

**A committed timing baseline.** 119s on 24 cores is not what a 2-core runner
does, so a shared baseline would be wrong nearly everywhere — and it would
rewrite a tracked file on every run, dirtying a tree that `cover-check` reads
HEAD-first. Machine-local and gitignored.

## Defects found while building it

Each was invisible to a passing run, which is the point:

- **`make -n ci` forged a pass** — `verdict: PASS, 14 steps, 1s` for a run that
  executed nothing. GNU make runs a recipe line containing `$(MAKE)` even under
  `-n` and passes the flag down, so every step returned instantly and
  successfully. Guarded now, and pinned by T-8.
- **The verdict was written twice**, once per phase, so the second overwrote the
  first — a file describing half a run while looking complete. `ci` is one
  invocation over all 14 steps.
- **Editing the script mid-run corrupted it.** Bash reads a script incrementally;
  a 14/14 green run died with `syntax error near unexpected token done` and lost
  its verdict. The body is now parsed in one pass.
- **A trap could not fire during a long step**, because bash defers it until the
  foreground command finishes. Steps run under an interruptible `wait`, and the
  handler takes `make` and `go test` down with it.

## The independent review

`/pr-review`, two lenses, doc-blind, different model family. Nine notes: **six
confirmed and fixed, two refuted** (recorded in §8.3 with their reasons, not
dropped), one folded.

The sharpest was a reversal: hiding `$(MAKE)` behind `MAKE_BIN` bought dry-run
safety and silently sold parallelism — `make -j4` warned `jobserver unavailable:
using -j1` on every step. Restoring `$(MAKE)` and relying on the guard gives both.
Also confirmed: the driver crashed when invoked directly (`MAKEFLAGS` unbound
under `set -u`), and the verdict was written non-atomically for a file whose
whole purpose is to be read by someone else.

**And one the review did not find.** Two of its fixes were each correct alone and
wrong together: putting the heartbeat in its own process group, so killing it
takes its `sleep` along, also put it outside the group the signal handler kills.
It surfaced on the first T-7 re-run after both landed — verify the combination,
not the changes.

## Verification

- `make ci` → **PASS 14/14 in 1m59s**, recorded at `.ci/last-run.json`.
- T-1…T-11: banners with increasing ordinals; SIGKILL leaves no verdict; a
  failing step names itself; a wrapper reporting exit 0 does not change a
  recorded FAIL; the baseline appears on the second run; the tree stays clean;
  SIGTERM records `interrupted by a signal` with zero surviving `go test`
  processes and zero stray sleeps; `make -n` records nothing; `-j4` warns
  nothing; direct invocation works; `workflow-check` green.
- No Go code changes, so diff-coverage has nothing to measure. The parity
  requirement is the step list, and `workflow-check` now enforces it: the list is
  duplicated in `check.yml` by necessity, and a duplicated list nothing compares
  is a list that drifts.

## Known limitation

The "typically …" figure is **warm-cache biased**. Measured on consecutive runs
of one commit: `examples-lint` 1m30s cold, 19s warm; `lint-core` 21s then 3s. The
median converges on warm runs and a fresh clone will overshoot it. The estimate
orients; the heartbeat, not the estimate, is what proves a step is alive.
