### PR TITLE
E0: close the ADR-003 layout, and build the adapter lifecycle seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Adapter lifecycle and observation hooks** (SRD-088, closes #269).
+  `renv.Starter`, `renv.Stopper`, `renv.HealthChecker` and
+  `renv.RuntimeAware` join `Migrator` and `ClusterAware` in
+  `pkg/renv/capabilities.go`. All are optional and satisfied
+  structurally — an adapter implements one by having the method. The
+  engine calls them at named per-seam sites in a fixed order, because
+  shutdown has one: the message broker stops accepting before the
+  repository closes, and telemetry flushes after everything it
+  observes. `Stop` is idempotent by contract, so an adapter the host
+  started before the engine existed can be stopped by either.
+  `Thresher.HealthCheck` asks every seam and joins what they report.
+- **Four conformance helpers for adapter authors** (SRD-088):
+  `messagingtest`, `expressiontest`, `taskstest` and `authtest`, the
+  names ADR-003 §4.2 had listed but nothing provided. Each publishes
+  its port's contract as `Conformance(t, factory)` — one line in an
+  adapter's test — and each carries a negative control proving the
+  suite can fail. `messagingtest` and `taskstest` also publish
+  `Waits()`/`SetWaits()`, so an adapter over a remote backend can widen
+  bounds tuned for an in-process one.
+- **A dependency-free Script Task engine** (SRD-088):
+  `pkg/script/gofunc` runs a Go function the host registered under a
+  name, the same move `gooper` makes for Service Tasks. It is opt-in —
+  an auto-wired empty registry would be `##None` with a longer name —
+  and `adapters/lua` remains the choice for interpreted source.
+
+### Changed
+
+- **A process whose Script Task no configured engine can run is refused
+  at registration** (SRD-088). `RegisterProcess` walks the model, nested
+  Sub-Processes included, and rejects any Script Task whose
+  `scriptFormat` no wired engine claims — naming the task, the format,
+  the formats that ARE registered, and the option to wire one. This
+  moves an existing failure earlier: it previously surfaced
+  asynchronously, inside an already-running instance, as an incident.
+  **Migration:** a model with a Script Task now needs its engine wired
+  before `RegisterProcess`, not before the token arrives.
+- **`pkg/**` may not import `internal/`** (SRD-088), enforced by
+  depguard, excepting the `pkg/thresher` facade. This is what makes a
+  bundled battery a reference implementation an outside author can
+  copy.
+- **The examples are linted** (SRD-088). An `exclusions.paths` entry had
+  been suppressing every finding across all 49 example modules, so the
+  `examples-no-internal` rule had never fired. 198 real issues surfaced
+  and are fixed.
+
+### Fixed
+
+- **`goexpr.Engine.Evaluate` panicked on a nil expression** (SRD-088)
+  where `lite` returns a named error — a public extension point turning
+  a caller's bug into a library crash. A nil *source* is still passed
+  through, deliberately: a `GExpression` may carry one bound at
+  construction.
+- **A failed start left already-started adapters running** (SRD-088).
+  `startSeams` now unwinds the started prefix in reverse before
+  returning, joining any rollback failure onto the cause rather than
+  replacing it.
+- **A replaced Data Store stayed in the lifecycle** (SRD-088).
+  `WithDataStore` documented replace-by-ref and the registry honoured
+  it, but the lifecycle list appended — so a superseded store was still
+  started, health-checked and stopped while serving no reference.
+- **`gofunc` could register an unreachable script** (SRD-088): the name
+  was stored untrimmed and looked up trimmed, so a padded registration
+  failed as "no script registered" on a name plainly in the registry.
+
 ### Changed
 
 - **BREAKING: instance discovery queries compose** (SRD-084, closes


### PR DESCRIPTION
Closes #269. Implements [SRD-088](docs/srd/SRD-088-adr-003-layout-closure.md),
and moves [ADR-003](docs/design/ADR-003-module-layout.md) `Draft → Accepted`.

E0's structural item: make ADR-003's catalogue true, close its §5 departure
table, and build the one seam it names that the code genuinely lacked — the
adapter lifecycle hooks.

## What this does

**The adapter lifecycle seam (FR-1…FR-3).** ADR-002 §8.3 named `Starter`,
`Stopper`, `HealthChecker` and `RuntimeAware`; nothing implemented them. They
now live in `pkg/renv/capabilities.go` beside the `Migrator` and `ClusterAware`
that were already there, all optional and satisfied structurally — an adapter
implements one by having the method, importing nothing.

The engine invokes them at **named per-seam call sites**, not by sweeping a
plugin list, because shutdown has an order and a loop cannot express one: the
message broker must stop accepting before the repository closes, or in-flight
state is lost, and telemetry flushes after everything it observes. `Stop` is
idempotent by contract — the server may stop an adapter it started before the
engine existed, and the engine stops what it holds.

**The catalogue, reconciled in both directions (FR-4).** SRD-088 §4.1 named
three entries describing packages that should not exist. Checking the other
direction found four ports that *do* exist and were never catalogued —
`rules`, `script`, `datastore`, `interactor`. ADR-003 §4.2 now matches the
tree, gains §4.2.1's **battery-vs-adapter criterion** (nothing had ever stated
why `adapters/dtable` sat beside `pkg/rules/gorules`, both dependency-free),
and amends §4.4 to permit `examples/* → adapters/*` — the rule forbade what
the code already did, and an adapter nobody demonstrates is an adapter nobody
can learn to wire.

**Four conformance helpers (FR-5).** `messagingtest`, `expressiontest`,
`taskstest`, `authtest` — the names ADR-003 §4.2 has listed since May. Each
publishes its port's contract as a one-line `Conformance(t, factory)`, and
each carries a **negative control**: a helper that cannot fail proves nothing
about the implementations it accepts.

Two could not take a bare factory, and the reason is a property of the ports.
An expression's *body* is written in the engine's own language; *which*
requests an authorization provider permits is its policy. Neither is knowable
to a generic suite, so both take a `Subject` carrying the caller's fixture and
expected verdicts.

**A zero-dependency script battery, and unrunnable models refused (FR-8).**
`pkg/script/gofunc` executes the one language the core already has — the same
move `gooper` makes for Service Tasks. It is opt-in: an auto-wired script
registry would be empty, which is `##None` with a longer name. And
`RegisterProcess` now **refuses a model whose Script Task formats no
configured engine claims**, walking nested Sub-Processes too. That failure
previously surfaced asynchronously, inside a running instance, as an incident.

**`pkg/**` may not import `internal/` (FR-9).** Measured: `pkg/thresher` is
the only non-test package that does, and it is the facade. depguard makes the
property a guarantee, which is what lets a battery serve as the reference
implementation an outside author copies.

**The examples are linted, and now genuinely (FR-10).** An `exclusions.paths`
entry had been suppressing every finding in all 49 example modules —
`examples-no-internal` had never fired in its life. Removing it surfaced 198
real issues, all fixed. The claim that the entry bought CI speed did not
survive measurement: 18.58s versus 18.67s.

## Independent review

`/pr-review` handed the diff to an external agent (a different model family,
doc-blind, four lenses, 7/7 chunks each). It returned 20 notes. **13 were
verified and fixed here**, 3 refuted with written reasons, the rest duplicates
across lenses.

Two were blockers, **both introduced by this branch**, and neither
`/check-srd`, `/check-style` nor a green 14/14 gate at 95.5% diff-coverage
could have found them:

- `startSeams` left running what it had already started when a later seam
  failed — the exact failure mode §3.2 argues against for shutdown, in the
  same file.
- `WithDataStore` appended where the registry replaced, so a superseded store
  was still started, health-checked and stopped while serving no reference.

Most of the rest were one mistake in several costumes: **an assertion that
reads strict and is weak** — an `exactly 1` that only caught same-instant
duplicates, a fan-out check budgeted on the silence window, two `time.Sleep`s
standing in for a handshake. The review also caught a `(nil, nil)` return the
lint sweep had introduced in `examples/process-data`, and that the suites'
timeouts were unexported constants — which contradicted NFR-3 outright, since
a suite published for remote adapters cannot assume delivery is instant.

Every fix carries a regression test confirmed to **fail with the fix
reverted**.

## Verification

- `make ci`: **PASS**, 14/14 steps (verdict in `.ci/last-run.json`).
- Diff-coverage **95.3%** of 555 changed lines (gate: ≥95%).
- `/check-srd`: PASS. It found three defects, all fixed — including a
  downward `ADR-003 → SRD-088` reference this branch had introduced, and two
  tests naming a `make` target that does not exist.
- `/pr-review`: 13 agreed and fixed, 3 refuted, **0 open**.

## Document hierarchy

ADR-003 moves to `Accepted` at **v.1, not v.2**. It had never been Accepted, and
a version bump records a change of contract on an accepted document — so a v.2
would be an intermediate version nobody accepted, noise for later readers and a
stale pin in anything referencing it. The ADR's own history row had said as
much; SRD-088 §4.9 records the correction rather than applying it silently.

Linked docs synced: the roadmap (which claimed nothing in CI checked import
direction) and SAD-001's ADR index. Four further mentions were inventoried and
**deliberately left alone** — hedged text in ADR-002, a note in ADR-024 about
draft parents, ADR-012's history rows (a history row records what was true
then), and SRD-078 (one-shot, and its claim is now true).

## What is next

- **#316** — the SQLite adapter. Still a scaffold; its `doc.go` now says so
  plainly instead of describing itself in the future tense.
- **#314** — the two iteration tests. This branch did not touch them, but it
  recorded a measurement that separates them: `TestIterationCorrelatedRouting`
  hangs at whatever deadline it is given, which is a lost delivery;
  `TestIterationRoutingKillAndResume` is load-sensitive and passed 9/9 under
  reproduced gate conditions. A red gate on the second alone is a re-run
  signal, not evidence.
