### PR TITLE
test(waiters): a test hook that could close its own channel twice

### DIFF
--- a/internal/eventproc/eventhub/waiters/message_keys_test.go
+++ b/internal/eventproc/eventhub/waiters/message_keys_test.go
@@ -2,6 +2,7 @@ package waiters_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -362,15 +363,33 @@ func TestStopDoesNotHoldTheWaiterLock(t *testing.T) {
 	var (
 		entered = make(chan struct{})
 		release = make(chan struct{})
+		first   sync.Once
 	)
 
+	// EXACTLY ONE caller takes the blocking branch, and `sync.Once` is what
+	// makes that true. Stop unsubscribes, and so does the service goroutine's
+	// own teardown, so this hook is entered TWICE and concurrently —
+	// FailingSubscription calls it before its lock and on every call, which is
+	// its contract (failing_test.go counts the calls).
+	//
+	// Deciding "am I first?" by reading `entered` and closing it if not —
+	// select/default — is check-then-act: both callers can see it open before
+	// either close lands, and the second close panics. That is not theoretical;
+	// it reddened `test-core` on 2026-08-29, and 200 isolated runs plus 8
+	// race-enabled package runs never reproduced it. The window is narrow, not
+	// absent.
 	broker := &messagingtest.FailingBroker{
 		OnUnsubscribe: func() {
-			select {
-			case <-entered: // the service goroutine's own teardown; let it pass
-			default:
+			blocking := false
+
+			first.Do(func() {
+				blocking = true
+
 				close(entered)
-				<-release
+			})
+
+			if blocking {
+				<-release // the later teardown passes straight through
 			}
 		},
 	}


### PR DESCRIPTION
TestStopDoesNotHoldTheWaiterLock panicked with "close of closed channel" on `test-core` (2026-08-29, at the v0.12.0 release commit), in the test's own broker hook rather than anywhere in the engine.

The hook decided "am I the first Unsubscribe?" by looking:

	select {
	case <-entered:
	default:
		close(entered)
		<-release
	}

That is check-then-act, and this hook is entered TWICE and concurrently — Stop unsubscribes, and so does the service goroutine's own deferred teardown. FailingSubscription calls the hook before taking its lock and on every call, which is its contract, not a bug: failing_test.go counts the calls. So both callers can see `entered` still open before either close lands, and the second close panics.

sync.Once makes the decision atomic instead of observed: exactly one caller closes `entered` and waits on `release`, and any later teardown passes straight through. The intent is unchanged — the first Unsubscribe is the one the test pins inside the broker.

Measured rather than argued. A throwaway probe drove both hooks with two goroutines spinning on one atomic barrier, 20 000 collisions each:

	OLD hook: 29 panics in 20000 rounds
	NEW hook:  0 panics in 20000 rounds

0.15% is why CI met it once and why it never appeared locally — 300 runs of the test alone and three race-enabled package runs are all green either way. A window that narrow is invisible to repetition and obvious to arithmetic.

Nothing in the shipped library is affected: the defect is entirely in test scaffolding, and v0.12.0 is unaffected by it.