### PR TITLE
Restore the Lane and Collaboration § pins from the spec text (closes #334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Lane and Collaboration § pins are restored, verified**
+  (closes #334). SRD-089.F FR-8 removed the invented section numbers
+  `laneSet`/`lane` and `collaboration`/`participant`/`messageFlow`
+  carried, because the vendored extract pins neither family. The
+  numbers now come from the BPMN 2.0 spec text itself
+  (formal/2011-01-03), the grounding order's second authority: Lanes
+  §10.7, Collaboration §9.1, Participant §9.2.1, Message Flow §9.3 —
+  so a refused element from either family points its modeler at the
+  right chapter again.
+
 - **A declared-int lite expression could never evaluate** (SRD-089.H
   §4.8). The lite evaluator unifies every numeric to `float64`
   (ADR-032 §2.3) while the Multi-Instance model guard REQUIRES the

--- a/pkg/convert/bpmn/bpmn_test.go
+++ b/pkg/convert/bpmn/bpmn_test.go
@@ -167,13 +167,15 @@ func TestImportErrors(t *testing.T) {
 		{
 			name: "unsupported in-namespace element",
 			doc: `<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
-  <bpmn:process id="p"><bpmn:participant id="part"/></bpmn:process>
+  <bpmn:process id="p"><bpmn:choreographyTask id="ct"/></bpmn:process>
 </bpmn:definitions>`,
-			want:    `unsupported element "participant"`,
+			want:    `unsupported element "choreographyTask"`,
 			wantUee: true,
-			// No §: the extract keeps <participant> in scope but pins
-			// no section for it, and an invented one is worse feedback
-			// than none (SRD-089.F FR-8).
+			// No §: neither the extract nor a spec-text verification
+			// pins the Choreography family, and an invented section is
+			// worse feedback than none (SRD-089.F FR-8). <participant>
+			// stopped being this test's sample when #334 pinned it at
+			// the spec text's §9.2.1.
 			wantSec: "",
 		},
 		{
@@ -1088,16 +1090,16 @@ func TestSectionFor(t *testing.T) {
 		"multiInstanceLoopCharacteristics": "§13.3.7",
 		"unknown":                          "",
 
-		// Pinned as ABSENT, not as a number. The extract keeps these
-		// in scope and pins no § for any of them; they carried
-		// invented ones until SRD-089.F FR-8. A future pin has to
-		// come with the spec text that supplies it, and changing
-		// these lines is where that gets noticed.
-		"laneSet":       "",
-		"lane":          "",
-		"collaboration": "",
-		"participant":   "",
-		"messageFlow":   "",
+		// Restored by #334 from the spec text (formal/2011-01-03),
+		// after SRD-089.F FR-8 removed the invented numbers they
+		// carried: Lanes §10.7 (spec p.305-307), Collaboration §9.1
+		// (p.111), Participant §9.2.1 (p.114), Message Flow §9.3
+		// (p.120).
+		"laneSet":       "§10.7",
+		"lane":          "§10.7",
+		"collaboration": "§9.1",
+		"participant":   "§9.2.1",
+		"messageFlow":   "§9.3",
 	}
 
 	for tag, want := range tests {

--- a/pkg/convert/bpmn/collab_test.go
+++ b/pkg/convert/bpmn/collab_test.go
@@ -275,17 +275,18 @@ func TestCollabFamilyIDsJoinTheLedger(t *testing.T) {
 	}
 }
 
-// TestParticipantOutsideACollaboration is T-12 (§4.5): still refused,
-// still no § — the extract pins none (#334).
+// TestParticipantOutsideACollaboration is T-12 (§4.5): still refused —
+// and since #334 the refusal carries the spec text's own §9.2.1, the
+// pin the extract could not supply.
 func TestParticipantOutsideACollaboration(t *testing.T) {
 	_, err := importEventDoc(t, propDoc("",
 		`    <bpmn:participant id="pa1" processRef="P"/>`))
 	if err == nil || !strings.Contains(err.Error(), `unsupported element "participant"`) {
-		t.Fatalf("error = %v, want the plain refusal", err)
+		t.Fatalf("error = %v, want the refusal", err)
 	}
 
-	if strings.Contains(err.Error(), "§") {
-		t.Errorf("error = %v carries a §; the extract pins none (#334)", err)
+	if !strings.Contains(err.Error(), "§9.2.1") {
+		t.Errorf("error = %v, want the spec text's §9.2.1 (#334)", err)
 	}
 }
 

--- a/pkg/convert/bpmn/dispatch.go
+++ b/pkg/convert/bpmn/dispatch.go
@@ -235,13 +235,21 @@ var sections = map[string]string{
 	// too, but carries no § here — the extract does not pin one, and a
 	// section asserted from memory is worse feedback than none.
 	//
-	// Three more families are absent for that same reason, having once
-	// been present with invented numbers: <laneSet>/<lane>, and the
-	// Collaboration group <collaboration>/<participant>/<messageFlow>.
-	// conformance.md line 32 and lines 165-176 keep all of them in
-	// scope but pin no § for any, and a modeler sent to the wrong
-	// chapter stops trusting the rest of the message. They are pinned
-	// when the spec text supplies a number, not before.
+	// The Lane and Collaboration families are pinned from the SPEC TEXT
+	// (formal/2011-01-03), the grounding order's second authority — the
+	// extract keeps them in scope and pins no § (conformance.md:32,
+	// 165-176), and both once carried invented numbers until SRD-089.F
+	// FR-8 removed them (#334 restores them verified): Lanes are §10.7
+	// (spec p.305-307 — "a Lane is contained within a LaneSet, which is
+	// contained within a Process"); the Collaboration concept is §9.1
+	// (p.111), a Participant §9.2.1 (p.114), a Message Flow §9.3
+	// (p.120).
+	"laneSet":       "§10.7",
+	"lane":          "§10.7",
+	"collaboration": "§9.1",
+	"participant":   "§9.2.1",
+	"messageFlow":   "§9.3",
+
 	"conversation":            "§9.5.1",
 	"subConversation":         "§9.5.1",
 	"callConversation":        "§9.5.1",


### PR DESCRIPTION
Closes #334 — the last feedback-quality item on epic #335.

SRD-089.F FR-8 removed the § pins for `laneSet`/`lane` and `collaboration`/`participant`/`messageFlow` because the vendored extract pins neither family and the numbers they carried (§10.5, §10.1) were invented — worse feedback than none. The issue recorded the gap until the grounding order's second authority could be consulted.

## What this PR does

Restores the five `sections` rows, each verified against the **BPMN 2.0 spec text** (formal/2011-01-03 — the NotebookLM path stays blocked on its login, and the spec text is the same authority tier):

| Element | § | Evidence |
|---|---|---|
| `laneSet`, `lane` | **§10.7** | spec p.305–307: "When a Lane is defined it is contained within a LaneSet, which is contained within a Process" |
| `collaboration` | **§9.1** | p.111, Basic Collaboration Concepts |
| `participant` | **§9.2.1** | p.114, Participants |
| `messageFlow` | **§9.3** | p.120, Message Flow |

The two tests that pinned the *absence* flip to pin the presence: the stray-participant refusal (SRD-089.I T-12) now wants §9.2.1, and `TestImportErrors`' no-section sample moves to `<choreographyTask>` — a family no authority has pinned. The sections grid asserts all five numbers, and the CHANGELOG carries the entry.

No SRD/FIX doc: a data-only restoration already specified by SRD-089.F §4.10 and #334 (the SDD triviality carve-out); the substantive requirement was the §-evidence above.

## Verification

`make ci` PASS on the committed branch, judged by `.ci/last-run.json`. Diff-coverage reports 0 changed coverable lines — the change is map-literal data plus tests, neither coverable.

Part of #284. After this merge, everything left on epic #335 is capability-blocked (#323, #325, #328–#331).
